### PR TITLE
docs: Update CHANGELOG.md for v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+This is a patch release with the sole purpose of releasing the Python package to our internal PyPI registry.
+
 ## 0.1.0
 
 This is the first release of the Sentry Conventions packages.


### PR DESCRIPTION
NPM complains if I try to create a new 0.1.0 release.
This prepares the changelog for 0.1.1, we can trigger it now that we've added the internal PyPI just to release it there.