### PR TITLE
Add `gen_ai.operation.type`

### DIFF
--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -94,7 +94,7 @@ The name of the operation being performed.
 
 ### gen_ai.operation.type
 
-The type of AI operation. Must be one of 'agent', 'ai_client', 'tool', 'handoff', 'guardrail'.
+The type of AI operation. Must be one of 'agent', 'ai_client', 'tool', 'handoff', 'guardrail'. Makes querying for spans in the UI easier.
 
 | Property | Value |
 | --- | --- |
@@ -522,4 +522,3 @@ The number of tokens used in the GenAI input (prompt).
 | Example | `20` |
 | Deprecated | Yes, use `gen_ai.usage.input_tokens` instead |
 | Aliases | `ai.prompt_tokens.used`, `gen_ai.usage.input_tokens` |
-

--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -522,3 +522,4 @@ The number of tokens used in the GenAI input (prompt).
 | Example | `20` |
 | Deprecated | Yes, use `gen_ai.usage.input_tokens` instead |
 | Aliases | `ai.prompt_tokens.used`, `gen_ai.usage.input_tokens` |
+

--- a/generated/attributes/gen_ai.md
+++ b/generated/attributes/gen_ai.md
@@ -7,6 +7,7 @@
   - [gen_ai.assistant.message](#gen_aiassistantmessage)
   - [gen_ai.choice](#gen_aichoice)
   - [gen_ai.operation.name](#gen_aioperationname)
+  - [gen_ai.operation.type](#gen_aioperationtype)
   - [gen_ai.pipeline.name](#gen_aipipelinename)
   - [gen_ai.prompt](#gen_aiprompt)
   - [gen_ai.request.available_tools](#gen_airequestavailable_tools)
@@ -90,6 +91,17 @@ The name of the operation being performed.
 | Has PII | false |
 | Exists in OpenTelemetry | Yes |
 | Example | `chat` |
+
+### gen_ai.operation.type
+
+The type of AI operation. Must be one of 'agent', 'ai_client', 'tool', 'handoff', 'guardrail'.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `tool` |
 
 ### gen_ai.pipeline.name
 

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2000,7 +2000,7 @@ export type GEN_AI_OPERATION_NAME_TYPE = string;
 // Path: model/attributes/gen_ai/gen_ai__operation__type.json
 
 /**
- * The type of AI operation. Must be one of 'agent', 'ai_client', 'tool', 'handoff', 'guardrail'. `gen_ai.operation.type`
+ * The type of AI operation. Must be one of 'agent', 'ai_client', 'tool', 'handoff', 'guardrail'. Makes querying for spans in the UI easier. `gen_ai.operation.type`
  *
  * Attribute Value Type: `string` {@link GEN_AI_OPERATION_TYPE_TYPE}
  *

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1997,6 +1997,26 @@ export const GEN_AI_OPERATION_NAME = 'gen_ai.operation.name';
  */
 export type GEN_AI_OPERATION_NAME_TYPE = string;
 
+// Path: model/attributes/gen_ai/gen_ai__operation__type.json
+
+/**
+ * The type of AI operation. Must be one of 'agent', 'ai_client', 'tool', 'handoff', 'guardrail'. `gen_ai.operation.type`
+ *
+ * Attribute Value Type: `string` {@link GEN_AI_OPERATION_TYPE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "tool"
+ */
+export const GEN_AI_OPERATION_TYPE = 'gen_ai.operation.type';
+
+/**
+ * Type for {@link GEN_AI_OPERATION_TYPE} gen_ai.operation.type
+ */
+export type GEN_AI_OPERATION_TYPE_TYPE = string;
+
 // Path: model/attributes/gen_ai/gen_ai__pipeline__name.json
 
 /**
@@ -6362,6 +6382,7 @@ export type Attributes = {
   [GEN_AI_ASSISTANT_MESSAGE]?: GEN_AI_ASSISTANT_MESSAGE_TYPE;
   [GEN_AI_CHOICE]?: GEN_AI_CHOICE_TYPE;
   [GEN_AI_OPERATION_NAME]?: GEN_AI_OPERATION_NAME_TYPE;
+  [GEN_AI_OPERATION_TYPE]?: GEN_AI_OPERATION_TYPE_TYPE;
   [GEN_AI_PIPELINE_NAME]?: GEN_AI_PIPELINE_NAME_TYPE;
   [GEN_AI_PROMPT]?: GEN_AI_PROMPT_TYPE;
   [GEN_AI_REQUEST_AVAILABLE_TOOLS]?: GEN_AI_REQUEST_AVAILABLE_TOOLS_TYPE;
@@ -6629,6 +6650,7 @@ export type FullAttributes = {
   [GEN_AI_ASSISTANT_MESSAGE]?: GEN_AI_ASSISTANT_MESSAGE_TYPE;
   [GEN_AI_CHOICE]?: GEN_AI_CHOICE_TYPE;
   [GEN_AI_OPERATION_NAME]?: GEN_AI_OPERATION_NAME_TYPE;
+  [GEN_AI_OPERATION_TYPE]?: GEN_AI_OPERATION_TYPE_TYPE;
   [GEN_AI_PIPELINE_NAME]?: GEN_AI_PIPELINE_NAME_TYPE;
   [GEN_AI_PROMPT]?: GEN_AI_PROMPT_TYPE;
   [GEN_AI_REQUEST_AVAILABLE_TOOLS]?: GEN_AI_REQUEST_AVAILABLE_TOOLS_TYPE;

--- a/model/attributes/gen_ai/gen_ai__operation__type.json
+++ b/model/attributes/gen_ai/gen_ai__operation__type.json
@@ -1,6 +1,6 @@
 {
   "key": "gen_ai.operation.type",
-  "brief": "The type of AI operation. Must be one of 'agent', 'ai_client', 'tool', 'handoff', 'guardrail'.",
+  "brief": "The type of AI operation. Must be one of 'agent', 'ai_client', 'tool', 'handoff', 'guardrail'. Makes querying for spans in the UI easier.",
   "type": "string",
   "pii": {
     "key": "false"

--- a/model/attributes/gen_ai/gen_ai__operation__type.json
+++ b/model/attributes/gen_ai/gen_ai__operation__type.json
@@ -1,0 +1,10 @@
+{
+  "key": "gen_ai.operation.type",
+  "brief": "The type of AI operation. Must be one of 'agent', 'ai_client', 'tool', 'handoff', 'guardrail'.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "tool"
+}


### PR DESCRIPTION
An attribute that marks spans as one of the `gen_ai` types: `agent`, `ai_client`, `tool`, `handoff`, or `guardrail`. Makes querying of spans in the UI way easier.