### PR TITLE
ref: Make `replacement` non-required on `attribute.deprecation`

### DIFF
--- a/generated/attributes/net.md
+++ b/generated/attributes/net.md
@@ -189,8 +189,8 @@ Peer address of the network connection - Unix domain socket name
 | Has PII | false |
 | Exists in OpenTelemetry | Yes |
 | Example | `/var/my.sock` |
-| Deprecated | Yes, use `` instead |
-| Deprecation Reason | Deprecated, no replacement at this time |
+| Deprecated | Yes, no replacement exists at this time |
+| Deprecation Reason | Deprecated in OTEL |
 
 ### net.sock.peer.port
 

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4369,7 +4369,7 @@ export type NET_SOCK_PEER_ADDR_TYPE = string;
  *
  * Attribute defined in OTEL: Yes
  *
- * @deprecated Use {@link } () instead - Deprecated, no replacement at this time
+ * @deprecated No replacement exists at this time - Deprecated in OTEL
  * @example "/var/my.sock"
  */
 export const NET_SOCK_PEER_NAME = 'net.sock.peer.name';

--- a/model/attributes/net/net__sock__peer__name.json
+++ b/model/attributes/net/net__sock__peer__name.json
@@ -9,7 +9,6 @@
   "example": "/var/my.sock",
   "deprecation": {
     "_status": null,
-    "replacement": "",
-    "reason": "Deprecated, no replacement at this time"
+    "reason": "Deprecated in OTEL"
   }
 }

--- a/schemas/attribute.schema.json
+++ b/schemas/attribute.schema.json
@@ -86,7 +86,7 @@
           "enum": [null, "backfill", "normalize"]
         }
       },
