### PR TITLE
Revert "fix: Change `http.request/response.header.<key>` to `pii: "true"`"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 #### Changes to attributes
 
 - feat(attributes): Add sentry.normalized_db_query.hash ([#200](https://github.com/getsentry/sentry-conventions/pull/200))
-- fix: Change `http.request/response.header.<key>` to `pii: "true"` ([#201](https://github.com/getsentry/sentry-conventions/pull/201))
 
 ## 0.3.1
 

--- a/generated/attributes/http.md
+++ b/generated/attributes/http.md
@@ -139,7 +139,7 @@ HTTP request headers, \<key\> being the normalized HTTP Header name (lowercase),
 | Property | Value |
 | --- | --- |
 | Type | `string[]` |
-| Has PII | true |
+| Has PII | maybe |
 | Exists in OpenTelemetry | Yes |
 | Has dynamic suffix | Yes |
 | Example | `http.request.header.custom-header=['foo', 'bar']` |
@@ -274,7 +274,7 @@ HTTP response headers, \<key\> being the normalized HTTP Header name (lowercase)
 | Property | Value |
 | --- | --- |
 | Type | `string[]` |
-| Has PII | true |
+| Has PII | maybe |
 | Exists in OpenTelemetry | Yes |
 | Has dynamic suffix | Yes |
 | Example | `http.response.header.custom-header=['foo', 'bar']` |

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3246,7 +3246,7 @@ export type HTTP_REQUEST_FETCH_START_TYPE = number;
  *
  * Attribute Value Type: `Array<string>` {@link HTTP_REQUEST_HEADER_KEY_TYPE}
  *
- * Contains PII: true
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: Yes
  *
@@ -3537,7 +3537,7 @@ export type HTTP_RESPONSE_HEADER_CONTENT_LENGTH_TYPE = string;
  *
  * Attribute Value Type: `Array<string>` {@link HTTP_RESPONSE_HEADER_KEY_TYPE}
  *
- * Contains PII: true
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: Yes
  *
@@ -11036,7 +11036,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       'HTTP request headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.',
     type: 'string[]',
     pii: {
-      isPii: 'true',
+      isPii: 'maybe',
     },
     isInOtel: true,
     hasDynamicSuffix: true,
@@ -11186,7 +11186,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       'HTTP response headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.',
     type: 'string[]',
     pii: {
-      isPii: 'true',
+      isPii: 'maybe',
     },
     isInOtel: true,
     hasDynamicSuffix: true,

--- a/model/attributes/http/http__request__header__[key].json
+++ b/model/attributes/http/http__request__header__[key].json
@@ -4,7 +4,7 @@
   "has_dynamic_suffix": true,
   "type": "string[]",
   "pii": {
-    "key": "true"
+    "key": "maybe"
   },
   "is_in_otel": true,
   "example": "http.request.header.custom-header=['foo', 'bar']"

--- a/model/attributes/http/http__response__header__[key].json
+++ b/model/attributes/http/http__response__header__[key].json
@@ -4,7 +4,7 @@
   "has_dynamic_suffix": true,
   "type": "string[]",
   "pii": {
-    "key": "true"
+    "key": "maybe"
   },
   "is_in_otel": true,
   "example": "http.response.header.custom-header=['foo', 'bar']"

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1894,7 +1894,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """HTTP request headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.
 
     Type: List[str]
-    Contains PII: true
+    Contains PII: maybe
     Defined in OTEL: Yes
     Has Dynamic Suffix: true
     Example: "http.request.header.custom-header=['foo', 'bar']"
@@ -2039,7 +2039,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """HTTP response headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.
 
     Type: List[str]
-    Contains PII: true
+    Contains PII: maybe
     Defined in OTEL: Yes
     Has Dynamic Suffix: true
     Example: "http.response.header.custom-header=['foo', 'bar']"
@@ -5920,7 +5920,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "http.request.header.<key>": AttributeMetadata(
         brief="HTTP request headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.",
         type=AttributeType.STRING_ARRAY,
-        pii=PiiInfo(isPii=IsPii.TRUE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         has_dynamic_suffix=True,
         example="http.request.header.custom-header=['foo', 'bar']",
@@ -6015,7 +6015,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "http.response.header.<key>": AttributeMetadata(
         brief="HTTP response headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.",
         type=AttributeType.STRING_ARRAY,
-        pii=PiiInfo(isPii=IsPii.TRUE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         has_dynamic_suffix=True,
         example="http.response.header.custom-header=['foo', 'bar']",


### PR DESCRIPTION
Reverts getsentry/sentry-conventions#201
Scrubbing all headers by default might significantly worsen UX.
We should, instead, keep this to `pii: "maybe"` and then add additional more specific entries for well-known sensitive headers that we always want to scrub, such as the new `cookie` ones.

#skip-changelog