### PR TITLE
feat: Allow multiple span operations per category in span name documentation

### DIFF
--- a/generated/name/index.md
+++ b/generated/name/index.md
@@ -1,24 +1,32 @@
 <!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT DIRECTLY. -->
 
 {% raw %}
-# Name Documentation
+# Span Name Documentation
 
-This page contains documentation for known span names. You can use this documentation to understand how to create the `name` attribute for a span, when you have the span's other attributes. This is useful for SDK development, as well as in-product when deriving the span name.
+This page contains documentation for known span names. You can use this documentation to understand how to create the `name` attribute for a span, when you have the span's other attributes. This is useful for SDK development, as well as in-product when deriving the span name. The documentation is organized by general category of work that spans represent, and further broken down by specific kinds of work.
 
 ## Generating Names
 
-Span names are generated via string template. Each span category has a set of templates for the span name. Curly brackets in the template indicate that the contents inside the curly brackets should be replaced with the contents of the span attribute of the name within the brackets. The templates should be evaluated in order of appearance. At least one template must be provided that doesn't require any attributes.
+Span names are generated via string template. Each span category of work has a set of templates for the span name. Curly brackets in the template indicate that the contents inside the curly brackets should be replaced with the contents of the span attribute of the name within the brackets. The templates should be evaluated in order of appearance. At least one template must be provided that doesn't require any attributes.
 
 ## `db`
 
-A description of an operation performed against a database.
+### Database Queries
 
-### Affected `op`s
+Database queries. Any operation that acts on the data in a database. Includes operations like fetching data, updating records. Does not include operations like connecting to the database, or updating permissions.
+
+#### Affected `op`s
 
 - `"db"`
 - `"db.query"`
+- `"db.sql.query"`
+- `"db.sql.prisma"`
+- `"db.sql.active_record"`
+- `"db.sql.execute"`
+- `"db.sql.room"`
+- `"db.sql.transaction"`
 
-### Name Templates
+#### Templates
 
 - `"{{db.query.summary}}"`
 - `"{{db.operation.name}} {{db.collection.name}}"`
@@ -32,18 +40,32 @@ A description of an operation performed against a database.
 - `"{{db.system.name}}"`
 - `"Database operation"`
 
-### Examples
+#### Examples
 
 - `"SELECT users"`
 - `"findAndModify products"`
 - `"users"`
 - `"postgres"`
 
+### Database Network
+
+Database network operations. Any operation that deals with database network communication. NOTE: Names for this category of span are **not** specified in OpenTelemetry Semantic Conventions.
+
+#### Affected `op`s
+
+- `"db.connection"`
+
+#### Templates
+
+- `"Database connection"`
+
 ## `file`
 
-A description of a filesystem operation. NOTE: Names for this category of span are **not** specified in OpenTelemetry Semantic Conventions.
+### File Operations
 
-### Affected `op`s
+Operations on individual files NOTE: Names for this category of span are **not** specified in OpenTelemetry Semantic Conventions.
+
+#### Affected `op`s
 
 - `"file.open"`
 - `"file.read"`
@@ -52,12 +74,12 @@ A description of a filesystem operation. NOTE: Names for this category of span a
 - `"file.delete"`
 - `"file.rename"`
 
-### Name Templates
+#### Templates
 
 - `"File {{sentry.category}}"`
 - `"File IO"`
 
-### Examples
+#### Examples
 
 - `"File open"`
 - `"File read"`

