### PR TITLE
feat(otlp): Add first set of convention documentation for span names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,21 @@ After you've created an attribute, the script will ask if you'd like to generate
 
 If you need help, run `yarn run create:attribute --help` to see the available options.
 
+## Adding a new convention for span names
+
+Span name conventions are organized loosely by type of span operation. To create a convention for a new type of span operation:
+
+1. Create a new file in the `models/name` directory. Ideally the file name should match a folder in the `models/attributes` directory (e.g., `ui.json`).
+2. Fill in the contents of the file with the necessary information. You can find the schema for the document in `schemas/name.schema.json`.
+
+- The `"brief"` field should be a short description of what kind of information the `name` field contains for this kind of span operation.
+- The `"is_in_otel"` field describes whether the [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/) describe how the `name` field should be constructed for this kind of span operation. If there are no OTel conventions for this kind of operation, set this field to `false`.
+- The `"op"` field contains a list of all known Sentry span operation names that the convention is applicable to. For example, in Sentry `"db"`, and `"db.query"` spans can construct their names using the `"db"` name conventions.
+- The `"templates"` field contains a list of string templates for constructing the `name` field from known span attributes. Strings in curly braces are replaced with the value of the corresponding attribute. For example, the template `"{{db.system}}"` becomes `"postgres"` for a span with the attribute `"db.system"` set to the string `"postgres"`. The top template should be the preferred version, with subsequent templates being fallbacks. The final template should be a static string without any curly braces.
+- The `"examples"` field contains a list of example span names. Please add a few examples that correspond to the available templates.
+
+Remember to run `yarn run generate` after editing or creating a `name` convention to recreate the documentation and auto-generated code.
+
 ## Code and Docs Generation
 
 After you edit an attribute or add a new one, you can run `yarn run generate` to generate the auto-generated code and docs from the json files stored in the `model` directly.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sentry Semantic Conventions
 
