### PR TITLE
fix: Improve span name conventions formatting

### DIFF
--- a/generated/name/index.md
+++ b/generated/name/index.md
@@ -18,22 +18,22 @@ Names for this category of span **are** specified in OpenTelemetry Semantic Conv
 
 ### Affected `op`s
 
-- `db`
-- `db.query`
+- `"db"`
+- `"db.query"`
 
 ### Name Templates
 
-- `{{db.query.summary}}`
-- `{{db.operation.name}} {{db.collection.name}}`
-- `{{db.operation.name}} {{db.stored_procedure.name}}`
-- `{{db.operation.name}} {{db.namespace}}`
-- `{{db.operation.name}} {{server.address}}:{{server.port}}`
-- `{{db.collection.name}}`
-- `{{db.stored_procedure.name}}`
-- `{{db.namespace}}`
-- `{{server.address}}:{{server.port}}`
-- `{{db.system.name}}`
-- `Database operation`
+- `"{{db.query.summary}}"`
+- `"{{db.operation.name}} {{db.collection.name}}"`
+- `"{{db.operation.name}} {{db.stored_procedure.name}}"`
+- `"{{db.operation.name}} {{db.namespace}}"`
+- `"{{db.operation.name}} {{server.address}}:{{server.port}}"`
+- `"{{db.collection.name}}"`
+- `"{{db.stored_procedure.name}}"`
+- `"{{db.namespace}}"`
+- `"{{server.address}}:{{server.port}}"`
+- `"{{db.system.name}}"`
+- `"Database operation"`
 
 ### Examples
 
@@ -50,17 +50,17 @@ Names for this category of span **are not** specified in OpenTelemetry Semantic 
 
 ### Affected `op`s
 
-- `file.open`
-- `file.read`
-- `file.write`
-- `file.copy`
-- `file.delete`
-- `file.rename`
+- `"file.open"`
+- `"file.read"`
+- `"file.write"`
+- `"file.copy"`
+- `"file.delete"`
+- `"file.rename"`
 
 ### Name Templates
 
-- `File {{sentry.category}}`
-- `File IO`
+- `"File {{sentry.category}}"`
+- `"File IO"`
 
 ### Examples
 

--- a/generated/name/index.md
+++ b/generated/name/index.md
@@ -15,8 +15,6 @@ Span names are generated via string template. Each span category has a set of te
 
 A description of an operation performed against a database.
 
-Names for this category of span **are** specified in OpenTelemetry Semantic Conventions.
-
 ### Affected `op`s
 
 - `"db"`
@@ -43,11 +41,12 @@ Names for this category of span **are** specified in OpenTelemetry Semantic Conv
 - `"users"`
 - `"postgres"`
 
-## `file`
+{% endraw %}## `file`
 
 A description of a filesystem operation.
 
-Names for this category of span **are not** specified in OpenTelemetry Semantic Conventions.
+> [!NOTE]
+> Names for this category of span are not specified in OpenTelemetry Semantic Conventions.
 
 ### Affected `op`s
 

--- a/generated/name/index.md
+++ b/generated/name/index.md
@@ -1,5 +1,6 @@
 <!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT DIRECTLY. -->
 
+{% raw %}
 # Name Documentation
 
 This page contains documentation for known span names. You can use this documentation to understand how to create the `name` attribute for a span, when you have the span's other attributes. This is useful for SDK development, as well as in-product when deriving the span name.
@@ -68,3 +69,4 @@ Names for this category of span **are not** specified in OpenTelemetry Semantic 
 - `"File read"`
 - `"File IO"`
 
+{% endraw %}

--- a/scripts/generate_name_docs.ts
+++ b/scripts/generate_name_docs.ts
@@ -83,7 +83,7 @@ function generateCategoryDocs(nameJSON: NameJson): string {
   content += '### Affected `op`s\n\n';
 
   for (const op of nameJSON.op) {
-    content += `- \`${op}\`\n`;
+    content += `- \`"${op}"\`\n`;
   }
 
   content += '\n';
@@ -91,7 +91,7 @@ function generateCategoryDocs(nameJSON: NameJson): string {
   content += '### Name Templates\n\n';
 
   for (const template of nameJSON.template) {
-    content += `- \`${template}\`\n`;
+    content += `- \`"${template}"\`\n`;
   }
 
   content += '\n';

--- a/scripts/generate_name_docs.ts
+++ b/scripts/generate_name_docs.ts
@@ -79,7 +79,10 @@ function generateCategoryDocs(nameJSON: NameJson): string {
 
   content += `${nameJSON.brief}\n\n`;
 
-  content += `Names for this category of span **${nameJSON.is_in_otel ? 'are' : 'are not'}** specified in OpenTelemetry Semantic Conventions.\n\n`;
+  if (!nameJSON.is_in_otel) {
+    content +=
+      '> [!NOTE]\n> Names for this category of span are not specified in OpenTelemetry Semantic Conventions.\n\n';
+  }
 
   content += '### Affected `op`s\n\n';
 

--- a/scripts/generate_name_docs.ts
+++ b/scripts/generate_name_docs.ts
@@ -39,6 +39,7 @@ export async function generateNameDocs() {
 
   // Create index.md file that links to all categories
   let indexContent = '<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT DIRECTLY. -->\n\n';
+  indexContent += '{% raw %}\n'; // GitHub pages use Jekyll which parsed and interpolates `"{{"` and `"}}"`. Since we're using double curlies to indicate placeholder in our template, we need to wrap the document in Jekyll Liquid escape tags
   indexContent += '# Name Documentation\n\n';
   indexContent +=
     "This page contains documentation for known span names. You can use this documentation to understand how to create the `name` attribute for a span, when you have the span's other attributes. This is useful for SDK development, as well as in-product when deriving the span name.\n\n";
@@ -105,6 +106,8 @@ function generateCategoryDocs(nameJSON: NameJson): string {
 
     content += '\n';
   }
+
+  content += '{% endraw %}';
 
   return content;
 }


### PR DESCRIPTION
I noticed that the output looked broken for the "Templates" section, turns out that GitHub pages uses Liquid parsing, and double curlies are interpolated! To avoid this, add escape tags top and bottom, we don't want Liquid interpolation anywhere. Also, some other small formatting tweaks.