### PR TITLE
ref(sentry): Add in Relay used but missing attributes

### DIFF
--- a/generated/attributes/sentry.md
+++ b/generated/attributes/sentry.md
@@ -16,8 +16,11 @@
   - [sentry.dsc.transaction](#sentrydsctransaction)
   - [sentry.environment](#sentryenvironment)
   - [sentry.exclusive_time](#sentryexclusive_time)
+  - [sentry.graphql.operation](#sentrygraphqloperation)
   - [sentry.http.prefetch](#sentryhttpprefetch)
   - [sentry.idle_span_finish_reason](#sentryidle_span_finish_reason)
+  - [sentry.is_remote](#sentryis_remote)
+  - [sentry.kind](#sentrykind)
   - [sentry.message.parameter.\<key\>](#sentrymessageparameterkey)
   - [sentry.message.template](#sentrymessagetemplate)
   - [sentry.module.\<key\>](#sentrymodulekey)
@@ -38,6 +41,7 @@
   - [sentry.segment.name](#sentrysegmentname)
   - [sentry.server_sample_rate](#sentryserver_sample_rate)
   - [sentry.span.source](#sentryspansource)
+  - [sentry.status.message](#sentrystatusmessage)
   - [sentry.trace.parent_span_id](#sentrytraceparent_span_id)
   - [sentry.transaction](#sentrytransaction)
 - [Deprecated Attributes](#deprecated-attributes)
@@ -191,6 +195,17 @@ The exclusive time duration of the span in milliseconds.
 | Exists in OpenTelemetry | No |
 | Example | `1234` |
 
+### sentry.graphql.operation
+
+Indicates the type of graphql operation, emitted by the Javascript SDK.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `getUserById` |
+
 ### sentry.http.prefetch
 
 If an http request was a prefetch request.
@@ -212,6 +227,28 @@ The reason why an idle span ended early.
 | Has PII | false |
 | Exists in OpenTelemetry | No |
 | Example | `idleTimeout` |
+
+### sentry.is_remote
+
+Indicates whether a span's parent is remote.
+
+| Property | Value |
+| --- | --- |
+| Type | `boolean` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `true` |
+
+### sentry.kind
+
+Used to clarify the relationship between parents and children, or to distinguish between spans, e.g. a `server` and `client` span with the same name.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `server` |
 
 ### sentry.message.parameter.\<key\>
 
@@ -437,6 +474,17 @@ The source of a span, also referred to as transaction source.
 | Has PII | false |
 | Exists in OpenTelemetry | No |
 | Example | `route` |
+
+### sentry.status.message
+
+The from OTLP extracted status message.
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `foobar` |
 
 ### sentry.trace.parent_span_id
 

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -6440,6 +6440,26 @@ export const SENTRY_EXCLUSIVE_TIME = 'sentry.exclusive_time';
  */
 export type SENTRY_EXCLUSIVE_TIME_TYPE = number;
 
+// Path: model/attributes/sentry/sentry__graphql__operation.json
+
+/**
+ * Indicates the type of graphql operation, emitted by the Javascript SDK. `sentry.graphql.operation`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_GRAPHQL_OPERATION_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "getUserById"
+ */
+export const SENTRY_GRAPHQL_OPERATION = 'sentry.graphql.operation';
+
+/**
+ * Type for {@link SENTRY_GRAPHQL_OPERATION} sentry.graphql.operation
+ */
+export type SENTRY_GRAPHQL_OPERATION_TYPE = string;
+
 // Path: model/attributes/sentry/sentry__http__prefetch.json
 
 /**
@@ -6479,6 +6499,46 @@ export const SENTRY_IDLE_SPAN_FINISH_REASON = 'sentry.idle_span_finish_reason';
  * Type for {@link SENTRY_IDLE_SPAN_FINISH_REASON} sentry.idle_span_finish_reason
  */
 export type SENTRY_IDLE_SPAN_FINISH_REASON_TYPE = string;
+
+// Path: model/attributes/sentry/sentry__is_remote.json
+
+/**
+ * Indicates whether a span's parent is remote. `sentry.is_remote`
+ *
+ * Attribute Value Type: `boolean` {@link SENTRY_IS_REMOTE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example true
+ */
+export const SENTRY_IS_REMOTE = 'sentry.is_remote';
+
+/**
+ * Type for {@link SENTRY_IS_REMOTE} sentry.is_remote
+ */
+export type SENTRY_IS_REMOTE_TYPE = boolean;
+
+// Path: model/attributes/sentry/sentry__kind.json
+
+/**
+ * Used to clarify the relationship between parents and children, or to distinguish between spans, e.g. a `server` and `client` span with the same name. `sentry.kind`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_KIND_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "server"
+ */
+export const SENTRY_KIND = 'sentry.kind';
+
+/**
+ * Type for {@link SENTRY_KIND} sentry.kind
+ */
+export type SENTRY_KIND_TYPE = string;
 
 // Path: model/attributes/sentry/sentry__message__parameter__[key].json
 
@@ -6912,6 +6972,26 @@ export const SENTRY_SPAN_SOURCE = 'sentry.span.source';
  * Type for {@link SENTRY_SPAN_SOURCE} sentry.span.source
  */
 export type SENTRY_SPAN_SOURCE_TYPE = string;
+
+// Path: model/attributes/sentry/sentry__status__message.json
+
+/**
+ * The from OTLP extracted status message. `sentry.status.message`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_STATUS_MESSAGE_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "foobar"
+ */
+export const SENTRY_STATUS_MESSAGE = 'sentry.status.message';
+
+/**
+ * Type for {@link SENTRY_STATUS_MESSAGE} sentry.status.message
+ */
+export type SENTRY_STATUS_MESSAGE_TYPE = string;
 
 // Path: model/attributes/sentry/sentry__trace__parent_span_id.json
 
@@ -8715,8 +8795,11 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SENTRY_DSC_TRANSACTION]: 'string',
   [SENTRY_ENVIRONMENT]: 'string',
   [SENTRY_EXCLUSIVE_TIME]: 'double',
+  [SENTRY_GRAPHQL_OPERATION]: 'string',
   [SENTRY_HTTP_PREFETCH]: 'boolean',
   [SENTRY_IDLE_SPAN_FINISH_REASON]: 'string',
+  [SENTRY_IS_REMOTE]: 'boolean',
+  [SENTRY_KIND]: 'string',
   [SENTRY_MESSAGE_PARAMETER_KEY]: 'string',
   [SENTRY_MESSAGE_TEMPLATE]: 'string',
   [SENTRY_MODULE_KEY]: 'string',
@@ -8738,6 +8821,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SENTRY_SEGMENT_NAME]: 'string',
   [SENTRY_SERVER_SAMPLE_RATE]: 'double',
   [SENTRY_SPAN_SOURCE]: 'string',
+  [SENTRY_STATUS_MESSAGE]: 'string',
   [SENTRY_TRACE_PARENT_SPAN_ID]: 'string',
   [SENTRY_TRANSACTION]: 'string',
   [SERVER_ADDRESS]: 'string',
@@ -9120,8 +9204,11 @@ export type AttributeName =
   | typeof SENTRY_DSC_TRANSACTION
   | typeof SENTRY_ENVIRONMENT
   | typeof SENTRY_EXCLUSIVE_TIME
+  | typeof SENTRY_GRAPHQL_OPERATION
   | typeof SENTRY_HTTP_PREFETCH
   | typeof SENTRY_IDLE_SPAN_FINISH_REASON
+  | typeof SENTRY_IS_REMOTE
+  | typeof SENTRY_KIND
   | typeof SENTRY_MESSAGE_PARAMETER_KEY
   | typeof SENTRY_MESSAGE_TEMPLATE
   | typeof SENTRY_MODULE_KEY
@@ -9143,6 +9230,7 @@ export type AttributeName =
   | typeof SENTRY_SEGMENT_NAME
   | typeof SENTRY_SERVER_SAMPLE_RATE
   | typeof SENTRY_SPAN_SOURCE
+  | typeof SENTRY_STATUS_MESSAGE
   | typeof SENTRY_TRACE_PARENT_SPAN_ID
   | typeof SENTRY_TRANSACTION
   | typeof SERVER_ADDRESS
@@ -12440,6 +12528,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: 1234,
   },
+  [SENTRY_GRAPHQL_OPERATION]: {
+    brief: 'Indicates the type of graphql operation, emitted by the Javascript SDK.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 'getUserById',
+  },
   [SENTRY_HTTP_PREFETCH]: {
     brief: 'If an http request was a prefetch request.',
     type: 'boolean',
@@ -12457,6 +12554,25 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 'idleTimeout',
+  },
+  [SENTRY_IS_REMOTE]: {
+    brief: "Indicates whether a span's parent is remote.",
+    type: 'boolean',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: true,
+  },
+  [SENTRY_KIND]: {
+    brief:
+      'Used to clarify the relationship between parents and children, or to distinguish between spans, e.g. a `server` and `client` span with the same name.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 'server',
   },
   [SENTRY_MESSAGE_PARAMETER_KEY]: {
     brief:
@@ -12662,6 +12778,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 'route',
+  },
+  [SENTRY_STATUS_MESSAGE]: {
+    brief: 'The from OTLP extracted status message.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 'foobar',
   },
   [SENTRY_TRACE_PARENT_SPAN_ID]: {
     brief:
@@ -13645,8 +13770,11 @@ export type Attributes = {
   [SENTRY_DSC_TRANSACTION]?: SENTRY_DSC_TRANSACTION_TYPE;
   [SENTRY_ENVIRONMENT]?: SENTRY_ENVIRONMENT_TYPE;
   [SENTRY_EXCLUSIVE_TIME]?: SENTRY_EXCLUSIVE_TIME_TYPE;
+  [SENTRY_GRAPHQL_OPERATION]?: SENTRY_GRAPHQL_OPERATION_TYPE;
   [SENTRY_HTTP_PREFETCH]?: SENTRY_HTTP_PREFETCH_TYPE;
   [SENTRY_IDLE_SPAN_FINISH_REASON]?: SENTRY_IDLE_SPAN_FINISH_REASON_TYPE;
+  [SENTRY_IS_REMOTE]?: SENTRY_IS_REMOTE_TYPE;
+  [SENTRY_KIND]?: SENTRY_KIND_TYPE;
   [SENTRY_MESSAGE_PARAMETER_KEY]?: SENTRY_MESSAGE_PARAMETER_KEY_TYPE;
   [SENTRY_MESSAGE_TEMPLATE]?: SENTRY_MESSAGE_TEMPLATE_TYPE;
   [SENTRY_MODULE_KEY]?: SENTRY_MODULE_KEY_TYPE;
@@ -13668,6 +13796,7 @@ export type Attributes = {
   [SENTRY_SEGMENT_NAME]?: SENTRY_SEGMENT_NAME_TYPE;
   [SENTRY_SERVER_SAMPLE_RATE]?: SENTRY_SERVER_SAMPLE_RATE_TYPE;
   [SENTRY_SPAN_SOURCE]?: SENTRY_SPAN_SOURCE_TYPE;
+  [SENTRY_STATUS_MESSAGE]?: SENTRY_STATUS_MESSAGE_TYPE;
   [SENTRY_TRACE_PARENT_SPAN_ID]?: SENTRY_TRACE_PARENT_SPAN_ID_TYPE;
   [SENTRY_TRANSACTION]?: SENTRY_TRANSACTION_TYPE;
   [SERVER_ADDRESS]?: SERVER_ADDRESS_TYPE;

--- a/model/attributes/sentry/sentry__graphql__operation.json
+++ b/model/attributes/sentry/sentry__graphql__operation.json
@@ -1,0 +1,10 @@
+{
+  "key": "sentry.graphql.operation",
+  "brief": "Indicates the type of graphql operation, emitted by the Javascript SDK.",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "getUserById"
+}

--- a/model/attributes/sentry/sentry__is_remote.json
+++ b/model/attributes/sentry/sentry__is_remote.json
@@ -1,0 +1,10 @@
+{
+  "key": "sentry.is_remote",
+  "brief": "Indicates whether a span's parent is remote.",
+  "type": "boolean",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": true
+}

--- a/model/attributes/sentry/sentry__kind.json
+++ b/model/attributes/sentry/sentry__kind.json
@@ -1,0 +1,10 @@
+{
+  "key": "sentry.kind",
+  "brief": "Used to clarify the relationship between parents and children, or to distinguish between spans, e.g. a `server` and `client` span with the same name.",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "server"
+}

--- a/model/attributes/sentry/sentry__status__message.json
+++ b/model/attributes/sentry/sentry__status__message.json
@@ -1,0 +1,10 @@
+{
+  "key": "sentry.status.message",
+  "brief": "The from OTLP extracted status message.",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "foobar"
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3588,6 +3588,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 1234
     """
 
+    # Path: model/attributes/sentry/sentry__graphql__operation.json
+    SENTRY_GRAPHQL_OPERATION: Literal["sentry.graphql.operation"] = (
+        "sentry.graphql.operation"
+    )
+    """Indicates the type of graphql operation, emitted by the Javascript SDK.
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "getUserById"
+    """
+
     # Path: model/attributes/sentry/sentry__http__prefetch.json
     SENTRY_HTTP_PREFETCH: Literal["sentry.http.prefetch"] = "sentry.http.prefetch"
     """If an http request was a prefetch request.
@@ -3608,6 +3620,26 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: false
     Defined in OTEL: No
     Example: "idleTimeout"
+    """
+
+    # Path: model/attributes/sentry/sentry__is_remote.json
+    SENTRY_IS_REMOTE: Literal["sentry.is_remote"] = "sentry.is_remote"
+    """Indicates whether a span's parent is remote.
+
+    Type: bool
+    Contains PII: false
+    Defined in OTEL: No
+    Example: true
+    """
+
+    # Path: model/attributes/sentry/sentry__kind.json
+    SENTRY_KIND: Literal["sentry.kind"] = "sentry.kind"
+    """Used to clarify the relationship between parents and children, or to distinguish between spans, e.g. a `server` and `client` span with the same name.
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "server"
     """
 
     # Path: model/attributes/sentry/sentry__message__parameter__[key].json
@@ -3841,6 +3873,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: false
     Defined in OTEL: No
     Example: "route"
+    """
+
+    # Path: model/attributes/sentry/sentry__status__message.json
+    SENTRY_STATUS_MESSAGE: Literal["sentry.status.message"] = "sentry.status.message"
+    """The from OTLP extracted status message.
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "foobar"
     """
 
     # Path: model/attributes/sentry/sentry__trace__parent_span_id.json
@@ -7036,6 +7078,13 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example=1234,
     ),
+    "sentry.graphql.operation": AttributeMetadata(
+        brief="Indicates the type of graphql operation, emitted by the Javascript SDK.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="getUserById",
+    ),
     "sentry.http.prefetch": AttributeMetadata(
         brief="If an http request was a prefetch request.",
         type=AttributeType.BOOLEAN,
@@ -7049,6 +7098,20 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=False,
         example="idleTimeout",
+    ),
+    "sentry.is_remote": AttributeMetadata(
+        brief="Indicates whether a span's parent is remote.",
+        type=AttributeType.BOOLEAN,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example=True,
+    ),
+    "sentry.kind": AttributeMetadata(
+        brief="Used to clarify the relationship between parents and children, or to distinguish between spans, e.g. a `server` and `client` span with the same name.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="server",
     ),
     "sentry.message.parameter.<key>": AttributeMetadata(
         brief="A parameter used in the message template. <key> can either be the number that represent the parameter's position in the template string (sentry.message.parameter.0, sentry.message.parameter.1, etc) or the parameter's name (sentry.message.parameter.item_id, sentry.message.parameter.user_id, etc)",
@@ -7210,6 +7273,13 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=False,
         example="route",
+    ),
+    "sentry.status.message": AttributeMetadata(
+        brief="The from OTLP extracted status message.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="foobar",
     ),
     "sentry.trace.parent_span_id": AttributeMetadata(
         brief="The span id of the span that was active when the log was collected. This should not be set if there was no active span.",
@@ -8046,8 +8116,11 @@ Attributes = TypedDict(
         "sentry.dsc.transaction": str,
         "sentry.environment": str,
         "sentry.exclusive_time": float,
+        "sentry.graphql.operation": str,
         "sentry.http.prefetch": bool,
         "sentry.idle_span_finish_reason": str,
+        "sentry.is_remote": bool,
+        "sentry.kind": str,
         "sentry.message.parameter.<key>": str,
         "sentry.message.template": str,
         "sentry.module.<key>": str,
@@ -8069,6 +8142,7 @@ Attributes = TypedDict(
         "sentry.segment_id": str,
         "sentry.server_sample_rate": float,
         "sentry.span.source": str,
+        "sentry.status.message": str,
         "sentry.trace.parent_span_id": str,
         "sentry.transaction": str,
         "server.address": str,


### PR DESCRIPTION
## Description

See: https://github.com/getsentry/relay/blob/9c491a185a289e09ee9d3f56d89bd9d1fa71d815/relay-conventions/src/consts.rs#L72-L82

## PR Checklist
- [X] I have run `yarn test` and verified that the tests pass.
- [X] I have run `yarn generate && yarn format` to generate and format code and docs.

If an attribute was added:
- [X] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [X] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)