### PR TITLE
fix: Update ai/gen_ai finish reasons attributes

### DIFF
--- a/model/attributes/ai/ai__finish_reason.json
+++ b/model/attributes/ai/ai__finish_reason.json
@@ -8,8 +8,6 @@
   "is_in_otel": false,
   "example": "COMPLETE",
   "deprecation": {
-    "_status": null,
-    "replacement": "gen_ai.response.finish_reason"
-  },
-  "alias": ["gen_ai.response.finish_reasons"]
+    "_status": null
+  }
 }

--- a/model/attributes/gen_ai/gen_ai__response__finish_reasons.json
+++ b/model/attributes/gen_ai/gen_ai__response__finish_reasons.json
@@ -1,11 +1,10 @@
 {
   "key": "gen_ai.response.finish_reasons",
-  "brief": "The reason why the model stopped generating.",
-  "type": "string",
+  "brief": "Array of reasons the model stopped generating tokens, corresponding to each generation received.",
+  "type": "string[]",
   "pii": {
     "key": "false"
   },
   "is_in_otel": true,
-  "example": "COMPLETE",
-  "alias": ["ai.finish_reason"]
+  "example": ["stop", "length"]
 }


### PR DESCRIPTION
- Adjust descriptions, types and examples of `gen_ai.response.finish_reasons` to match the OTEL spec
- Mark `ai.finish_reason` as completely deprecated (no replacement), as the new type is not compatible with the previous one