### PR TITLE
feat: Add vercel log drain attributes

### DIFF
--- a/generated/attributes/index.md
+++ b/generated/attributes/index.md
@@ -48,3 +48,4 @@ This directory contains documentation for all available attributes.
 - [`url` Attributes](./url.md)
 - [`user` Attributes](./user.md)
 - [`user_agent` Attributes](./user_agent.md)
+- [`vercel` Attributes](./vercel.md)

--- a/generated/attributes/vercel.md
+++ b/generated/attributes/vercel.md
@@ -1,0 +1,428 @@
+<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT DIRECTLY. -->
+
+# Vercel Attributes
+
+- [Stable Attributes](#stable-attributes)
+  - [vercel.branch](#vercelbranch)
+  - [vercel.build_id](#vercelbuild_id)
+  - [vercel.deployment_id](#verceldeployment_id)
+  - [vercel.destination](#verceldestination)
+  - [vercel.edge_type](#verceledge_type)
+  - [vercel.entrypoint](#vercelentrypoint)
+  - [vercel.execution_region](#vercelexecution_region)
+  - [vercel.id](#vercelid)
+  - [vercel.ja3_digest](#vercelja3_digest)
+  - [vercel.ja4_digest](#vercelja4_digest)
+  - [vercel.log_type](#vercellog_type)
+  - [vercel.project_id](#vercelproject_id)
+  - [vercel.project_name](#vercelproject_name)
+  - [vercel.proxy.cache_id](#vercelproxycache_id)
+  - [vercel.proxy.client_ip](#vercelproxyclient_ip)
+  - [vercel.proxy.host](#vercelproxyhost)
+  - [vercel.proxy.lambda_region](#vercelproxylambda_region)
+  - [vercel.proxy.method](#vercelproxymethod)
+  - [vercel.proxy.path](#vercelproxypath)
+  - [vercel.proxy.path_type](#vercelproxypath_type)
+  - [vercel.proxy.path_type_variant](#vercelproxypath_type_variant)
+  - [vercel.proxy.referer](#vercelproxyreferer)
+  - [vercel.proxy.region](#vercelproxyregion)
+  - [vercel.proxy.response_byte_size](#vercelproxyresponse_byte_size)
+  - [vercel.proxy.scheme](#vercelproxyscheme)
+  - [vercel.proxy.status_code](#vercelproxystatus_code)
+  - [vercel.proxy.timestamp](#vercelproxytimestamp)
+  - [vercel.proxy.user_agent](#vercelproxyuser_agent)
+  - [vercel.proxy.vercel_cache](#vercelproxyvercel_cache)
+  - [vercel.proxy.vercel_id](#vercelproxyvercel_id)
+  - [vercel.proxy.waf_action](#vercelproxywaf_action)
+  - [vercel.proxy.waf_rule_id](#vercelproxywaf_rule_id)
+  - [vercel.request_id](#vercelrequest_id)
+  - [vercel.source](#vercelsource)
+  - [vercel.status_code](#vercelstatus_code)
+
+## Stable Attributes
+
+### vercel.branch
+
+Git branch name for Vercel project
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `main` |
+
+### vercel.build_id
+
+Identifier for the Vercel build (only present on build logs)
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `bld_cotnkcr76` |
+
+### vercel.deployment_id
+
+Identifier for the Vercel deployment
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `dpl_233NRGRjVZX1caZrXWtz5g1TAksD` |
+
+### vercel.destination
+
+Origin of the external content in Vercel (only on external logs)
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `https://vitals.vercel-insights.com/v1` |
+
+### vercel.edge_type
+
+Type of edge runtime in Vercel
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `edge-function` |
+
+### vercel.entrypoint
+
+Entrypoint for the request in Vercel
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `api/index.js` |
+
+### vercel.execution_region
+
+Region where the request is executed
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `sfo1` |
+
+### vercel.id
+
+Unique identifier for the log entry in Vercel
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `1573817187330377061717300000` |
+
+### vercel.ja3_digest
+
+JA3 fingerprint digest of Vercel request
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0` |
+
+### vercel.ja4_digest
+
+JA4 fingerprint digest
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `t13d1516h2_8daaf6152771_02713d6af862` |
+
+### vercel.log_type
+
+Vercel log output type
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `stdout` |
+
+### vercel.project_id
+
+Identifier for the Vercel project
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `gdufoJxB6b9b1fEqr1jUtFkyavUU` |
+
+### vercel.project_name
+
+Name of the Vercel project
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `my-app` |
+
+### vercel.proxy.cache_id
+
+Original request ID when request is served from cache
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `pdx1::v8g4b-1744143786684-93dafbc0f70d` |
+
+### vercel.proxy.client_ip
+
+Client IP address
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | true |
+| Exists in OpenTelemetry | No |
+| Example | `120.75.16.101` |
+
+### vercel.proxy.host
+
+Hostname of the request
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `test.vercel.app` |
+
+### vercel.proxy.lambda_region
+
+Region where lambda function executed
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `sfo1` |
+
+### vercel.proxy.method
+
+HTTP method of the request
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `GET` |
+
+### vercel.proxy.path
+
+Request path with query parameters
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `/dynamic/some-value.json?route=some-value` |
+
+### vercel.proxy.path_type
+
+How the request was served based on its path and project configuration
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `func` |
+
+### vercel.proxy.path_type_variant
+
+Variant of the path type
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `api` |
+
+### vercel.proxy.referer
+
+Referer of the request
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `*.vercel.app` |
+
+### vercel.proxy.region
+
+Region where the request is processed
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `sfo1` |
+
+### vercel.proxy.response_byte_size
+
+Size of the response in bytes
+
+| Property | Value |
+| --- | --- |
+| Type | `integer` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `1024` |
+
+### vercel.proxy.scheme
+
+Protocol of the request
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `https` |
+
+### vercel.proxy.status_code
+
+HTTP status code of the proxy request
+
+| Property | Value |
+| --- | --- |
+| Type | `integer` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `200` |
+
+### vercel.proxy.timestamp
+
+Unix timestamp when the proxy request was made
+
+| Property | Value |
+| --- | --- |
+| Type | `integer` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `1573817250172` |
+
+### vercel.proxy.user_agent
+
+User agent strings of the request
+
+| Property | Value |
+| --- | --- |
+| Type | `string[]` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `["Mozilla/5.0..."]` |
+
+### vercel.proxy.vercel_cache
+
+Cache status sent to the browser
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `REVALIDATED` |
+
+### vercel.proxy.vercel_id
+
+Vercel-specific identifier
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `sfo1::abc123` |
+
+### vercel.proxy.waf_action
+
+Action taken by firewall rules
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `deny` |
+
+### vercel.proxy.waf_rule_id
+
+ID of the firewall rule that matched
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `rule_gAHz8jtSB1Gy` |
+
+### vercel.request_id
+
+Identifier of the Vercel request
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `643af4e3-975a-4cc7-9e7a-1eda11539d90` |
+
+### vercel.source
+
+Origin of the Vercel log (build, edge, lambda, static, external, or firewall)
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `build` |
+
+### vercel.status_code
+
+HTTP status code of the request (-1 means no response returned and the lambda crashed)
+
+| Property | Value |
+| --- | --- |
+| Type | `integer` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `200` |
+

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -6920,6 +6920,706 @@ export const USER_AGENT_ORIGINAL = 'user_agent.original';
  */
 export type USER_AGENT_ORIGINAL_TYPE = string;
 
+// Path: model/attributes/vercel/vercel__branch.json
+
+/**
+ * Git branch name for Vercel project `vercel.branch`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_BRANCH_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "main"
+ */
+export const VERCEL_BRANCH = 'vercel.branch';
+
+/**
+ * Type for {@link VERCEL_BRANCH} vercel.branch
+ */
+export type VERCEL_BRANCH_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__build_id.json
+
+/**
+ * Identifier for the Vercel build (only present on build logs) `vercel.build_id`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_BUILD_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "bld_cotnkcr76"
+ */
+export const VERCEL_BUILD_ID = 'vercel.build_id';
+
+/**
+ * Type for {@link VERCEL_BUILD_ID} vercel.build_id
+ */
+export type VERCEL_BUILD_ID_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__deployment_id.json
+
+/**
+ * Identifier for the Vercel deployment `vercel.deployment_id`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_DEPLOYMENT_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "dpl_233NRGRjVZX1caZrXWtz5g1TAksD"
+ */
+export const VERCEL_DEPLOYMENT_ID = 'vercel.deployment_id';
+
+/**
+ * Type for {@link VERCEL_DEPLOYMENT_ID} vercel.deployment_id
+ */
+export type VERCEL_DEPLOYMENT_ID_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__destination.json
+
+/**
+ * Origin of the external content in Vercel (only on external logs) `vercel.destination`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_DESTINATION_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "https://vitals.vercel-insights.com/v1"
+ */
+export const VERCEL_DESTINATION = 'vercel.destination';
+
+/**
+ * Type for {@link VERCEL_DESTINATION} vercel.destination
+ */
+export type VERCEL_DESTINATION_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__edge_type.json
+
+/**
+ * Type of edge runtime in Vercel `vercel.edge_type`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_EDGE_TYPE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "edge-function"
+ */
+export const VERCEL_EDGE_TYPE = 'vercel.edge_type';
+
+/**
+ * Type for {@link VERCEL_EDGE_TYPE} vercel.edge_type
+ */
+export type VERCEL_EDGE_TYPE_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__entrypoint.json
+
+/**
+ * Entrypoint for the request in Vercel `vercel.entrypoint`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_ENTRYPOINT_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "api/index.js"
+ */
+export const VERCEL_ENTRYPOINT = 'vercel.entrypoint';
+
+/**
+ * Type for {@link VERCEL_ENTRYPOINT} vercel.entrypoint
+ */
+export type VERCEL_ENTRYPOINT_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__execution_region.json
+
+/**
+ * Region where the request is executed `vercel.execution_region`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_EXECUTION_REGION_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "sfo1"
+ */
+export const VERCEL_EXECUTION_REGION = 'vercel.execution_region';
+
+/**
+ * Type for {@link VERCEL_EXECUTION_REGION} vercel.execution_region
+ */
+export type VERCEL_EXECUTION_REGION_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__id.json
+
+/**
+ * Unique identifier for the log entry in Vercel `vercel.id`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "1573817187330377061717300000"
+ */
+export const VERCEL_ID = 'vercel.id';
+
+/**
+ * Type for {@link VERCEL_ID} vercel.id
+ */
+export type VERCEL_ID_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__ja3_digest.json
+
+/**
+ * JA3 fingerprint digest of Vercel request `vercel.ja3_digest`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_JA3_DIGEST_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0"
+ */
+export const VERCEL_JA3_DIGEST = 'vercel.ja3_digest';
+
+/**
+ * Type for {@link VERCEL_JA3_DIGEST} vercel.ja3_digest
+ */
+export type VERCEL_JA3_DIGEST_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__ja4_digest.json
+
+/**
+ * JA4 fingerprint digest `vercel.ja4_digest`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_JA4_DIGEST_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "t13d1516h2_8daaf6152771_02713d6af862"
+ */
+export const VERCEL_JA4_DIGEST = 'vercel.ja4_digest';
+
+/**
+ * Type for {@link VERCEL_JA4_DIGEST} vercel.ja4_digest
+ */
+export type VERCEL_JA4_DIGEST_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__log_type.json
+
+/**
+ * Vercel log output type `vercel.log_type`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_LOG_TYPE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "stdout"
+ */
+export const VERCEL_LOG_TYPE = 'vercel.log_type';
+
+/**
+ * Type for {@link VERCEL_LOG_TYPE} vercel.log_type
+ */
+export type VERCEL_LOG_TYPE_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__project_id.json
+
+/**
+ * Identifier for the Vercel project `vercel.project_id`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROJECT_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "gdufoJxB6b9b1fEqr1jUtFkyavUU"
+ */
+export const VERCEL_PROJECT_ID = 'vercel.project_id';
+
+/**
+ * Type for {@link VERCEL_PROJECT_ID} vercel.project_id
+ */
+export type VERCEL_PROJECT_ID_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__project_name.json
+
+/**
+ * Name of the Vercel project `vercel.project_name`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROJECT_NAME_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "my-app"
+ */
+export const VERCEL_PROJECT_NAME = 'vercel.project_name';
+
+/**
+ * Type for {@link VERCEL_PROJECT_NAME} vercel.project_name
+ */
+export type VERCEL_PROJECT_NAME_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__cache_id.json
+
+/**
+ * Original request ID when request is served from cache `vercel.proxy.cache_id`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_CACHE_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "pdx1::v8g4b-1744143786684-93dafbc0f70d"
+ */
+export const VERCEL_PROXY_CACHE_ID = 'vercel.proxy.cache_id';
+
+/**
+ * Type for {@link VERCEL_PROXY_CACHE_ID} vercel.proxy.cache_id
+ */
+export type VERCEL_PROXY_CACHE_ID_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__client_ip.json
+
+/**
+ * Client IP address `vercel.proxy.client_ip`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_CLIENT_IP_TYPE}
+ *
+ * Contains PII: true
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "120.75.16.101"
+ */
+export const VERCEL_PROXY_CLIENT_IP = 'vercel.proxy.client_ip';
+
+/**
+ * Type for {@link VERCEL_PROXY_CLIENT_IP} vercel.proxy.client_ip
+ */
+export type VERCEL_PROXY_CLIENT_IP_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__host.json
+
+/**
+ * Hostname of the request `vercel.proxy.host`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_HOST_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "test.vercel.app"
+ */
+export const VERCEL_PROXY_HOST = 'vercel.proxy.host';
+
+/**
+ * Type for {@link VERCEL_PROXY_HOST} vercel.proxy.host
+ */
+export type VERCEL_PROXY_HOST_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__lambda_region.json
+
+/**
+ * Region where lambda function executed `vercel.proxy.lambda_region`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_LAMBDA_REGION_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "sfo1"
+ */
+export const VERCEL_PROXY_LAMBDA_REGION = 'vercel.proxy.lambda_region';
+
+/**
+ * Type for {@link VERCEL_PROXY_LAMBDA_REGION} vercel.proxy.lambda_region
+ */
+export type VERCEL_PROXY_LAMBDA_REGION_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__method.json
+
+/**
+ * HTTP method of the request `vercel.proxy.method`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_METHOD_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "GET"
+ */
+export const VERCEL_PROXY_METHOD = 'vercel.proxy.method';
+
+/**
+ * Type for {@link VERCEL_PROXY_METHOD} vercel.proxy.method
+ */
+export type VERCEL_PROXY_METHOD_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__path.json
+
+/**
+ * Request path with query parameters `vercel.proxy.path`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_PATH_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "/dynamic/some-value.json?route=some-value"
+ */
+export const VERCEL_PROXY_PATH = 'vercel.proxy.path';
+
+/**
+ * Type for {@link VERCEL_PROXY_PATH} vercel.proxy.path
+ */
+export type VERCEL_PROXY_PATH_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__path_type.json
+
+/**
+ * How the request was served based on its path and project configuration `vercel.proxy.path_type`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_PATH_TYPE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "func"
+ */
+export const VERCEL_PROXY_PATH_TYPE = 'vercel.proxy.path_type';
+
+/**
+ * Type for {@link VERCEL_PROXY_PATH_TYPE} vercel.proxy.path_type
+ */
+export type VERCEL_PROXY_PATH_TYPE_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__path_type_variant.json
+
+/**
+ * Variant of the path type `vercel.proxy.path_type_variant`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_PATH_TYPE_VARIANT_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "api"
+ */
+export const VERCEL_PROXY_PATH_TYPE_VARIANT = 'vercel.proxy.path_type_variant';
+
+/**
+ * Type for {@link VERCEL_PROXY_PATH_TYPE_VARIANT} vercel.proxy.path_type_variant
+ */
+export type VERCEL_PROXY_PATH_TYPE_VARIANT_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__referer.json
+
+/**
+ * Referer of the request `vercel.proxy.referer`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_REFERER_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "*.vercel.app"
+ */
+export const VERCEL_PROXY_REFERER = 'vercel.proxy.referer';
+
+/**
+ * Type for {@link VERCEL_PROXY_REFERER} vercel.proxy.referer
+ */
+export type VERCEL_PROXY_REFERER_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__region.json
+
+/**
+ * Region where the request is processed `vercel.proxy.region`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_REGION_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "sfo1"
+ */
+export const VERCEL_PROXY_REGION = 'vercel.proxy.region';
+
+/**
+ * Type for {@link VERCEL_PROXY_REGION} vercel.proxy.region
+ */
+export type VERCEL_PROXY_REGION_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__response_byte_size.json
+
+/**
+ * Size of the response in bytes `vercel.proxy.response_byte_size`
+ *
+ * Attribute Value Type: `number` {@link VERCEL_PROXY_RESPONSE_BYTE_SIZE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 1024
+ */
+export const VERCEL_PROXY_RESPONSE_BYTE_SIZE = 'vercel.proxy.response_byte_size';
+
+/**
+ * Type for {@link VERCEL_PROXY_RESPONSE_BYTE_SIZE} vercel.proxy.response_byte_size
+ */
+export type VERCEL_PROXY_RESPONSE_BYTE_SIZE_TYPE = number;
+
+// Path: model/attributes/vercel/vercel__proxy__scheme.json
+
+/**
+ * Protocol of the request `vercel.proxy.scheme`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_SCHEME_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "https"
+ */
+export const VERCEL_PROXY_SCHEME = 'vercel.proxy.scheme';
+
+/**
+ * Type for {@link VERCEL_PROXY_SCHEME} vercel.proxy.scheme
+ */
+export type VERCEL_PROXY_SCHEME_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__status_code.json
+
+/**
+ * HTTP status code of the proxy request `vercel.proxy.status_code`
+ *
+ * Attribute Value Type: `number` {@link VERCEL_PROXY_STATUS_CODE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 200
+ */
+export const VERCEL_PROXY_STATUS_CODE = 'vercel.proxy.status_code';
+
+/**
+ * Type for {@link VERCEL_PROXY_STATUS_CODE} vercel.proxy.status_code
+ */
+export type VERCEL_PROXY_STATUS_CODE_TYPE = number;
+
+// Path: model/attributes/vercel/vercel__proxy__timestamp.json
+
+/**
+ * Unix timestamp when the proxy request was made `vercel.proxy.timestamp`
+ *
+ * Attribute Value Type: `number` {@link VERCEL_PROXY_TIMESTAMP_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 1573817250172
+ */
+export const VERCEL_PROXY_TIMESTAMP = 'vercel.proxy.timestamp';
+
+/**
+ * Type for {@link VERCEL_PROXY_TIMESTAMP} vercel.proxy.timestamp
+ */
+export type VERCEL_PROXY_TIMESTAMP_TYPE = number;
+
+// Path: model/attributes/vercel/vercel__proxy__user_agent.json
+
+/**
+ * User agent strings of the request `vercel.proxy.user_agent`
+ *
+ * Attribute Value Type: `Array<string>` {@link VERCEL_PROXY_USER_AGENT_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example ["Mozilla/5.0..."]
+ */
+export const VERCEL_PROXY_USER_AGENT = 'vercel.proxy.user_agent';
+
+/**
+ * Type for {@link VERCEL_PROXY_USER_AGENT} vercel.proxy.user_agent
+ */
+export type VERCEL_PROXY_USER_AGENT_TYPE = Array<string>;
+
+// Path: model/attributes/vercel/vercel__proxy__vercel_cache.json
+
+/**
+ * Cache status sent to the browser `vercel.proxy.vercel_cache`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_VERCEL_CACHE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "REVALIDATED"
+ */
+export const VERCEL_PROXY_VERCEL_CACHE = 'vercel.proxy.vercel_cache';
+
+/**
+ * Type for {@link VERCEL_PROXY_VERCEL_CACHE} vercel.proxy.vercel_cache
+ */
+export type VERCEL_PROXY_VERCEL_CACHE_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__vercel_id.json
+
+/**
+ * Vercel-specific identifier `vercel.proxy.vercel_id`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_VERCEL_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "sfo1::abc123"
+ */
+export const VERCEL_PROXY_VERCEL_ID = 'vercel.proxy.vercel_id';
+
+/**
+ * Type for {@link VERCEL_PROXY_VERCEL_ID} vercel.proxy.vercel_id
+ */
+export type VERCEL_PROXY_VERCEL_ID_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__waf_action.json
+
+/**
+ * Action taken by firewall rules `vercel.proxy.waf_action`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_WAF_ACTION_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "deny"
+ */
+export const VERCEL_PROXY_WAF_ACTION = 'vercel.proxy.waf_action';
+
+/**
+ * Type for {@link VERCEL_PROXY_WAF_ACTION} vercel.proxy.waf_action
+ */
+export type VERCEL_PROXY_WAF_ACTION_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__proxy__waf_rule_id.json
+
+/**
+ * ID of the firewall rule that matched `vercel.proxy.waf_rule_id`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_PROXY_WAF_RULE_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "rule_gAHz8jtSB1Gy"
+ */
+export const VERCEL_PROXY_WAF_RULE_ID = 'vercel.proxy.waf_rule_id';
+
+/**
+ * Type for {@link VERCEL_PROXY_WAF_RULE_ID} vercel.proxy.waf_rule_id
+ */
+export type VERCEL_PROXY_WAF_RULE_ID_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__request_id.json
+
+/**
+ * Identifier of the Vercel request `vercel.request_id`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_REQUEST_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "643af4e3-975a-4cc7-9e7a-1eda11539d90"
+ */
+export const VERCEL_REQUEST_ID = 'vercel.request_id';
+
+/**
+ * Type for {@link VERCEL_REQUEST_ID} vercel.request_id
+ */
+export type VERCEL_REQUEST_ID_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__source.json
+
+/**
+ * Origin of the Vercel log (build, edge, lambda, static, external, or firewall) `vercel.source`
+ *
+ * Attribute Value Type: `string` {@link VERCEL_SOURCE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "build"
+ */
+export const VERCEL_SOURCE = 'vercel.source';
+
+/**
+ * Type for {@link VERCEL_SOURCE} vercel.source
+ */
+export type VERCEL_SOURCE_TYPE = string;
+
+// Path: model/attributes/vercel/vercel__status_code.json
+
+/**
+ * HTTP status code of the request (-1 means no response returned and the lambda crashed) `vercel.status_code`
+ *
+ * Attribute Value Type: `number` {@link VERCEL_STATUS_CODE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 200
+ */
+export const VERCEL_STATUS_CODE = 'vercel.status_code';
+
+/**
+ * Type for {@link VERCEL_STATUS_CODE} vercel.status_code
+ */
+export type VERCEL_STATUS_CODE_TYPE = number;
+
 export type AttributeValue = string | number | boolean | Array<string> | Array<number> | Array<boolean>;
 
 export type Attributes = {
@@ -7253,4 +7953,39 @@ export type Attributes = {
   [USER_NAME]?: USER_NAME_TYPE;
   [USER_ROLES]?: USER_ROLES_TYPE;
   [USER_AGENT_ORIGINAL]?: USER_AGENT_ORIGINAL_TYPE;
+  [VERCEL_BRANCH]?: VERCEL_BRANCH_TYPE;
+  [VERCEL_BUILD_ID]?: VERCEL_BUILD_ID_TYPE;
+  [VERCEL_DEPLOYMENT_ID]?: VERCEL_DEPLOYMENT_ID_TYPE;
+  [VERCEL_DESTINATION]?: VERCEL_DESTINATION_TYPE;
+  [VERCEL_EDGE_TYPE]?: VERCEL_EDGE_TYPE_TYPE;
+  [VERCEL_ENTRYPOINT]?: VERCEL_ENTRYPOINT_TYPE;
+  [VERCEL_EXECUTION_REGION]?: VERCEL_EXECUTION_REGION_TYPE;
+  [VERCEL_ID]?: VERCEL_ID_TYPE;
+  [VERCEL_JA3_DIGEST]?: VERCEL_JA3_DIGEST_TYPE;
+  [VERCEL_JA4_DIGEST]?: VERCEL_JA4_DIGEST_TYPE;
+  [VERCEL_LOG_TYPE]?: VERCEL_LOG_TYPE_TYPE;
+  [VERCEL_PROJECT_ID]?: VERCEL_PROJECT_ID_TYPE;
+  [VERCEL_PROJECT_NAME]?: VERCEL_PROJECT_NAME_TYPE;
+  [VERCEL_PROXY_CACHE_ID]?: VERCEL_PROXY_CACHE_ID_TYPE;
+  [VERCEL_PROXY_CLIENT_IP]?: VERCEL_PROXY_CLIENT_IP_TYPE;
+  [VERCEL_PROXY_HOST]?: VERCEL_PROXY_HOST_TYPE;
+  [VERCEL_PROXY_LAMBDA_REGION]?: VERCEL_PROXY_LAMBDA_REGION_TYPE;
+  [VERCEL_PROXY_METHOD]?: VERCEL_PROXY_METHOD_TYPE;
+  [VERCEL_PROXY_PATH]?: VERCEL_PROXY_PATH_TYPE;
+  [VERCEL_PROXY_PATH_TYPE]?: VERCEL_PROXY_PATH_TYPE_TYPE;
+  [VERCEL_PROXY_PATH_TYPE_VARIANT]?: VERCEL_PROXY_PATH_TYPE_VARIANT_TYPE;
+  [VERCEL_PROXY_REFERER]?: VERCEL_PROXY_REFERER_TYPE;
+  [VERCEL_PROXY_REGION]?: VERCEL_PROXY_REGION_TYPE;
+  [VERCEL_PROXY_RESPONSE_BYTE_SIZE]?: VERCEL_PROXY_RESPONSE_BYTE_SIZE_TYPE;
+  [VERCEL_PROXY_SCHEME]?: VERCEL_PROXY_SCHEME_TYPE;
+  [VERCEL_PROXY_STATUS_CODE]?: VERCEL_PROXY_STATUS_CODE_TYPE;
+  [VERCEL_PROXY_TIMESTAMP]?: VERCEL_PROXY_TIMESTAMP_TYPE;
+  [VERCEL_PROXY_USER_AGENT]?: VERCEL_PROXY_USER_AGENT_TYPE;
+  [VERCEL_PROXY_VERCEL_CACHE]?: VERCEL_PROXY_VERCEL_CACHE_TYPE;
+  [VERCEL_PROXY_VERCEL_ID]?: VERCEL_PROXY_VERCEL_ID_TYPE;
+  [VERCEL_PROXY_WAF_ACTION]?: VERCEL_PROXY_WAF_ACTION_TYPE;
+  [VERCEL_PROXY_WAF_RULE_ID]?: VERCEL_PROXY_WAF_RULE_ID_TYPE;
+  [VERCEL_REQUEST_ID]?: VERCEL_REQUEST_ID_TYPE;
+  [VERCEL_SOURCE]?: VERCEL_SOURCE_TYPE;
+  [VERCEL_STATUS_CODE]?: VERCEL_STATUS_CODE_TYPE;
 } & Record<string, AttributeValue | undefined>;

--- a/model/attributes/vercel/vercel__branch.json
+++ b/model/attributes/vercel/vercel__branch.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.branch",
+  "brief": "Git branch name for Vercel project",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "main"
+}

--- a/model/attributes/vercel/vercel__build_id.json
+++ b/model/attributes/vercel/vercel__build_id.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.build_id",
+  "brief": "Identifier for the Vercel build (only present on build logs)",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "bld_cotnkcr76"
+}

--- a/model/attributes/vercel/vercel__deployment_id.json
+++ b/model/attributes/vercel/vercel__deployment_id.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.deployment_id",
+  "brief": "Identifier for the Vercel deployment",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "dpl_233NRGRjVZX1caZrXWtz5g1TAksD"
+}

--- a/model/attributes/vercel/vercel__destination.json
+++ b/model/attributes/vercel/vercel__destination.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.destination",
+  "brief": "Origin of the external content in Vercel (only on external logs)",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "https://vitals.vercel-insights.com/v1"
+}

--- a/model/attributes/vercel/vercel__edge_type.json
+++ b/model/attributes/vercel/vercel__edge_type.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.edge_type",
+  "brief": "Type of edge runtime in Vercel",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "edge-function"
+}

--- a/model/attributes/vercel/vercel__entrypoint.json
+++ b/model/attributes/vercel/vercel__entrypoint.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.entrypoint",
+  "brief": "Entrypoint for the request in Vercel",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "api/index.js"
+}

--- a/model/attributes/vercel/vercel__execution_region.json
+++ b/model/attributes/vercel/vercel__execution_region.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.execution_region",
+  "brief": "Region where the request is executed",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "sfo1"
+}

--- a/model/attributes/vercel/vercel__id.json
+++ b/model/attributes/vercel/vercel__id.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.id",
+  "brief": "Unique identifier for the log entry in Vercel",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "1573817187330377061717300000"
+}

--- a/model/attributes/vercel/vercel__ja3_digest.json
+++ b/model/attributes/vercel/vercel__ja3_digest.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.ja3_digest",
+  "brief": "JA3 fingerprint digest of Vercel request",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0"
+}

--- a/model/attributes/vercel/vercel__ja4_digest.json
+++ b/model/attributes/vercel/vercel__ja4_digest.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.ja4_digest",
+  "brief": "JA4 fingerprint digest",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "t13d1516h2_8daaf6152771_02713d6af862"
+}

--- a/model/attributes/vercel/vercel__log_type.json
+++ b/model/attributes/vercel/vercel__log_type.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.log_type",
+  "brief": "Vercel log output type",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "stdout"
+}

--- a/model/attributes/vercel/vercel__project_id.json
+++ b/model/attributes/vercel/vercel__project_id.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.project_id",
+  "brief": "Identifier for the Vercel project",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "gdufoJxB6b9b1fEqr1jUtFkyavUU"
+}

--- a/model/attributes/vercel/vercel__project_name.json
+++ b/model/attributes/vercel/vercel__project_name.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.project_name",
+  "brief": "Name of the Vercel project",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "my-app"
+}

--- a/model/attributes/vercel/vercel__proxy__cache_id.json
+++ b/model/attributes/vercel/vercel__proxy__cache_id.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.cache_id",
+  "brief": "Original request ID when request is served from cache",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "pdx1::v8g4b-1744143786684-93dafbc0f70d"
+}

--- a/model/attributes/vercel/vercel__proxy__client_ip.json
+++ b/model/attributes/vercel/vercel__proxy__client_ip.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.client_ip",
+  "brief": "Client IP address",
+  "type": "string",
+  "pii": {
+    "key": "true"
+  },
+  "is_in_otel": false,
+  "example": "120.75.16.101"
+}

--- a/model/attributes/vercel/vercel__proxy__host.json
+++ b/model/attributes/vercel/vercel__proxy__host.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.host",
+  "brief": "Hostname of the request",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "test.vercel.app"
+}

--- a/model/attributes/vercel/vercel__proxy__lambda_region.json
+++ b/model/attributes/vercel/vercel__proxy__lambda_region.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.lambda_region",
+  "brief": "Region where lambda function executed",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "sfo1"
+}

--- a/model/attributes/vercel/vercel__proxy__method.json
+++ b/model/attributes/vercel/vercel__proxy__method.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.method",
+  "brief": "HTTP method of the request",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "GET"
+}

--- a/model/attributes/vercel/vercel__proxy__path.json
+++ b/model/attributes/vercel/vercel__proxy__path.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.path",
+  "brief": "Request path with query parameters",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "/dynamic/some-value.json?route=some-value"
+}

--- a/model/attributes/vercel/vercel__proxy__path_type.json
+++ b/model/attributes/vercel/vercel__proxy__path_type.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.path_type",
+  "brief": "How the request was served based on its path and project configuration",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "func"
+}

--- a/model/attributes/vercel/vercel__proxy__path_type_variant.json
+++ b/model/attributes/vercel/vercel__proxy__path_type_variant.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.path_type_variant",
+  "brief": "Variant of the path type",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "api"
+}

--- a/model/attributes/vercel/vercel__proxy__referer.json
+++ b/model/attributes/vercel/vercel__proxy__referer.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.referer",
+  "brief": "Referer of the request",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "*.vercel.app"
+}

--- a/model/attributes/vercel/vercel__proxy__region.json
+++ b/model/attributes/vercel/vercel__proxy__region.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.region",
+  "brief": "Region where the request is processed",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "sfo1"
+}

--- a/model/attributes/vercel/vercel__proxy__response_byte_size.json
+++ b/model/attributes/vercel/vercel__proxy__response_byte_size.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.response_byte_size",
+  "brief": "Size of the response in bytes",
+  "type": "integer",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": 1024
+}

--- a/model/attributes/vercel/vercel__proxy__scheme.json
+++ b/model/attributes/vercel/vercel__proxy__scheme.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.scheme",
+  "brief": "Protocol of the request",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "https"
+}

--- a/model/attributes/vercel/vercel__proxy__status_code.json
+++ b/model/attributes/vercel/vercel__proxy__status_code.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.status_code",
+  "brief": "HTTP status code of the proxy request",
+  "type": "integer",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": 200
+}

--- a/model/attributes/vercel/vercel__proxy__timestamp.json
+++ b/model/attributes/vercel/vercel__proxy__timestamp.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.timestamp",
+  "brief": "Unix timestamp when the proxy request was made",
+  "type": "integer",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": 1573817250172
+}

--- a/model/attributes/vercel/vercel__proxy__user_agent.json
+++ b/model/attributes/vercel/vercel__proxy__user_agent.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.user_agent",
+  "brief": "User agent strings of the request",
+  "type": "string[]",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": ["Mozilla/5.0..."]
+}

--- a/model/attributes/vercel/vercel__proxy__vercel_cache.json
+++ b/model/attributes/vercel/vercel__proxy__vercel_cache.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.vercel_cache",
+  "brief": "Cache status sent to the browser",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "REVALIDATED"
+}

--- a/model/attributes/vercel/vercel__proxy__vercel_id.json
+++ b/model/attributes/vercel/vercel__proxy__vercel_id.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.vercel_id",
+  "brief": "Vercel-specific identifier",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "sfo1::abc123"
+}

--- a/model/attributes/vercel/vercel__proxy__waf_action.json
+++ b/model/attributes/vercel/vercel__proxy__waf_action.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.waf_action",
+  "brief": "Action taken by firewall rules",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "deny"
+}

--- a/model/attributes/vercel/vercel__proxy__waf_rule_id.json
+++ b/model/attributes/vercel/vercel__proxy__waf_rule_id.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.proxy.waf_rule_id",
+  "brief": "ID of the firewall rule that matched",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "rule_gAHz8jtSB1Gy"
+}

--- a/model/attributes/vercel/vercel__request_id.json
+++ b/model/attributes/vercel/vercel__request_id.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.request_id",
+  "brief": "Identifier of the Vercel request",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "643af4e3-975a-4cc7-9e7a-1eda11539d90"
+}

--- a/model/attributes/vercel/vercel__source.json
+++ b/model/attributes/vercel/vercel__source.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.source",
+  "brief": "Origin of the Vercel log (build, edge, lambda, static, external, or firewall)",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "build"
+}

--- a/model/attributes/vercel/vercel__status_code.json
+++ b/model/attributes/vercel/vercel__status_code.json
@@ -1,0 +1,10 @@
+{
+  "key": "vercel.status_code",
+  "brief": "HTTP status code of the request (-1 means no response returned and the lambda crashed)",
+  "type": "integer",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": 200
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3849,6 +3849,374 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1"
     """
 
+    # Path: model/attributes/vercel/vercel__branch.json
+    VERCEL_BRANCH: Literal["vercel.branch"] = "vercel.branch"
+    """Git branch name for Vercel project
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "main"
+    """
+
+    # Path: model/attributes/vercel/vercel__build_id.json
+    VERCEL_BUILD_ID: Literal["vercel.build_id"] = "vercel.build_id"
+    """Identifier for the Vercel build (only present on build logs)
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "bld_cotnkcr76"
+    """
+
+    # Path: model/attributes/vercel/vercel__deployment_id.json
+    VERCEL_DEPLOYMENT_ID: Literal["vercel.deployment_id"] = "vercel.deployment_id"
+    """Identifier for the Vercel deployment
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "dpl_233NRGRjVZX1caZrXWtz5g1TAksD"
+    """
+
+    # Path: model/attributes/vercel/vercel__destination.json
+    VERCEL_DESTINATION: Literal["vercel.destination"] = "vercel.destination"
+    """Origin of the external content in Vercel (only on external logs)
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "https://vitals.vercel-insights.com/v1"
+    """
+
+    # Path: model/attributes/vercel/vercel__edge_type.json
+    VERCEL_EDGE_TYPE: Literal["vercel.edge_type"] = "vercel.edge_type"
+    """Type of edge runtime in Vercel
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "edge-function"
+    """
+
+    # Path: model/attributes/vercel/vercel__entrypoint.json
+    VERCEL_ENTRYPOINT: Literal["vercel.entrypoint"] = "vercel.entrypoint"
+    """Entrypoint for the request in Vercel
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "api/index.js"
+    """
+
+    # Path: model/attributes/vercel/vercel__execution_region.json
+    VERCEL_EXECUTION_REGION: Literal["vercel.execution_region"] = (
+        "vercel.execution_region"
+    )
+    """Region where the request is executed
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "sfo1"
+    """
+
+    # Path: model/attributes/vercel/vercel__id.json
+    VERCEL_ID: Literal["vercel.id"] = "vercel.id"
+    """Unique identifier for the log entry in Vercel
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "1573817187330377061717300000"
+    """
+
+    # Path: model/attributes/vercel/vercel__ja3_digest.json
+    VERCEL_JA3_DIGEST: Literal["vercel.ja3_digest"] = "vercel.ja3_digest"
+    """JA3 fingerprint digest of Vercel request
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0"
+    """
+
+    # Path: model/attributes/vercel/vercel__ja4_digest.json
+    VERCEL_JA4_DIGEST: Literal["vercel.ja4_digest"] = "vercel.ja4_digest"
+    """JA4 fingerprint digest
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "t13d1516h2_8daaf6152771_02713d6af862"
+    """
+
+    # Path: model/attributes/vercel/vercel__log_type.json
+    VERCEL_LOG_TYPE: Literal["vercel.log_type"] = "vercel.log_type"
+    """Vercel log output type
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "stdout"
+    """
+
+    # Path: model/attributes/vercel/vercel__project_id.json
+    VERCEL_PROJECT_ID: Literal["vercel.project_id"] = "vercel.project_id"
+    """Identifier for the Vercel project
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "gdufoJxB6b9b1fEqr1jUtFkyavUU"
+    """
+
+    # Path: model/attributes/vercel/vercel__project_name.json
+    VERCEL_PROJECT_NAME: Literal["vercel.project_name"] = "vercel.project_name"
+    """Name of the Vercel project
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "my-app"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__cache_id.json
+    VERCEL_PROXY_CACHE_ID: Literal["vercel.proxy.cache_id"] = "vercel.proxy.cache_id"
+    """Original request ID when request is served from cache
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "pdx1::v8g4b-1744143786684-93dafbc0f70d"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__client_ip.json
+    VERCEL_PROXY_CLIENT_IP: Literal["vercel.proxy.client_ip"] = "vercel.proxy.client_ip"
+    """Client IP address
+
+    Type: str
+    Contains PII: true
+    Defined in OTEL: No
+    Example: "120.75.16.101"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__host.json
+    VERCEL_PROXY_HOST: Literal["vercel.proxy.host"] = "vercel.proxy.host"
+    """Hostname of the request
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "test.vercel.app"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__lambda_region.json
+    VERCEL_PROXY_LAMBDA_REGION: Literal["vercel.proxy.lambda_region"] = (
+        "vercel.proxy.lambda_region"
+    )
+    """Region where lambda function executed
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "sfo1"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__method.json
+    VERCEL_PROXY_METHOD: Literal["vercel.proxy.method"] = "vercel.proxy.method"
+    """HTTP method of the request
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "GET"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__path.json
+    VERCEL_PROXY_PATH: Literal["vercel.proxy.path"] = "vercel.proxy.path"
+    """Request path with query parameters
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "/dynamic/some-value.json?route=some-value"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__path_type.json
+    VERCEL_PROXY_PATH_TYPE: Literal["vercel.proxy.path_type"] = "vercel.proxy.path_type"
+    """How the request was served based on its path and project configuration
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "func"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__path_type_variant.json
+    VERCEL_PROXY_PATH_TYPE_VARIANT: Literal["vercel.proxy.path_type_variant"] = (
+        "vercel.proxy.path_type_variant"
+    )
+    """Variant of the path type
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "api"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__referer.json
+    VERCEL_PROXY_REFERER: Literal["vercel.proxy.referer"] = "vercel.proxy.referer"
+    """Referer of the request
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "*.vercel.app"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__region.json
+    VERCEL_PROXY_REGION: Literal["vercel.proxy.region"] = "vercel.proxy.region"
+    """Region where the request is processed
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "sfo1"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__response_byte_size.json
+    VERCEL_PROXY_RESPONSE_BYTE_SIZE: Literal["vercel.proxy.response_byte_size"] = (
+        "vercel.proxy.response_byte_size"
+    )
+    """Size of the response in bytes
+
+    Type: int
+    Contains PII: false
+    Defined in OTEL: No
+    Example: 1024
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__scheme.json
+    VERCEL_PROXY_SCHEME: Literal["vercel.proxy.scheme"] = "vercel.proxy.scheme"
+    """Protocol of the request
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "https"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__status_code.json
+    VERCEL_PROXY_STATUS_CODE: Literal["vercel.proxy.status_code"] = (
+        "vercel.proxy.status_code"
+    )
+    """HTTP status code of the proxy request
+
+    Type: int
+    Contains PII: false
+    Defined in OTEL: No
+    Example: 200
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__timestamp.json
+    VERCEL_PROXY_TIMESTAMP: Literal["vercel.proxy.timestamp"] = "vercel.proxy.timestamp"
+    """Unix timestamp when the proxy request was made
+
+    Type: int
+    Contains PII: false
+    Defined in OTEL: No
+    Example: 1573817250172
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__user_agent.json
+    VERCEL_PROXY_USER_AGENT: Literal["vercel.proxy.user_agent"] = (
+        "vercel.proxy.user_agent"
+    )
+    """User agent strings of the request
+
+    Type: List[str]
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: ["Mozilla/5.0..."]
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__vercel_cache.json
+    VERCEL_PROXY_VERCEL_CACHE: Literal["vercel.proxy.vercel_cache"] = (
+        "vercel.proxy.vercel_cache"
+    )
+    """Cache status sent to the browser
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "REVALIDATED"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__vercel_id.json
+    VERCEL_PROXY_VERCEL_ID: Literal["vercel.proxy.vercel_id"] = "vercel.proxy.vercel_id"
+    """Vercel-specific identifier
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "sfo1::abc123"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__waf_action.json
+    VERCEL_PROXY_WAF_ACTION: Literal["vercel.proxy.waf_action"] = (
+        "vercel.proxy.waf_action"
+    )
+    """Action taken by firewall rules
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "deny"
+    """
+
+    # Path: model/attributes/vercel/vercel__proxy__waf_rule_id.json
+    VERCEL_PROXY_WAF_RULE_ID: Literal["vercel.proxy.waf_rule_id"] = (
+        "vercel.proxy.waf_rule_id"
+    )
+    """ID of the firewall rule that matched
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "rule_gAHz8jtSB1Gy"
+    """
+
+    # Path: model/attributes/vercel/vercel__request_id.json
+    VERCEL_REQUEST_ID: Literal["vercel.request_id"] = "vercel.request_id"
+    """Identifier of the Vercel request
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "643af4e3-975a-4cc7-9e7a-1eda11539d90"
+    """
+
+    # Path: model/attributes/vercel/vercel__source.json
+    VERCEL_SOURCE: Literal["vercel.source"] = "vercel.source"
+    """Origin of the Vercel log (build, edge, lambda, static, external, or firewall)
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "build"
+    """
+
+    # Path: model/attributes/vercel/vercel__status_code.json
+    VERCEL_STATUS_CODE: Literal["vercel.status_code"] = "vercel.status_code"
+    """HTTP status code of the request (-1 means no response returned and the lambda crashed)
+
+    Type: int
+    Contains PII: false
+    Defined in OTEL: No
+    Example: 200
+    """
+
 
 _ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "ai.citations": AttributeMetadata(
@@ -6468,6 +6836,251 @@ _ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1",
         aliases=["http.user_agent"],
     ),
+    "vercel.branch": AttributeMetadata(
+        brief="Git branch name for Vercel project",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="main",
+    ),
+    "vercel.build_id": AttributeMetadata(
+        brief="Identifier for the Vercel build (only present on build logs)",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="bld_cotnkcr76",
+    ),
+    "vercel.deployment_id": AttributeMetadata(
+        brief="Identifier for the Vercel deployment",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="dpl_233NRGRjVZX1caZrXWtz5g1TAksD",
+    ),
+    "vercel.destination": AttributeMetadata(
+        brief="Origin of the external content in Vercel (only on external logs)",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="https://vitals.vercel-insights.com/v1",
+    ),
+    "vercel.edge_type": AttributeMetadata(
+        brief="Type of edge runtime in Vercel",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="edge-function",
+    ),
+    "vercel.entrypoint": AttributeMetadata(
+        brief="Entrypoint for the request in Vercel",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="api/index.js",
+    ),
+    "vercel.execution_region": AttributeMetadata(
+        brief="Region where the request is executed",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="sfo1",
+    ),
+    "vercel.id": AttributeMetadata(
+        brief="Unique identifier for the log entry in Vercel",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="1573817187330377061717300000",
+    ),
+    "vercel.ja3_digest": AttributeMetadata(
+        brief="JA3 fingerprint digest of Vercel request",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0",
+    ),
+    "vercel.ja4_digest": AttributeMetadata(
+        brief="JA4 fingerprint digest",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="t13d1516h2_8daaf6152771_02713d6af862",
+    ),
+    "vercel.log_type": AttributeMetadata(
+        brief="Vercel log output type",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="stdout",
+    ),
+    "vercel.project_id": AttributeMetadata(
+        brief="Identifier for the Vercel project",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="gdufoJxB6b9b1fEqr1jUtFkyavUU",
+    ),
+    "vercel.project_name": AttributeMetadata(
+        brief="Name of the Vercel project",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="my-app",
+    ),
+    "vercel.proxy.cache_id": AttributeMetadata(
+        brief="Original request ID when request is served from cache",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="pdx1::v8g4b-1744143786684-93dafbc0f70d",
+    ),
+    "vercel.proxy.client_ip": AttributeMetadata(
+        brief="Client IP address",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.TRUE),
+        is_in_otel=False,
+        example="120.75.16.101",
+    ),
+    "vercel.proxy.host": AttributeMetadata(
+        brief="Hostname of the request",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="test.vercel.app",
+    ),
+    "vercel.proxy.lambda_region": AttributeMetadata(
+        brief="Region where lambda function executed",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="sfo1",
+    ),
+    "vercel.proxy.method": AttributeMetadata(
+        brief="HTTP method of the request",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="GET",
+    ),
+    "vercel.proxy.path": AttributeMetadata(
+        brief="Request path with query parameters",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="/dynamic/some-value.json?route=some-value",
+    ),
+    "vercel.proxy.path_type": AttributeMetadata(
+        brief="How the request was served based on its path and project configuration",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="func",
+    ),
+    "vercel.proxy.path_type_variant": AttributeMetadata(
+        brief="Variant of the path type",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="api",
+    ),
+    "vercel.proxy.referer": AttributeMetadata(
+        brief="Referer of the request",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="*.vercel.app",
+    ),
+    "vercel.proxy.region": AttributeMetadata(
+        brief="Region where the request is processed",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="sfo1",
+    ),
+    "vercel.proxy.response_byte_size": AttributeMetadata(
+        brief="Size of the response in bytes",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example=1024,
+    ),
+    "vercel.proxy.scheme": AttributeMetadata(
+        brief="Protocol of the request",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="https",
+    ),
+    "vercel.proxy.status_code": AttributeMetadata(
+        brief="HTTP status code of the proxy request",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example=200,
+    ),
+    "vercel.proxy.timestamp": AttributeMetadata(
+        brief="Unix timestamp when the proxy request was made",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example=1573817250172,
+    ),
+    "vercel.proxy.user_agent": AttributeMetadata(
+        brief="User agent strings of the request",
+        type=AttributeType.STRING_ARRAY,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=["Mozilla/5.0..."],
+    ),
+    "vercel.proxy.vercel_cache": AttributeMetadata(
+        brief="Cache status sent to the browser",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="REVALIDATED",
+    ),
+    "vercel.proxy.vercel_id": AttributeMetadata(
+        brief="Vercel-specific identifier",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="sfo1::abc123",
+    ),
+    "vercel.proxy.waf_action": AttributeMetadata(
+        brief="Action taken by firewall rules",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="deny",
+    ),
+    "vercel.proxy.waf_rule_id": AttributeMetadata(
+        brief="ID of the firewall rule that matched",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="rule_gAHz8jtSB1Gy",
+    ),
+    "vercel.request_id": AttributeMetadata(
+        brief="Identifier of the Vercel request",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="643af4e3-975a-4cc7-9e7a-1eda11539d90",
+    ),
+    "vercel.source": AttributeMetadata(
+        brief="Origin of the Vercel log (build, edge, lambda, static, external, or firewall)",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="build",
+    ),
+    "vercel.status_code": AttributeMetadata(
+        brief="HTTP status code of the request (-1 means no response returned and the lambda crashed)",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example=200,
+    ),
 }
 
 """
@@ -6808,6 +7421,41 @@ Attributes = TypedDict(
         "user.name": str,
         "user.roles": List[str],
         "user_agent.original": str,
+        "vercel.branch": str,
+        "vercel.build_id": str,
+        "vercel.deployment_id": str,
+        "vercel.destination": str,
+        "vercel.edge_type": str,
+        "vercel.entrypoint": str,
+        "vercel.execution_region": str,
+        "vercel.id": str,
+        "vercel.ja3_digest": str,
+        "vercel.ja4_digest": str,
+        "vercel.log_type": str,
+        "vercel.project_id": str,
+        "vercel.project_name": str,
+        "vercel.proxy.cache_id": str,
+        "vercel.proxy.client_ip": str,
+        "vercel.proxy.host": str,
+        "vercel.proxy.lambda_region": str,
+        "vercel.proxy.method": str,
+        "vercel.proxy.path": str,
+        "vercel.proxy.path_type": str,
+        "vercel.proxy.path_type_variant": str,
+        "vercel.proxy.referer": str,
+        "vercel.proxy.region": str,
+        "vercel.proxy.response_byte_size": int,
+        "vercel.proxy.scheme": str,
+        "vercel.proxy.status_code": int,
+        "vercel.proxy.timestamp": int,
+        "vercel.proxy.user_agent": List[str],
+        "vercel.proxy.vercel_cache": str,
+        "vercel.proxy.vercel_id": str,
+        "vercel.proxy.waf_action": str,
+        "vercel.proxy.waf_rule_id": str,
+        "vercel.request_id": str,
+        "vercel.source": str,
+        "vercel.status_code": int,
     },
     total=False,
 )


### PR DESCRIPTION
resolves https://linear.app/getsentry/issue/LOGS-388/document-vercel-log-drain-attributes-in-conventions

This PR adds a set of attributes to the conventions for attributes that we'll generate in the upcoming vercel log drain endpoint.

These attributes are created when we map the vercel log schema to the sentry schema and attributes as relevant. See this notion doc for details about the schema and the transform: https://www.notion.so/sentry/Vercel-Log-Drain-2808b10e4b5d808c95f3ebcfe2b8828a.

Most attribute keys here align in naming as per https://vercel.com/docs/drains/reference/logs. There are some fields in the vercel log drain schema that don't show up in this PR. These are:

1. `timestamp`, which is mapped directly to the log timestamp
2. `level` which is mapped directly to the log level
3. `message` which is mapped directly to the log body