--- a/model/name/db.json
+++ b/model/name/db.json
@@ -1,19 +1,41 @@
 {
-  "brief": "A description of an operation performed against a database.",
-  "is_in_otel": true,
-  "op": ["db", "db.query"],
-  "template": [
-    "{{db.query.summary}}",
-    "{{db.operation.name}} {{db.collection.name}}",
-    "{{db.operation.name}} {{db.stored_procedure.name}}",
-    "{{db.operation.name}} {{db.namespace}}",
-    "{{db.operation.name}} {{server.address}}:{{server.port}}",
-    "{{db.collection.name}}",
-    "{{db.stored_procedure.name}}",
-    "{{db.namespace}}",
-    "{{server.address}}:{{server.port}}",
-    "{{db.system.name}}",
-    "Database operation"
-  ],
-  "example": ["SELECT users", "findAndModify products", "users", "postgres"]
+  "brief": "Operations performed against a database.",
+  "operations": [
+    {
+      "name": "Database Queries",
+      "brief": "Database queries. Any operation that acts on the data in a database. Includes operations like fetching data, updating records. Does not include operations like connecting to the database, or updating permissions.",
+      "is_in_otel": true,
+      "ops": [
+        "db",
+        "db.query",
+        "db.sql.query",
+        "db.sql.prisma",
+        "db.sql.active_record",
+        "db.sql.execute",
+        "db.sql.room",
+        "db.sql.transaction"
+      ],
+      "templates": [
+        "{{db.query.summary}}",
+        "{{db.operation.name}} {{db.collection.name}}",
+        "{{db.operation.name}} {{db.stored_procedure.name}}",
+        "{{db.operation.name}} {{db.namespace}}",
+        "{{db.operation.name}} {{server.address}}:{{server.port}}",
+        "{{db.collection.name}}",
+        "{{db.stored_procedure.name}}",
+        "{{db.namespace}}",
+        "{{server.address}}:{{server.port}}",
+        "{{db.system.name}}",
+        "Database operation"
+      ],
+      "examples": ["SELECT users", "findAndModify products", "users", "postgres"]
+    },
+    {
+      "name": "Database Network",
+      "brief": "Database network operations. Any operation that deals with database network communication.",
+      "is_in_otel": false,
+      "ops": ["db.connection"],
+      "templates": ["Database connection"]
+    }
+  ]
 }

--- a/model/name/file.json
+++ b/model/name/file.json
@@ -1,7 +1,13 @@
 {
-  "brief": "A description of a filesystem operation.",
-  "is_in_otel": false,
-  "op": ["file.open", "file.read", "file.write", "file.copy", "file.delete", "file.rename"],
-  "template": ["File {{sentry.category}}", "File IO"],
-  "example": ["File open", "File read", "File IO"]
+  "brief": "Operations against the filesystem.",
+  "operations": [
+    {
+      "name": "File Operations",
+      "brief": "Operations on individual files.",
+      "is_in_otel": false,
+      "ops": ["file.open", "file.read", "file.write", "file.copy", "file.delete", "file.rename"],
+      "templates": ["File {{sentry.category}}", "File IO"],
+      "examples": ["File open", "File read", "File IO"]
+    }
+  ]
 }

--- a/schemas/name.schema.json
+++ b/schemas/name.schema.json
@@ -10,31 +10,52 @@
         "brief": {
           "type": "string"
         },
+        "operations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SpanOperation",
+            "minItems": 1
+          }
+        }
+      },
+      "required": ["brief", "operations"]
+    },
+    "SpanOperation": {
+      "title": "SpanOperation",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "brief": {
+          "type": "string"
+        },
         "is_in_otel": {
           "type": "boolean"
         },
-        "op": {
+        "ops": {
           "type": "array",
           "items": {
             "type": "string",
             "minItems": 1
           }
         },
-        "template": {
+        "templates": {
           "type": "array",
           "items": {
             "type": "string",
             "minItems": 1
           }
         },
-        "example": {
+        "examples": {
           "type": "array",
           "items": {
             "type": "string"
           }
         }
       },
-      "required": ["brief", "is_in_otel", "op", "template"]
+      "required": ["brief", "is_in_otel", "ops", "templates"]
     }
   }
 }

--- a/scripts/generate_name_docs.ts
+++ b/scripts/generate_name_docs.ts
@@ -3,10 +3,14 @@ import * as path from 'node:path';
 
 interface NameJson {
   brief: string;
-  is_in_otel: boolean;
-  op: string[];
-  template: string[];
-  example?: string[];
+  operations: Array<{
+    name: string;
+    brief: string;
+    is_in_otel: boolean;
+    ops: string[];
+    templates: string[];
+    examples?: string[];
+  }>;
 }
 
 // Main function to generate all markdown docs
