### PR TITLE
chore(repo): Run `yarn format` after `yarn generate`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:tarball:model": "tsx scripts/gzip_folder.ts model model/sentry-conventions-json.tgz",
 
     "create:attribute": "tsx scripts/create_attribute.ts",
-    "generate": "tsx scripts/generate.ts"
+    "generate": "tsx scripts/generate.ts && yarn format"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
This always annoyed me: We run `biome` directly in the generation script but this leads to incorrect formatting for python files, causing PRs to fail in CI. So you always needed to run `yarn format` in addition afterwards. This PR now simply adds the format command to the generate command so that this happens in one go.

#skip-changelog