### PR TITLE
fix(js): Handle clashing constant names

### DIFF
--- a/scripts/generate_attributes.ts
+++ b/scripts/generate_attributes.ts
@@ -153,7 +153,7 @@ function getConstantName(key: string, isDeprecated: boolean): string {
   // If this key is deprecated and there's another key that maps to the same name, append underscores
   if (isDeprecated) {
     while (usedConstantNames.has(constantName)) {
-      constantName = `${constantName}_`;
+      constantName = `_${constantName}`;
     }
   }
 


### PR DESCRIPTION
Provides a solution for https://github.com/getsentry/sentry-conventions/pull/124#discussion_r2324798416

If there's a clash in the constant names, we now append underscores at the end of the variable name (for both the attribute name and its type).

This is not great but other solutions are not great either, any solution will lead to 2 names that look very similar when users of the generated package.

Hopefully this is an edge case and we try to avoid such clashes in the future.