@@ -40,13 +44,13 @@ export async function generateNameDocs() {
   // Create index.md file that links to all categories
   let indexContent = '<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT DIRECTLY. -->\n\n';
   indexContent += '{% raw %}\n'; // GitHub pages use Jekyll which parsed and interpolates `"{{"` and `"}}"`. Since we're using double curlies to indicate placeholder in our template, we need to wrap the document in Jekyll Liquid escape tags
-  indexContent += '# Name Documentation\n\n';
+  indexContent += '# Span Name Documentation\n\n';
   indexContent +=
-    "This page contains documentation for known span names. You can use this documentation to understand how to create the `name` attribute for a span, when you have the span's other attributes. This is useful for SDK development, as well as in-product when deriving the span name.\n\n";
+    "This page contains documentation for known span names. You can use this documentation to understand how to create the `name` attribute for a span, when you have the span's other attributes. This is useful for SDK development, as well as in-product when deriving the span name. The documentation is organized by general category of work that spans represent, and further broken down by specific kinds of work.\n\n";
 
   indexContent += '## Generating Names\n\n';
   indexContent +=
-    "Span names are generated via string template. Each span category has a set of templates for the span name. Curly brackets in the template indicate that the contents inside the curly brackets should be replaced with the contents of the span attribute of the name within the brackets. The templates should be evaluated in order of appearance. At least one template must be provided that doesn't require any attributes.\n\n";
+    "Span names are generated via string template. Each span category of work has a set of templates for the span name. Curly brackets in the template indicate that the contents inside the curly brackets should be replaced with the contents of the span attribute of the name within the brackets. The templates should be evaluated in order of appearance. At least one template must be provided that doesn't require any attributes.\n\n";
 
   // Generate documentation for each category
   for (const category of Object.keys(categories).sort()) {
@@ -77,38 +81,41 @@ function readJsonFile(filePath: string): NameJson {
 function generateCategoryDocs(nameJSON: NameJson): string {
   let content = '';
 
-  content += `${nameJSON.brief}`;
+  for (const operation of nameJSON.operations) {
+    content += `### ${operation.name}\n\n`;
+    content += `${operation.brief}`;
 
-  if (!nameJSON.is_in_otel) {
-    content += ' NOTE: Names for this category of span are **not** specified in OpenTelemetry Semantic Conventions.';
-  }
+    if (!operation.is_in_otel) {
+      content += ' NOTE: Names for this category of span are **not** specified in OpenTelemetry Semantic Conventions.';
+    }
 
-  content += '\n\n';
+    content += '\n\n';
 
-  content += '### Affected `op`s\n\n';
+    content += '#### Affected `op`s\n\n';
 
-  for (const op of nameJSON.op) {
-    content += `- \`"${op}"\`\n`;
-  }
-
-  content += '\n';
-
-  content += '### Name Templates\n\n';
-
-  for (const template of nameJSON.template) {
-    content += `- \`"${template}"\`\n`;
-  }
-
-  content += '\n';
-
-  if (nameJSON.example?.length) {
-    content += '### Examples\n\n';
-
-    for (const example of nameJSON.example) {
-      content += `- \`"${example}"\`\n`;
+    for (const op of operation.ops) {
+      content += `- \`"${op}"\`\n`;
     }
 
     content += '\n';
+
+    content += '#### Templates\n\n';
+
+    for (const template of operation.templates) {
+      content += `- \`"${template}"\`\n`;
+    }
+
+    content += '\n';
+
+    if (operation.examples?.length) {
+      content += '#### Examples\n\n';
+
+      for (const example of operation.examples) {
+        content += `- \`"${example}"\`\n`;
+      }
+
+      content += '\n';
+    }
   }
 
   return content;


### PR DESCRIPTION
I started gathering more information about the spans we're ingesting, and immediately ran into a limitation with the current schema. Allowing only one set of template and one description per category is too restrictive!

This PR expands the schema to take a few pointers from the OpenTelemetry documentation. Each category now has multiple sections, arranged by the kinds of work spans in this category might be doing. The database category has an example of this: queries and connections are different kinds of work that spans might represent, but they're in the same category.

This makes it much easier to document more complex areas like UI spans, Generative AI, etc. This is preparation for documenting more kinds of spans.

I also updated the schema a bit to pluralize any plural attributes, to make things a little tidier.