### PR TITLE
ref(internal): Remove sentry._internal from conventions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,6 @@
 
 If an attribute was added:
 - [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
-- [ ] I've used the `sentry._internal` namespace if the attribute should not be visibile to end-users
 - [ ] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)
 
 If an attribute was deprecated:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,6 @@ After you edit an attribute or add a new one, you should run `yarn run generate 
 
 Here's a list of policies that any newly added attributes MUST follow. Most of these are automatically enforced by the test suite.
 - The attribute MUST be namespaced. Example: `nextjs.function_id`, not `function_id`.
-- If the attribute shall not be visibile by end users, it MUST be in the `sentry._internal` namespace.
 - The `pii` field in the attribute definition MUST be `maybe` or `true` (if the attribute can contain sensitive data). It SHOULD be `false` only if scrubbing the attribute value for PII would potentially break product features. For example, `sentry.replay_id` should have `pii` set to `false`.
 - When an attribute is added that deprecates an old one:
   - The old one should be marked as deprecated, and it MUST point to the new one using the `deprecation.replacement` field.

--- a/generated/attributes/sentry.md
+++ b/generated/attributes/sentry.md
@@ -3,20 +3,19 @@
 # Sentry Attributes
 
 - [Stable Attributes](#stable-attributes)
-  - [sentry._internal.dsc.environment](#sentry_internaldscenvironment)
-  - [sentry._internal.dsc.org_id](#sentry_internaldscorg_id)
-  - [sentry._internal.dsc.public_key](#sentry_internaldscpublic_key)
-  - [sentry._internal.dsc.release](#sentry_internaldscrelease)
-  - [sentry._internal.dsc.sample_rand](#sentry_internaldscsample_rand)
-  - [sentry._internal.dsc.sample_rate](#sentry_internaldscsample_rate)
-  - [sentry._internal.dsc.sampled](#sentry_internaldscsampled)
-  - [sentry._internal.dsc.trace_id](#sentry_internaldsctrace_id)
-  - [sentry._internal.dsc.transaction](#sentry_internaldsctransaction)
-  - [sentry._internal.replay_is_buffering](#sentry_internalreplay_is_buffering)
   - [sentry.cancellation_reason](#sentrycancellation_reason)
   - [sentry.client_sample_rate](#sentryclient_sample_rate)
   - [sentry.description](#sentrydescription)
   - [sentry.dist](#sentrydist)
+  - [sentry.dsc.environment](#sentrydscenvironment)
+  - [sentry.dsc.org_id](#sentrydscorg_id)
+  - [sentry.dsc.public_key](#sentrydscpublic_key)
+  - [sentry.dsc.release](#sentrydscrelease)
+  - [sentry.dsc.sample_rand](#sentrydscsample_rand)
+  - [sentry.dsc.sample_rate](#sentrydscsample_rate)
+  - [sentry.dsc.sampled](#sentrydscsampled)
+  - [sentry.dsc.trace_id](#sentrydsctrace_id)
+  - [sentry.dsc.transaction](#sentrydsctransaction)
   - [sentry.environment](#sentryenvironment)
   - [sentry.exclusive_time](#sentryexclusive_time)
   - [sentry.http.prefetch](#sentryhttpprefetch)
@@ -33,6 +32,7 @@
   - [sentry.profile_id](#sentryprofile_id)
   - [sentry.release](#sentryrelease)
   - [sentry.replay_id](#sentryreplay_id)
+  - [sentry.replay_is_buffering](#sentryreplay_is_buffering)
   - [sentry.sdk.integrations](#sentrysdkintegrations)
   - [sentry.sdk.name](#sentrysdkname)
   - [sentry.sdk.version](#sentrysdkversion)
@@ -48,116 +48,6 @@
   - [sentry.segment_id](#sentrysegment_id)
 
 ## Stable Attributes
-
-### sentry._internal.dsc.environment
-
-The environment from the dynamic sampling context.
-
-| Property | Value |
-| --- | --- |
-| Type | `string` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `prod` |
-
-### sentry._internal.dsc.org_id
-
-The organization ID from the dynamic sampling context.
-
-| Property | Value |
-| --- | --- |
-| Type | `string` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `1` |
-
-### sentry._internal.dsc.public_key
-
-The public key from the dynamic sampling context.
-
-| Property | Value |
-| --- | --- |
-| Type | `string` |
-| Has PII | maybe |
-| Exists in OpenTelemetry | No |
-| Example | `c51734c603c4430eb57cb0a5728a479d` |
-
-### sentry._internal.dsc.release
-
-The release identifier from the dynamic sampling context.
-
-| Property | Value |
-| --- | --- |
-| Type | `string` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `frontend@e8211be71b214afab5b85de4b4c54be3714952bb` |
-
-### sentry._internal.dsc.sample_rand
-
-The random sampling value from the dynamic sampling context.
-
-| Property | Value |
-| --- | --- |
-| Type | `string` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `0.8286147972820134` |
-
-### sentry._internal.dsc.sample_rate
-
-The sample rate from the dynamic sampling context.
-
-| Property | Value |
-| --- | --- |
-| Type | `string` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `1.0` |
-
-### sentry._internal.dsc.sampled
-
-Whether the event was sampled according to the dynamic sampling context.
-
-| Property | Value |
-| --- | --- |
-| Type | `boolean` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `true` |
-
-### sentry._internal.dsc.trace_id
-
-The trace ID from the dynamic sampling context.
-
-| Property | Value |
-| --- | --- |
-| Type | `string` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `047372980460430cbc78d9779df33a46` |
-
-### sentry._internal.dsc.transaction
-
-The transaction name from the dynamic sampling context.
-
-| Property | Value |
-| --- | --- |
-| Type | `string` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `/issues/errors-outages/` |
-
-### sentry._internal.replay_is_buffering
-
-A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate).
-
-| Property | Value |
-| --- | --- |
-| Type | `boolean` |
-| Has PII | false |
-| Exists in OpenTelemetry | No |
-| Example | `true` |
 
 ### sentry.cancellation_reason
 
@@ -202,6 +92,105 @@ The sentry dist.
 | Has PII | false |
 | Exists in OpenTelemetry | No |
 | Example | `1.0` |
+
+### sentry.dsc.environment
+
+The environment from the dynamic sampling context.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `prod` |
+
+### sentry.dsc.org_id
+
+The organization ID from the dynamic sampling context.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `1` |
+
+### sentry.dsc.public_key
+
+The public key from the dynamic sampling context.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `c51734c603c4430eb57cb0a5728a479d` |
+
+### sentry.dsc.release
+
+The release identifier from the dynamic sampling context.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `frontend@e8211be71b214afab5b85de4b4c54be3714952bb` |
+
+### sentry.dsc.sample_rand
+
+The random sampling value from the dynamic sampling context.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `0.8286147972820134` |
+
+### sentry.dsc.sample_rate
+
+The sample rate from the dynamic sampling context.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `1.0` |
+
+### sentry.dsc.sampled
+
+Whether the event was sampled according to the dynamic sampling context.
+
+| Property | Value |
+| --- | --- |
+| Type | `boolean` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `true` |
+
+### sentry.dsc.trace_id
+
+The trace ID from the dynamic sampling context.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `047372980460430cbc78d9779df33a46` |
+
+### sentry.dsc.transaction
+
+The transaction name from the dynamic sampling context.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `/issues/errors-outages/` |
 
 ### sentry.environment
 
@@ -383,6 +372,17 @@ The id of the sentry replay.
 | Exists in OpenTelemetry | No |
 | Example | `123e4567e89b12d3a456426614174000` |
 | Aliases | `replay_id` |
+
+### sentry.replay_is_buffering
+
+A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate).
+
+| Property | Value |
+| --- | --- |
+| Type | `boolean` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `true` |
 
 ### sentry.sdk.integrations
 

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -6258,6 +6258,186 @@ export const SENTRY_DIST = 'sentry.dist';
  */
 export type SENTRY_DIST_TYPE = string;
 
+// Path: model/attributes/sentry/sentry__dsc__environment.json
+
+/**
+ * The environment from the dynamic sampling context. `sentry.dsc.environment`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_DSC_ENVIRONMENT_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "prod"
+ */
+export const SENTRY_DSC_ENVIRONMENT = 'sentry.dsc.environment';
+
+/**
+ * Type for {@link SENTRY_DSC_ENVIRONMENT} sentry.dsc.environment
+ */
+export type SENTRY_DSC_ENVIRONMENT_TYPE = string;
+
+// Path: model/attributes/sentry/sentry__dsc__org_id.json
+
+/**
+ * The organization ID from the dynamic sampling context. `sentry.dsc.org_id`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_DSC_ORG_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "1"
+ */
+export const SENTRY_DSC_ORG_ID = 'sentry.dsc.org_id';
+
+/**
+ * Type for {@link SENTRY_DSC_ORG_ID} sentry.dsc.org_id
+ */
+export type SENTRY_DSC_ORG_ID_TYPE = string;
+
+// Path: model/attributes/sentry/sentry__dsc__public_key.json
+
+/**
+ * The public key from the dynamic sampling context. `sentry.dsc.public_key`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_DSC_PUBLIC_KEY_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "c51734c603c4430eb57cb0a5728a479d"
+ */
+export const SENTRY_DSC_PUBLIC_KEY = 'sentry.dsc.public_key';
+
+/**
+ * Type for {@link SENTRY_DSC_PUBLIC_KEY} sentry.dsc.public_key
+ */
+export type SENTRY_DSC_PUBLIC_KEY_TYPE = string;
+
+// Path: model/attributes/sentry/sentry__dsc__release.json
+
+/**
+ * The release identifier from the dynamic sampling context. `sentry.dsc.release`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_DSC_RELEASE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "frontend@e8211be71b214afab5b85de4b4c54be3714952bb"
+ */
+export const SENTRY_DSC_RELEASE = 'sentry.dsc.release';
+
+/**
+ * Type for {@link SENTRY_DSC_RELEASE} sentry.dsc.release
+ */
+export type SENTRY_DSC_RELEASE_TYPE = string;
+
+// Path: model/attributes/sentry/sentry__dsc__sampled.json
+
+/**
+ * Whether the event was sampled according to the dynamic sampling context. `sentry.dsc.sampled`
+ *
+ * Attribute Value Type: `boolean` {@link SENTRY_DSC_SAMPLED_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example true
+ */
+export const SENTRY_DSC_SAMPLED = 'sentry.dsc.sampled';
+
+/**
+ * Type for {@link SENTRY_DSC_SAMPLED} sentry.dsc.sampled
+ */
+export type SENTRY_DSC_SAMPLED_TYPE = boolean;
+
+// Path: model/attributes/sentry/sentry__dsc__sample_rand.json
+
+/**
+ * The random sampling value from the dynamic sampling context. `sentry.dsc.sample_rand`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_DSC_SAMPLE_RAND_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "0.8286147972820134"
+ */
+export const SENTRY_DSC_SAMPLE_RAND = 'sentry.dsc.sample_rand';
+
+/**
+ * Type for {@link SENTRY_DSC_SAMPLE_RAND} sentry.dsc.sample_rand
+ */
+export type SENTRY_DSC_SAMPLE_RAND_TYPE = string;
+
+// Path: model/attributes/sentry/sentry__dsc__sample_rate.json
+
+/**
+ * The sample rate from the dynamic sampling context. `sentry.dsc.sample_rate`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_DSC_SAMPLE_RATE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "1.0"
+ */
+export const SENTRY_DSC_SAMPLE_RATE = 'sentry.dsc.sample_rate';
+
+/**
+ * Type for {@link SENTRY_DSC_SAMPLE_RATE} sentry.dsc.sample_rate
+ */
+export type SENTRY_DSC_SAMPLE_RATE_TYPE = string;
+
+// Path: model/attributes/sentry/sentry__dsc__trace_id.json
+
+/**
+ * The trace ID from the dynamic sampling context. `sentry.dsc.trace_id`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_DSC_TRACE_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "047372980460430cbc78d9779df33a46"
+ */
+export const SENTRY_DSC_TRACE_ID = 'sentry.dsc.trace_id';
+
+/**
+ * Type for {@link SENTRY_DSC_TRACE_ID} sentry.dsc.trace_id
+ */
+export type SENTRY_DSC_TRACE_ID_TYPE = string;
+
+// Path: model/attributes/sentry/sentry__dsc__transaction.json
+
+/**
+ * The transaction name from the dynamic sampling context. `sentry.dsc.transaction`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_DSC_TRANSACTION_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "/issues/errors-outages/"
+ */
+export const SENTRY_DSC_TRANSACTION = 'sentry.dsc.transaction';
+
+/**
+ * Type for {@link SENTRY_DSC_TRANSACTION} sentry.dsc.transaction
+ */
+export type SENTRY_DSC_TRANSACTION_TYPE = string;
+
 // Path: model/attributes/sentry/sentry__environment.json
 
 /**
@@ -6339,206 +6519,6 @@ export const SENTRY_IDLE_SPAN_FINISH_REASON = 'sentry.idle_span_finish_reason';
  * Type for {@link SENTRY_IDLE_SPAN_FINISH_REASON} sentry.idle_span_finish_reason
  */
 export type SENTRY_IDLE_SPAN_FINISH_REASON_TYPE = string;
-
-// Path: model/attributes/sentry/sentry___internal__dsc__environment.json
-
-/**
- * The environment from the dynamic sampling context. `sentry._internal.dsc.environment`
- *
- * Attribute Value Type: `string` {@link SENTRY_INTERNAL_DSC_ENVIRONMENT_TYPE}
- *
- * Contains PII: false
- *
- * Attribute defined in OTEL: No
- *
- * @example "prod"
- */
-export const SENTRY_INTERNAL_DSC_ENVIRONMENT = 'sentry._internal.dsc.environment';
-
-/**
- * Type for {@link SENTRY_INTERNAL_DSC_ENVIRONMENT} sentry._internal.dsc.environment
- */
-export type SENTRY_INTERNAL_DSC_ENVIRONMENT_TYPE = string;
-
-// Path: model/attributes/sentry/sentry___internal__dsc__org_id.json
-
-/**
- * The organization ID from the dynamic sampling context. `sentry._internal.dsc.org_id`
- *
- * Attribute Value Type: `string` {@link SENTRY_INTERNAL_DSC_ORG_ID_TYPE}
- *
- * Contains PII: false
- *
- * Attribute defined in OTEL: No
- *
- * @example "1"
- */
-export const SENTRY_INTERNAL_DSC_ORG_ID = 'sentry._internal.dsc.org_id';
-
-/**
- * Type for {@link SENTRY_INTERNAL_DSC_ORG_ID} sentry._internal.dsc.org_id
- */
-export type SENTRY_INTERNAL_DSC_ORG_ID_TYPE = string;
-
-// Path: model/attributes/sentry/sentry___internal__dsc__public_key.json
-
-/**
- * The public key from the dynamic sampling context. `sentry._internal.dsc.public_key`
- *
- * Attribute Value Type: `string` {@link SENTRY_INTERNAL_DSC_PUBLIC_KEY_TYPE}
- *
- * Contains PII: maybe
- *
- * Attribute defined in OTEL: No
- *
- * @example "c51734c603c4430eb57cb0a5728a479d"
- */
-export const SENTRY_INTERNAL_DSC_PUBLIC_KEY = 'sentry._internal.dsc.public_key';
-
-/**
- * Type for {@link SENTRY_INTERNAL_DSC_PUBLIC_KEY} sentry._internal.dsc.public_key
- */
-export type SENTRY_INTERNAL_DSC_PUBLIC_KEY_TYPE = string;
-
-// Path: model/attributes/sentry/sentry___internal__dsc__release.json
-
-/**
- * The release identifier from the dynamic sampling context. `sentry._internal.dsc.release`
- *
- * Attribute Value Type: `string` {@link SENTRY_INTERNAL_DSC_RELEASE_TYPE}
- *
- * Contains PII: false
- *
- * Attribute defined in OTEL: No
- *
- * @example "frontend@e8211be71b214afab5b85de4b4c54be3714952bb"
- */
-export const SENTRY_INTERNAL_DSC_RELEASE = 'sentry._internal.dsc.release';
-
-/**
- * Type for {@link SENTRY_INTERNAL_DSC_RELEASE} sentry._internal.dsc.release
- */
-export type SENTRY_INTERNAL_DSC_RELEASE_TYPE = string;
-
-// Path: model/attributes/sentry/sentry___internal__dsc__sampled.json
-
-/**
- * Whether the event was sampled according to the dynamic sampling context. `sentry._internal.dsc.sampled`
- *
- * Attribute Value Type: `boolean` {@link SENTRY_INTERNAL_DSC_SAMPLED_TYPE}
- *
- * Contains PII: false
- *
- * Attribute defined in OTEL: No
- *
- * @example true
- */
-export const SENTRY_INTERNAL_DSC_SAMPLED = 'sentry._internal.dsc.sampled';
-
-/**
- * Type for {@link SENTRY_INTERNAL_DSC_SAMPLED} sentry._internal.dsc.sampled
- */
-export type SENTRY_INTERNAL_DSC_SAMPLED_TYPE = boolean;
-
-// Path: model/attributes/sentry/sentry___internal__dsc__sample_rand.json
-
-/**
- * The random sampling value from the dynamic sampling context. `sentry._internal.dsc.sample_rand`
- *
- * Attribute Value Type: `string` {@link SENTRY_INTERNAL_DSC_SAMPLE_RAND_TYPE}
- *
- * Contains PII: false
- *
- * Attribute defined in OTEL: No
- *
- * @example "0.8286147972820134"
- */
-export const SENTRY_INTERNAL_DSC_SAMPLE_RAND = 'sentry._internal.dsc.sample_rand';
-
-/**
- * Type for {@link SENTRY_INTERNAL_DSC_SAMPLE_RAND} sentry._internal.dsc.sample_rand
- */
-export type SENTRY_INTERNAL_DSC_SAMPLE_RAND_TYPE = string;
-
-// Path: model/attributes/sentry/sentry___internal__dsc__sample_rate.json
-
-/**
- * The sample rate from the dynamic sampling context. `sentry._internal.dsc.sample_rate`
- *
- * Attribute Value Type: `string` {@link SENTRY_INTERNAL_DSC_SAMPLE_RATE_TYPE}
- *
- * Contains PII: false
- *
- * Attribute defined in OTEL: No
- *
- * @example "1.0"
- */
-export const SENTRY_INTERNAL_DSC_SAMPLE_RATE = 'sentry._internal.dsc.sample_rate';
-
-/**
- * Type for {@link SENTRY_INTERNAL_DSC_SAMPLE_RATE} sentry._internal.dsc.sample_rate
- */
-export type SENTRY_INTERNAL_DSC_SAMPLE_RATE_TYPE = string;
-
-// Path: model/attributes/sentry/sentry___internal__dsc__trace_id.json
-
-/**
- * The trace ID from the dynamic sampling context. `sentry._internal.dsc.trace_id`
- *
- * Attribute Value Type: `string` {@link SENTRY_INTERNAL_DSC_TRACE_ID_TYPE}
- *
- * Contains PII: false
- *
- * Attribute defined in OTEL: No
- *
- * @example "047372980460430cbc78d9779df33a46"
- */
-export const SENTRY_INTERNAL_DSC_TRACE_ID = 'sentry._internal.dsc.trace_id';
-
-/**
- * Type for {@link SENTRY_INTERNAL_DSC_TRACE_ID} sentry._internal.dsc.trace_id
- */
-export type SENTRY_INTERNAL_DSC_TRACE_ID_TYPE = string;
-
-// Path: model/attributes/sentry/sentry___internal__dsc__transaction.json
-
-/**
- * The transaction name from the dynamic sampling context. `sentry._internal.dsc.transaction`
- *
- * Attribute Value Type: `string` {@link SENTRY_INTERNAL_DSC_TRANSACTION_TYPE}
- *
- * Contains PII: false
- *
- * Attribute defined in OTEL: No
- *
- * @example "/issues/errors-outages/"
- */
-export const SENTRY_INTERNAL_DSC_TRANSACTION = 'sentry._internal.dsc.transaction';
-
-/**
- * Type for {@link SENTRY_INTERNAL_DSC_TRANSACTION} sentry._internal.dsc.transaction
- */
-export type SENTRY_INTERNAL_DSC_TRANSACTION_TYPE = string;
-
-// Path: model/attributes/sentry/sentry___internal__replay_is_buffering.json
-
-/**
- * A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate). `sentry._internal.replay_is_buffering`
- *
- * Attribute Value Type: `boolean` {@link SENTRY_INTERNAL_REPLAY_IS_BUFFERING_TYPE}
- *
- * Contains PII: false
- *
- * Attribute defined in OTEL: No
- *
- * @example true
- */
-export const SENTRY_INTERNAL_REPLAY_IS_BUFFERING = 'sentry._internal.replay_is_buffering';
-
-/**
- * Type for {@link SENTRY_INTERNAL_REPLAY_IS_BUFFERING} sentry._internal.replay_is_buffering
- */
-export type SENTRY_INTERNAL_REPLAY_IS_BUFFERING_TYPE = boolean;
 
 // Path: model/attributes/sentry/sentry__message__parameter__[key].json
 
@@ -6787,6 +6767,26 @@ export const SENTRY_REPLAY_ID = 'sentry.replay_id';
  * Type for {@link SENTRY_REPLAY_ID} sentry.replay_id
  */
 export type SENTRY_REPLAY_ID_TYPE = string;
+
+// Path: model/attributes/sentry/sentry__replay_is_buffering.json
+
+/**
+ * A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate). `sentry.replay_is_buffering`
+ *
+ * Attribute Value Type: `boolean` {@link SENTRY_REPLAY_IS_BUFFERING_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example true
+ */
+export const SENTRY_REPLAY_IS_BUFFERING = 'sentry.replay_is_buffering';
+
+/**
+ * Type for {@link SENTRY_REPLAY_IS_BUFFERING} sentry.replay_is_buffering
+ */
+export type SENTRY_REPLAY_IS_BUFFERING_TYPE = boolean;
 
 // Path: model/attributes/sentry/sentry__sdk__integrations.json
 
@@ -8726,20 +8726,19 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SENTRY_CLIENT_SAMPLE_RATE]: 'double',
   [SENTRY_DESCRIPTION]: 'string',
   [SENTRY_DIST]: 'string',
+  [SENTRY_DSC_ENVIRONMENT]: 'string',
+  [SENTRY_DSC_ORG_ID]: 'string',
+  [SENTRY_DSC_PUBLIC_KEY]: 'string',
+  [SENTRY_DSC_RELEASE]: 'string',
+  [SENTRY_DSC_SAMPLED]: 'boolean',
+  [SENTRY_DSC_SAMPLE_RAND]: 'string',
+  [SENTRY_DSC_SAMPLE_RATE]: 'string',
+  [SENTRY_DSC_TRACE_ID]: 'string',
+  [SENTRY_DSC_TRANSACTION]: 'string',
   [SENTRY_ENVIRONMENT]: 'string',
   [SENTRY_EXCLUSIVE_TIME]: 'integer',
   [SENTRY_HTTP_PREFETCH]: 'boolean',
   [SENTRY_IDLE_SPAN_FINISH_REASON]: 'string',
-  [SENTRY_INTERNAL_DSC_ENVIRONMENT]: 'string',
-  [SENTRY_INTERNAL_DSC_ORG_ID]: 'string',
-  [SENTRY_INTERNAL_DSC_PUBLIC_KEY]: 'string',
-  [SENTRY_INTERNAL_DSC_RELEASE]: 'string',
-  [SENTRY_INTERNAL_DSC_SAMPLED]: 'boolean',
-  [SENTRY_INTERNAL_DSC_SAMPLE_RAND]: 'string',
-  [SENTRY_INTERNAL_DSC_SAMPLE_RATE]: 'string',
-  [SENTRY_INTERNAL_DSC_TRACE_ID]: 'string',
-  [SENTRY_INTERNAL_DSC_TRANSACTION]: 'string',
-  [SENTRY_INTERNAL_REPLAY_IS_BUFFERING]: 'boolean',
   [SENTRY_MESSAGE_PARAMETER_KEY]: 'string',
   [SENTRY_MESSAGE_TEMPLATE]: 'string',
   [SENTRY_MODULE_KEY]: 'string',
@@ -8752,6 +8751,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SENTRY_PROFILE_ID]: 'string',
   [SENTRY_RELEASE]: 'string',
   [SENTRY_REPLAY_ID]: 'string',
+  [SENTRY_REPLAY_IS_BUFFERING]: 'boolean',
   [SENTRY_SDK_INTEGRATIONS]: 'string[]',
   [SENTRY_SDK_NAME]: 'string',
   [SENTRY_SDK_VERSION]: 'string',
@@ -9132,20 +9132,19 @@ export type AttributeName =
   | typeof SENTRY_CLIENT_SAMPLE_RATE
   | typeof SENTRY_DESCRIPTION
   | typeof SENTRY_DIST
+  | typeof SENTRY_DSC_ENVIRONMENT
+  | typeof SENTRY_DSC_ORG_ID
+  | typeof SENTRY_DSC_PUBLIC_KEY
+  | typeof SENTRY_DSC_RELEASE
+  | typeof SENTRY_DSC_SAMPLED
+  | typeof SENTRY_DSC_SAMPLE_RAND
+  | typeof SENTRY_DSC_SAMPLE_RATE
+  | typeof SENTRY_DSC_TRACE_ID
+  | typeof SENTRY_DSC_TRANSACTION
   | typeof SENTRY_ENVIRONMENT
   | typeof SENTRY_EXCLUSIVE_TIME
   | typeof SENTRY_HTTP_PREFETCH
   | typeof SENTRY_IDLE_SPAN_FINISH_REASON
-  | typeof SENTRY_INTERNAL_DSC_ENVIRONMENT
-  | typeof SENTRY_INTERNAL_DSC_ORG_ID
-  | typeof SENTRY_INTERNAL_DSC_PUBLIC_KEY
-  | typeof SENTRY_INTERNAL_DSC_RELEASE
-  | typeof SENTRY_INTERNAL_DSC_SAMPLED
-  | typeof SENTRY_INTERNAL_DSC_SAMPLE_RAND
-  | typeof SENTRY_INTERNAL_DSC_SAMPLE_RATE
-  | typeof SENTRY_INTERNAL_DSC_TRACE_ID
-  | typeof SENTRY_INTERNAL_DSC_TRANSACTION
-  | typeof SENTRY_INTERNAL_REPLAY_IS_BUFFERING
   | typeof SENTRY_MESSAGE_PARAMETER_KEY
   | typeof SENTRY_MESSAGE_TEMPLATE
   | typeof SENTRY_MODULE_KEY
@@ -9158,6 +9157,7 @@ export type AttributeName =
   | typeof SENTRY_PROFILE_ID
   | typeof SENTRY_RELEASE
   | typeof SENTRY_REPLAY_ID
+  | typeof SENTRY_REPLAY_IS_BUFFERING
   | typeof SENTRY_SDK_INTEGRATIONS
   | typeof SENTRY_SDK_NAME
   | typeof SENTRY_SDK_VERSION
@@ -12380,6 +12380,87 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: '1.0',
   },
+  [SENTRY_DSC_ENVIRONMENT]: {
+    brief: 'The environment from the dynamic sampling context.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 'prod',
+  },
+  [SENTRY_DSC_ORG_ID]: {
+    brief: 'The organization ID from the dynamic sampling context.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '1',
+  },
+  [SENTRY_DSC_PUBLIC_KEY]: {
+    brief: 'The public key from the dynamic sampling context.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 'c51734c603c4430eb57cb0a5728a479d',
+  },
+  [SENTRY_DSC_RELEASE]: {
+    brief: 'The release identifier from the dynamic sampling context.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 'frontend@e8211be71b214afab5b85de4b4c54be3714952bb',
+  },
+  [SENTRY_DSC_SAMPLED]: {
+    brief: 'Whether the event was sampled according to the dynamic sampling context.',
+    type: 'boolean',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: true,
+  },
+  [SENTRY_DSC_SAMPLE_RAND]: {
+    brief: 'The random sampling value from the dynamic sampling context.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '0.8286147972820134',
+  },
+  [SENTRY_DSC_SAMPLE_RATE]: {
+    brief: 'The sample rate from the dynamic sampling context.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '1.0',
+  },
+  [SENTRY_DSC_TRACE_ID]: {
+    brief: 'The trace ID from the dynamic sampling context.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '047372980460430cbc78d9779df33a46',
+  },
+  [SENTRY_DSC_TRANSACTION]: {
+    brief: 'The transaction name from the dynamic sampling context.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '/issues/errors-outages/',
+  },
   [SENTRY_ENVIRONMENT]: {
     brief: 'The sentry environment.',
     type: 'string',
@@ -12416,97 +12497,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 'idleTimeout',
-  },
-  [SENTRY_INTERNAL_DSC_ENVIRONMENT]: {
-    brief: 'The environment from the dynamic sampling context.',
-    type: 'string',
-    pii: {
-      isPii: 'false',
-    },
-    isInOtel: false,
-    example: 'prod',
-  },
-  [SENTRY_INTERNAL_DSC_ORG_ID]: {
-    brief: 'The organization ID from the dynamic sampling context.',
-    type: 'string',
-    pii: {
-      isPii: 'false',
-    },
-    isInOtel: false,
-    example: '1',
-  },
-  [SENTRY_INTERNAL_DSC_PUBLIC_KEY]: {
-    brief: 'The public key from the dynamic sampling context.',
-    type: 'string',
-    pii: {
-      isPii: 'maybe',
-    },
-    isInOtel: false,
-    example: 'c51734c603c4430eb57cb0a5728a479d',
-  },
-  [SENTRY_INTERNAL_DSC_RELEASE]: {
-    brief: 'The release identifier from the dynamic sampling context.',
-    type: 'string',
-    pii: {
-      isPii: 'false',
-    },
-    isInOtel: false,
-    example: 'frontend@e8211be71b214afab5b85de4b4c54be3714952bb',
-  },
-  [SENTRY_INTERNAL_DSC_SAMPLED]: {
-    brief: 'Whether the event was sampled according to the dynamic sampling context.',
-    type: 'boolean',
-    pii: {
-      isPii: 'false',
-    },
-    isInOtel: false,
-    example: true,
-  },
-  [SENTRY_INTERNAL_DSC_SAMPLE_RAND]: {
-    brief: 'The random sampling value from the dynamic sampling context.',
-    type: 'string',
-    pii: {
-      isPii: 'false',
-    },
-    isInOtel: false,
-    example: '0.8286147972820134',
-  },
-  [SENTRY_INTERNAL_DSC_SAMPLE_RATE]: {
-    brief: 'The sample rate from the dynamic sampling context.',
-    type: 'string',
-    pii: {
-      isPii: 'false',
-    },
-    isInOtel: false,
-    example: '1.0',
-  },
-  [SENTRY_INTERNAL_DSC_TRACE_ID]: {
-    brief: 'The trace ID from the dynamic sampling context.',
-    type: 'string',
-    pii: {
-      isPii: 'false',
-    },
-    isInOtel: false,
-    example: '047372980460430cbc78d9779df33a46',
-  },
-  [SENTRY_INTERNAL_DSC_TRANSACTION]: {
-    brief: 'The transaction name from the dynamic sampling context.',
-    type: 'string',
-    pii: {
-      isPii: 'false',
-    },
-    isInOtel: false,
-    example: '/issues/errors-outages/',
-  },
-  [SENTRY_INTERNAL_REPLAY_IS_BUFFERING]: {
-    brief:
-      'A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate).',
-    type: 'boolean',
-    pii: {
-      isPii: 'false',
-    },
-    isInOtel: false,
-    example: true,
   },
   [SENTRY_MESSAGE_PARAMETER_KEY]: {
     brief:
@@ -12624,6 +12614,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: '123e4567e89b12d3a456426614174000',
     aliases: [REPLAY_ID],
+  },
+  [SENTRY_REPLAY_IS_BUFFERING]: {
+    brief:
+      'A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate).',
+    type: 'boolean',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: true,
   },
   [SENTRY_SDK_INTEGRATIONS]: {
     brief:
@@ -13666,20 +13666,19 @@ export type Attributes = {
   [SENTRY_CLIENT_SAMPLE_RATE]?: SENTRY_CLIENT_SAMPLE_RATE_TYPE;
   [SENTRY_DESCRIPTION]?: SENTRY_DESCRIPTION_TYPE;
   [SENTRY_DIST]?: SENTRY_DIST_TYPE;
+  [SENTRY_DSC_ENVIRONMENT]?: SENTRY_DSC_ENVIRONMENT_TYPE;
+  [SENTRY_DSC_ORG_ID]?: SENTRY_DSC_ORG_ID_TYPE;
+  [SENTRY_DSC_PUBLIC_KEY]?: SENTRY_DSC_PUBLIC_KEY_TYPE;
+  [SENTRY_DSC_RELEASE]?: SENTRY_DSC_RELEASE_TYPE;
+  [SENTRY_DSC_SAMPLED]?: SENTRY_DSC_SAMPLED_TYPE;
+  [SENTRY_DSC_SAMPLE_RAND]?: SENTRY_DSC_SAMPLE_RAND_TYPE;
+  [SENTRY_DSC_SAMPLE_RATE]?: SENTRY_DSC_SAMPLE_RATE_TYPE;
+  [SENTRY_DSC_TRACE_ID]?: SENTRY_DSC_TRACE_ID_TYPE;
+  [SENTRY_DSC_TRANSACTION]?: SENTRY_DSC_TRANSACTION_TYPE;
   [SENTRY_ENVIRONMENT]?: SENTRY_ENVIRONMENT_TYPE;
   [SENTRY_EXCLUSIVE_TIME]?: SENTRY_EXCLUSIVE_TIME_TYPE;
   [SENTRY_HTTP_PREFETCH]?: SENTRY_HTTP_PREFETCH_TYPE;
   [SENTRY_IDLE_SPAN_FINISH_REASON]?: SENTRY_IDLE_SPAN_FINISH_REASON_TYPE;
-  [SENTRY_INTERNAL_DSC_ENVIRONMENT]?: SENTRY_INTERNAL_DSC_ENVIRONMENT_TYPE;
-  [SENTRY_INTERNAL_DSC_ORG_ID]?: SENTRY_INTERNAL_DSC_ORG_ID_TYPE;
-  [SENTRY_INTERNAL_DSC_PUBLIC_KEY]?: SENTRY_INTERNAL_DSC_PUBLIC_KEY_TYPE;
-  [SENTRY_INTERNAL_DSC_RELEASE]?: SENTRY_INTERNAL_DSC_RELEASE_TYPE;
-  [SENTRY_INTERNAL_DSC_SAMPLED]?: SENTRY_INTERNAL_DSC_SAMPLED_TYPE;
-  [SENTRY_INTERNAL_DSC_SAMPLE_RAND]?: SENTRY_INTERNAL_DSC_SAMPLE_RAND_TYPE;
-  [SENTRY_INTERNAL_DSC_SAMPLE_RATE]?: SENTRY_INTERNAL_DSC_SAMPLE_RATE_TYPE;
-  [SENTRY_INTERNAL_DSC_TRACE_ID]?: SENTRY_INTERNAL_DSC_TRACE_ID_TYPE;
-  [SENTRY_INTERNAL_DSC_TRANSACTION]?: SENTRY_INTERNAL_DSC_TRANSACTION_TYPE;
-  [SENTRY_INTERNAL_REPLAY_IS_BUFFERING]?: SENTRY_INTERNAL_REPLAY_IS_BUFFERING_TYPE;
   [SENTRY_MESSAGE_PARAMETER_KEY]?: SENTRY_MESSAGE_PARAMETER_KEY_TYPE;
   [SENTRY_MESSAGE_TEMPLATE]?: SENTRY_MESSAGE_TEMPLATE_TYPE;
   [SENTRY_MODULE_KEY]?: SENTRY_MODULE_KEY_TYPE;
@@ -13692,6 +13691,7 @@ export type Attributes = {
   [SENTRY_PROFILE_ID]?: SENTRY_PROFILE_ID_TYPE;
   [SENTRY_RELEASE]?: SENTRY_RELEASE_TYPE;
   [SENTRY_REPLAY_ID]?: SENTRY_REPLAY_ID_TYPE;
+  [SENTRY_REPLAY_IS_BUFFERING]?: SENTRY_REPLAY_IS_BUFFERING_TYPE;
   [SENTRY_SDK_INTEGRATIONS]?: SENTRY_SDK_INTEGRATIONS_TYPE;
   [SENTRY_SDK_NAME]?: SENTRY_SDK_NAME_TYPE;
   [SENTRY_SDK_VERSION]?: SENTRY_SDK_VERSION_TYPE;

--- a/model/attributes/sentry/sentry__dsc__environment.json
+++ b/model/attributes/sentry/sentry__dsc__environment.json
@@ -1,5 +1,5 @@
 {
-  "key": "sentry._internal.dsc.environment",
+  "key": "sentry.dsc.environment",
   "brief": "The environment from the dynamic sampling context.",
   "type": "string",
   "pii": {

--- a/model/attributes/sentry/sentry__dsc__org_id.json
+++ b/model/attributes/sentry/sentry__dsc__org_id.json
@@ -1,5 +1,5 @@
 {
-  "key": "sentry._internal.dsc.org_id",
+  "key": "sentry.dsc.org_id",
   "brief": "The organization ID from the dynamic sampling context.",
   "type": "string",
   "pii": {

--- a/model/attributes/sentry/sentry__dsc__public_key.json
+++ b/model/attributes/sentry/sentry__dsc__public_key.json
@@ -1,5 +1,5 @@
 {
-  "key": "sentry._internal.dsc.public_key",
+  "key": "sentry.dsc.public_key",
   "brief": "The public key from the dynamic sampling context.",
   "type": "string",
   "pii": {

--- a/model/attributes/sentry/sentry__dsc__release.json
+++ b/model/attributes/sentry/sentry__dsc__release.json
@@ -1,5 +1,5 @@
 {
-  "key": "sentry._internal.dsc.release",
+  "key": "sentry.dsc.release",
   "brief": "The release identifier from the dynamic sampling context.",
   "type": "string",
   "pii": {

--- a/model/attributes/sentry/sentry__dsc__sample_rand.json
+++ b/model/attributes/sentry/sentry__dsc__sample_rand.json
@@ -1,5 +1,5 @@
 {
-  "key": "sentry._internal.dsc.sample_rand",
+  "key": "sentry.dsc.sample_rand",
   "brief": "The random sampling value from the dynamic sampling context.",
   "type": "string",
   "pii": {

--- a/model/attributes/sentry/sentry__dsc__sample_rate.json
+++ b/model/attributes/sentry/sentry__dsc__sample_rate.json
@@ -1,5 +1,5 @@
 {
-  "key": "sentry._internal.dsc.sample_rate",
+  "key": "sentry.dsc.sample_rate",
   "brief": "The sample rate from the dynamic sampling context.",
   "type": "string",
   "pii": {

--- a/model/attributes/sentry/sentry__dsc__sampled.json
+++ b/model/attributes/sentry/sentry__dsc__sampled.json
@@ -1,5 +1,5 @@
 {
-  "key": "sentry._internal.dsc.sampled",
+  "key": "sentry.dsc.sampled",
   "brief": "Whether the event was sampled according to the dynamic sampling context.",
   "type": "boolean",
   "pii": {

--- a/model/attributes/sentry/sentry__dsc__trace_id.json
+++ b/model/attributes/sentry/sentry__dsc__trace_id.json
@@ -1,5 +1,5 @@
 {
-  "key": "sentry._internal.dsc.trace_id",
+  "key": "sentry.dsc.trace_id",
   "brief": "The trace ID from the dynamic sampling context.",
   "type": "string",
   "pii": {

--- a/model/attributes/sentry/sentry__dsc__transaction.json
+++ b/model/attributes/sentry/sentry__dsc__transaction.json
@@ -1,5 +1,5 @@
 {
-  "key": "sentry._internal.dsc.transaction",
+  "key": "sentry.dsc.transaction",
   "brief": "The transaction name from the dynamic sampling context.",
   "type": "string",
   "pii": {

--- a/model/attributes/sentry/sentry__replay_is_buffering.json
+++ b/model/attributes/sentry/sentry__replay_is_buffering.json
@@ -1,5 +1,5 @@
 {
-  "key": "sentry._internal.replay_is_buffering",
+  "key": "sentry.replay_is_buffering",
   "brief": "A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate).",
   "type": "boolean",
   "pii": {

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3429,126 +3429,6 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "myService.BestService"
     """
 
-    # Path: model/attributes/sentry/sentry___internal__dsc__environment.json
-    SENTRY_INTERNAL_DSC_ENVIRONMENT: Literal["sentry._internal.dsc.environment"] = (
-        "sentry._internal.dsc.environment"
-    )
-    """The environment from the dynamic sampling context.
-
-    Type: str
-    Contains PII: false
-    Defined in OTEL: No
-    Example: "prod"
-    """
-
-    # Path: model/attributes/sentry/sentry___internal__dsc__org_id.json
-    SENTRY_INTERNAL_DSC_ORG_ID: Literal["sentry._internal.dsc.org_id"] = (
-        "sentry._internal.dsc.org_id"
-    )
-    """The organization ID from the dynamic sampling context.
-
-    Type: str
-    Contains PII: false
-    Defined in OTEL: No
-    Example: "1"
-    """
-
-    # Path: model/attributes/sentry/sentry___internal__dsc__public_key.json
-    SENTRY_INTERNAL_DSC_PUBLIC_KEY: Literal["sentry._internal.dsc.public_key"] = (
-        "sentry._internal.dsc.public_key"
-    )
-    """The public key from the dynamic sampling context.
-
-    Type: str
-    Contains PII: maybe
-    Defined in OTEL: No
-    Example: "c51734c603c4430eb57cb0a5728a479d"
-    """
-
-    # Path: model/attributes/sentry/sentry___internal__dsc__release.json
-    SENTRY_INTERNAL_DSC_RELEASE: Literal["sentry._internal.dsc.release"] = (
-        "sentry._internal.dsc.release"
-    )
-    """The release identifier from the dynamic sampling context.
-
-    Type: str
-    Contains PII: false
-    Defined in OTEL: No
-    Example: "frontend@e8211be71b214afab5b85de4b4c54be3714952bb"
-    """
-
-    # Path: model/attributes/sentry/sentry___internal__dsc__sample_rand.json
-    SENTRY_INTERNAL_DSC_SAMPLE_RAND: Literal["sentry._internal.dsc.sample_rand"] = (
-        "sentry._internal.dsc.sample_rand"
-    )
-    """The random sampling value from the dynamic sampling context.
-
-    Type: str
-    Contains PII: false
-    Defined in OTEL: No
-    Example: "0.8286147972820134"
-    """
-
-    # Path: model/attributes/sentry/sentry___internal__dsc__sample_rate.json
-    SENTRY_INTERNAL_DSC_SAMPLE_RATE: Literal["sentry._internal.dsc.sample_rate"] = (
-        "sentry._internal.dsc.sample_rate"
-    )
-    """The sample rate from the dynamic sampling context.
-
-    Type: str
-    Contains PII: false
-    Defined in OTEL: No
-    Example: "1.0"
-    """
-
-    # Path: model/attributes/sentry/sentry___internal__dsc__sampled.json
-    SENTRY_INTERNAL_DSC_SAMPLED: Literal["sentry._internal.dsc.sampled"] = (
-        "sentry._internal.dsc.sampled"
-    )
-    """Whether the event was sampled according to the dynamic sampling context.
-
-    Type: bool
-    Contains PII: false
-    Defined in OTEL: No
-    Example: true
-    """
-
-    # Path: model/attributes/sentry/sentry___internal__dsc__trace_id.json
-    SENTRY_INTERNAL_DSC_TRACE_ID: Literal["sentry._internal.dsc.trace_id"] = (
-        "sentry._internal.dsc.trace_id"
-    )
-    """The trace ID from the dynamic sampling context.
-
-    Type: str
-    Contains PII: false
-    Defined in OTEL: No
-    Example: "047372980460430cbc78d9779df33a46"
-    """
-
-    # Path: model/attributes/sentry/sentry___internal__dsc__transaction.json
-    SENTRY_INTERNAL_DSC_TRANSACTION: Literal["sentry._internal.dsc.transaction"] = (
-        "sentry._internal.dsc.transaction"
-    )
-    """The transaction name from the dynamic sampling context.
-
-    Type: str
-    Contains PII: false
-    Defined in OTEL: No
-    Example: "/issues/errors-outages/"
-    """
-
-    # Path: model/attributes/sentry/sentry___internal__replay_is_buffering.json
-    SENTRY_INTERNAL_REPLAY_IS_BUFFERING: Literal[
-        "sentry._internal.replay_is_buffering"
-    ] = "sentry._internal.replay_is_buffering"
-    """A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate).
-
-    Type: bool
-    Contains PII: false
-    Defined in OTEL: No
-    Example: true
-    """
-
     # Path: model/attributes/sentry/sentry__browser__name.json
     SENTRY_BROWSER_NAME: Literal["sentry.browser.name"] = "sentry.browser.name"
     """The name of the browser.
@@ -3615,6 +3495,96 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: false
     Defined in OTEL: No
     Example: "1.0"
+    """
+
+    # Path: model/attributes/sentry/sentry__dsc__environment.json
+    SENTRY_DSC_ENVIRONMENT: Literal["sentry.dsc.environment"] = "sentry.dsc.environment"
+    """The environment from the dynamic sampling context.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "prod"
+    """
+
+    # Path: model/attributes/sentry/sentry__dsc__org_id.json
+    SENTRY_DSC_ORG_ID: Literal["sentry.dsc.org_id"] = "sentry.dsc.org_id"
+    """The organization ID from the dynamic sampling context.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "1"
+    """
+
+    # Path: model/attributes/sentry/sentry__dsc__public_key.json
+    SENTRY_DSC_PUBLIC_KEY: Literal["sentry.dsc.public_key"] = "sentry.dsc.public_key"
+    """The public key from the dynamic sampling context.
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "c51734c603c4430eb57cb0a5728a479d"
+    """
+
+    # Path: model/attributes/sentry/sentry__dsc__release.json
+    SENTRY_DSC_RELEASE: Literal["sentry.dsc.release"] = "sentry.dsc.release"
+    """The release identifier from the dynamic sampling context.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "frontend@e8211be71b214afab5b85de4b4c54be3714952bb"
+    """
+
+    # Path: model/attributes/sentry/sentry__dsc__sample_rand.json
+    SENTRY_DSC_SAMPLE_RAND: Literal["sentry.dsc.sample_rand"] = "sentry.dsc.sample_rand"
+    """The random sampling value from the dynamic sampling context.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "0.8286147972820134"
+    """
+
+    # Path: model/attributes/sentry/sentry__dsc__sample_rate.json
+    SENTRY_DSC_SAMPLE_RATE: Literal["sentry.dsc.sample_rate"] = "sentry.dsc.sample_rate"
+    """The sample rate from the dynamic sampling context.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "1.0"
+    """
+
+    # Path: model/attributes/sentry/sentry__dsc__sampled.json
+    SENTRY_DSC_SAMPLED: Literal["sentry.dsc.sampled"] = "sentry.dsc.sampled"
+    """Whether the event was sampled according to the dynamic sampling context.
+
+    Type: bool
+    Contains PII: false
+    Defined in OTEL: No
+    Example: true
+    """
+
+    # Path: model/attributes/sentry/sentry__dsc__trace_id.json
+    SENTRY_DSC_TRACE_ID: Literal["sentry.dsc.trace_id"] = "sentry.dsc.trace_id"
+    """The trace ID from the dynamic sampling context.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "047372980460430cbc78d9779df33a46"
+    """
+
+    # Path: model/attributes/sentry/sentry__dsc__transaction.json
+    SENTRY_DSC_TRANSACTION: Literal["sentry.dsc.transaction"] = "sentry.dsc.transaction"
+    """The transaction name from the dynamic sampling context.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "/issues/errors-outages/"
     """
 
     # Path: model/attributes/sentry/sentry__environment.json
@@ -3792,6 +3762,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Aliases: replay_id
     Example: "123e4567e89b12d3a456426614174000"
+    """
+
+    # Path: model/attributes/sentry/sentry__replay_is_buffering.json
+    SENTRY_REPLAY_IS_BUFFERING: Literal["sentry.replay_is_buffering"] = (
+        "sentry.replay_is_buffering"
+    )
+    """A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate).
+
+    Type: bool
+    Contains PII: false
+    Defined in OTEL: No
+    Example: true
     """
 
     # Path: model/attributes/sentry/sentry__sdk__integrations.json
@@ -6954,76 +6936,6 @@ _ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         example="myService.BestService",
     ),
-    "sentry._internal.dsc.environment": AttributeMetadata(
-        brief="The environment from the dynamic sampling context.",
-        type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
-        is_in_otel=False,
-        example="prod",
-    ),
-    "sentry._internal.dsc.org_id": AttributeMetadata(
-        brief="The organization ID from the dynamic sampling context.",
-        type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
-        is_in_otel=False,
-        example="1",
-    ),
-    "sentry._internal.dsc.public_key": AttributeMetadata(
-        brief="The public key from the dynamic sampling context.",
-        type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.MAYBE),
-        is_in_otel=False,
-        example="c51734c603c4430eb57cb0a5728a479d",
-    ),
-    "sentry._internal.dsc.release": AttributeMetadata(
-        brief="The release identifier from the dynamic sampling context.",
-        type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
-        is_in_otel=False,
-        example="frontend@e8211be71b214afab5b85de4b4c54be3714952bb",
-    ),
-    "sentry._internal.dsc.sample_rand": AttributeMetadata(
-        brief="The random sampling value from the dynamic sampling context.",
-        type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
-        is_in_otel=False,
-        example="0.8286147972820134",
-    ),
-    "sentry._internal.dsc.sample_rate": AttributeMetadata(
-        brief="The sample rate from the dynamic sampling context.",
-        type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
-        is_in_otel=False,
-        example="1.0",
-    ),
-    "sentry._internal.dsc.sampled": AttributeMetadata(
-        brief="Whether the event was sampled according to the dynamic sampling context.",
-        type=AttributeType.BOOLEAN,
-        pii=PiiInfo(isPii=IsPii.FALSE),
-        is_in_otel=False,
-        example=True,
-    ),
-    "sentry._internal.dsc.trace_id": AttributeMetadata(
-        brief="The trace ID from the dynamic sampling context.",
-        type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
-        is_in_otel=False,
-        example="047372980460430cbc78d9779df33a46",
-    ),
-    "sentry._internal.dsc.transaction": AttributeMetadata(
-        brief="The transaction name from the dynamic sampling context.",
-        type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
-        is_in_otel=False,
-        example="/issues/errors-outages/",
-    ),
-    "sentry._internal.replay_is_buffering": AttributeMetadata(
-        brief="A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate).",
-        type=AttributeType.BOOLEAN,
-        pii=PiiInfo(isPii=IsPii.FALSE),
-        is_in_otel=False,
-        example=True,
-    ),
     "sentry.browser.name": AttributeMetadata(
         brief="The name of the browser.",
         type=AttributeType.STRING,
@@ -7069,6 +6981,69 @@ _ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=False,
         example="1.0",
+    ),
+    "sentry.dsc.environment": AttributeMetadata(
+        brief="The environment from the dynamic sampling context.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="prod",
+    ),
+    "sentry.dsc.org_id": AttributeMetadata(
+        brief="The organization ID from the dynamic sampling context.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="1",
+    ),
+    "sentry.dsc.public_key": AttributeMetadata(
+        brief="The public key from the dynamic sampling context.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="c51734c603c4430eb57cb0a5728a479d",
+    ),
+    "sentry.dsc.release": AttributeMetadata(
+        brief="The release identifier from the dynamic sampling context.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="frontend@e8211be71b214afab5b85de4b4c54be3714952bb",
+    ),
+    "sentry.dsc.sample_rand": AttributeMetadata(
+        brief="The random sampling value from the dynamic sampling context.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="0.8286147972820134",
+    ),
+    "sentry.dsc.sample_rate": AttributeMetadata(
+        brief="The sample rate from the dynamic sampling context.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="1.0",
+    ),
+    "sentry.dsc.sampled": AttributeMetadata(
+        brief="Whether the event was sampled according to the dynamic sampling context.",
+        type=AttributeType.BOOLEAN,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example=True,
+    ),
+    "sentry.dsc.trace_id": AttributeMetadata(
+        brief="The trace ID from the dynamic sampling context.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="047372980460430cbc78d9779df33a46",
+    ),
+    "sentry.dsc.transaction": AttributeMetadata(
+        brief="The transaction name from the dynamic sampling context.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="/issues/errors-outages/",
     ),
     "sentry.environment": AttributeMetadata(
         brief="The sentry environment.",
@@ -7188,6 +7163,13 @@ _ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example="123e4567e89b12d3a456426614174000",
         aliases=["replay_id"],
+    ),
+    "sentry.replay_is_buffering": AttributeMetadata(
+        brief="A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate).",
+        type=AttributeType.BOOLEAN,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example=True,
     ),
     "sentry.sdk.integrations": AttributeMetadata(
         brief="A list of names identifying enabled integrations. The list shouldhave all enabled integrations, including default integrations. Defaultintegrations are included because different SDK releases may contain differentdefault integrations.",
@@ -8065,22 +8047,21 @@ Attributes = TypedDict(
         "route": str,
         "rpc.grpc.status_code": int,
         "rpc.service": str,
-        "sentry._internal.dsc.environment": str,
-        "sentry._internal.dsc.org_id": str,
-        "sentry._internal.dsc.public_key": str,
-        "sentry._internal.dsc.release": str,
-        "sentry._internal.dsc.sample_rand": str,
-        "sentry._internal.dsc.sample_rate": str,
-        "sentry._internal.dsc.sampled": bool,
-        "sentry._internal.dsc.trace_id": str,
-        "sentry._internal.dsc.transaction": str,
-        "sentry._internal.replay_is_buffering": bool,
         "sentry.browser.name": str,
         "sentry.browser.version": str,
         "sentry.cancellation_reason": str,
         "sentry.client_sample_rate": float,
         "sentry.description": str,
         "sentry.dist": str,
+        "sentry.dsc.environment": str,
+        "sentry.dsc.org_id": str,
+        "sentry.dsc.public_key": str,
+        "sentry.dsc.release": str,
+        "sentry.dsc.sample_rand": str,
+        "sentry.dsc.sample_rate": str,
+        "sentry.dsc.sampled": bool,
+        "sentry.dsc.trace_id": str,
+        "sentry.dsc.transaction": str,
         "sentry.environment": str,
         "sentry.exclusive_time": int,
         "sentry.http.prefetch": bool,
@@ -8097,6 +8078,7 @@ Attributes = TypedDict(
         "sentry.profile_id": str,
         "sentry.release": str,
         "sentry.replay_id": str,
+        "sentry.replay_is_buffering": bool,
         "sentry.sdk.integrations": List[str],
         "sentry.sdk.name": str,
         "sentry.sdk.version": str,


### PR DESCRIPTION
## Description

As discussed, `sentry._internal` should be reserved for the EAP data model, when converting from a span/log/.. to EAP, not for actual attributes.

In a future change, we'll introduce a way to hide attributes.


## PR Checklist
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate && yarn format` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I've used the `sentry._internal` namespace if the attribute should not be visibile to end-users
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md)
