### PR TITLE
chore(attributes): Normalize deprecated db attribute names

### DIFF
--- a/model/attributes/db/db__operation.json
+++ b/model/attributes/db/db__operation.json
@@ -8,7 +8,7 @@
   "is_in_otel": true,
   "example": "SELECT",
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "db.operation.name"
   },
   "alias": ["db.operation.name"]

--- a/model/attributes/db/db__statement.json
+++ b/model/attributes/db/db__statement.json
@@ -8,7 +8,7 @@
   "is_in_otel": true,
   "example": "SELECT * FROM users",
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "db.query.text"
   },
   "alias": ["db.query.text"]

--- a/model/attributes/db/db__system.json
+++ b/model/attributes/db/db__system.json
@@ -8,7 +8,7 @@
   "is_in_otel": true,
   "example": "postgresql",
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "db.system.name"
   },
   "alias": ["db.system.name"]

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5186,7 +5186,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         example="SELECT",
         deprecation=DeprecationInfo(
-            replacement="db.operation.name", status=DeprecationStatus.BACKFILL
+            replacement="db.operation.name", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["db.operation.name"],
     ),
@@ -5256,7 +5256,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         example="SELECT * FROM users",
         deprecation=DeprecationInfo(
-            replacement="db.query.text", status=DeprecationStatus.BACKFILL
+            replacement="db.query.text", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["db.query.text"],
     ),
@@ -5267,7 +5267,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         example="postgresql",
         deprecation=DeprecationInfo(
-            replacement="db.system.name", status=DeprecationStatus.BACKFILL
+            replacement="db.system.name", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["db.system.name"],
     ),

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -529,7 +529,7 @@
       "is_in_otel": true,
       "example": "SELECT",
       "deprecation": {
-        "_status": "backfill",
+        "_status": "normalize",
         "replacement": "db.operation.name"
       },
       "alias": ["db.operation.name"]
@@ -560,7 +560,7 @@
       "is_in_otel": true,
       "example": "SELECT * FROM users",
       "deprecation": {
-        "_status": "backfill",
+        "_status": "normalize",
         "replacement": "db.query.text"
       },
       "alias": ["db.query.text"]
@@ -575,7 +575,7 @@
       "is_in_otel": true,
       "example": "postgresql",
       "deprecation": {
-        "_status": "backfill",
+        "_status": "normalize",
         "replacement": "db.system.name"
       },
       "alias": ["db.system.name"]


### PR DESCRIPTION
Normalizes deprecated db attributes. It's important that these attributes get their names normalized to the latest convention because we normalize their values afterwards (and we expect the latest attribute names during normalization).