### PR TITLE
feat(ai): Add `gen_ai.response.tokens_per_second` attribute

### DIFF
--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -22,6 +22,7 @@
   - [gen_ai.response.id](#gen_airesponseid)
   - [gen_ai.response.model](#gen_airesponsemodel)
   - [gen_ai.response.text](#gen_airesponsetext)
+  - [gen_ai.response.tokens_per_second](#gen_airesponsetokens_per_second)
   - [gen_ai.response.tool_calls](#gen_airesponsetool_calls)
   - [gen_ai.system](#gen_aisystem)
   - [gen_ai.system.message](#gen_aisystemmessage)
@@ -261,6 +262,17 @@ The model's response text messages. It has to be a stringified version of an arr
 | Has PII | true |
 | Exists in OpenTelemetry | No |
 | Example | `["The weather in Paris is rainy and overcast, with temperatures around 57°F", "The weather in London is sunny and warm, with temperatures around 65°F"]` |
+
+### gen_ai.response.tokens_per_second
+
+The total output tokens per seconds throughput
+
+| Property | Value |
+| --- | --- |
+| Type | `double` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `12345.67` |
 
 ### gen_ai.response.tool_calls
 

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2253,6 +2253,26 @@ export const GEN_AI_RESPONSE_TEXT = 'gen_ai.response.text';
  */
 export type GEN_AI_RESPONSE_TEXT_TYPE = string;
 
+// Path: model/attributes/gen_ai/gen_ai__response__tokens_per_second.json
+
+/**
+ * The total output tokens per seconds throughput `gen_ai.response.tokens_per_second`
+ *
+ * Attribute Value Type: `number` {@link GEN_AI_RESPONSE_TOKENS_PER_SECOND_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 12345.67
+ */
+export const GEN_AI_RESPONSE_TOKENS_PER_SECOND = 'gen_ai.response.tokens_per_second';
+
+/**
+ * Type for {@link GEN_AI_RESPONSE_TOKENS_PER_SECOND} gen_ai.response.tokens_per_second
+ */
+export type GEN_AI_RESPONSE_TOKENS_PER_SECOND_TYPE = number;
+
 // Path: model/attributes/gen_ai/gen_ai__response__tool_calls.json
 
 /**
@@ -6070,6 +6090,7 @@ export type Attributes = {
   [GEN_AI_RESPONSE_ID]?: GEN_AI_RESPONSE_ID_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_RESPONSE_TEXT]?: GEN_AI_RESPONSE_TEXT_TYPE;
+  [GEN_AI_RESPONSE_TOKENS_PER_SECOND]?: GEN_AI_RESPONSE_TOKENS_PER_SECOND_TYPE;
   [GEN_AI_RESPONSE_TOOL_CALLS]?: GEN_AI_RESPONSE_TOOL_CALLS_TYPE;
   [GEN_AI_SYSTEM]?: GEN_AI_SYSTEM_TYPE;
   [GEN_AI_SYSTEM_MESSAGE]?: GEN_AI_SYSTEM_MESSAGE_TYPE;
@@ -6322,6 +6343,7 @@ export type FullAttributes = {
   [GEN_AI_RESPONSE_ID]?: GEN_AI_RESPONSE_ID_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
   [GEN_AI_RESPONSE_TEXT]?: GEN_AI_RESPONSE_TEXT_TYPE;
+  [GEN_AI_RESPONSE_TOKENS_PER_SECOND]?: GEN_AI_RESPONSE_TOKENS_PER_SECOND_TYPE;
   [GEN_AI_RESPONSE_TOOL_CALLS]?: GEN_AI_RESPONSE_TOOL_CALLS_TYPE;
   [GEN_AI_SYSTEM]?: GEN_AI_SYSTEM_TYPE;
   [GEN_AI_SYSTEM_MESSAGE]?: GEN_AI_SYSTEM_MESSAGE_TYPE;

--- a/model/attributes/gen_ai/gen_ai__response__tokens_per_second.json
+++ b/model/attributes/gen_ai/gen_ai__response__tokens_per_second.json
@@ -1,0 +1,10 @@
+{
+  "key": "gen_ai.response.tokens_per_second",
+  "brief": "The total output tokens per seconds throughput",
+  "type": "double",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": 12345.67
+}


### PR DESCRIPTION
We have introduced this attribute in relay in https://github.com/getsentry/relay/pull/4883.

This is a metric that [Nvidia is using for benchmarking LLMs](https://docs.nvidia.com/nim/benchmarking/llm/latest/metrics.html#tokens-per-second-tps), and it is useful to know how fast LLM models are.

Closes [TET-618: tokens per second](https://linear.app/getsentry/issue/TET-618/tokens-per-second)