### PR TITLE
ref(schema): Allow deprecated attributes with no replacement

### DIFF
--- a/schemas/attribute.schema.json
+++ b/schemas/attribute.schema.json
@@ -86,7 +86,7 @@
           "enum": [null, "backfill", "normalize"]
         }
       },
-      "required": ["replacement", "_status"]
+      "required": ["_status"]
     },
     "alias": {
       "description": "If there are attributes that alias to this attribute",

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -10,9 +10,9 @@ export interface AttributeJson {
   is_in_otel: boolean;
   example?: string | boolean | number | string[] | boolean[] | number[];
   deprecation?: {
-    replacement: string;
+    replacement?: string;
     reason?: string;
-    _status?: string;
+    _status: string;
   };
   alias?: string[];
   sdks?: string[];


### PR DESCRIPTION
There are some cases where an attribute is completely removed from OTEL and has no direct replacement.
This is rare but can happen with attributes that are not stabilized.

For example, see the deprecated [Gen AI attributes](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#deprecated-genai-attributes).
Some of them were deprecated and have no direct replacement.
It's suggested to use e.g. [gen_ai.input.messages](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-input-messages) instead, which doesn't have the same semantic meaning and also requires a different format for attribute values.

We wouldn't want to mark e.g. `gen_ai.input_messages` as a replacement for `gen_ai.prompt`, as the former is more general and requires a different format for the values.

This extends the schema so that `deprecation.replacement` is nullable, allowing us to represent those cases.

Also fixes the type in `scripts` to correctly match the schema.