### PR TITLE
ci(release): Simplify release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,26 +22,15 @@ jobs:
           app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0
-          
-      - name: Install node modules
-        run: yarn install --frozen-lockfile
 
-      - name: Run generate
-        run: yarn run generate
-  
-      - name: Check for changes
-        id: verify-changed-files
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            git status
-            exit 1
-          else
-            exit 0
-          fi
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
 
       - name: Prepare release
         uses: getsentry/action-prepare-release@v1


### PR DESCRIPTION
Simplify the release workflow by simply releasing, not attempting to build/generate code.
This is how we do it for SDKs.
I believe craft will still try to run the build before publishing, so this should be fine, otherwise we can add it back later to prevent mistakes.