### PR TITLE
meta: Fix changelog to say "0.2.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.2.0
 
 ### Features
 


### PR DESCRIPTION
Craft complains about not finding the "0.2.0" section, this is because we're using `changelogPolicy: simple`. With this policy, `Unreleased` won't cut it, it appears you need to specify the version explicitly.
I intend to change this with https://github.com/getsentry/sentry-conventions/pull/169.
For now we'll need to specify `0.2.0` in order to be able to release.