### PR TITLE
ci: Fix "Check for changes" step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,18 +42,18 @@ jobs:
         run: yarn lint
   
       - name: Check for changes
+        if: matrix.os == 'ubuntu-latest'
         id: verify-changed-files
-        shell: pwsh
         run: |
-          $changes = git status --porcelain
-          if ($changes) {
-            Write-Host "::error::Uncommitted changes found after build/script execution. Failing job."
+          changes=$(git status --porcelain)
+          if [ -n "$changes" ]; then
+            echo "Uncommitted changes found after build/script execution. Failing job."
             git status
             exit 1
-          } else {
-            Write-Host "Working tree is clean. No uncommitted changes found."
+          else
+            echo "Working tree is clean. No uncommitted changes found."
             exit 0
-          }
+          fi
 
   build:
     name: Build


### PR DESCRIPTION
This step was intended to check for changes in the files tracked by git. This PR solves a couple issues with it:
- Fix a logic error: we should check the output to detect changes, not the exit code
- Only run this on `ubuntu-latest`: looks like biome would apply different formatting on Windows (maybe due to newlines and such things), so let's just run the check for changed files only on Ubuntu. We'll still be running the linting step on Windows but just not checking for changes.