### PR TITLE
Cleanup `ai` attributes

### DIFF
--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -15,7 +15,6 @@
   - [ai.model_id](#aimodel_id)
   - [ai.pipeline.name](#aipipelinename)
   - [ai.preamble](#aipreamble)
-  - [ai.presence_penalty](#aipresence_penalty)
   - [ai.prompt_tokens.used](#aiprompt_tokensused)
   - [ai.raw_prompting](#airaw_prompting)
   - [ai.response_format](#airesponse_format)
@@ -36,6 +35,7 @@
   - [ai.warnings](#aiwarnings)
 - [Deprecated Attributes](#deprecated-attributes)
   - [ai.frequency_penalty](#aifrequency_penalty)
+  - [ai.presence_penalty](#aipresence_penalty)
 
 ## Stable Attributes
 
@@ -173,17 +173,6 @@ For an AI model call, the preamble parameter. Preambles are a part of the prompt
 | Has PII | true |
 | Exists in OpenTelemetry | No |
 | Example | `You are now a clown.` |
-
-### ai.presence_penalty
-
-Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.
-
-| Property | Value |
-| --- | --- |
-| Type | `double` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `0.5` |
 
 ### ai.prompt_tokens.used
 
@@ -399,4 +388,16 @@ Used to reduce repetitiveness of generated tokens. The higher the value, the str
 | Exists in OpenTelemetry | No |
 | Example | `0.5` |
 | Deprecated | Yes, use `gen_ai.request.frequency_penalty` instead |
+
+### ai.presence_penalty
+
+Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.
+
+| Property | Value |
+| --- | --- |
+| Type | `double` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `0.5` |
+| Deprecated | Yes, use `gen_ai.request.presence_penalty` instead |
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -26,7 +26,6 @@
   - [ai.texts](#aitexts)
   - [ai.tool_calls](#aitool_calls)
   - [ai.tools](#aitools)
-  - [ai.top_k](#aitop_k)
   - [ai.top_p](#aitop_p)
   - [ai.total_cost](#aitotal_cost)
   - [ai.total_tokens.used](#aitotal_tokensused)
@@ -36,6 +35,7 @@
   - [ai.presence_penalty](#aipresence_penalty)
   - [ai.seed](#aiseed)
   - [ai.temperature](#aitemperature)
+  - [ai.top_k](#aitop_k)
 
 ## Stable Attributes
 
@@ -296,17 +296,6 @@ For an AI model call, the functions that are available
 | Exists in OpenTelemetry | No |
 | Example | `["function_1","function_2"]` |
 
-### ai.top_k
-
- Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).
-
-| Property | Value |
-| --- | --- |
-| Type | `integer` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `35` |
-
 ### ai.top_p
 
 Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).
@@ -402,4 +391,16 @@ For an AI model call, the temperature parameter. Temperature essentially means h
 | Exists in OpenTelemetry | No |
 | Example | `0.1` |
 | Deprecated | Yes, use `gen_ai.request.temperature` instead |
+
+### ai.top_k
+
+Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).
+
+| Property | Value |
+| --- | --- |
+| Type | `integer` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `35` |
+| Deprecated | Yes, use `gen_ai.request.top_k` instead |
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -5,7 +5,6 @@
 - [Stable Attributes](#stable-attributes)
   - [ai.citations](#aicitations)
   - [ai.documents](#aidocuments)
-  - [ai.function_call](#aifunction_call)
   - [ai.input_messages](#aiinput_messages)
   - [ai.is_search_required](#aiis_search_required)
   - [ai.metadata](#aimetadata)
@@ -27,6 +26,7 @@
   - [ai.completion_tokens.used](#aicompletion_tokensused)
   - [ai.finish_reason](#aifinish_reason)
   - [ai.frequency_penalty](#aifrequency_penalty)
+  - [ai.function_call](#aifunction_call)
   - [ai.generation_id](#aigeneration_id)
   - [ai.model_id](#aimodel_id)
   - [ai.presence_penalty](#aipresence_penalty)
@@ -60,17 +60,6 @@ Documents or content chunks used as context for the AI model.
 | Has PII | true |
 | Exists in OpenTelemetry | No |
 | Example | `["document1.txt","document2.pdf"]` |
-
-### ai.function_call
-
-For an AI model call, the function that was called. This is deprecated for OpenAI, and replaced by tool_calls
-
-| Property | Value |
-| --- | --- |
-| Type | `string` |
-| Has PII | true |
-| Exists in OpenTelemetry | No |
-| Example | `function_name` |
 
 ### ai.input_messages
 
@@ -300,6 +289,18 @@ Used to reduce repetitiveness of generated tokens. The higher the value, the str
 | Exists in OpenTelemetry | No |
 | Example | `0.5` |
 | Deprecated | Yes, use `gen_ai.request.frequency_penalty` instead |
+
+### ai.function_call
+
+For an AI model call, the function that was called. This is deprecated for OpenAI, and replaced by tool_calls
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | true |
+| Exists in OpenTelemetry | No |
+| Example | `function_name` |
+| Deprecated | Yes, use `gen_ai.tool.name` instead |
 
 ### ai.generation_id
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -4,7 +4,6 @@
 
 - [Stable Attributes](#stable-attributes)
   - [ai.citations](#aicitations)
-  - [ai.completion_tokens.used](#aicompletion_tokensused)
   - [ai.documents](#aidocuments)
   - [ai.function_call](#aifunction_call)
   - [ai.input_messages](#aiinput_messages)
@@ -26,6 +25,7 @@
   - [ai.total_tokens.used](#aitotal_tokensused)
   - [ai.warnings](#aiwarnings)
 - [Deprecated Attributes](#deprecated-attributes)
+  - [ai.completion_tokens.used](#aicompletion_tokensused)
   - [ai.finish_reason](#aifinish_reason)
   - [ai.frequency_penalty](#aifrequency_penalty)
   - [ai.generation_id](#aigeneration_id)
@@ -49,18 +49,6 @@ References or sources cited by the AI model in its response.
 | Has PII | true |
 | Exists in OpenTelemetry | No |
 | Example | `["Citation 1","Citation 2"]` |
-
-### ai.completion_tokens.used
-
-The number of tokens used to respond to the message.
-
-| Property | Value |
-| --- | --- |
-| Type | `integer` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `10` |
-| Aliases | `gen_ai.usage.output_tokens`, `gen_ai.usage.completion_tokens` |
 
 ### ai.documents
 
@@ -286,6 +274,19 @@ Warning messages generated during model execution.
 ## Deprecated Attributes
 
 These attributes are deprecated and will be removed in a future version. Please use the recommended replacements.
+
+### ai.completion_tokens.used
+
+The number of tokens used to respond to the message.
+
+| Property | Value |
+| --- | --- |
+| Type | `integer` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `10` |
+| Deprecated | Yes, use `gen_ai.usage.output_tokens` instead |
+| Aliases | `gen_ai.usage.output_tokens`, `gen_ai.usage.completion_tokens` |
 
 ### ai.finish_reason
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -7,7 +7,6 @@
   - [ai.completion_tokens.used](#aicompletion_tokensused)
   - [ai.documents](#aidocuments)
   - [ai.function_call](#aifunction_call)
-  - [ai.generation_id](#aigeneration_id)
   - [ai.input_messages](#aiinput_messages)
   - [ai.is_search_required](#aiis_search_required)
   - [ai.metadata](#aimetadata)
@@ -31,6 +30,7 @@
 - [Deprecated Attributes](#deprecated-attributes)
   - [ai.finish_reason](#aifinish_reason)
   - [ai.frequency_penalty](#aifrequency_penalty)
+  - [ai.generation_id](#aigeneration_id)
   - [ai.presence_penalty](#aipresence_penalty)
   - [ai.seed](#aiseed)
   - [ai.temperature](#aitemperature)
@@ -83,17 +83,6 @@ For an AI model call, the function that was called. This is deprecated for OpenA
 | Has PII | true |
 | Exists in OpenTelemetry | No |
 | Example | `function_name` |
-
-### ai.generation_id
-
-Unique identifier for the completion.
-
-| Property | Value |
-| --- | --- |
-| Type | `string` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `gen_123abc` |
 
 ### ai.input_messages
 
@@ -345,6 +334,18 @@ Used to reduce repetitiveness of generated tokens. The higher the value, the str
 | Exists in OpenTelemetry | No |
 | Example | `0.5` |
 | Deprecated | Yes, use `gen_ai.request.frequency_penalty` instead |
+
+### ai.generation_id
+
+Unique identifier for the completion.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `gen_123abc` |
+| Deprecated | Yes, use `gen_ai.response.generation_id` instead |
 
 ### ai.presence_penalty
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -7,7 +7,6 @@
   - [ai.completion_tokens.used](#aicompletion_tokensused)
   - [ai.documents](#aidocuments)
   - [ai.finish_reason](#aifinish_reason)
-  - [ai.frequency_penalty](#aifrequency_penalty)
   - [ai.function_call](#aifunction_call)
   - [ai.generation_id](#aigeneration_id)
   - [ai.input_messages](#aiinput_messages)
@@ -35,6 +34,8 @@
   - [ai.total_cost](#aitotal_cost)
   - [ai.total_tokens.used](#aitotal_tokensused)
   - [ai.warnings](#aiwarnings)
+- [Deprecated Attributes](#deprecated-attributes)
+  - [ai.frequency_penalty](#aifrequency_penalty)
 
 ## Stable Attributes
 
@@ -44,9 +45,10 @@ References or sources cited by the AI model in its response.
 
 | Property | Value |
 | --- | --- |
-| Type | `string` |
+| Type | `string[]` |
 | Has PII | true |
 | Exists in OpenTelemetry | No |
+| Example | `["Citation 1","Citation 2"]` |
 
 ### ai.completion_tokens.used
 
@@ -81,17 +83,6 @@ The reason why the model stopped generating.
 | Has PII | false |
 | Exists in OpenTelemetry | No |
 | Example | `COMPLETE` |
-
-### ai.frequency_penalty
-
-Used to reduce repetitiveness of generated tokens. The higher the value, the stronger a penalty is applied to previously present tokens, proportional to how many times they have already appeared in the prompt or prior generation.
-
-| Property | Value |
-| --- | --- |
-| Type | `double` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `0.5` |
 
 ### ai.function_call
 
@@ -392,4 +383,20 @@ Warning messages generated during model execution.
 | Has PII | true |
 | Exists in OpenTelemetry | No |
 | Example | `["Token limit exceeded"]` |
+
+## Deprecated Attributes
+
+These attributes are deprecated and will be removed in a future version. Please use the recommended replacements.
+
+### ai.frequency_penalty
+
+Used to reduce repetitiveness of generated tokens. The higher the value, the stronger a penalty is applied to previously present tokens, proportional to how many times they have already appeared in the prompt or prior generation.
+
+| Property | Value |
+| --- | --- |
+| Type | `double` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `0.5` |
+| Deprecated | Yes, use `gen_ai.request.frequency_penalty` instead |
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -29,6 +29,7 @@
   - [ai.function_call](#aifunction_call)
   - [ai.generation_id](#aigeneration_id)
   - [ai.model_id](#aimodel_id)
+  - [ai.model.provider](#aimodelprovider)
   - [ai.presence_penalty](#aipresence_penalty)
   - [ai.prompt_tokens.used](#aiprompt_tokensused)
   - [ai.seed](#aiseed)
@@ -326,6 +327,19 @@ The vendor-specific ID of the model used.
 | Example | `gpt-4` |
 | Deprecated | Yes, use `gen_ai.response.model` instead |
 | Aliases | `gen_ai.response.model` |
+
+### ai.model.provider
+
+The provider of the model.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `openai` |
+| Deprecated | Yes, use `gen_ai.system` instead |
+| Aliases | `gen_ai.system` |
 
 ### ai.presence_penalty
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -21,7 +21,6 @@
   - [ai.responses](#airesponses)
   - [ai.search_queries](#aisearch_queries)
   - [ai.search_results](#aisearch_results)
-  - [ai.seed](#aiseed)
   - [ai.streaming](#aistreaming)
   - [ai.tags](#aitags)
   - [ai.temperature](#aitemperature)
@@ -36,6 +35,7 @@
 - [Deprecated Attributes](#deprecated-attributes)
   - [ai.frequency_penalty](#aifrequency_penalty)
   - [ai.presence_penalty](#aipresence_penalty)
+  - [ai.seed](#aiseed)
 
 ## Stable Attributes
 
@@ -241,17 +241,6 @@ Results returned from search queries for context.
 | Exists in OpenTelemetry | No |
 | Example | `["search_result_1, search_result_2"]` |
 
-### ai.seed
-
-The seed, ideally models given the same seed and same other parameters will produce the exact same output.
-
-| Property | Value |
-| --- | --- |
-| Type | `string` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `1234567890` |
-
 ### ai.streaming
 
 Whether the request was streamed back.
@@ -400,4 +389,16 @@ Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty,
 | Exists in OpenTelemetry | No |
 | Example | `0.5` |
 | Deprecated | Yes, use `gen_ai.request.presence_penalty` instead |
+
+### ai.seed
+
+The seed, ideally models given the same seed and same other parameters will produce the exact same output.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `1234567890` |
+| Deprecated | Yes, use `gen_ai.request.seed` instead |
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -22,7 +22,6 @@
   - [ai.tool_calls](#aitool_calls)
   - [ai.tools](#aitools)
   - [ai.total_cost](#aitotal_cost)
-  - [ai.total_tokens.used](#aitotal_tokensused)
   - [ai.warnings](#aiwarnings)
 - [Deprecated Attributes](#deprecated-attributes)
   - [ai.completion_tokens.used](#aicompletion_tokensused)
@@ -36,6 +35,7 @@
   - [ai.temperature](#aitemperature)
   - [ai.top_k](#aitop_k)
   - [ai.top_p](#aitop_p)
+  - [ai.total_tokens.used](#aitotal_tokensused)
 
 ## Stable Attributes
 
@@ -249,17 +249,6 @@ The total cost for the tokens used.
 | Exists in OpenTelemetry | No |
 | Example | `12.34` |
 
-### ai.total_tokens.used
-
-The total number of tokens used to process the prompt.
-
-| Property | Value |
-| --- | --- |
-| Type | `integer` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `30` |
-
 ### ai.warnings
 
 Warning messages generated during model execution.
@@ -409,4 +398,16 @@ Limits the model to only consider tokens whose cumulative probability mass adds 
 | Exists in OpenTelemetry | No |
 | Example | `0.7` |
 | Deprecated | Yes, use `gen_ai.request.top_p` instead |
+
+### ai.total_tokens.used
+
+The total number of tokens used to process the prompt.
+
+| Property | Value |
+| --- | --- |
+| Type | `integer` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `30` |
+| Deprecated | Yes, use `gen_ai.usage.total_tokens` instead |
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -23,7 +23,6 @@
   - [ai.search_results](#aisearch_results)
   - [ai.streaming](#aistreaming)
   - [ai.tags](#aitags)
-  - [ai.temperature](#aitemperature)
   - [ai.texts](#aitexts)
   - [ai.tool_calls](#aitool_calls)
   - [ai.tools](#aitools)
@@ -36,6 +35,7 @@
   - [ai.frequency_penalty](#aifrequency_penalty)
   - [ai.presence_penalty](#aipresence_penalty)
   - [ai.seed](#aiseed)
+  - [ai.temperature](#aitemperature)
 
 ## Stable Attributes
 
@@ -263,17 +263,6 @@ Tags that describe an AI pipeline step.
 | Exists in OpenTelemetry | No |
 | Example | `{"executed_function": "add_integers"}` |
 
-### ai.temperature
-
-For an AI model call, the temperature parameter. Temperature essentially means how random the output will be.
-
-| Property | Value |
-| --- | --- |
-| Type | `double` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `0.1` |
-
 ### ai.texts
 
 Raw text inputs provided to the model.
@@ -401,4 +390,16 @@ The seed, ideally models given the same seed and same other parameters will prod
 | Exists in OpenTelemetry | No |
 | Example | `1234567890` |
 | Deprecated | Yes, use `gen_ai.request.seed` instead |
+
+### ai.temperature
+
+For an AI model call, the temperature parameter. Temperature essentially means how random the output will be.
+
+| Property | Value |
+| --- | --- |
+| Type | `double` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `0.1` |
+| Deprecated | Yes, use `gen_ai.request.temperature` instead |
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -10,7 +10,6 @@
   - [ai.input_messages](#aiinput_messages)
   - [ai.is_search_required](#aiis_search_required)
   - [ai.metadata](#aimetadata)
-  - [ai.model_id](#aimodel_id)
   - [ai.pipeline.name](#aipipelinename)
   - [ai.preamble](#aipreamble)
   - [ai.prompt_tokens.used](#aiprompt_tokensused)
@@ -31,6 +30,7 @@
   - [ai.finish_reason](#aifinish_reason)
   - [ai.frequency_penalty](#aifrequency_penalty)
   - [ai.generation_id](#aigeneration_id)
+  - [ai.model_id](#aimodel_id)
   - [ai.presence_penalty](#aipresence_penalty)
   - [ai.seed](#aiseed)
   - [ai.temperature](#aitemperature)
@@ -117,18 +117,6 @@ Extra metadata passed to an AI pipeline step.
 | Has PII | false |
 | Exists in OpenTelemetry | No |
 | Example | `{"user_id": 123, "session_id": "abc123"}` |
-
-### ai.model_id
-
-The vendor-specific ID of the model used.
-
-| Property | Value |
-| --- | --- |
-| Type | `string` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `gpt-4` |
-| Aliases | `gen_ai.response.model` |
 
 ### ai.pipeline.name
 
@@ -346,6 +334,19 @@ Unique identifier for the completion.
 | Exists in OpenTelemetry | No |
 | Example | `gen_123abc` |
 | Deprecated | Yes, use `gen_ai.response.generation_id` instead |
+
+### ai.model_id
+
+The vendor-specific ID of the model used.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `gpt-4` |
+| Deprecated | Yes, use `gen_ai.response.model` instead |
+| Aliases | `gen_ai.response.model` |
 
 ### ai.presence_penalty
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -313,7 +313,7 @@ Unique identifier for the completion.
 | Has PII | false |
 | Exists in OpenTelemetry | No |
 | Example | `gen_123abc` |
-| Deprecated | Yes, use `gen_ai.response.generation_id` instead |
+| Deprecated | Yes, use `gen_ai.response.id` instead |
 
 ### ai.model_id
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -339,7 +339,6 @@ The provider of the model.
 | Exists in OpenTelemetry | No |
 | Example | `openai` |
 | Deprecated | Yes, use `gen_ai.system` instead |
-| Aliases | `gen_ai.system` |
 
 ### ai.presence_penalty
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -12,7 +12,6 @@
   - [ai.metadata](#aimetadata)
   - [ai.pipeline.name](#aipipelinename)
   - [ai.preamble](#aipreamble)
-  - [ai.prompt_tokens.used](#aiprompt_tokensused)
   - [ai.raw_prompting](#airaw_prompting)
   - [ai.response_format](#airesponse_format)
   - [ai.responses](#airesponses)
@@ -32,6 +31,7 @@
   - [ai.generation_id](#aigeneration_id)
   - [ai.model_id](#aimodel_id)
   - [ai.presence_penalty](#aipresence_penalty)
+  - [ai.prompt_tokens.used](#aiprompt_tokensused)
   - [ai.seed](#aiseed)
   - [ai.temperature](#aitemperature)
   - [ai.top_k](#aitop_k)
@@ -139,18 +139,6 @@ For an AI model call, the preamble parameter. Preambles are a part of the prompt
 | Has PII | true |
 | Exists in OpenTelemetry | No |
 | Example | `You are now a clown.` |
-
-### ai.prompt_tokens.used
-
-The number of tokens used to process just the prompt.
-
-| Property | Value |
-| --- | --- |
-| Type | `integer` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `20` |
-| Aliases | `gen_ai.usage.prompt_tokens`, `gen_ai.usage.input_tokens` |
 
 ### ai.raw_prompting
 
@@ -359,6 +347,19 @@ Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty,
 | Exists in OpenTelemetry | No |
 | Example | `0.5` |
 | Deprecated | Yes, use `gen_ai.request.presence_penalty` instead |
+
+### ai.prompt_tokens.used
+
+The number of tokens used to process just the prompt.
+
+| Property | Value |
+| --- | --- |
+| Type | `integer` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `20` |
+| Deprecated | Yes, use `gen_ai.usage.input_tokens` instead |
+| Aliases | `gen_ai.usage.prompt_tokens`, `gen_ai.usage.input_tokens` |
 
 ### ai.seed
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -26,7 +26,6 @@
   - [ai.texts](#aitexts)
   - [ai.tool_calls](#aitool_calls)
   - [ai.tools](#aitools)
-  - [ai.top_p](#aitop_p)
   - [ai.total_cost](#aitotal_cost)
   - [ai.total_tokens.used](#aitotal_tokensused)
   - [ai.warnings](#aiwarnings)
@@ -36,6 +35,7 @@
   - [ai.seed](#aiseed)
   - [ai.temperature](#aitemperature)
   - [ai.top_k](#aitop_k)
+  - [ai.top_p](#aitop_p)
 
 ## Stable Attributes
 
@@ -296,17 +296,6 @@ For an AI model call, the functions that are available
 | Exists in OpenTelemetry | No |
 | Example | `["function_1","function_2"]` |
 
-### ai.top_p
-
-Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).
-
-| Property | Value |
-| --- | --- |
-| Type | `double` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `0.7` |
-
 ### ai.total_cost
 
 The total cost for the tokens used.
@@ -403,4 +392,16 @@ Limits the model to only consider the K most likely next tokens, where K is an i
 | Exists in OpenTelemetry | No |
 | Example | `35` |
 | Deprecated | Yes, use `gen_ai.request.top_k` instead |
+
+### ai.top_p
+
+Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).
+
+| Property | Value |
+| --- | --- |
+| Type | `double` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `0.7` |
+| Deprecated | Yes, use `gen_ai.request.top_p` instead |
 

--- a/generated/attributes/ai.md
+++ b/generated/attributes/ai.md
@@ -6,7 +6,6 @@
   - [ai.citations](#aicitations)
   - [ai.completion_tokens.used](#aicompletion_tokensused)
   - [ai.documents](#aidocuments)
-  - [ai.finish_reason](#aifinish_reason)
   - [ai.function_call](#aifunction_call)
   - [ai.generation_id](#aigeneration_id)
   - [ai.input_messages](#aiinput_messages)
@@ -30,6 +29,7 @@
   - [ai.total_tokens.used](#aitotal_tokensused)
   - [ai.warnings](#aiwarnings)
 - [Deprecated Attributes](#deprecated-attributes)
+  - [ai.finish_reason](#aifinish_reason)
   - [ai.frequency_penalty](#aifrequency_penalty)
   - [ai.presence_penalty](#aipresence_penalty)
   - [ai.seed](#aiseed)
@@ -72,17 +72,6 @@ Documents or content chunks used as context for the AI model.
 | Has PII | true |
 | Exists in OpenTelemetry | No |
 | Example | `["document1.txt","document2.pdf"]` |
-
-### ai.finish_reason
-
-The reason why the model stopped generating.
-
-| Property | Value |
-| --- | --- |
-| Type | `string` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `COMPLETE` |
 
 ### ai.function_call
 
@@ -332,6 +321,18 @@ Warning messages generated during model execution.
 ## Deprecated Attributes
 
 These attributes are deprecated and will be removed in a future version. Please use the recommended replacements.
+
+### ai.finish_reason
+
+The reason why the model stopped generating.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `COMPLETE` |
+| Deprecated | Yes, use `gen_ai.response.finish_reason` instead |
 
 ### ai.frequency_penalty
 

--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -14,6 +14,7 @@
   - [gen_ai.response.model](#gen_airesponsemodel)
   - [gen_ai.usage.input_tokens](#gen_aiusageinput_tokens)
   - [gen_ai.usage.output_tokens](#gen_aiusageoutput_tokens)
+  - [gen_ai.usage.total_tokens](#gen_aiusagetotal_tokens)
 - [Deprecated Attributes](#deprecated-attributes)
   - [gen_ai.usage.completion_tokens](#gen_aiusagecompletion_tokens)
   - [gen_ai.usage.prompt_tokens](#gen_aiusageprompt_tokens)
@@ -150,6 +151,18 @@ The number of tokens used in the GenAI response (completion).
 | Exists in OpenTelemetry | Yes |
 | Example | `10` |
 | Aliases | `ai.completion_tokens.used`, `gen_ai.usage.completion_tokens` |
+
+### gen_ai.usage.total_tokens
+
+The total number of tokens used to process the prompt. (input tokens plus output todkens)
+
+| Property | Value |
+| --- | --- |
+| Type | `integer` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `20` |
+| Aliases | `ai.total_tokens.used` |
 
 ## Deprecated Attributes
 

--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -10,6 +10,7 @@
   - [gen_ai.request.temperature](#gen_airequesttemperature)
   - [gen_ai.request.top_k](#gen_airequesttop_k)
   - [gen_ai.response.finish_reasons](#gen_airesponsefinish_reasons)
+  - [gen_ai.response.id](#gen_airesponseid)
   - [gen_ai.response.model](#gen_airesponsemodel)
   - [gen_ai.usage.input_tokens](#gen_aiusageinput_tokens)
   - [gen_ai.usage.output_tokens](#gen_aiusageoutput_tokens)
@@ -101,6 +102,18 @@ The reason why the model stopped generating.
 | Exists in OpenTelemetry | Yes |
 | Example | `COMPLETE` |
 | Aliases | `ai.finish_reason` |
+
+### gen_ai.response.id
+
+Unique identifier for the completion.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | Yes |
+| Example | `gen_123abc` |
+| Aliases | `ai.generation_id` |
 
 ### gen_ai.response.model
 

--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -79,15 +79,15 @@ For an AI model call, the temperature parameter. Temperature essentially means h
 
 ### gen_ai.request.top_k
 
-Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).
+Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).
 
 | Property | Value |
 | --- | --- |
-| Type | `integer` |
+| Type | `double` |
 | Has PII | false |
 | Exists in OpenTelemetry | Yes |
-| Example | `351` |
-| Aliases | `ai.top_k` |
+| Example | `0.7` |
+| Aliases | `ai.top_p` |
 
 ### gen_ai.response.model
 

--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -6,6 +6,7 @@
   - [gen_ai.prompt](#gen_aiprompt)
   - [gen_ai.request.frequency_penalty](#gen_airequestfrequency_penalty)
   - [gen_ai.request.presence_penalty](#gen_airequestpresence_penalty)
+  - [gen_ai.request.seed](#gen_airequestseed)
   - [gen_ai.response.model](#gen_airesponsemodel)
   - [gen_ai.usage.input_tokens](#gen_aiusageinput_tokens)
   - [gen_ai.usage.output_tokens](#gen_aiusageoutput_tokens)
@@ -49,6 +50,18 @@ Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty,
 | Exists in OpenTelemetry | Yes |
 | Example | `0.5` |
 | Aliases | `ai.presence_penalty` |
+
+### gen_ai.request.seed
+
+The seed, ideally models given the same seed and same other parameters will produce the exact same output.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | Yes |
+| Example | `1234567890` |
+| Aliases | `ai.seed` |
 
 ### gen_ai.response.model
 

--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -5,6 +5,7 @@
 - [Stable Attributes](#stable-attributes)
   - [gen_ai.prompt](#gen_aiprompt)
   - [gen_ai.request.frequency_penalty](#gen_airequestfrequency_penalty)
+  - [gen_ai.request.presence_penalty](#gen_airequestpresence_penalty)
   - [gen_ai.response.model](#gen_airesponsemodel)
   - [gen_ai.usage.input_tokens](#gen_aiusageinput_tokens)
   - [gen_ai.usage.output_tokens](#gen_aiusageoutput_tokens)
@@ -36,6 +37,18 @@ Used to reduce repetitiveness of generated tokens. The higher the value, the str
 | Exists in OpenTelemetry | Yes |
 | Example | `0.5` |
 | Aliases | `ai.frequency_penalty` |
+
+### gen_ai.request.presence_penalty
+
+Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.
+
+| Property | Value |
+| --- | --- |
+| Type | `double` |
+| Has PII | false |
+| Exists in OpenTelemetry | Yes |
+| Example | `0.5` |
+| Aliases | `ai.presence_penalty` |
 
 ### gen_ai.response.model
 

--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -12,6 +12,7 @@
   - [gen_ai.response.finish_reasons](#gen_airesponsefinish_reasons)
   - [gen_ai.response.id](#gen_airesponseid)
   - [gen_ai.response.model](#gen_airesponsemodel)
+  - [gen_ai.system](#gen_aisystem)
   - [gen_ai.tool.name](#gen_aitoolname)
   - [gen_ai.usage.input_tokens](#gen_aiusageinput_tokens)
   - [gen_ai.usage.output_tokens](#gen_aiusageoutput_tokens)
@@ -128,6 +129,18 @@ The vendor-specific ID of the model used.
 | Exists in OpenTelemetry | Yes |
 | Example | `gpt-4` |
 | Aliases | `ai.model_id` |
+
+### gen_ai.system
+
+The provider of the model.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | Yes |
+| Example | `openai` |
+| Aliases | `ai.model.provider` |
 
 ### gen_ai.tool.name
 

--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -8,6 +8,7 @@
   - [gen_ai.request.presence_penalty](#gen_airequestpresence_penalty)
   - [gen_ai.request.seed](#gen_airequestseed)
   - [gen_ai.request.temperature](#gen_airequesttemperature)
+  - [gen_ai.request.top_k](#gen_airequesttop_k)
   - [gen_ai.response.model](#gen_airesponsemodel)
   - [gen_ai.usage.input_tokens](#gen_aiusageinput_tokens)
   - [gen_ai.usage.output_tokens](#gen_aiusageoutput_tokens)
@@ -75,6 +76,18 @@ For an AI model call, the temperature parameter. Temperature essentially means h
 | Exists in OpenTelemetry | Yes |
 | Example | `0.1` |
 | Aliases | `ai.temperature` |
+
+### gen_ai.request.top_k
+
+Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).
+
+| Property | Value |
+| --- | --- |
+| Type | `integer` |
+| Has PII | false |
+| Exists in OpenTelemetry | Yes |
+| Example | `351` |
+| Aliases | `ai.top_k` |
 
 ### gen_ai.response.model
 

--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -9,6 +9,7 @@
   - [gen_ai.request.seed](#gen_airequestseed)
   - [gen_ai.request.temperature](#gen_airequesttemperature)
   - [gen_ai.request.top_k](#gen_airequesttop_k)
+  - [gen_ai.request.top_p](#gen_airequesttop_p)
   - [gen_ai.response.finish_reasons](#gen_airesponsefinish_reasons)
   - [gen_ai.response.id](#gen_airesponseid)
   - [gen_ai.response.model](#gen_airesponsemodel)
@@ -83,6 +84,18 @@ For an AI model call, the temperature parameter. Temperature essentially means h
 | Aliases | `ai.temperature` |
 
 ### gen_ai.request.top_k
+
+Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).
+
+| Property | Value |
+| --- | --- |
+| Type | `integer` |
+| Has PII | false |
+| Exists in OpenTelemetry | Yes |
+| Example | `35` |
+| Aliases | `ai.top_k` |
+
+### gen_ai.request.top_p
 
 Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).
 

--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -12,6 +12,7 @@
   - [gen_ai.response.finish_reasons](#gen_airesponsefinish_reasons)
   - [gen_ai.response.id](#gen_airesponseid)
   - [gen_ai.response.model](#gen_airesponsemodel)
+  - [gen_ai.tool.name](#gen_aitoolname)
   - [gen_ai.usage.input_tokens](#gen_aiusageinput_tokens)
   - [gen_ai.usage.output_tokens](#gen_aiusageoutput_tokens)
   - [gen_ai.usage.total_tokens](#gen_aiusagetotal_tokens)
@@ -127,6 +128,18 @@ The vendor-specific ID of the model used.
 | Exists in OpenTelemetry | Yes |
 | Example | `gpt-4` |
 | Aliases | `ai.model_id` |
+
+### gen_ai.tool.name
+
+Name of the tool utilized by the agent.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | Yes |
+| Example | `Flights` |
+| Aliases | `ai.function_call` |
 
 ### gen_ai.usage.input_tokens
 

--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -7,6 +7,7 @@
   - [gen_ai.request.frequency_penalty](#gen_airequestfrequency_penalty)
   - [gen_ai.request.presence_penalty](#gen_airequestpresence_penalty)
   - [gen_ai.request.seed](#gen_airequestseed)
+  - [gen_ai.request.temperature](#gen_airequesttemperature)
   - [gen_ai.response.model](#gen_airesponsemodel)
   - [gen_ai.usage.input_tokens](#gen_aiusageinput_tokens)
   - [gen_ai.usage.output_tokens](#gen_aiusageoutput_tokens)
@@ -62,6 +63,18 @@ The seed, ideally models given the same seed and same other parameters will prod
 | Exists in OpenTelemetry | Yes |
 | Example | `1234567890` |
 | Aliases | `ai.seed` |
+
+### gen_ai.request.temperature
+
+For an AI model call, the temperature parameter. Temperature essentially means how random the output will be.
+
+| Property | Value |
+| --- | --- |
+| Type | `double` |
+| Has PII | false |
+| Exists in OpenTelemetry | Yes |
+| Example | `0.1` |
+| Aliases | `ai.temperature` |
 
 ### gen_ai.response.model
 

--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -9,6 +9,7 @@
   - [gen_ai.request.seed](#gen_airequestseed)
   - [gen_ai.request.temperature](#gen_airequesttemperature)
   - [gen_ai.request.top_k](#gen_airequesttop_k)
+  - [gen_ai.response.finish_reasons](#gen_airesponsefinish_reasons)
   - [gen_ai.response.model](#gen_airesponsemodel)
   - [gen_ai.usage.input_tokens](#gen_aiusageinput_tokens)
   - [gen_ai.usage.output_tokens](#gen_aiusageoutput_tokens)
@@ -88,6 +89,18 @@ Limits the model to only consider tokens whose cumulative probability mass adds 
 | Exists in OpenTelemetry | Yes |
 | Example | `0.7` |
 | Aliases | `ai.top_p` |
+
+### gen_ai.response.finish_reasons
+
+The reason why the model stopped generating.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | Yes |
+| Example | `COMPLETE` |
+| Aliases | `ai.finish_reason` |
 
 ### gen_ai.response.model
 

--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -4,6 +4,7 @@
 
 - [Stable Attributes](#stable-attributes)
   - [gen_ai.prompt](#gen_aiprompt)
+  - [gen_ai.request.frequency_penalty](#gen_airequestfrequency_penalty)
   - [gen_ai.response.model](#gen_airesponsemodel)
   - [gen_ai.usage.input_tokens](#gen_aiusageinput_tokens)
   - [gen_ai.usage.output_tokens](#gen_aiusageoutput_tokens)
@@ -23,6 +24,18 @@ The input messages sent to the model
 | Has PII | false |
 | Exists in OpenTelemetry | Yes |
 | Example | `[{"role": "user", "message": "hello"}]` |
+
+### gen_ai.request.frequency_penalty
+
+Used to reduce repetitiveness of generated tokens. The higher the value, the stronger a penalty is applied to previously present tokens, proportional to how many times they have already appeared in the prompt or prior generation.
+
+| Property | Value |
+| --- | --- |
+| Type | `double` |
+| Has PII | false |
+| Exists in OpenTelemetry | Yes |
+| Example | `0.5` |
+| Aliases | `ai.frequency_penalty` |
 
 ### gen_ai.response.model
 

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -278,6 +278,7 @@ export type AI_PREAMBLE_TYPE = string;
  *
  * Attribute defined in OTEL: No
  *
+ * @deprecated Use {@link GEN_AI_REQUEST_PRESENCE_PENALTY} (gen_ai.request.presence_penalty) instead
  * @example 0.5
  */
 export const AI_PRESENCE_PENALTY = 'ai.presence_penalty';
@@ -1839,6 +1840,28 @@ export const GEN_AI_REQUEST_FREQUENCY_PENALTY = 'gen_ai.request.frequency_penalt
  * Type for {@link GEN_AI_REQUEST_FREQUENCY_PENALTY} gen_ai.request.frequency_penalty
  */
 export type GEN_AI_REQUEST_FREQUENCY_PENALTY_TYPE = number;
+
+// Path: model/attributes/gen_ai/gen_ai__request__presence_penalty.json
+
+/**
+ * Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies. `gen_ai.request.presence_penalty`
+ *
+ * Attribute Value Type: `number` {@link GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * Aliases: {@link AI_PRESENCE_PENALTY} `ai.presence_penalty`
+ *
+ * @example 0.5
+ */
+export const GEN_AI_REQUEST_PRESENCE_PENALTY = 'gen_ai.request.presence_penalty';
+
+/**
+ * Type for {@link GEN_AI_REQUEST_PRESENCE_PENALTY} gen_ai.request.presence_penalty
+ */
+export type GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE = number;
 
 // Path: model/attributes/gen_ai/gen_ai__response__model.json
 
@@ -5326,7 +5349,6 @@ export type Attributes = {
   [AI_MODEL_ID]?: AI_MODEL_ID_TYPE;
   [AI_PIPELINE_NAME]?: AI_PIPELINE_NAME_TYPE;
   [AI_PREAMBLE]?: AI_PREAMBLE_TYPE;
-  [AI_PRESENCE_PENALTY]?: AI_PRESENCE_PENALTY_TYPE;
   [AI_PROMPT_TOKENS_USED]?: AI_PROMPT_TOKENS_USED_TYPE;
   [AI_RAW_PROMPTING]?: AI_RAW_PROMPTING_TYPE;
   [AI_RESPONSE_FORMAT]?: AI_RESPONSE_FORMAT_TYPE;
@@ -5391,6 +5413,7 @@ export type Attributes = {
   [FRAMES_TOTAL]?: FRAMES_TOTAL_TYPE;
   [GEN_AI_PROMPT]?: GEN_AI_PROMPT_TYPE;
   [GEN_AI_REQUEST_FREQUENCY_PENALTY]?: GEN_AI_REQUEST_FREQUENCY_PENALTY_TYPE;
+  [GEN_AI_REQUEST_PRESENCE_PENALTY]?: GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_OUTPUT_TOKENS]?: GEN_AI_USAGE_OUTPUT_TOKENS_TYPE;
@@ -5611,6 +5634,7 @@ export type FullAttributes = {
   [FS_ERROR]?: FS_ERROR_TYPE;
   [GEN_AI_PROMPT]?: GEN_AI_PROMPT_TYPE;
   [GEN_AI_REQUEST_FREQUENCY_PENALTY]?: GEN_AI_REQUEST_FREQUENCY_PENALTY_TYPE;
+  [GEN_AI_REQUEST_PRESENCE_PENALTY]?: GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_COMPLETION_TOKENS]?: GEN_AI_USAGE_COMPLETION_TOKENS_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -73,6 +73,7 @@ export type AI_DOCUMENTS_TYPE = Array<string>;
  *
  * Attribute defined in OTEL: No
  *
+ * @deprecated Use {@link GEN_AI_RESPONSE_FINISH_REASON} (gen_ai.response.finish_reason) instead
  * @example "COMPLETE"
  */
 export const AI_FINISH_REASON = 'ai.finish_reason';
@@ -1932,6 +1933,28 @@ export const GEN_AI_REQUEST_TOP_K = 'gen_ai.request.top_k';
  * Type for {@link GEN_AI_REQUEST_TOP_K} gen_ai.request.top_k
  */
 export type GEN_AI_REQUEST_TOP_K_TYPE = number;
+
+// Path: model/attributes/gen_ai/gen_ai__response__finish_reasons.json
+
+/**
+ * The reason why the model stopped generating. `gen_ai.response.finish_reasons`
+ *
+ * Attribute Value Type: `string` {@link GEN_AI_RESPONSE_FINISH_REASONS_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * Aliases: {@link AI_FINISH_REASON} `ai.finish_reason`
+ *
+ * @example "COMPLETE"
+ */
+export const GEN_AI_RESPONSE_FINISH_REASONS = 'gen_ai.response.finish_reasons';
+
+/**
+ * Type for {@link GEN_AI_RESPONSE_FINISH_REASONS} gen_ai.response.finish_reasons
+ */
+export type GEN_AI_RESPONSE_FINISH_REASONS_TYPE = string;
 
 // Path: model/attributes/gen_ai/gen_ai__response__model.json
 
@@ -5410,7 +5433,6 @@ export type Attributes = {
   [AI_CITATIONS]?: AI_CITATIONS_TYPE;
   [AI_COMPLETION_TOKENS_USED]?: AI_COMPLETION_TOKENS_USED_TYPE;
   [AI_DOCUMENTS]?: AI_DOCUMENTS_TYPE;
-  [AI_FINISH_REASON]?: AI_FINISH_REASON_TYPE;
   [AI_FUNCTION_CALL]?: AI_FUNCTION_CALL_TYPE;
   [AI_GENERATION_ID]?: AI_GENERATION_ID_TYPE;
   [AI_INPUT_MESSAGES]?: AI_INPUT_MESSAGES_TYPE;
@@ -5483,6 +5505,7 @@ export type Attributes = {
   [GEN_AI_REQUEST_SEED]?: GEN_AI_REQUEST_SEED_TYPE;
   [GEN_AI_REQUEST_TEMPERATURE]?: GEN_AI_REQUEST_TEMPERATURE_TYPE;
   [GEN_AI_REQUEST_TOP_K]?: GEN_AI_REQUEST_TOP_K_TYPE;
+  [GEN_AI_RESPONSE_FINISH_REASONS]?: GEN_AI_RESPONSE_FINISH_REASONS_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_OUTPUT_TOKENS]?: GEN_AI_USAGE_OUTPUT_TOKENS_TYPE;
@@ -5707,6 +5730,7 @@ export type FullAttributes = {
   [GEN_AI_REQUEST_SEED]?: GEN_AI_REQUEST_SEED_TYPE;
   [GEN_AI_REQUEST_TEMPERATURE]?: GEN_AI_REQUEST_TEMPERATURE_TYPE;
   [GEN_AI_REQUEST_TOP_K]?: GEN_AI_REQUEST_TOP_K_TYPE;
+  [GEN_AI_RESPONSE_FINISH_REASONS]?: GEN_AI_RESPONSE_FINISH_REASONS_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_COMPLETION_TOKENS]?: GEN_AI_USAGE_COMPLETION_TOKENS_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -5,19 +5,20 @@
 /**
  * References or sources cited by the AI model in its response. `ai.citations`
  *
- * Attribute Value Type: `string` {@link AI_CITATIONS_TYPE}
+ * Attribute Value Type: `Array<string>` {@link AI_CITATIONS_TYPE}
  *
  * Contains PII: true
  *
  * Attribute defined in OTEL: No
  *
+ * @example ["Citation 1","Citation 2"]
  */
 export const AI_CITATIONS = 'ai.citations';
 
 /**
  * Type for {@link AI_CITATIONS} ai.citations
  */
-export type AI_CITATIONS_TYPE = string;
+export type AI_CITATIONS_TYPE = Array<string>;
 
 // Path: model/attributes/ai/ai__completion_tokens__used.json
 
@@ -92,6 +93,7 @@ export type AI_FINISH_REASON_TYPE = string;
  *
  * Attribute defined in OTEL: No
  *
+ * @deprecated Use {@link GEN_AI_REQUEST_FREQUENCY_PENALTY} (gen_ai.request.frequency_penalty) instead
  * @example 0.5
  */
 export const AI_FREQUENCY_PENALTY = 'ai.frequency_penalty';
@@ -1815,6 +1817,28 @@ export const GEN_AI_PROMPT = 'gen_ai.prompt';
  * Type for {@link GEN_AI_PROMPT} gen_ai.prompt
  */
 export type GEN_AI_PROMPT_TYPE = string;
+
+// Path: model/attributes/gen_ai/gen_ai__request__frequency_penalty.json
+
+/**
+ * Used to reduce repetitiveness of generated tokens. The higher the value, the stronger a penalty is applied to previously present tokens, proportional to how many times they have already appeared in the prompt or prior generation. `gen_ai.request.frequency_penalty`
+ *
+ * Attribute Value Type: `number` {@link GEN_AI_REQUEST_FREQUENCY_PENALTY_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * Aliases: {@link AI_FREQUENCY_PENALTY} `ai.frequency_penalty`
+ *
+ * @example 0.5
+ */
+export const GEN_AI_REQUEST_FREQUENCY_PENALTY = 'gen_ai.request.frequency_penalty';
+
+/**
+ * Type for {@link GEN_AI_REQUEST_FREQUENCY_PENALTY} gen_ai.request.frequency_penalty
+ */
+export type GEN_AI_REQUEST_FREQUENCY_PENALTY_TYPE = number;
 
 // Path: model/attributes/gen_ai/gen_ai__response__model.json
 
@@ -5294,7 +5318,6 @@ export type Attributes = {
   [AI_COMPLETION_TOKENS_USED]?: AI_COMPLETION_TOKENS_USED_TYPE;
   [AI_DOCUMENTS]?: AI_DOCUMENTS_TYPE;
   [AI_FINISH_REASON]?: AI_FINISH_REASON_TYPE;
-  [AI_FREQUENCY_PENALTY]?: AI_FREQUENCY_PENALTY_TYPE;
   [AI_FUNCTION_CALL]?: AI_FUNCTION_CALL_TYPE;
   [AI_GENERATION_ID]?: AI_GENERATION_ID_TYPE;
   [AI_INPUT_MESSAGES]?: AI_INPUT_MESSAGES_TYPE;
@@ -5367,6 +5390,7 @@ export type Attributes = {
   [FRAMES_SLOW]?: FRAMES_SLOW_TYPE;
   [FRAMES_TOTAL]?: FRAMES_TOTAL_TYPE;
   [GEN_AI_PROMPT]?: GEN_AI_PROMPT_TYPE;
+  [GEN_AI_REQUEST_FREQUENCY_PENALTY]?: GEN_AI_REQUEST_FREQUENCY_PENALTY_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_OUTPUT_TOKENS]?: GEN_AI_USAGE_OUTPUT_TOKENS_TYPE;
@@ -5586,6 +5610,7 @@ export type FullAttributes = {
   [FRAMES_TOTAL]?: FRAMES_TOTAL_TYPE;
   [FS_ERROR]?: FS_ERROR_TYPE;
   [GEN_AI_PROMPT]?: GEN_AI_PROMPT_TYPE;
+  [GEN_AI_REQUEST_FREQUENCY_PENALTY]?: GEN_AI_REQUEST_FREQUENCY_PENALTY_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_COMPLETION_TOKENS]?: GEN_AI_USAGE_COMPLETION_TOKENS_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -630,6 +630,7 @@ export type AI_TOTAL_COST_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
+ * @deprecated Use {@link GEN_AI_USAGE_TOTAL_TOKENS} (gen_ai.usage.total_tokens) instead
  * @example 30
  */
 export const AI_TOTAL_TOKENS_USED = 'ai.total_tokens.used';
@@ -2093,6 +2094,28 @@ export const GEN_AI_USAGE_PROMPT_TOKENS = 'gen_ai.usage.prompt_tokens';
  * Type for {@link GEN_AI_USAGE_PROMPT_TOKENS} gen_ai.usage.prompt_tokens
  */
 export type GEN_AI_USAGE_PROMPT_TOKENS_TYPE = number;
+
+// Path: model/attributes/gen_ai/gen_ai__usage__total_tokens.json
+
+/**
+ * The total number of tokens used to process the prompt. (input tokens plus output todkens) `gen_ai.usage.total_tokens`
+ *
+ * Attribute Value Type: `number` {@link GEN_AI_USAGE_TOTAL_TOKENS_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Aliases: {@link AI_TOTAL_TOKENS_USED} `ai.total_tokens.used`
+ *
+ * @example 20
+ */
+export const GEN_AI_USAGE_TOTAL_TOKENS = 'gen_ai.usage.total_tokens';
+
+/**
+ * Type for {@link GEN_AI_USAGE_TOTAL_TOKENS} gen_ai.usage.total_tokens
+ */
+export type GEN_AI_USAGE_TOTAL_TOKENS_TYPE = number;
 
 // Path: model/attributes/graphql/graphql__operation__name.json
 
@@ -5475,7 +5498,6 @@ export type Attributes = {
   [AI_TOOL_CALLS]?: AI_TOOL_CALLS_TYPE;
   [AI_TOOLS]?: AI_TOOLS_TYPE;
   [AI_TOTAL_COST]?: AI_TOTAL_COST_TYPE;
-  [AI_TOTAL_TOKENS_USED]?: AI_TOTAL_TOKENS_USED_TYPE;
   [AI_WARNINGS]?: AI_WARNINGS_TYPE;
   [APP_START_TYPE]?: APP_START_TYPE_TYPE;
   [BLOCKED_MAIN_THREAD]?: BLOCKED_MAIN_THREAD_TYPE;
@@ -5532,6 +5554,7 @@ export type Attributes = {
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_OUTPUT_TOKENS]?: GEN_AI_USAGE_OUTPUT_TOKENS_TYPE;
+  [GEN_AI_USAGE_TOTAL_TOKENS]?: GEN_AI_USAGE_TOTAL_TOKENS_TYPE;
   [GRAPHQL_OPERATION_NAME]?: GRAPHQL_OPERATION_NAME_TYPE;
   [GRAPHQL_OPERATION_TYPE]?: GRAPHQL_OPERATION_TYPE_TYPE;
   [HTTP_DECODED_RESPONSE_CONTENT_LENGTH]?: HTTP_DECODED_RESPONSE_CONTENT_LENGTH_TYPE;
@@ -5760,6 +5783,7 @@ export type FullAttributes = {
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_OUTPUT_TOKENS]?: GEN_AI_USAGE_OUTPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_PROMPT_TOKENS]?: GEN_AI_USAGE_PROMPT_TOKENS_TYPE;
+  [GEN_AI_USAGE_TOTAL_TOKENS]?: GEN_AI_USAGE_TOTAL_TOKENS_TYPE;
   [GRAPHQL_OPERATION_NAME]?: GRAPHQL_OPERATION_NAME_TYPE;
   [GRAPHQL_OPERATION_TYPE]?: GRAPHQL_OPERATION_TYPE_TYPE;
   [HTTP_CLIENT_IP]?: HTTP_CLIENT_IP_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -209,6 +209,29 @@ export const AI_METADATA = 'ai.metadata';
  */
 export type AI_METADATA_TYPE = string;
 
+// Path: model/attributes/ai/ai__model__provider.json
+
+/**
+ * The provider of the model. `ai.model.provider`
+ *
+ * Attribute Value Type: `string` {@link AI_MODEL_PROVIDER_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Aliases: {@link GEN_AI_SYSTEM} `gen_ai.system`
+ *
+ * @deprecated Use {@link GEN_AI_SYSTEM} (gen_ai.system) instead
+ * @example "openai"
+ */
+export const AI_MODEL_PROVIDER = 'ai.model.provider';
+
+/**
+ * Type for {@link AI_MODEL_PROVIDER} ai.model.provider
+ */
+export type AI_MODEL_PROVIDER_TYPE = string;
+
 // Path: model/attributes/ai/ai__model_id.json
 
 /**
@@ -2005,6 +2028,28 @@ export const GEN_AI_RESPONSE_MODEL = 'gen_ai.response.model';
  * Type for {@link GEN_AI_RESPONSE_MODEL} gen_ai.response.model
  */
 export type GEN_AI_RESPONSE_MODEL_TYPE = string;
+
+// Path: model/attributes/gen_ai/gen_ai__system.json
+
+/**
+ * The provider of the model. `gen_ai.system`
+ *
+ * Attribute Value Type: `string` {@link GEN_AI_SYSTEM_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * Aliases: {@link AI_MODEL_PROVIDER} `ai.model.provider`
+ *
+ * @example "openai"
+ */
+export const GEN_AI_SYSTEM = 'gen_ai.system';
+
+/**
+ * Type for {@link GEN_AI_SYSTEM} gen_ai.system
+ */
+export type GEN_AI_SYSTEM_TYPE = string;
 
 // Path: model/attributes/gen_ai/gen_ai__tool__name.json
 
@@ -5574,6 +5619,7 @@ export type Attributes = {
   [GEN_AI_RESPONSE_FINISH_REASONS]?: GEN_AI_RESPONSE_FINISH_REASONS_TYPE;
   [GEN_AI_RESPONSE_ID]?: GEN_AI_RESPONSE_ID_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
+  [GEN_AI_SYSTEM]?: GEN_AI_SYSTEM_TYPE;
   [GEN_AI_TOOL_NAME]?: GEN_AI_TOOL_NAME_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_OUTPUT_TOKENS]?: GEN_AI_USAGE_OUTPUT_TOKENS_TYPE;
@@ -5716,6 +5762,7 @@ export type FullAttributes = {
   [AI_INPUT_MESSAGES]?: AI_INPUT_MESSAGES_TYPE;
   [AI_IS_SEARCH_REQUIRED]?: AI_IS_SEARCH_REQUIRED_TYPE;
   [AI_METADATA]?: AI_METADATA_TYPE;
+  [AI_MODEL_PROVIDER]?: AI_MODEL_PROVIDER_TYPE;
   [AI_MODEL_ID]?: AI_MODEL_ID_TYPE;
   [AI_PIPELINE_NAME]?: AI_PIPELINE_NAME_TYPE;
   [AI_PREAMBLE]?: AI_PREAMBLE_TYPE;
@@ -5802,6 +5849,7 @@ export type FullAttributes = {
   [GEN_AI_RESPONSE_FINISH_REASONS]?: GEN_AI_RESPONSE_FINISH_REASONS_TYPE;
   [GEN_AI_RESPONSE_ID]?: GEN_AI_RESPONSE_ID_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
+  [GEN_AI_SYSTEM]?: GEN_AI_SYSTEM_TYPE;
   [GEN_AI_TOOL_NAME]?: GEN_AI_TOOL_NAME_TYPE;
   [GEN_AI_USAGE_COMPLETION_TOKENS]?: GEN_AI_USAGE_COMPLETION_TOKENS_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -116,6 +116,7 @@ export type AI_FREQUENCY_PENALTY_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
+ * @deprecated Use {@link GEN_AI_TOOL_NAME} (gen_ai.tool.name) instead
  * @example "function_name"
  */
 export const AI_FUNCTION_CALL = 'ai.function_call';
@@ -2004,6 +2005,28 @@ export const GEN_AI_RESPONSE_MODEL = 'gen_ai.response.model';
  * Type for {@link GEN_AI_RESPONSE_MODEL} gen_ai.response.model
  */
 export type GEN_AI_RESPONSE_MODEL_TYPE = string;
+
+// Path: model/attributes/gen_ai/gen_ai__tool__name.json
+
+/**
+ * Name of the tool utilized by the agent. `gen_ai.tool.name`
+ *
+ * Attribute Value Type: `string` {@link GEN_AI_TOOL_NAME_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * Aliases: {@link AI_FUNCTION_CALL} `ai.function_call`
+ *
+ * @example "Flights"
+ */
+export const GEN_AI_TOOL_NAME = 'gen_ai.tool.name';
+
+/**
+ * Type for {@link GEN_AI_TOOL_NAME} gen_ai.tool.name
+ */
+export type GEN_AI_TOOL_NAME_TYPE = string;
 
 // Path: model/attributes/gen_ai/gen_ai__usage__completion_tokens.json
 
@@ -5481,7 +5504,6 @@ export type AttributeValue = string | number | boolean | Array<string> | Array<n
 export type Attributes = {
   [AI_CITATIONS]?: AI_CITATIONS_TYPE;
   [AI_DOCUMENTS]?: AI_DOCUMENTS_TYPE;
-  [AI_FUNCTION_CALL]?: AI_FUNCTION_CALL_TYPE;
   [AI_INPUT_MESSAGES]?: AI_INPUT_MESSAGES_TYPE;
   [AI_IS_SEARCH_REQUIRED]?: AI_IS_SEARCH_REQUIRED_TYPE;
   [AI_METADATA]?: AI_METADATA_TYPE;
@@ -5552,6 +5574,7 @@ export type Attributes = {
   [GEN_AI_RESPONSE_FINISH_REASONS]?: GEN_AI_RESPONSE_FINISH_REASONS_TYPE;
   [GEN_AI_RESPONSE_ID]?: GEN_AI_RESPONSE_ID_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
+  [GEN_AI_TOOL_NAME]?: GEN_AI_TOOL_NAME_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_OUTPUT_TOKENS]?: GEN_AI_USAGE_OUTPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_TOTAL_TOKENS]?: GEN_AI_USAGE_TOTAL_TOKENS_TYPE;
@@ -5779,6 +5802,7 @@ export type FullAttributes = {
   [GEN_AI_RESPONSE_FINISH_REASONS]?: GEN_AI_RESPONSE_FINISH_REASONS_TYPE;
   [GEN_AI_RESPONSE_ID]?: GEN_AI_RESPONSE_ID_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
+  [GEN_AI_TOOL_NAME]?: GEN_AI_TOOL_NAME_TYPE;
   [GEN_AI_USAGE_COMPLETION_TOKENS]?: GEN_AI_USAGE_COMPLETION_TOKENS_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_OUTPUT_TOKENS]?: GEN_AI_USAGE_OUTPUT_TOKENS_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -220,6 +220,7 @@ export type AI_METADATA_TYPE = string;
  *
  * Aliases: {@link GEN_AI_RESPONSE_MODEL} `gen_ai.response.model`
  *
+ * @deprecated Use {@link GEN_AI_RESPONSE_MODEL} (gen_ai.response.model) instead
  * @example "gpt-4"
  */
 export const AI_MODEL_ID = 'ai.model_id';
@@ -5460,7 +5461,6 @@ export type Attributes = {
   [AI_INPUT_MESSAGES]?: AI_INPUT_MESSAGES_TYPE;
   [AI_IS_SEARCH_REQUIRED]?: AI_IS_SEARCH_REQUIRED_TYPE;
   [AI_METADATA]?: AI_METADATA_TYPE;
-  [AI_MODEL_ID]?: AI_MODEL_ID_TYPE;
   [AI_PIPELINE_NAME]?: AI_PIPELINE_NAME_TYPE;
   [AI_PREAMBLE]?: AI_PREAMBLE_TYPE;
   [AI_PROMPT_TOKENS_USED]?: AI_PROMPT_TOKENS_USED_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -304,6 +304,7 @@ export type AI_PRESENCE_PENALTY_TYPE = number;
  *
  * Aliases: {@link GEN_AI_USAGE_PROMPT_TOKENS} `gen_ai.usage.prompt_tokens`, {@link GEN_AI_USAGE_INPUT_TOKENS} `gen_ai.usage.input_tokens`
  *
+ * @deprecated Use {@link GEN_AI_USAGE_INPUT_TOKENS} (gen_ai.usage.input_tokens) instead
  * @example 20
  */
 export const AI_PROMPT_TOKENS_USED = 'ai.prompt_tokens.used';
@@ -5463,7 +5464,6 @@ export type Attributes = {
   [AI_METADATA]?: AI_METADATA_TYPE;
   [AI_PIPELINE_NAME]?: AI_PIPELINE_NAME_TYPE;
   [AI_PREAMBLE]?: AI_PREAMBLE_TYPE;
-  [AI_PROMPT_TOKENS_USED]?: AI_PROMPT_TOKENS_USED_TYPE;
   [AI_RAW_PROMPTING]?: AI_RAW_PROMPTING_TYPE;
   [AI_RESPONSE_FORMAT]?: AI_RESPONSE_FORMAT_TYPE;
   [AI_RESPONSES]?: AI_RESPONSES_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -33,6 +33,7 @@ export type AI_CITATIONS_TYPE = Array<string>;
  *
  * Aliases: {@link GEN_AI_USAGE_OUTPUT_TOKENS} `gen_ai.usage.output_tokens`, {@link GEN_AI_USAGE_COMPLETION_TOKENS} `gen_ai.usage.completion_tokens`
  *
+ * @deprecated Use {@link GEN_AI_USAGE_OUTPUT_TOKENS} (gen_ai.usage.output_tokens) instead
  * @example 10
  */
 export const AI_COMPLETION_TOKENS_USED = 'ai.completion_tokens.used';
@@ -5456,7 +5457,6 @@ export type AttributeValue = string | number | boolean | Array<string> | Array<n
 
 export type Attributes = {
   [AI_CITATIONS]?: AI_CITATIONS_TYPE;
-  [AI_COMPLETION_TOKENS_USED]?: AI_COMPLETION_TOKENS_USED_TYPE;
   [AI_DOCUMENTS]?: AI_DOCUMENTS_TYPE;
   [AI_FUNCTION_CALL]?: AI_FUNCTION_CALL_TYPE;
   [AI_INPUT_MESSAGES]?: AI_INPUT_MESSAGES_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -555,7 +555,7 @@ export type AI_TOOLS_TYPE = Array<string>;
 // Path: model/attributes/ai/ai__top_k.json
 
 /**
- *  Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered). `ai.top_k`
+ * Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered). `ai.top_k`
  *
  * Attribute Value Type: `number` {@link AI_TOP_K_TYPE}
  *
@@ -563,6 +563,7 @@ export type AI_TOOLS_TYPE = Array<string>;
  *
  * Attribute defined in OTEL: No
  *
+ * @deprecated Use {@link GEN_AI_REQUEST_TOP_K} (gen_ai.request.top_k) instead
  * @example 35
  */
 export const AI_TOP_K = 'ai.top_k';
@@ -1908,6 +1909,28 @@ export const GEN_AI_REQUEST_TEMPERATURE = 'gen_ai.request.temperature';
  * Type for {@link GEN_AI_REQUEST_TEMPERATURE} gen_ai.request.temperature
  */
 export type GEN_AI_REQUEST_TEMPERATURE_TYPE = number;
+
+// Path: model/attributes/gen_ai/gen_ai__request__top_k.json
+
+/**
+ * Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered). `gen_ai.request.top_k`
+ *
+ * Attribute Value Type: `number` {@link GEN_AI_REQUEST_TOP_K_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * Aliases: {@link AI_TOP_K} `ai.top_k`
+ *
+ * @example 351
+ */
+export const GEN_AI_REQUEST_TOP_K = 'gen_ai.request.top_k';
+
+/**
+ * Type for {@link GEN_AI_REQUEST_TOP_K} gen_ai.request.top_k
+ */
+export type GEN_AI_REQUEST_TOP_K_TYPE = number;
 
 // Path: model/attributes/gen_ai/gen_ai__response__model.json
 
@@ -5406,7 +5429,6 @@ export type Attributes = {
   [AI_TEXTS]?: AI_TEXTS_TYPE;
   [AI_TOOL_CALLS]?: AI_TOOL_CALLS_TYPE;
   [AI_TOOLS]?: AI_TOOLS_TYPE;
-  [AI_TOP_K]?: AI_TOP_K_TYPE;
   [AI_TOP_P]?: AI_TOP_P_TYPE;
   [AI_TOTAL_COST]?: AI_TOTAL_COST_TYPE;
   [AI_TOTAL_TOKENS_USED]?: AI_TOTAL_TOKENS_USED_TYPE;
@@ -5460,6 +5482,7 @@ export type Attributes = {
   [GEN_AI_REQUEST_PRESENCE_PENALTY]?: GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE;
   [GEN_AI_REQUEST_SEED]?: GEN_AI_REQUEST_SEED_TYPE;
   [GEN_AI_REQUEST_TEMPERATURE]?: GEN_AI_REQUEST_TEMPERATURE_TYPE;
+  [GEN_AI_REQUEST_TOP_K]?: GEN_AI_REQUEST_TOP_K_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_OUTPUT_TOKENS]?: GEN_AI_USAGE_OUTPUT_TOKENS_TYPE;
@@ -5683,6 +5706,7 @@ export type FullAttributes = {
   [GEN_AI_REQUEST_PRESENCE_PENALTY]?: GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE;
   [GEN_AI_REQUEST_SEED]?: GEN_AI_REQUEST_SEED_TYPE;
   [GEN_AI_REQUEST_TEMPERATURE]?: GEN_AI_REQUEST_TEMPERATURE_TYPE;
+  [GEN_AI_REQUEST_TOP_K]?: GEN_AI_REQUEST_TOP_K_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_COMPLETION_TOKENS]?: GEN_AI_USAGE_COMPLETION_TOKENS_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -220,8 +220,6 @@ export type AI_METADATA_TYPE = string;
  *
  * Attribute defined in OTEL: No
  *
- * Aliases: {@link GEN_AI_SYSTEM} `gen_ai.system`
- *
  * @deprecated Use {@link GEN_AI_SYSTEM} (gen_ai.system) instead
  * @example "openai"
  */
@@ -1944,9 +1942,31 @@ export type GEN_AI_REQUEST_TEMPERATURE_TYPE = number;
 // Path: model/attributes/gen_ai/gen_ai__request__top_k.json
 
 /**
- * Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered). `gen_ai.request.top_k`
+ * Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered). `gen_ai.request.top_k`
  *
  * Attribute Value Type: `number` {@link GEN_AI_REQUEST_TOP_K_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * Aliases: {@link AI_TOP_K} `ai.top_k`
+ *
+ * @example 35
+ */
+export const GEN_AI_REQUEST_TOP_K = 'gen_ai.request.top_k';
+
+/**
+ * Type for {@link GEN_AI_REQUEST_TOP_K} gen_ai.request.top_k
+ */
+export type GEN_AI_REQUEST_TOP_K_TYPE = number;
+
+// Path: model/attributes/gen_ai/gen_ai__request__top_p.json
+
+/**
+ * Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered). `gen_ai.request.top_p`
+ *
+ * Attribute Value Type: `number` {@link GEN_AI_REQUEST_TOP_P_TYPE}
  *
  * Contains PII: false
  *
@@ -1956,12 +1976,12 @@ export type GEN_AI_REQUEST_TEMPERATURE_TYPE = number;
  *
  * @example 0.7
  */
-export const GEN_AI_REQUEST_TOP_K = 'gen_ai.request.top_k';
+export const GEN_AI_REQUEST_TOP_P = 'gen_ai.request.top_p';
 
 /**
- * Type for {@link GEN_AI_REQUEST_TOP_K} gen_ai.request.top_k
+ * Type for {@link GEN_AI_REQUEST_TOP_P} gen_ai.request.top_p
  */
-export type GEN_AI_REQUEST_TOP_K_TYPE = number;
+export type GEN_AI_REQUEST_TOP_P_TYPE = number;
 
 // Path: model/attributes/gen_ai/gen_ai__response__finish_reasons.json
 
@@ -5616,6 +5636,7 @@ export type Attributes = {
   [GEN_AI_REQUEST_SEED]?: GEN_AI_REQUEST_SEED_TYPE;
   [GEN_AI_REQUEST_TEMPERATURE]?: GEN_AI_REQUEST_TEMPERATURE_TYPE;
   [GEN_AI_REQUEST_TOP_K]?: GEN_AI_REQUEST_TOP_K_TYPE;
+  [GEN_AI_REQUEST_TOP_P]?: GEN_AI_REQUEST_TOP_P_TYPE;
   [GEN_AI_RESPONSE_FINISH_REASONS]?: GEN_AI_RESPONSE_FINISH_REASONS_TYPE;
   [GEN_AI_RESPONSE_ID]?: GEN_AI_RESPONSE_ID_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
@@ -5846,6 +5867,7 @@ export type FullAttributes = {
   [GEN_AI_REQUEST_SEED]?: GEN_AI_REQUEST_SEED_TYPE;
   [GEN_AI_REQUEST_TEMPERATURE]?: GEN_AI_REQUEST_TEMPERATURE_TYPE;
   [GEN_AI_REQUEST_TOP_K]?: GEN_AI_REQUEST_TOP_K_TYPE;
+  [GEN_AI_REQUEST_TOP_P]?: GEN_AI_REQUEST_TOP_P_TYPE;
   [GEN_AI_RESPONSE_FINISH_REASONS]?: GEN_AI_RESPONSE_FINISH_REASONS_TYPE;
   [GEN_AI_RESPONSE_ID]?: GEN_AI_RESPONSE_ID_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -482,6 +482,7 @@ export type AI_TAGS_TYPE = string;
  *
  * Attribute defined in OTEL: No
  *
+ * @deprecated Use {@link GEN_AI_REQUEST_TEMPERATURE} (gen_ai.request.temperature) instead
  * @example 0.1
  */
 export const AI_TEMPERATURE = 'ai.temperature';
@@ -1885,6 +1886,28 @@ export const GEN_AI_REQUEST_SEED = 'gen_ai.request.seed';
  * Type for {@link GEN_AI_REQUEST_SEED} gen_ai.request.seed
  */
 export type GEN_AI_REQUEST_SEED_TYPE = string;
+
+// Path: model/attributes/gen_ai/gen_ai__request__temperature.json
+
+/**
+ * For an AI model call, the temperature parameter. Temperature essentially means how random the output will be. `gen_ai.request.temperature`
+ *
+ * Attribute Value Type: `number` {@link GEN_AI_REQUEST_TEMPERATURE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * Aliases: {@link AI_TEMPERATURE} `ai.temperature`
+ *
+ * @example 0.1
+ */
+export const GEN_AI_REQUEST_TEMPERATURE = 'gen_ai.request.temperature';
+
+/**
+ * Type for {@link GEN_AI_REQUEST_TEMPERATURE} gen_ai.request.temperature
+ */
+export type GEN_AI_REQUEST_TEMPERATURE_TYPE = number;
 
 // Path: model/attributes/gen_ai/gen_ai__response__model.json
 
@@ -5380,7 +5403,6 @@ export type Attributes = {
   [AI_SEARCH_RESULTS]?: AI_SEARCH_RESULTS_TYPE;
   [AI_STREAMING]?: AI_STREAMING_TYPE;
   [AI_TAGS]?: AI_TAGS_TYPE;
-  [AI_TEMPERATURE]?: AI_TEMPERATURE_TYPE;
   [AI_TEXTS]?: AI_TEXTS_TYPE;
   [AI_TOOL_CALLS]?: AI_TOOL_CALLS_TYPE;
   [AI_TOOLS]?: AI_TOOLS_TYPE;
@@ -5437,6 +5459,7 @@ export type Attributes = {
   [GEN_AI_REQUEST_FREQUENCY_PENALTY]?: GEN_AI_REQUEST_FREQUENCY_PENALTY_TYPE;
   [GEN_AI_REQUEST_PRESENCE_PENALTY]?: GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE;
   [GEN_AI_REQUEST_SEED]?: GEN_AI_REQUEST_SEED_TYPE;
+  [GEN_AI_REQUEST_TEMPERATURE]?: GEN_AI_REQUEST_TEMPERATURE_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_OUTPUT_TOKENS]?: GEN_AI_USAGE_OUTPUT_TOKENS_TYPE;
@@ -5659,6 +5682,7 @@ export type FullAttributes = {
   [GEN_AI_REQUEST_FREQUENCY_PENALTY]?: GEN_AI_REQUEST_FREQUENCY_PENALTY_TYPE;
   [GEN_AI_REQUEST_PRESENCE_PENALTY]?: GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE;
   [GEN_AI_REQUEST_SEED]?: GEN_AI_REQUEST_SEED_TYPE;
+  [GEN_AI_REQUEST_TEMPERATURE]?: GEN_AI_REQUEST_TEMPERATURE_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_COMPLETION_TOKENS]?: GEN_AI_USAGE_COMPLETION_TOKENS_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -584,6 +584,7 @@ export type AI_TOP_K_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
+ * @deprecated Use {@link GEN_AI_REQUEST_TOP_P} (gen_ai.request.top_p) instead
  * @example 0.7
  */
 export const AI_TOP_P = 'ai.top_p';
@@ -1913,7 +1914,7 @@ export type GEN_AI_REQUEST_TEMPERATURE_TYPE = number;
 // Path: model/attributes/gen_ai/gen_ai__request__top_k.json
 
 /**
- * Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered). `gen_ai.request.top_k`
+ * Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered). `gen_ai.request.top_k`
  *
  * Attribute Value Type: `number` {@link GEN_AI_REQUEST_TOP_K_TYPE}
  *
@@ -1921,9 +1922,9 @@ export type GEN_AI_REQUEST_TEMPERATURE_TYPE = number;
  *
  * Attribute defined in OTEL: Yes
  *
- * Aliases: {@link AI_TOP_K} `ai.top_k`
+ * Aliases: {@link AI_TOP_P} `ai.top_p`
  *
- * @example 351
+ * @example 0.7
  */
 export const GEN_AI_REQUEST_TOP_K = 'gen_ai.request.top_k';
 
@@ -5429,7 +5430,6 @@ export type Attributes = {
   [AI_TEXTS]?: AI_TEXTS_TYPE;
   [AI_TOOL_CALLS]?: AI_TOOL_CALLS_TYPE;
   [AI_TOOLS]?: AI_TOOLS_TYPE;
-  [AI_TOP_P]?: AI_TOP_P_TYPE;
   [AI_TOTAL_COST]?: AI_TOTAL_COST_TYPE;
   [AI_TOTAL_TOKENS_USED]?: AI_TOTAL_TOKENS_USED_TYPE;
   [AI_WARNINGS]?: AI_WARNINGS_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -137,7 +137,7 @@ export type AI_FUNCTION_CALL_TYPE = string;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated Use {@link GEN_AI_RESPONSE_GENERATION_ID} (gen_ai.response.generation_id) instead
+ * @deprecated Use {@link GEN_AI_RESPONSE_ID} (gen_ai.response.id) instead
  * @example "gen_123abc"
  */
 export const AI_GENERATION_ID = 'ai.generation_id';

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -135,6 +135,7 @@ export type AI_FUNCTION_CALL_TYPE = string;
  *
  * Attribute defined in OTEL: No
  *
+ * @deprecated Use {@link GEN_AI_RESPONSE_GENERATION_ID} (gen_ai.response.generation_id) instead
  * @example "gen_123abc"
  */
 export const AI_GENERATION_ID = 'ai.generation_id';
@@ -1955,6 +1956,28 @@ export const GEN_AI_RESPONSE_FINISH_REASONS = 'gen_ai.response.finish_reasons';
  * Type for {@link GEN_AI_RESPONSE_FINISH_REASONS} gen_ai.response.finish_reasons
  */
 export type GEN_AI_RESPONSE_FINISH_REASONS_TYPE = string;
+
+// Path: model/attributes/gen_ai/gen_ai__response__id.json
+
+/**
+ * Unique identifier for the completion. `gen_ai.response.id`
+ *
+ * Attribute Value Type: `string` {@link GEN_AI_RESPONSE_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * Aliases: {@link AI_GENERATION_ID} `ai.generation_id`
+ *
+ * @example "gen_123abc"
+ */
+export const GEN_AI_RESPONSE_ID = 'gen_ai.response.id';
+
+/**
+ * Type for {@link GEN_AI_RESPONSE_ID} gen_ai.response.id
+ */
+export type GEN_AI_RESPONSE_ID_TYPE = string;
 
 // Path: model/attributes/gen_ai/gen_ai__response__model.json
 
@@ -5434,7 +5457,6 @@ export type Attributes = {
   [AI_COMPLETION_TOKENS_USED]?: AI_COMPLETION_TOKENS_USED_TYPE;
   [AI_DOCUMENTS]?: AI_DOCUMENTS_TYPE;
   [AI_FUNCTION_CALL]?: AI_FUNCTION_CALL_TYPE;
-  [AI_GENERATION_ID]?: AI_GENERATION_ID_TYPE;
   [AI_INPUT_MESSAGES]?: AI_INPUT_MESSAGES_TYPE;
   [AI_IS_SEARCH_REQUIRED]?: AI_IS_SEARCH_REQUIRED_TYPE;
   [AI_METADATA]?: AI_METADATA_TYPE;
@@ -5506,6 +5528,7 @@ export type Attributes = {
   [GEN_AI_REQUEST_TEMPERATURE]?: GEN_AI_REQUEST_TEMPERATURE_TYPE;
   [GEN_AI_REQUEST_TOP_K]?: GEN_AI_REQUEST_TOP_K_TYPE;
   [GEN_AI_RESPONSE_FINISH_REASONS]?: GEN_AI_RESPONSE_FINISH_REASONS_TYPE;
+  [GEN_AI_RESPONSE_ID]?: GEN_AI_RESPONSE_ID_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_OUTPUT_TOKENS]?: GEN_AI_USAGE_OUTPUT_TOKENS_TYPE;
@@ -5731,6 +5754,7 @@ export type FullAttributes = {
   [GEN_AI_REQUEST_TEMPERATURE]?: GEN_AI_REQUEST_TEMPERATURE_TYPE;
   [GEN_AI_REQUEST_TOP_K]?: GEN_AI_REQUEST_TOP_K_TYPE;
   [GEN_AI_RESPONSE_FINISH_REASONS]?: GEN_AI_RESPONSE_FINISH_REASONS_TYPE;
+  [GEN_AI_RESPONSE_ID]?: GEN_AI_RESPONSE_ID_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_COMPLETION_TOKENS]?: GEN_AI_USAGE_COMPLETION_TOKENS_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -421,6 +421,7 @@ export type AI_SEARCH_RESULTS_TYPE = Array<string>;
  *
  * Attribute defined in OTEL: No
  *
+ * @deprecated Use {@link GEN_AI_REQUEST_SEED} (gen_ai.request.seed) instead
  * @example "1234567890"
  */
 export const AI_SEED = 'ai.seed';
@@ -1862,6 +1863,28 @@ export const GEN_AI_REQUEST_PRESENCE_PENALTY = 'gen_ai.request.presence_penalty'
  * Type for {@link GEN_AI_REQUEST_PRESENCE_PENALTY} gen_ai.request.presence_penalty
  */
 export type GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE = number;
+
+// Path: model/attributes/gen_ai/gen_ai__request__seed.json
+
+/**
+ * The seed, ideally models given the same seed and same other parameters will produce the exact same output. `gen_ai.request.seed`
+ *
+ * Attribute Value Type: `string` {@link GEN_AI_REQUEST_SEED_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * Aliases: {@link AI_SEED} `ai.seed`
+ *
+ * @example "1234567890"
+ */
+export const GEN_AI_REQUEST_SEED = 'gen_ai.request.seed';
+
+/**
+ * Type for {@link GEN_AI_REQUEST_SEED} gen_ai.request.seed
+ */
+export type GEN_AI_REQUEST_SEED_TYPE = string;
 
 // Path: model/attributes/gen_ai/gen_ai__response__model.json
 
@@ -5355,7 +5378,6 @@ export type Attributes = {
   [AI_RESPONSES]?: AI_RESPONSES_TYPE;
   [AI_SEARCH_QUERIES]?: AI_SEARCH_QUERIES_TYPE;
   [AI_SEARCH_RESULTS]?: AI_SEARCH_RESULTS_TYPE;
-  [AI_SEED]?: AI_SEED_TYPE;
   [AI_STREAMING]?: AI_STREAMING_TYPE;
   [AI_TAGS]?: AI_TAGS_TYPE;
   [AI_TEMPERATURE]?: AI_TEMPERATURE_TYPE;
@@ -5414,6 +5436,7 @@ export type Attributes = {
   [GEN_AI_PROMPT]?: GEN_AI_PROMPT_TYPE;
   [GEN_AI_REQUEST_FREQUENCY_PENALTY]?: GEN_AI_REQUEST_FREQUENCY_PENALTY_TYPE;
   [GEN_AI_REQUEST_PRESENCE_PENALTY]?: GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE;
+  [GEN_AI_REQUEST_SEED]?: GEN_AI_REQUEST_SEED_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_OUTPUT_TOKENS]?: GEN_AI_USAGE_OUTPUT_TOKENS_TYPE;
@@ -5635,6 +5658,7 @@ export type FullAttributes = {
   [GEN_AI_PROMPT]?: GEN_AI_PROMPT_TYPE;
   [GEN_AI_REQUEST_FREQUENCY_PENALTY]?: GEN_AI_REQUEST_FREQUENCY_PENALTY_TYPE;
   [GEN_AI_REQUEST_PRESENCE_PENALTY]?: GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE;
+  [GEN_AI_REQUEST_SEED]?: GEN_AI_REQUEST_SEED_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_USAGE_COMPLETION_TOKENS]?: GEN_AI_USAGE_COMPLETION_TOKENS_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;

--- a/model/attributes/ai/ai__completion_tokens__used.json
+++ b/model/attributes/ai/ai__completion_tokens__used.json
@@ -8,5 +8,8 @@
   "is_in_otel": false,
   "example": 10,
   "alias": ["gen_ai.usage.output_tokens", "gen_ai.usage.completion_tokens"],
-  "sdks": ["python"]
+  "sdks": ["python"],
+  "deprecation": {
+    "replacement": "gen_ai.usage.output_tokens"
+  }
 }

--- a/model/attributes/ai/ai__finish_reason.json
+++ b/model/attributes/ai/ai__finish_reason.json
@@ -6,5 +6,8 @@
     "key": "false"
   },
   "is_in_otel": false,
-  "example": "COMPLETE"
+  "example": "COMPLETE",
+  "deprecation": {
+    "replacement": "gen_ai.response.finish_reason"
+  }
 }

--- a/model/attributes/ai/ai__frequency_penalty.json
+++ b/model/attributes/ai/ai__frequency_penalty.json
@@ -6,5 +6,8 @@
     "key": "false"
   },
   "is_in_otel": false,
-  "example": 0.5
+  "example": 0.5,
+  "deprecation": {
+    "replacement": "gen_ai.request.frequency_penalty"
+  }
 }

--- a/model/attributes/ai/ai__function_call.json
+++ b/model/attributes/ai/ai__function_call.json
@@ -6,5 +6,8 @@
     "key": "true"
   },
   "is_in_otel": false,
-  "example": "function_name"
+  "example": "function_name",
+  "deprecation": {
+    "replacement": "gen_ai.tool.name"
+  }
 }

--- a/model/attributes/ai/ai__generation_id.json
+++ b/model/attributes/ai/ai__generation_id.json
@@ -8,6 +8,6 @@
   "is_in_otel": false,
   "example": "gen_123abc",
   "deprecation": {
-    "replacement": "gen_ai.response.generation_id"
+    "replacement": "gen_ai.response.id"
   }
 }

--- a/model/attributes/ai/ai__model__provider.json
+++ b/model/attributes/ai/ai__model__provider.json
@@ -7,9 +7,6 @@
   },
   "is_in_otel": false,
   "example": "openai",
-  "alias": [
-    "gen_ai.system"
-  ],
   "deprecation": {
     "replacement": "gen_ai.system"
   }

--- a/model/attributes/ai/ai__model__provider.json
+++ b/model/attributes/ai/ai__model__provider.json
@@ -1,0 +1,16 @@
+{
+  "key": "ai.model.provider",
+  "brief": "The provider of the model.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "openai",
+  "alias": [
+    "gen_ai.system"
+  ],
+  "deprecation": {
+    "replacement": "gen_ai.system"
+  }
+}

--- a/model/attributes/ai/ai__model_id.json
+++ b/model/attributes/ai/ai__model_id.json
@@ -8,5 +8,8 @@
   "is_in_otel": false,
   "example": "gpt-4",
   "alias": ["gen_ai.response.model"],
-  "sdks": ["python"]
+  "sdks": ["python"],
+  "deprecation": {
+    "replacement": "gen_ai.response.model"
+  }
 }

--- a/model/attributes/ai/ai__presence_penalty.json
+++ b/model/attributes/ai/ai__presence_penalty.json
@@ -6,5 +6,8 @@
     "key": "false"
   },
   "is_in_otel": false,
-  "example": 0.5
+  "example": 0.5,
+  "deprecation": {
+    "replacement": "gen_ai.request.presence_penalty"
+  }
 }

--- a/model/attributes/ai/ai__prompt_tokens__used.json
+++ b/model/attributes/ai/ai__prompt_tokens__used.json
@@ -8,5 +8,8 @@
   "is_in_otel": false,
   "example": 20,
   "alias": ["gen_ai.usage.prompt_tokens", "gen_ai.usage.input_tokens"],
-  "sdks": ["python"]
+  "sdks": ["python"],
+  "deprecation": {
+    "replacement": "gen_ai.usage.input_tokens"
+  }
 }

--- a/model/attributes/ai/ai__seed.json
+++ b/model/attributes/ai/ai__seed.json
@@ -6,5 +6,8 @@
     "key": "false"
   },
   "is_in_otel": false,
-  "example": "1234567890"
+  "example": "1234567890",
+  "deprecation": {
+    "replacement": "gen_ai.request.seed"
+  }
 }

--- a/model/attributes/ai/ai__temperature.json
+++ b/model/attributes/ai/ai__temperature.json
@@ -6,5 +6,8 @@
     "key": "false"
   },
   "is_in_otel": false,
-  "example": 0.1
+  "example": 0.1,
+  "deprecation": {
+    "replacement": "gen_ai.request.temperature"
+  }
 }

--- a/model/attributes/ai/ai__top_k.json
+++ b/model/attributes/ai/ai__top_k.json
@@ -1,10 +1,13 @@
 {
   "key": "ai.top_k",
-  "brief": " Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).",
+  "brief": "Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).",
   "type": "integer",
   "pii": {
     "key": "false"
   },
   "is_in_otel": false,
-  "example": 35
+  "example": 35,
+  "deprecation": {
+    "replacement": "gen_ai.request.top_k"
+  }
 }

--- a/model/attributes/ai/ai__top_p.json
+++ b/model/attributes/ai/ai__top_p.json
@@ -6,5 +6,8 @@
     "key": "false"
   },
   "is_in_otel": false,
-  "example": 0.7
+  "example": 0.7,
+  "deprecation": {
+    "replacement": "gen_ai.request.top_p"
+  }
 }

--- a/model/attributes/ai/ai__total_tokens__used.json
+++ b/model/attributes/ai/ai__total_tokens__used.json
@@ -7,5 +7,8 @@
   },
   "is_in_otel": false,
   "example": 30,
-  "sdks": ["python"]
+  "sdks": ["python"],
+  "deprecation": {
+    "replacement": "gen_ai.usage.total_tokens"
+  }
 }

--- a/model/attributes/gen_ai/gen_ai__request__frequency_penalty.json
+++ b/model/attributes/gen_ai/gen_ai__request__frequency_penalty.json
@@ -7,7 +7,5 @@
   },
   "is_in_otel": true,
   "example": 0.5,
-  "alias": [
-    "ai.frequency_penalty"
-  ]
+  "alias": ["ai.frequency_penalty"]
 }

--- a/model/attributes/gen_ai/gen_ai__request__frequency_penalty.json
+++ b/model/attributes/gen_ai/gen_ai__request__frequency_penalty.json
@@ -1,0 +1,13 @@
+{
+  "key": "gen_ai.request.frequency_penalty",
+  "brief": "Used to reduce repetitiveness of generated tokens. The higher the value, the stronger a penalty is applied to previously present tokens, proportional to how many times they have already appeared in the prompt or prior generation.",
+  "type": "double",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": 0.5,
+  "alias": [
+    "ai.frequency_penalty"
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__request__presence_penalty.json
+++ b/model/attributes/gen_ai/gen_ai__request__presence_penalty.json
@@ -1,0 +1,13 @@
+{
+  "key": "gen_ai.request.presence_penalty",
+  "brief": "Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.",
+  "type": "double",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": 0.5,
+  "alias": [
+    "ai.presence_penalty"
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__request__presence_penalty.json
+++ b/model/attributes/gen_ai/gen_ai__request__presence_penalty.json
@@ -7,7 +7,5 @@
   },
   "is_in_otel": true,
   "example": 0.5,
-  "alias": [
-    "ai.presence_penalty"
-  ]
+  "alias": ["ai.presence_penalty"]
 }

--- a/model/attributes/gen_ai/gen_ai__request__seed.json
+++ b/model/attributes/gen_ai/gen_ai__request__seed.json
@@ -7,7 +7,5 @@
   },
   "is_in_otel": true,
   "example": "1234567890",
-  "alias": [
-    "ai.seed"
-  ]
+  "alias": ["ai.seed"]
 }

--- a/model/attributes/gen_ai/gen_ai__request__seed.json
+++ b/model/attributes/gen_ai/gen_ai__request__seed.json
@@ -1,0 +1,13 @@
+{
+  "key": "gen_ai.request.seed",
+  "brief": "The seed, ideally models given the same seed and same other parameters will produce the exact same output.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": "1234567890",
+  "alias": [
+    "ai.seed"
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__request__temperature.json
+++ b/model/attributes/gen_ai/gen_ai__request__temperature.json
@@ -7,7 +7,5 @@
   },
   "is_in_otel": true,
   "example": 0.1,
-  "alias": [
-    "ai.temperature"
-  ]
+  "alias": ["ai.temperature"]
 }

--- a/model/attributes/gen_ai/gen_ai__request__temperature.json
+++ b/model/attributes/gen_ai/gen_ai__request__temperature.json
@@ -1,0 +1,13 @@
+{
+  "key": "gen_ai.request.temperature",
+  "brief": "For an AI model call, the temperature parameter. Temperature essentially means how random the output will be.",
+  "type": "double",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": 0.1,
+  "alias": [
+    "ai.temperature"
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__request__top_k.json
+++ b/model/attributes/gen_ai/gen_ai__request__top_k.json
@@ -1,11 +1,13 @@
 {
   "key": "gen_ai.request.top_k",
-  "brief": "Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).",
-  "type": "double",
+  "brief": "Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).",
+  "type": "integer",
   "pii": {
     "key": "false"
   },
   "is_in_otel": true,
-  "example": 0.7,
-  "alias": ["ai.top_p"]
+  "example": 35,
+  "alias": [
+    "ai.top_k"
+  ]
 }

--- a/model/attributes/gen_ai/gen_ai__request__top_k.json
+++ b/model/attributes/gen_ai/gen_ai__request__top_k.json
@@ -7,7 +7,5 @@
   },
   "is_in_otel": true,
   "example": 35,
-  "alias": [
-    "ai.top_k"
-  ]
+  "alias": ["ai.top_k"]
 }

--- a/model/attributes/gen_ai/gen_ai__request__top_k.json
+++ b/model/attributes/gen_ai/gen_ai__request__top_k.json
@@ -7,7 +7,5 @@
   },
   "is_in_otel": true,
   "example": 0.7,
-  "alias": [
-    "ai.top_p"
-  ]
+  "alias": ["ai.top_p"]
 }

--- a/model/attributes/gen_ai/gen_ai__request__top_k.json
+++ b/model/attributes/gen_ai/gen_ai__request__top_k.json
@@ -1,0 +1,13 @@
+{
+  "key": "gen_ai.request.top_k",
+  "brief": "Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).",
+  "type": "double",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": 0.7,
+  "alias": [
+    "ai.top_p"
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__request__top_p.json
+++ b/model/attributes/gen_ai/gen_ai__request__top_p.json
@@ -7,7 +7,5 @@
   },
   "is_in_otel": true,
   "example": 0.7,
-  "alias": [
-    "ai.top_p"
-  ]
+  "alias": ["ai.top_p"]
 }

--- a/model/attributes/gen_ai/gen_ai__request__top_p.json
+++ b/model/attributes/gen_ai/gen_ai__request__top_p.json
@@ -1,0 +1,13 @@
+{
+  "key": "gen_ai.request.top_p",
+  "brief": "Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).",
+  "type": "double",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": 0.7,
+  "alias": [
+    "ai.top_p"
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__response__finish_reasons.json
+++ b/model/attributes/gen_ai/gen_ai__response__finish_reasons.json
@@ -1,0 +1,13 @@
+{
+  "key": "gen_ai.response.finish_reasons",
+  "brief": "The reason why the model stopped generating.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": "COMPLETE",
+  "alias": [
+    "ai.finish_reason"
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__response__finish_reasons.json
+++ b/model/attributes/gen_ai/gen_ai__response__finish_reasons.json
@@ -7,7 +7,5 @@
   },
   "is_in_otel": true,
   "example": "COMPLETE",
-  "alias": [
-    "ai.finish_reason"
-  ]
+  "alias": ["ai.finish_reason"]
 }

--- a/model/attributes/gen_ai/gen_ai__response__id.json
+++ b/model/attributes/gen_ai/gen_ai__response__id.json
@@ -1,13 +1,13 @@
 {
-  "key": "ai.generation_id",
+  "key": "gen_ai.response.id",
   "brief": "Unique identifier for the completion.",
   "type": "string",
   "pii": {
     "key": "false"
   },
-  "is_in_otel": false,
+  "is_in_otel": true,
   "example": "gen_123abc",
-  "deprecation": {
-    "replacement": "gen_ai.response.generation_id"
-  }
+  "alias": [
+    "ai.generation_id"
+  ]
 }

--- a/model/attributes/gen_ai/gen_ai__response__id.json
+++ b/model/attributes/gen_ai/gen_ai__response__id.json
@@ -7,7 +7,5 @@
   },
   "is_in_otel": true,
   "example": "gen_123abc",
-  "alias": [
-    "ai.generation_id"
-  ]
+  "alias": ["ai.generation_id"]
 }

--- a/model/attributes/gen_ai/gen_ai__response__model.json
+++ b/model/attributes/gen_ai/gen_ai__response__model.json
@@ -7,5 +7,7 @@
   },
   "is_in_otel": true,
   "example": "gpt-4",
-  "alias": ["ai.model_id"]
+  "alias": [
+    "ai.model_id"
+  ]
 }

--- a/model/attributes/gen_ai/gen_ai__response__model.json
+++ b/model/attributes/gen_ai/gen_ai__response__model.json
@@ -7,7 +7,5 @@
   },
   "is_in_otel": true,
   "example": "gpt-4",
-  "alias": [
-    "ai.model_id"
-  ]
+  "alias": ["ai.model_id"]
 }

--- a/model/attributes/gen_ai/gen_ai__system.json
+++ b/model/attributes/gen_ai/gen_ai__system.json
@@ -7,7 +7,5 @@
   },
   "is_in_otel": true,
   "example": "openai",
-  "alias": [
-    "ai.model.provider"
-  ]
+  "alias": ["ai.model.provider"]
 }

--- a/model/attributes/gen_ai/gen_ai__system.json
+++ b/model/attributes/gen_ai/gen_ai__system.json
@@ -1,0 +1,13 @@
+{
+  "key": "gen_ai.system",
+  "brief": "The provider of the model.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": "openai",
+  "alias": [
+    "ai.model.provider"
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__tool__name.json
+++ b/model/attributes/gen_ai/gen_ai__tool__name.json
@@ -7,7 +7,5 @@
   },
   "is_in_otel": true,
   "example": "Flights",
-  "alias": [
-    "ai.function_call"
-  ]
+  "alias": ["ai.function_call"]
 }

--- a/model/attributes/gen_ai/gen_ai__tool__name.json
+++ b/model/attributes/gen_ai/gen_ai__tool__name.json
@@ -1,0 +1,13 @@
+{
+  "key": "gen_ai.tool.name",
+  "brief": "Name of the tool utilized by the agent.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": "Flights",
+  "alias": [
+    "ai.function_call"
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__usage__input_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__usage__input_tokens.json
@@ -7,5 +7,7 @@
   },
   "is_in_otel": true,
   "example": 10,
-  "alias": ["ai.prompt_tokens.used", "gen_ai.usage.prompt_tokens"]
+  "alias": [
+    "ai.prompt_tokens.used", "gen_ai.usage.prompt_tokens"
+  ]
 }

--- a/model/attributes/gen_ai/gen_ai__usage__input_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__usage__input_tokens.json
@@ -7,7 +7,5 @@
   },
   "is_in_otel": true,
   "example": 10,
-  "alias": [
-    "ai.prompt_tokens.used", "gen_ai.usage.prompt_tokens"
-  ]
+  "alias": ["ai.prompt_tokens.used", "gen_ai.usage.prompt_tokens"]
 }

--- a/model/attributes/gen_ai/gen_ai__usage__total_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__usage__total_tokens.json
@@ -7,7 +7,5 @@
   },
   "is_in_otel": false,
   "example": 20,
-  "alias": [
-    "ai.total_tokens.used"
-  ]
+  "alias": ["ai.total_tokens.used"]
 }

--- a/model/attributes/gen_ai/gen_ai__usage__total_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__usage__total_tokens.json
@@ -1,0 +1,13 @@
+{
+  "key": "gen_ai.usage.total_tokens",
+  "brief": "The total number of tokens used to process the prompt. (input tokens plus output todkens)",
+  "type": "integer",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": 20,
+  "alias": [
+    "ai.total_tokens.used"
+  ]
+}


### PR DESCRIPTION
Deprecated the `ai.*` attributes in favor of `gen_ai.*` attributes specified by OptenTelemetry. 
(Some of our `ai.*` attribues do not exist in OptenTelemetry. There will be a separate PR where we create those new `gen_ai` attributes)