-> [!WARNING]  
+> [!WARNING]
 > This repository is currently in WIP status. It is not meant for production usage yet.
 
 This repository contains the Sentry Semantic Conventions as defined by [RFC #116](https://github.com/getsentry/rfcs/blob/main/text/0116-sentry-semantic-conventions.md).
@@ -9,7 +9,9 @@ Sentry's semantic conventions align with [OpenTelemetry's semantic conventions](
 
 These will be a standardized naming scheme for operations and data that will be shared across the SDKs, ingest, and the product. This allows us to have a single source of truth for the semantic conventions, and also allows us to generate code for all parts of the stack (ingest, frontend, backend, data pipelines) that need to be aware of this.
 
-To see the current list of attributes, see [the generated documentation](generated/attributes/index.md).
+To see the current list of attributes, see [the generated documentation for attributes](generated/attributes/index.md).
+
+To learn about creating span `name` fields, see [the generated documentation for span `name`](generated/name/index.md)
 
 # Contributing
 

--- a/generated/name/index.md
+++ b/generated/name/index.md
@@ -1,0 +1,70 @@
+<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT DIRECTLY. -->
+
+# Name Documentation
+
+This page contains documentation for known span names. You can use this documentation to understand how to create the `name` attribute for a span, when you have the span's other attributes. This is useful for SDK development, as well as in-product when deriving the span name.
+
+## Generating Names
+
+Span names are generated via string template. Each span category has a set of templates for the span name. Curly brackets in the template indicate that the contents inside the curly brackets should be replaced with the contents of the span attribute of the name within the brackets. The templates should be evaluated in order of appearance. At least one template must be provided that doesn't require any attributes.
+
+## Available Categories
+
+## `db`
+
+A description of an operation performed against a database.
+
+Names for this category of span **are** specified in OpenTelemetry Semantic Conventions.
+
+### Affected `op`s
+
+- `db`
+- `db.query`
+
+### Name Templates
+
+- `{{db.query.summary}}`
+- `{{db.operation.name}} {{db.collection.name}}`
+- `{{db.operation.name}} {{db.stored_procedure.name}}`
+- `{{db.operation.name}} {{db.namespace}}`
+- `{{db.operation.name}} {{server.address}}:{{server.port}}`
+- `{{db.collection.name}}`
+- `{{db.stored_procedure.name}}`
+- `{{db.namespace}}`
+- `{{server.address}}:{{server.port}}`
+- `{{db.system.name}}`
+- `Database operation`
+
+### Examples
+
+- `"SELECT users"`
+- `"findAndModify products"`
+- `"users"`
+- `"postgres"`
+
+## `file`
+
+A description of a filesystem operation.
+
+Names for this category of span **are not** specified in OpenTelemetry Semantic Conventions.
+
+### Affected `op`s
+
+- `file.open`
+- `file.read`
+- `file.write`
+- `file.copy`
+- `file.delete`
+- `file.rename`
+
+### Name Templates
+
+- `File {{sentry.category}}`
+- `File IO`
+
+### Examples
+
+- `"File open"`
+- `"File read"`
+- `"File IO"`
+

--- a/model/name/db.json
+++ b/model/name/db.json
@@ -1,0 +1,19 @@
+{
+  "brief": "A description of an operation performed against a database.",
+  "is_in_otel": true,
+  "op": ["db", "db.query"],
+  "template": [
+    "{{db.query.summary}}",
+    "{{db.operation.name}} {{db.collection.name}}",
+    "{{db.operation.name}} {{db.stored_procedure.name}}",
+    "{{db.operation.name}} {{db.namespace}}",
+    "{{db.operation.name}} {{server.address}}:{{server.port}}",
+    "{{db.collection.name}}",
+    "{{db.stored_procedure.name}}",
+    "{{db.namespace}}",
+    "{{server.address}}:{{server.port}}",
+    "{{db.system.name}}",
+    "Database operation"
+  ],
+  "example": ["SELECT users", "findAndModify products", "users", "postgres"]
+}

--- a/model/name/file.json
+++ b/model/name/file.json
@@ -1,0 +1,14 @@
+{
+  "brief": "A description of a filesystem operation.",
+  "is_in_otel": false,
+  "op": [
+    "file.open",
+    "file.read",
+    "file.write",
+    "file.copy",
+    "file.delete",
+    "file.rename"
+  ],
+  "template": ["File {{sentry.category}}", "File IO"],
+  "example": ["File open", "File read", "File IO"]
+}

--- a/model/name/file.json
+++ b/model/name/file.json
@@ -1,14 +1,7 @@
 {
   "brief": "A description of a filesystem operation.",
   "is_in_otel": false,
-  "op": [
-    "file.open",
-    "file.read",
-    "file.write",
-    "file.copy",
-    "file.delete",
-    "file.rename"
-  ],
+  "op": ["file.open", "file.read", "file.write", "file.copy", "file.delete", "file.rename"],
   "template": ["File {{sentry.category}}", "File IO"],
   "example": ["File open", "File read", "File IO"]
 }

--- a/schemas/name.schema.json
+++ b/schemas/name.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/SpanName",
+  "definitions": {
+    "SpanName": {
+      "title": "SpanName",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "brief": {
+          "type": "string"
+        },
+        "is_in_otel": {
+          "type": "boolean"
+        },
+        "op": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minItems": 1
+          }
+        },
+        "template": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minItems": 1
+          }
+        },
+        "example": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["brief", "is_in_otel", "op", "template"]
+    }
+  }
+}

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -1,8 +1,8 @@
-import { generateAttributeDocs } from "./generate_attribute_docs";
-import { generateAttributes } from "./generate_attributes";
-import { generateDeprecatedAttributesJSON } from "./generate_deprecated_attributes_json";
-import { generateNameDocs } from "./generate_name_docs";
-import { generateOps } from "./generate_op";
+import { generateAttributeDocs } from './generate_attribute_docs';
+import { generateAttributes } from './generate_attributes';
+import { generateDeprecatedAttributesJSON } from './generate_deprecated_attributes_json';
+import { generateNameDocs } from './generate_name_docs';
+import { generateOps } from './generate_op';
 
 generateOps();
 generateAttributes();

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -1,9 +1,11 @@
-import { generateAttributeDocs } from './generate_attribute_docs';
-import { generateAttributes } from './generate_attributes';
-import { generateDeprecatedAttributesJSON } from './generate_deprecated_attributes_json';
-import { generateOps } from './generate_op';
+import { generateAttributeDocs } from "./generate_attribute_docs";
+import { generateAttributes } from "./generate_attributes";
+import { generateDeprecatedAttributesJSON } from "./generate_deprecated_attributes_json";
+import { generateNameDocs } from "./generate_name_docs";
+import { generateOps } from "./generate_op";
 
 generateOps();
 generateAttributes();
 generateAttributeDocs();
 generateDeprecatedAttributesJSON();
