### PR TITLE
feat: Add user.ip_address

### DIFF
--- a/generated/attributes/user.md
+++ b/generated/attributes/user.md
@@ -11,6 +11,7 @@
   - [user.geo.subdivision](#usergeosubdivision)
   - [user.hash](#userhash)
   - [user.id](#userid)
+  - [user.ip_address](#userip_address)
   - [user.name](#username)
   - [user.roles](#userroles)
 
@@ -103,6 +104,17 @@ Unique identifier of the user.
 | Has PII | true |
 | Exists in OpenTelemetry | Yes |
 | Example | `S-1-5-21-202424912787-2692429404-2351956786-1000` |
+
+### user.ip_address
+
+The IP address of the user.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | true |
+| Exists in OpenTelemetry | No |
+| Example | `192.168.1.1` |
 
 ### user.name
 

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -6066,6 +6066,26 @@ export const USER_ID = 'user.id';
  */
 export type USER_ID_TYPE = string;
 
+// Path: model/attributes/user/user__ip_address.json
+
+/**
+ * The IP address of the user. `user.ip_address`
+ *
+ * Attribute Value Type: `string` {@link USER_IP_ADDRESS_TYPE}
+ *
+ * Contains PII: true
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "192.168.1.1"
+ */
+export const USER_IP_ADDRESS = 'user.ip_address';
+
+/**
+ * Type for {@link USER_IP_ADDRESS} user.ip_address
+ */
+export type USER_IP_ADDRESS_TYPE = string;
+
 // Path: model/attributes/user/user__name.json
 
 /**
@@ -6355,6 +6375,7 @@ export type Attributes = {
   [USER_GEO_SUBDIVISION]?: USER_GEO_SUBDIVISION_TYPE;
   [USER_HASH]?: USER_HASH_TYPE;
   [USER_ID]?: USER_ID_TYPE;
+  [USER_IP_ADDRESS]?: USER_IP_ADDRESS_TYPE;
   [USER_NAME]?: USER_NAME_TYPE;
   [USER_ROLES]?: USER_ROLES_TYPE;
   [USER_AGENT_ORIGINAL]?: USER_AGENT_ORIGINAL_TYPE;
@@ -6651,6 +6672,7 @@ export type FullAttributes = {
   [USER_GEO_SUBDIVISION]?: USER_GEO_SUBDIVISION_TYPE;
   [USER_HASH]?: USER_HASH_TYPE;
   [USER_ID]?: USER_ID_TYPE;
+  [USER_IP_ADDRESS]?: USER_IP_ADDRESS_TYPE;
   [USER_NAME]?: USER_NAME_TYPE;
   [USER_ROLES]?: USER_ROLES_TYPE;
   [USER_AGENT_ORIGINAL]?: USER_AGENT_ORIGINAL_TYPE;

--- a/model/attributes/user/user__ip_address.json
+++ b/model/attributes/user/user__ip_address.json
@@ -1,0 +1,10 @@
+{
+  "key": "user.ip_address",
+  "brief": "The IP address of the user.",
+  "type": "string",
+  "pii": {
+    "key": "true"
+  },
+  "is_in_otel": false,
+  "example": "192.168.1.1"
+}


### PR DESCRIPTION
Although there is some overlap with `client.address` here, we have this field because it specifically meant to be only for ip addresses. This also aligns well with https://develop.sentry.dev/sdk/data-model/event-payloads/user/