### PR TITLE
feat(sentry): Add sentry.description attribute

### DIFF
--- a/generated/attributes/sentry.md
+++ b/generated/attributes/sentry.md
@@ -5,6 +5,7 @@
 - [Stable Attributes](#stable-attributes)
   - [sentry.cancellation_reason](#sentrycancellation_reason)
   - [sentry.client_sample_rate](#sentryclient_sample_rate)
+  - [sentry.description](#sentrydescription)
   - [sentry.dist](#sentrydist)
   - [sentry.environment](#sentryenvironment)
   - [sentry.exclusive_time](#sentryexclusive_time)
@@ -56,6 +57,17 @@ Rate at which a span was sampled in the SDK.
 | Has PII | false |
 | Exists in OpenTelemetry | No |
 | Example | `0.5` |
+
+### sentry.description
+
+The human-readable description of a span.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `index view query` |
 
 ### sentry.dist
 

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -5364,6 +5364,26 @@ export const SENTRY_CLIENT_SAMPLE_RATE = 'sentry.client_sample_rate';
  */
 export type SENTRY_CLIENT_SAMPLE_RATE_TYPE = number;
 
+// Path: model/attributes/sentry/sentry__description.json
+
+/**
+ * The human-readable description of a span. `sentry.description`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_DESCRIPTION_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "index view query"
+ */
+export const SENTRY_DESCRIPTION = 'sentry.description';
+
+/**
+ * Type for {@link SENTRY_DESCRIPTION} sentry.description
+ */
+export type SENTRY_DESCRIPTION_TYPE = string;
+
 // Path: model/attributes/sentry/sentry__dist.json
 
 /**
@@ -6775,6 +6795,7 @@ export type Attributes = {
   [RPC_SERVICE]?: RPC_SERVICE_TYPE;
   [SENTRY_CANCELLATION_REASON]?: SENTRY_CANCELLATION_REASON_TYPE;
   [SENTRY_CLIENT_SAMPLE_RATE]?: SENTRY_CLIENT_SAMPLE_RATE_TYPE;
+  [SENTRY_DESCRIPTION]?: SENTRY_DESCRIPTION_TYPE;
   [SENTRY_DIST]?: SENTRY_DIST_TYPE;
   [SENTRY_ENVIRONMENT]?: SENTRY_ENVIRONMENT_TYPE;
   [SENTRY_EXCLUSIVE_TIME]?: SENTRY_EXCLUSIVE_TIME_TYPE;
@@ -7089,6 +7110,7 @@ export type FullAttributes = {
   [RPC_SERVICE]?: RPC_SERVICE_TYPE;
   [SENTRY_CANCELLATION_REASON]?: SENTRY_CANCELLATION_REASON_TYPE;
   [SENTRY_CLIENT_SAMPLE_RATE]?: SENTRY_CLIENT_SAMPLE_RATE_TYPE;
+  [SENTRY_DESCRIPTION]?: SENTRY_DESCRIPTION_TYPE;
   [SENTRY_DIST]?: SENTRY_DIST_TYPE;
   [SENTRY_ENVIRONMENT]?: SENTRY_ENVIRONMENT_TYPE;
   [SENTRY_EXCLUSIVE_TIME]?: SENTRY_EXCLUSIVE_TIME_TYPE;

--- a/model/attributes/sentry/sentry__description.json
+++ b/model/attributes/sentry/sentry__description.json
@@ -1,0 +1,10 @@
+{
+  "key": "sentry.description",
+  "brief": "The human-readable description of a span.",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "index view query"
+}


### PR DESCRIPTION
This attribute roughly corresponds to the `description` field on SpanV1, which is marked as `Pii::Maybe`. If this attribute is not defined in this repo, Relay assumes `Pii::True`.

Implements INGEST-571.