### PR TITLE
test(name): verify attribute usage in template lists

### DIFF
--- a/test/name.test.ts
+++ b/test/name.test.ts
@@ -31,6 +31,7 @@ describe('Name JSON', async () => {
         }
       });
 
+      // This invariant is important for the span-to-name code generation inside Relay.
       it('should fall back to a template without attributes', () => {
         for (const operation of content.operations) {
           for (const nameTemplate of operation.templates.slice(0, -1)) {

--- a/test/name.test.ts
+++ b/test/name.test.ts
@@ -30,6 +30,17 @@ describe('Name JSON', async () => {
           expect(new Set(operation.ops).size).toBe(operation.ops.length);
         }
       });
+
+      it('should fall back to a template without attributes', () => {
+        for (const operation of content.operations) {
+          for (const nameTemplate of operation.templates.slice(0, -1)) {
+            expect(nameTemplate, 'all but the last template should reference an attribute').toContain('{{');
+          }
+
+          const lastNameTemplate = operation.templates.at(-1);
+          expect(lastNameTemplate, "the last template shouldn't reference any attributes").not.toContain('{{');
+        }
+      });
     });
   }
 });


### PR DESCRIPTION
To assist the code generation in Relay, it is best if name template lists always contain a single entry without attributes as a fallback, and that that entry is the final template in the list.

This is already the case for our existing templates, but this test enforces it going forward as well.