### PR TITLE
fix: More better name conventions formatting

### DIFF
--- a/generated/name/index.md
+++ b/generated/name/index.md
@@ -9,8 +9,6 @@ This page contains documentation for known span names. You can use this document
 
 Span names are generated via string template. Each span category has a set of templates for the span name. Curly brackets in the template indicate that the contents inside the curly brackets should be replaced with the contents of the span attribute of the name within the brackets. The templates should be evaluated in order of appearance. At least one template must be provided that doesn't require any attributes.
 
-## Available Categories
-
 ## `db`
 
 A description of an operation performed against a database.

--- a/generated/name/index.md
+++ b/generated/name/index.md
@@ -43,10 +43,7 @@ A description of an operation performed against a database.
 
 ## `file`
 
-A description of a filesystem operation.
-
-> [!NOTE]
-> Names for this category of span are not specified in OpenTelemetry Semantic Conventions.
+A description of a filesystem operation. NOTE: Names for this category of span are **not** specified in OpenTelemetry Semantic Conventions.
 
 ### Affected `op`s
 

--- a/scripts/generate_name_docs.ts
+++ b/scripts/generate_name_docs.ts
@@ -79,12 +79,13 @@ function readJsonFile(filePath: string): NameJson {
 function generateCategoryDocs(nameJSON: NameJson): string {
   let content = '';
 
-  content += `${nameJSON.brief}\n\n`;
+  content += `${nameJSON.brief}`;
 
   if (!nameJSON.is_in_otel) {
-    content +=
-      '> [!NOTE]\n> Names for this category of span are not specified in OpenTelemetry Semantic Conventions.\n\n';
+    content += ' NOTE: Names for this category of span are **not** specified in OpenTelemetry Semantic Conventions.';
   }
+
+  content += '\n\n';
 
   content += '### Affected `op`s\n\n';
 

--- a/scripts/generate_name_docs.ts
+++ b/scripts/generate_name_docs.ts
@@ -48,8 +48,6 @@ export async function generateNameDocs() {
   indexContent +=
     "Span names are generated via string template. Each span category has a set of templates for the span name. Curly brackets in the template indicate that the contents inside the curly brackets should be replaced with the contents of the span attribute of the name within the brackets. The templates should be evaluated in order of appearance. At least one template must be provided that doesn't require any attributes.\n\n";
 
-  indexContent += '## Available Categories\n\n';
-
   // Generate documentation for each category
   for (const category of Object.keys(categories).sort()) {
     indexContent += `## \`${category}\`\n\n`;


### PR DESCRIPTION
- **Better formatting for NOTE**, since GitHub pages don't support callouts
- **Remove unnecessary heading**, just to keep it tidier
