### PR TITLE
feat(ai): Add `gen_ai.usage.total_cost` inspired by `ai.total_cost`

### DIFF
--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -17,6 +17,7 @@
   - [gen_ai.tool.name](#gen_aitoolname)
   - [gen_ai.usage.input_tokens](#gen_aiusageinput_tokens)
   - [gen_ai.usage.output_tokens](#gen_aiusageoutput_tokens)
+  - [gen_ai.usage.total_cost](#gen_aiusagetotal_cost)
   - [gen_ai.usage.total_tokens](#gen_aiusagetotal_tokens)
 - [Deprecated Attributes](#deprecated-attributes)
   - [gen_ai.usage.completion_tokens](#gen_aiusagecompletion_tokens)
@@ -190,6 +191,17 @@ The number of tokens used in the GenAI response (completion).
 | Exists in OpenTelemetry | Yes |
 | Example | `10` |
 | Aliases | `ai.completion_tokens.used`, `gen_ai.usage.completion_tokens` |
+
+### gen_ai.usage.total_cost
+
+The total cost for the tokens used.
+
+| Property | Value |
+| --- | --- |
+| Type | `double` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `12.34` |
 
 ### gen_ai.usage.total_tokens
 

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2203,6 +2203,26 @@ export const GEN_AI_USAGE_PROMPT_TOKENS = 'gen_ai.usage.prompt_tokens';
  */
 export type GEN_AI_USAGE_PROMPT_TOKENS_TYPE = number;
 
+// Path: model/attributes/gen_ai/gen_ai__usage__total_cost.json
+
+/**
+ * The total cost for the tokens used. `gen_ai.usage.total_cost`
+ *
+ * Attribute Value Type: `number` {@link GEN_AI_USAGE_TOTAL_COST_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 12.34
+ */
+export const GEN_AI_USAGE_TOTAL_COST = 'gen_ai.usage.total_cost';
+
+/**
+ * Type for {@link GEN_AI_USAGE_TOTAL_COST} gen_ai.usage.total_cost
+ */
+export type GEN_AI_USAGE_TOTAL_COST_TYPE = number;
+
 // Path: model/attributes/gen_ai/gen_ai__usage__total_tokens.json
 
 /**
@@ -5665,6 +5685,7 @@ export type Attributes = {
   [GEN_AI_TOOL_NAME]?: GEN_AI_TOOL_NAME_TYPE;
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_OUTPUT_TOKENS]?: GEN_AI_USAGE_OUTPUT_TOKENS_TYPE;
+  [GEN_AI_USAGE_TOTAL_COST]?: GEN_AI_USAGE_TOTAL_COST_TYPE;
   [GEN_AI_USAGE_TOTAL_TOKENS]?: GEN_AI_USAGE_TOTAL_TOKENS_TYPE;
   [GRAPHQL_OPERATION_NAME]?: GRAPHQL_OPERATION_NAME_TYPE;
   [GRAPHQL_OPERATION_TYPE]?: GRAPHQL_OPERATION_TYPE_TYPE;
@@ -5899,6 +5920,7 @@ export type FullAttributes = {
   [GEN_AI_USAGE_INPUT_TOKENS]?: GEN_AI_USAGE_INPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_OUTPUT_TOKENS]?: GEN_AI_USAGE_OUTPUT_TOKENS_TYPE;
   [GEN_AI_USAGE_PROMPT_TOKENS]?: GEN_AI_USAGE_PROMPT_TOKENS_TYPE;
+  [GEN_AI_USAGE_TOTAL_COST]?: GEN_AI_USAGE_TOTAL_COST_TYPE;
   [GEN_AI_USAGE_TOTAL_TOKENS]?: GEN_AI_USAGE_TOTAL_TOKENS_TYPE;
   [GRAPHQL_OPERATION_NAME]?: GRAPHQL_OPERATION_NAME_TYPE;
   [GRAPHQL_OPERATION_TYPE]?: GRAPHQL_OPERATION_TYPE_TYPE;

--- a/model/attributes/gen_ai/gen_ai__usage__total_cost.json
+++ b/model/attributes/gen_ai/gen_ai__usage__total_cost.json
@@ -1,0 +1,10 @@
+{
+  "key": "gen_ai.usage.total_cost",
+  "brief": "The total cost for the tokens used.",
+  "type": "double",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": 12.34
+}


### PR DESCRIPTION
Currently working in Relay on these 2 issues:
- https://linear.app/getsentry/issue/RELAY-70/update-metrics-extraction-to-new-span-data-names
- https://linear.app/getsentry/issue/RELAY-69/normalise-ai-related-span-data

As part of these we want to get rid of the measurements and transition to span data. While most of them are already present in their `gen_ai` form there is not yet any counterpart to `ai.total_cost` so this introduces that (note the documentation is a copy of `ai.total_cost` documentation).

---
If you have any objections to this being added please don't hesitate to object and we can also do this a different way if you feel that this fields should not exist.