+generateNameDocs();

--- a/scripts/generate_name_docs.ts
+++ b/scripts/generate_name_docs.ts
@@ -1,5 +1,5 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 interface NameJson {
   brief: string;
@@ -11,8 +11,8 @@ interface NameJson {
 
 // Main function to generate all markdown docs
 export async function generateNameDocs() {
-  const baseDir = "model/name";
-  const outputDir = "generated/name";
+  const baseDir = 'model/name';
+  const outputDir = 'generated/name';
   const categories: Record<string, NameJson> = {};
 
   // Ensure output directory exists
@@ -23,34 +23,31 @@ export async function generateNameDocs() {
   // Process every file in the directory, there is no nesting
   const topLevelFiles = fs
     .readdirSync(baseDir)
-    .filter((file) => file.endsWith(".json"))
+    .filter((file) => file.endsWith('.json'))
     .map((file) => path.join(baseDir, file));
 
   if (topLevelFiles.length === 0) {
-    console.error(
-      `No files found in ${baseDir}, could not generate name docs.`,
-    );
+    console.error(`No files found in ${baseDir}, could not generate name docs.`);
     process.exit(1);
   }
 
   for (const file of topLevelFiles) {
     const nameJSON = readJsonFile(file);
-    const categoryName = path.basename(file, ".json");
+    const categoryName = path.basename(file, '.json');
     categories[categoryName] = nameJSON;
   }
 
   // Create index.md file that links to all categories
-  let indexContent =
-    "<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT DIRECTLY. -->\n\n";
-  indexContent += "# Name Documentation\n\n";
+  let indexContent = '<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT DIRECTLY. -->\n\n';
+  indexContent += '# Name Documentation\n\n';
   indexContent +=
     "This page contains documentation for known span names. You can use this documentation to understand how to create the `name` attribute for a span, when you have the span's other attributes. This is useful for SDK development, as well as in-product when deriving the span name.\n\n";
 
-  indexContent += "## Generating Names\n\n";
+  indexContent += '## Generating Names\n\n';
   indexContent +=
     "Span names are generated via string template. Each span category has a set of templates for the span name. Curly brackets in the template indicate that the contents inside the curly brackets should be replaced with the contents of the span attribute of the name within the brackets. The templates should be evaluated in order of appearance. At least one template must be provided that doesn't require any attributes.\n\n";
 
-  indexContent += "## Available Categories\n\n";
+  indexContent += '## Available Categories\n\n';
 
   // Generate documentation for each category
   for (const category of Object.keys(categories).sort()) {
@@ -62,51 +59,51 @@ export async function generateNameDocs() {
   }
 
   // Write the index.md file
-  const indexFile = path.join(outputDir, "index.md");
+  const indexFile = path.join(outputDir, 'index.md');
   fs.writeFileSync(indexFile, indexContent);
   console.log(`Generated index file: ${indexFile}`);
 
-  console.log("Documentation generation complete!");
+  console.log('Documentation generation complete!');
 }
 
 // Function to read and parse a JSON file
 function readJsonFile(filePath: string): NameJson {
-  const fileContent = fs.readFileSync(filePath, "utf8");
+  const fileContent = fs.readFileSync(filePath, 'utf8');
   return JSON.parse(fileContent) as NameJson;
 }
 
 // Function to generate text content for a category
 function generateCategoryDocs(nameJSON: NameJson): string {
-  let content = "";
+  let content = '';
 
   content += `${nameJSON.brief}\n\n`;
 
-  content += `Names for this category of span **${nameJSON.is_in_otel ? "are" : "are not"}** specified in OpenTelemetry Semantic Conventions.\n\n`;
+  content += `Names for this category of span **${nameJSON.is_in_otel ? 'are' : 'are not'}** specified in OpenTelemetry Semantic Conventions.\n\n`;
 
-  content += "### Affected `op`s\n\n";
+  content += '### Affected `op`s\n\n';
 
   for (const op of nameJSON.op) {
     content += `- \`${op}\`\n`;
   }
 
-  content += "\n";
+  content += '\n';
 
-  content += "### Name Templates\n\n";
+  content += '### Name Templates\n\n';
 
   for (const template of nameJSON.template) {
     content += `- \`${template}\`\n`;
   }
 
-  content += "\n";
+  content += '\n';
 
   if (nameJSON.example?.length) {
-    content += "### Examples\n\n";
+    content += '### Examples\n\n';
 
     for (const example of nameJSON.example) {
       content += `- \`"${example}"\`\n`;
     }
 
-    content += "\n";
+    content += '\n';
   }
 
   return content;

--- a/scripts/generate_name_docs.ts
+++ b/scripts/generate_name_docs.ts
@@ -1,0 +1,111 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+interface NameJson {
+  brief: string;
+  is_in_otel: boolean;
+  op: string[];
+  template: string[];
+  example?: string[];
+}
+
+// Main function to generate all markdown docs
+export async function generateNameDocs() {
+  const baseDir = "model/name";
+  const outputDir = "generated/name";
+  const categories: Record<string, NameJson> = {};
+
+  // Ensure output directory exists
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  // Process every file in the directory, there is no nesting
+  const topLevelFiles = fs
+    .readdirSync(baseDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(baseDir, file));
+
+  if (topLevelFiles.length === 0) {
+    console.error(
+      `No files found in ${baseDir}, could not generate name docs.`,
+    );
+    process.exit(1);
+  }
+
+  topLevelFiles.forEach((file) => {
+    const nameJSON = readJsonFile(file);
+    const categoryName = path.basename(file, ".json");
+    categories[categoryName] = nameJSON;
+  });
+
+  // Create index.md file that links to all categories
+  let indexContent =
+    "<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT DIRECTLY. -->\n\n";
+  indexContent += "# Name Documentation\n\n";
+  indexContent +=
+    "This page contains documentation for known span names. You can use this documentation to understand how to create the \`name\` attribute for a span, when you have the span's other attributes. This is useful for SDK development, as well as in-product when deriving the span name.\n\n";
+
+  indexContent += "## Generating Names\n\n";
+  indexContent +=
+    "Span names are generated via string template. Each span category has a set of templates for the span name. Curly brackets in the template indicate that the contents inside the curly brackets should be replaced with the contents of the span attribute of the name within the brackets. The templates should be evaluated in order of appearance. At least one template must be provided that doesn't require any attributes.\n\n";
+
+  indexContent += "## Available Categories\n\n";
+
+  // Generate documentation for each category
+  for (const category of Object.keys(categories).sort()) {
+    indexContent += `## \`${category}\`\n\n`;
+    const nameJSON = categories[category]!;
+    indexContent += `${generateCategoryDocs(nameJSON)}`;
+  }
+
+  // Write the index.md file
+  const indexFile = path.join(outputDir, "index.md");
+  fs.writeFileSync(indexFile, indexContent);
+  console.log(`Generated index file: ${indexFile}`);
+
+  console.log("Documentation generation complete!");
+}
+
+// Function to read and parse a JSON file
+function readJsonFile(filePath: string): NameJson {
+  const fileContent = fs.readFileSync(filePath, "utf8");
+  return JSON.parse(fileContent) as NameJson;
+}
+
+// Function to generate text content for a category
+function generateCategoryDocs(nameJSON: NameJson): string {
+  let content = ``;
+
+  content += `${nameJSON.brief}\n\n`;
+
+  content += `Names for this category of span **${nameJSON.is_in_otel ? "are" : "are not"}** specified in OpenTelemetry Semantic Conventions.\n\n`;
+
+  content += "### Affected `op`s\n\n";
+
+  nameJSON.op.forEach((op) => {
+    content += `- \`${op}\`\n`;
+  });
+
+  content += "\n";
+
+  content += "### Name Templates\n\n";
+
+  nameJSON.template.forEach((template) => {
+    content += `- \`${template}\`\n`;
+  });
+
+  content += "\n";
+
+  if (nameJSON.example?.length) {
+    content += "### Examples\n\n";
+
+    nameJSON.example.forEach((example) => {
+      content += `- \`"${example}"\`\n`;
+    });
+
+    content += "\n";
+  }
+
+  return content;
+}

--- a/scripts/generate_name_docs.ts
+++ b/scripts/generate_name_docs.ts
@@ -33,18 +33,18 @@ export async function generateNameDocs() {
     process.exit(1);
   }
 
-  topLevelFiles.forEach((file) => {
+  for (const file of topLevelFiles) {
     const nameJSON = readJsonFile(file);
     const categoryName = path.basename(file, ".json");
     categories[categoryName] = nameJSON;
-  });
+  }
 
   // Create index.md file that links to all categories
   let indexContent =
     "<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT DIRECTLY. -->\n\n";
   indexContent += "# Name Documentation\n\n";
   indexContent +=
-    "This page contains documentation for known span names. You can use this documentation to understand how to create the \`name\` attribute for a span, when you have the span's other attributes. This is useful for SDK development, as well as in-product when deriving the span name.\n\n";
+    "This page contains documentation for known span names. You can use this documentation to understand how to create the `name` attribute for a span, when you have the span's other attributes. This is useful for SDK development, as well as in-product when deriving the span name.\n\n";
 
   indexContent += "## Generating Names\n\n";
   indexContent +=
@@ -55,8 +55,10 @@ export async function generateNameDocs() {
   // Generate documentation for each category
   for (const category of Object.keys(categories).sort()) {
     indexContent += `## \`${category}\`\n\n`;
-    const nameJSON = categories[category]!;
-    indexContent += `${generateCategoryDocs(nameJSON)}`;
+    const nameJSON = categories[category];
+    if (nameJSON) {
+      indexContent += `${generateCategoryDocs(nameJSON)}`;
+    }
   }
 
   // Write the index.md file
@@ -75,7 +77,7 @@ function readJsonFile(filePath: string): NameJson {
 
 // Function to generate text content for a category
 function generateCategoryDocs(nameJSON: NameJson): string {
-  let content = ``;
+  let content = "";
 
   content += `${nameJSON.brief}\n\n`;
 
@@ -83,26 +85,26 @@ function generateCategoryDocs(nameJSON: NameJson): string {
 
   content += "### Affected `op`s\n\n";
 
-  nameJSON.op.forEach((op) => {
+  for (const op of nameJSON.op) {
     content += `- \`${op}\`\n`;
-  });
+  }
 
   content += "\n";
 
   content += "### Name Templates\n\n";
 
-  nameJSON.template.forEach((template) => {
+  for (const template of nameJSON.template) {
     content += `- \`${template}\`\n`;
-  });
+  }
 
   content += "\n";
 
   if (nameJSON.example?.length) {
     content += "### Examples\n\n";
 
-    nameJSON.example.forEach((example) => {
+    for (const example of nameJSON.example) {
       content += `- \`"${example}"\`\n`;
-    });
+    }
 
     content += "\n";
   }


### PR DESCRIPTION
This is an experimental PR! I'm soliciting suggestions on how to tackle this, and this PR is meant as a point of discussion to figure out how to move forward.

---

👋🏻 I would like to start documenting semantic conventions for the `name` field of a span. To me, semantic conventions for `name` are useful in at least two places:

1. SDKs. As we create more and more V2 SDKs (or continue to use POTel) we will need to set a `name` on every span. Since Sentry makes spans that OTel does not, we need to document conventions for how to make span names, so the SDKs create the span names consistently. I've already noticed inconsistencies in casing of some `name` attributes in the AI namespace
2. In the product. There's at least one use case in Relay where we need to generate a `name` attribute from a span's other attributes and fields. We need a way to refer to what span names should look like, rather than hunting through every SDK

I added a schema for a span name definition, added some examples, and added a simple documentation page generator. Here are the main approaches of my first take:

- The files have the same directory structures as `attributes`, roughly. There is one file for every directory in `attributes`
- Each name definition has a few fields:
  - A brief description (not that useful IMO, but nice to look at)
  - A list of span `op`s that are relevant. The idea is that this documentation is relevant for only a few known `op`s. I assume this is contentious since we're moving away from `op` fields, but this is critical to know in the code, since we need to know which span to apply the conventions to. Perhaps `category` would be more palatable?
  - A list of templates on how to create a span name from attributes. This would be great to codegen, but it also works well as documentation, IMO, combined with the examples. I'm a little worried that not every case can be done via this kind of template approach, but I haven't kicked the tires on it yet
- There is a little script to create a single documentation page for span name generation. Maybe separate pages are better, but I wanted to spike something quick for us to talk about