-      "required": ["replacement", "_status"]
+      "required": ["_status"]
     },
     "alias": {
       "description": "If there are attributes that alias to this attribute",

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -10,7 +10,7 @@ export interface AttributeJson {
   is_in_otel: boolean;
   example?: string | boolean | number | string[] | boolean[] | number[];
   deprecation?: {
-    replacement: string;
+    replacement?: string;
     reason?: string;
     _status?: string;
   };

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -1,0 +1,19 @@
+export interface AttributeJson {
+  key: string;
+  brief: string;
+  has_dynamic_suffix?: boolean;
+  type: 'string' | 'boolean' | 'integer' | 'double' | 'string[]' | 'boolean[]' | 'integer[]' | 'double[]';
+  pii: {
+    key: 'true' | 'maybe' | 'false';
+    reason?: string;
+  };
+  is_in_otel: boolean;
+  example?: string | boolean | number | string[] | boolean[] | number[];
+  deprecation?: {
+    replacement: string;
+    reason?: string;
+    _status?: string;
+  };
+  alias?: string[];
+  sdks?: string[];
+}

--- a/scripts/generate_attribute_docs.ts
+++ b/scripts/generate_attribute_docs.ts
@@ -32,7 +32,11 @@ function generateAttributeTable(attribute: AttributeJson): string {
   }
 
   if (attribute.deprecation) {
-    table += `| Deprecated | Yes, use \`${attribute.deprecation.replacement}\` instead |\n`;
+    if (attribute.deprecation.replacement) {
+      table += `| Deprecated | Yes, use \`${attribute.deprecation.replacement}\` instead |\n`;
+    } else {
+      table += '| Deprecated | Yes, no replacement exists at this time |\n';
+    }
     if (attribute.deprecation.reason) {
       table += `| Deprecation Reason | ${attribute.deprecation.reason} |\n`;
     }

--- a/scripts/generate_attribute_docs.ts
+++ b/scripts/generate_attribute_docs.ts
@@ -1,24 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-
-interface AttributeJson {
-  key: string;
-  brief: string;
-  has_dynamic_suffix?: boolean;
-  type: 'string' | 'boolean' | 'integer' | 'double' | 'string[]' | 'boolean[]' | 'integer[]' | 'double[]';
-  pii: {
-    key: 'true' | 'maybe' | 'false';
-    reason?: string;
-  };
-  is_in_otel: boolean;
-  example?: string | boolean | number | string[] | boolean[] | number[];
-  deprecation?: {
-    replacement: string;
-    reason?: string;
-  };
-  alias?: string[];
-  sdks?: string[];
-}
+import type { AttributeJson } from './common';
 
 // Function to read and parse a JSON file
 function readJsonFile(filePath: string): AttributeJson {

--- a/scripts/generate_attributes.ts
+++ b/scripts/generate_attributes.ts
@@ -1,24 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-
-interface AttributeJson {
-  key: string;
-  brief: string;
-  has_dynamic_suffix?: boolean;
-  type: 'string' | 'boolean' | 'integer' | 'double' | 'string[]' | 'boolean[]' | 'integer[]' | 'double[]';
-  pii: {
-    key: 'true' | 'maybe' | 'false';
-    reason?: string;
-  };
-  is_in_otel: boolean;
-  example?: string | boolean | number | string[] | boolean[] | number[];
-  deprecation?: {
-    replacement: string;
-    reason?: string;
-  };
-  alias?: string[];
-  sdks?: string[];
-}
+import type { AttributeJson } from './common';
 
 export async function generateAttributes() {
   const attributesDir = path.join(__dirname, '..', 'model', 'attributes');

--- a/scripts/generate_attributes.ts
+++ b/scripts/generate_attributes.ts
@@ -91,7 +91,11 @@ function writeToJs(attributesDir: string, attributeFiles: string[]) {
 
     // Add deprecation info if present
     if (deprecation) {
-      attributesContent += ` * @deprecated Use {@link ${getConstantName(deprecation.replacement)}} (${deprecation.replacement}) instead${deprecation.reason ? ` - ${deprecation.reason}` : ''}\n`;
+      if (deprecation.replacement) {
+        attributesContent += ` * @deprecated Use {@link ${getConstantName(deprecation.replacement)}} (${deprecation.replacement}) instead${deprecation.reason ? ` - ${deprecation.reason}` : ''}\n`;
+      } else {
+        attributesContent += ` * @deprecated No replacement exists at this time${deprecation.reason ? ` - ${deprecation.reason}` : ''}\n`;
+      }
       fullAttributeTypeMap += `\n  [${constantName}]?: ${typeConstantName};`;
     } else {
       fullAttributeTypeMap += `\n  [${constantName}]?: ${typeConstantName};`;

--- a/scripts/generate_deprecated_attributes_json.ts
+++ b/scripts/generate_deprecated_attributes_json.ts
@@ -1,26 +1,7 @@
 import { execSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-
-interface AttributeJson {
-  key: string;
-  brief: string;
-  has_dynamic_suffix?: boolean;
-  type: 'string' | 'boolean' | 'integer' | 'double' | 'string[]' | 'boolean[]' | 'integer[]' | 'double[]';
-  pii: {
-    key: 'true' | 'maybe' | 'false';
-    reason?: string;
-  };
-  is_in_otel: boolean;
-  example?: string | boolean | number | string[] | boolean[] | number[];
-  deprecation?: {
-    replacement: string;
-    reason?: string;
-    _status?: string;
-  };
-  alias?: string[];
-  sdks?: string[];
-}
+import type { AttributeJson } from './common';
 
 // Function to read and parse a JSON file
 function readJsonFile(filePath: string): AttributeJson {

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -973,8 +973,7 @@
       "example": "/var/my.sock",
       "deprecation": {
         "_status": null,
-        "replacement": "",
-        "reason": "Deprecated, no replacement at this time"
+        "reason": "Deprecated in OTEL"
       }
     },
     {


### PR DESCRIPTION
### Commit 1
Move duplicated `AttributeJson` type to a `common.ts` file

### Commit 2
Certain attributes are completely deprecated in OTEL, see https://opentelemetry.io/blog/2023/http-conventions-declared-stable/#:~:text=as%20server.port-,net.sock.peer.name,-Removed
We were representing this as `"replacement": ""`, which is incorrect.
This change makes the `replacement` field on attributes optional to be able to handle cases like this, adapts the generation logic, and updates the relevant generated files by rerunning the `generate` script.

Other examples of completely removed OTEL attributes https://opentelemetry.io/docs/specs/semconv/non-normative/db-migration/

### Alternative
As an alternative, we could instead remove the problematic attribute from the conventions when we consider something to be completely removed, but I think it's better to represent it as deprecated without any replacement.