### PR TITLE
fix: Remove incorrect `endraw` tags

### DIFF
--- a/generated/name/index.md
+++ b/generated/name/index.md
@@ -41,7 +41,7 @@ A description of an operation performed against a database.
 - `"users"`
 - `"postgres"`
 
-{% endraw %}## `file`
+## `file`
 
 A description of a filesystem operation.
 

--- a/scripts/generate_name_docs.ts
+++ b/scripts/generate_name_docs.ts
@@ -59,6 +59,8 @@ export async function generateNameDocs() {
     }
   }
 
+  indexContent += '{% endraw %}';
+
   // Write the index.md file
   const indexFile = path.join(outputDir, 'index.md');
   fs.writeFileSync(indexFile, indexContent);
@@ -109,8 +111,6 @@ function generateCategoryDocs(nameJSON: NameJson): string {
 
     content += '\n';
   }
-
-  content += '{% endraw %}';
 
   return content;
 }


### PR DESCRIPTION
In https://github.com/getsentry/sentry-conventions/pull/81 I broke the build by accident, by placing too many `endraw` tags in the document. There should be exactly one, and it should not be added in the loop, sorry.
