### PR TITLE
Updated some AI attributes

### DIFF
--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -6,9 +6,11 @@
   - [ai.completion_tokens.used](#aicompletion_tokensused)
   - [ai.input_messages](#aiinput_messages)
   - [ai.model_id](#aimodel_id)
+  - [ai.pipeline.name](#aipipelinename)
   - [ai.prompt_tokens.used](#aiprompt_tokensused)
   - [ai.responses](#airesponses)
   - [ai.streaming](#aistreaming)
+  - [ai.total_cost](#aitotal_cost)
   - [ai.total_tokens.used](#aitotal_tokensused)
 
 ## Stable Attributes
@@ -49,6 +51,17 @@ The vendor-specific ID of the model used.
 | Example | `gpt-4` |
 | Aliases | `gen_ai.response.model` |
 
+### ai.pipeline.name
+
+The name of the AI pipeline.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `Autofix Pipeline` |
+
 ### ai.prompt_tokens.used
 
 The number of tokens used to process just the prompt.
@@ -82,6 +95,17 @@ Whether the request was streamed back.
 | Has PII | false |
 | Exists in OpenTelemetry | No |
 | Example | `true` |
+
+### ai.total_cost
+
+The total cost for the tokens used.
+
+| Property | Value |
+| --- | --- |
+| Type | `double` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `12.34` |
 
 ### ai.total_tokens.used
 

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -66,6 +66,26 @@ export const AI_MODEL_ID = 'ai.model_id';
  */
 export type AI_MODEL_ID_TYPE = string;
 
+// Path: model/attributes/ai/ai__pipeline__name.json
+
+/**
+ * The name of the AI pipeline. `ai.pipeline.name`
+ *
+ * Attribute Value Type: `string` {@link AI_PIPELINE_NAME_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "Autofix Pipeline"
+ */
+export const AI_PIPELINE_NAME = 'ai.pipeline.name';
+
+/**
+ * Type for {@link AI_PIPELINE_NAME} ai.pipeline.name
+ */
+export type AI_PIPELINE_NAME_TYPE = string;
+
 // Path: model/attributes/ai/ai__prompt_tokens__used.json
 
 /**
@@ -127,6 +147,26 @@ export const AI_STREAMING = 'ai.streaming';
  * Type for {@link AI_STREAMING} ai.streaming
  */
 export type AI_STREAMING_TYPE = boolean;
+
+// Path: model/attributes/ai/ai__total_cost.json
+
+/**
+ * The total cost for the tokens used. `ai.total_cost`
+ *
+ * Attribute Value Type: `number` {@link AI_TOTAL_COST_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 12.34
+ */
+export const AI_TOTAL_COST = 'ai.total_cost';
+
+/**
+ * Type for {@link AI_TOTAL_COST} ai.total_cost
+ */
+export type AI_TOTAL_COST_TYPE = number;
 
 // Path: model/attributes/ai/ai__total_tokens__used.json
 
@@ -4750,9 +4790,11 @@ export type Attributes = {
   [AI_COMPLETION_TOKENS_USED]?: AI_COMPLETION_TOKENS_USED_TYPE;
   [AI_INPUT_MESSAGES]?: AI_INPUT_MESSAGES_TYPE;
   [AI_MODEL_ID]?: AI_MODEL_ID_TYPE;
+  [AI_PIPELINE_NAME]?: AI_PIPELINE_NAME_TYPE;
   [AI_PROMPT_TOKENS_USED]?: AI_PROMPT_TOKENS_USED_TYPE;
   [AI_RESPONSES]?: AI_RESPONSES_TYPE;
   [AI_STREAMING]?: AI_STREAMING_TYPE;
+  [AI_TOTAL_COST]?: AI_TOTAL_COST_TYPE;
   [AI_TOTAL_TOKENS_USED]?: AI_TOTAL_TOKENS_USED_TYPE;
   [APP_START_TYPE]?: APP_START_TYPE_TYPE;
   [BLOCKED_MAIN_THREAD]?: BLOCKED_MAIN_THREAD_TYPE;
@@ -4931,9 +4973,11 @@ export type FullAttributes = {
   [AI_COMPLETION_TOKENS_USED]?: AI_COMPLETION_TOKENS_USED_TYPE;
   [AI_INPUT_MESSAGES]?: AI_INPUT_MESSAGES_TYPE;
   [AI_MODEL_ID]?: AI_MODEL_ID_TYPE;
+  [AI_PIPELINE_NAME]?: AI_PIPELINE_NAME_TYPE;
   [AI_PROMPT_TOKENS_USED]?: AI_PROMPT_TOKENS_USED_TYPE;
   [AI_RESPONSES]?: AI_RESPONSES_TYPE;
   [AI_STREAMING]?: AI_STREAMING_TYPE;
+  [AI_TOTAL_COST]?: AI_TOTAL_COST_TYPE;
   [AI_TOTAL_TOKENS_USED]?: AI_TOTAL_TOKENS_USED_TYPE;
   [APP_START_TYPE]?: APP_START_TYPE_TYPE;
   [BLOCKED_MAIN_THREAD]?: BLOCKED_MAIN_THREAD_TYPE;

--- a/model/attributes/ai/ai__pipeline__name.json
+++ b/model/attributes/ai/ai__pipeline__name.json
@@ -1,0 +1,10 @@
+{
+  "key": "ai.pipeline.name",
+  "brief": "The name of the AI pipeline.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "Autofix Pipeline"
+}

--- a/model/attributes/ai/ai__total_cost.json
+++ b/model/attributes/ai/ai__total_cost.json
@@ -1,0 +1,10 @@
+{
+  "key": "ai.total_cost",
+  "brief": "The total cost for the tokens used.",
+  "type": "double",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": 12.34
+}


### PR DESCRIPTION
There were `ai.total_cost` and `ai.pipeline.name` missing that are both used in `relay`.