### PR TITLE
feat(attributes): Add `browser.connection.rtt` attribute

### DIFF
--- a/generated/attributes/all.md
+++ b/generated/attributes/all.md
@@ -4,7 +4,7 @@
 
 This page lists all available attributes across all categories.
 
-Total attributes: 423
+Total attributes: 425
 
 ## Stable Attributes
 
@@ -25,6 +25,7 @@ Total attributes: 423
 | [`ai.warnings`](./ai.md#aiwarnings) | Warning messages generated during model execution. |
 | [`app_start_type`](./general.md#app_start_type) | Mobile app start variant. Either cold or warm. |
 | [`blocked_main_thread`](./general.md#blocked_main_thread) | Whether the main thread was blocked by the span. |
+| [`browser.connection.rtt`](./browser.md#browserconnectionrtt) | The estimated request round trip time (RTT) in milliseconds based on the current connection's quality. Values are always multiples of 25 milliseconds. |
 | [`browser.name`](./browser.md#browsername) | The name of the browser. |
 | [`browser.report.type`](./browser.md#browserreporttype) | A browser report sent via reporting API.. |
 | [`browser.script.invoker`](./browser.md#browserscriptinvoker) | How a script was called in the browser. |
@@ -384,6 +385,7 @@ Total attributes: 423
 | [`code.function`](./code.md#codefunction) | [`code.function.name`](./code.md#codefunctionname) |
 | [`code.lineno`](./code.md#codelineno) | [`code.line.number`](./code.md#codelinenumber) |
 | [`code.namespace`](./code.md#codenamespace) | [`code.function.name`](./code.md#codefunctionname) |
+| [`connection.rtt`](./connection.md#connectionrtt) | [`browser.connection.rtt`](./browser.md#browserconnectionrtt) |
 | [`db.name`](./db.md#dbname) | [`db.namespace`](./db.md#dbnamespace) |
 | [`db.operation`](./db.md#dboperation) | [`db.operation.name`](./db.md#dboperationname) |
 | [`db.sql.bindings`](./db.md#dbsqlbindings) | [`db.query.parameter.\<key\>`](./db.md#dbqueryparameterkey) |

--- a/generated/attributes/browser.md
+++ b/generated/attributes/browser.md
@@ -3,6 +3,7 @@
 # Browser Attributes
 
 - [Stable Attributes](#stable-attributes)
+  - [browser.connection.rtt](#browserconnectionrtt)
   - [browser.name](#browsername)
   - [browser.report.type](#browserreporttype)
   - [browser.script.invoker](#browserscriptinvoker)
@@ -11,6 +12,18 @@
   - [browser.version](#browserversion)
 
 ## Stable Attributes
+
+### browser.connection.rtt
+
+The estimated request round trip time (RTT) in milliseconds based on the current connection's quality. Values are always multiples of 25 milliseconds.
+
+| Property | Value |
+| --- | --- |
+| Type | `integer` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `50` |
+| Aliases | `connection.rtt` |
 
 ### browser.name
 

--- a/generated/attributes/connection.md
+++ b/generated/attributes/connection.md
@@ -1,0 +1,25 @@
+<!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT DIRECTLY. -->
+
+# Connection Attributes
+
+- [Deprecated Attributes](#deprecated-attributes)
+  - [connection.rtt](#connectionrtt)
+
+## Deprecated Attributes
+
+These attributes are deprecated and will be removed in a future version. Please use the recommended replacements.
+
+### connection.rtt
+
+The estimated request round trip time (RTT) in milliseconds based on the current connection's quality. Values are always multiples of 25 milliseconds.
+
+| Property | Value |
+| --- | --- |
+| Type | `integer` |
+| Has PII | maybe |
+| Exists in OpenTelemetry | No |
+| Example | `50` |
+| Deprecated | Yes, use `browser.connection.rtt` instead |
+| Deprecation Reason | This attribute is being deprecated in favor of browser.connection.rtt |
+| Aliases | `browser.connection.rtt` |
+

--- a/generated/attributes/index.md
+++ b/generated/attributes/index.md
@@ -14,6 +14,7 @@ This directory contains documentation for all available attributes.
 - [`client` Attributes](./client.md)
 - [`cloudflare` Attributes](./cloudflare.md)
 - [`code` Attributes](./code.md)
+- [`connection` Attributes](./connection.md)
 - [`db` Attributes](./db.md)
 - [`device` Attributes](./device.md)
 - [`error` Attributes](./error.md)

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -754,6 +754,28 @@ export const BLOCKED_MAIN_THREAD = 'blocked_main_thread';
  */
 export type BLOCKED_MAIN_THREAD_TYPE = boolean;
 
+// Path: model/attributes/browser/browser__connection__rtt.json
+
+/**
+ * The estimated request round trip time (RTT) in milliseconds based on the current connection's quality. Values are always multiples of 25 milliseconds. `browser.connection.rtt`
+ *
+ * Attribute Value Type: `number` {@link BROWSER_CONNECTION_RTT_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Aliases: {@link CONNECTION_RTT} `connection.rtt`
+ *
+ * @example 50
+ */
+export const BROWSER_CONNECTION_RTT = 'browser.connection.rtt';
+
+/**
+ * Type for {@link BROWSER_CONNECTION_RTT} browser.connection.rtt
+ */
+export type BROWSER_CONNECTION_RTT_TYPE = number;
+
 // Path: model/attributes/browser/browser__name.json
 
 /**
@@ -1255,6 +1277,29 @@ export const CODE_NAMESPACE = 'code.namespace';
  * Type for {@link CODE_NAMESPACE} code.namespace
  */
 export type CODE_NAMESPACE_TYPE = string;
+
+// Path: model/attributes/connection/connection__rtt.json
+
+/**
+ * The estimated request round trip time (RTT) in milliseconds based on the current connection's quality. Values are always multiples of 25 milliseconds. `connection.rtt`
+ *
+ * Attribute Value Type: `number` {@link CONNECTION_RTT_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Aliases: {@link BROWSER_CONNECTION_RTT} `browser.connection.rtt`
+ *
+ * @deprecated Use {@link BROWSER_CONNECTION_RTT} (browser.connection.rtt) instead - This attribute is being deprecated in favor of browser.connection.rtt
+ * @example 50
+ */
+export const CONNECTION_RTT = 'connection.rtt';
+
+/**
+ * Type for {@link CONNECTION_RTT} connection.rtt
+ */
+export type CONNECTION_RTT_TYPE = number;
 
 // Path: model/attributes/db/db__collection__name.json
 
@@ -8863,6 +8908,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [AI_WARNINGS]: 'string[]',
   [APP_START_TYPE]: 'string',
   [BLOCKED_MAIN_THREAD]: 'boolean',
+  [BROWSER_CONNECTION_RTT]: 'integer',
   [BROWSER_NAME]: 'string',
   [BROWSER_REPORT_TYPE]: 'string',
   [BROWSER_SCRIPT_INVOKER]: 'string',
@@ -8887,6 +8933,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [CODE_LINENO]: 'integer',
   [CODE_LINE_NUMBER]: 'integer',
   [CODE_NAMESPACE]: 'string',
+  [CONNECTION_RTT]: 'integer',
   [DB_COLLECTION_NAME]: 'string',
   [DB_NAME]: 'string',
   [DB_NAMESPACE]: 'string',
@@ -9289,6 +9336,7 @@ export type AttributeName =
   | typeof AI_WARNINGS
   | typeof APP_START_TYPE
   | typeof BLOCKED_MAIN_THREAD
+  | typeof BROWSER_CONNECTION_RTT
   | typeof BROWSER_NAME
   | typeof BROWSER_REPORT_TYPE
   | typeof BROWSER_SCRIPT_INVOKER
@@ -9313,6 +9361,7 @@ export type AttributeName =
   | typeof CODE_LINENO
   | typeof CODE_LINE_NUMBER
   | typeof CODE_NAMESPACE
+  | typeof CONNECTION_RTT
   | typeof DB_COLLECTION_NAME
   | typeof DB_NAME
   | typeof DB_NAMESPACE
@@ -10085,6 +10134,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: true,
   },
+  [BROWSER_CONNECTION_RTT]: {
+    brief:
+      "The estimated request round trip time (RTT) in milliseconds based on the current connection's quality. Values are always multiples of 25 milliseconds.",
+    type: 'integer',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 50,
+    aliases: [CONNECTION_RTT],
+    sdks: ['javascript-browser'],
+  },
   [BROWSER_NAME]: {
     brief: 'The name of the browser.',
     type: 'string',
@@ -10339,6 +10400,21 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'code.function.name',
       reason: 'code.function.name should include the namespace.',
     },
+  },
+  [CONNECTION_RTT]: {
+    brief:
+      "The estimated request round trip time (RTT) in milliseconds based on the current connection's quality. Values are always multiples of 25 milliseconds.",
+    type: 'integer',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 50,
+    deprecation: {
+      replacement: 'browser.connection.rtt',
+      reason: 'This attribute is being deprecated in favor of browser.connection.rtt',
+    },
+    aliases: [BROWSER_CONNECTION_RTT],
   },
   [DB_COLLECTION_NAME]: {
     brief: 'The name of a collection (table, container) within the database.',
@@ -14051,6 +14127,7 @@ export type Attributes = {
   [AI_WARNINGS]?: AI_WARNINGS_TYPE;
   [APP_START_TYPE]?: APP_START_TYPE_TYPE;
   [BLOCKED_MAIN_THREAD]?: BLOCKED_MAIN_THREAD_TYPE;
+  [BROWSER_CONNECTION_RTT]?: BROWSER_CONNECTION_RTT_TYPE;
   [BROWSER_NAME]?: BROWSER_NAME_TYPE;
   [BROWSER_REPORT_TYPE]?: BROWSER_REPORT_TYPE_TYPE;
   [BROWSER_SCRIPT_INVOKER]?: BROWSER_SCRIPT_INVOKER_TYPE;
@@ -14075,6 +14152,7 @@ export type Attributes = {
   [CODE_LINENO]?: CODE_LINENO_TYPE;
   [CODE_LINE_NUMBER]?: CODE_LINE_NUMBER_TYPE;
   [CODE_NAMESPACE]?: CODE_NAMESPACE_TYPE;
+  [CONNECTION_RTT]?: CONNECTION_RTT_TYPE;
   [DB_COLLECTION_NAME]?: DB_COLLECTION_NAME_TYPE;
   [DB_NAME]?: DB_NAME_TYPE;
   [DB_NAMESPACE]?: DB_NAMESPACE_TYPE;

--- a/model/attributes/browser/browser__connection__rtt.json
+++ b/model/attributes/browser/browser__connection__rtt.json
@@ -1,0 +1,12 @@
+{
+  "key": "browser.connection.rtt",
+  "brief": "The estimated request round trip time (RTT) in milliseconds based on the current connection's quality. Values are always multiples of 25 milliseconds.",
+  "type": "integer",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": 50,
+  "alias": ["connection.rtt"],
+  "sdks": ["javascript-browser"]
+}

--- a/model/attributes/connection/connection__rtt.json
+++ b/model/attributes/connection/connection__rtt.json
@@ -1,0 +1,16 @@
+{
+  "key": "connection.rtt",
+  "brief": "The estimated request round trip time (RTT) in milliseconds based on the current connection's quality. Values are always multiples of 25 milliseconds.",
+  "type": "integer",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": 50,
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "browser.connection.rtt",
+    "reason": "This attribute is being deprecated in favor of browser.connection.rtt"
+  },
+  "alias": ["browser.connection.rtt"]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -109,6 +109,7 @@ class _AttributeNamesMeta(type):
         "CODE_FUNCTION",
         "CODE_LINENO",
         "CODE_NAMESPACE",
+        "CONNECTION_RTT",
         "DB_NAME",
         "DB_OPERATION",
         "DB_SQL_BINDINGS",
@@ -569,6 +570,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: true
     """
 
+    # Path: model/attributes/browser/browser__connection__rtt.json
+    BROWSER_CONNECTION_RTT: Literal["browser.connection.rtt"] = "browser.connection.rtt"
+    """The estimated request round trip time (RTT) in milliseconds based on the current connection's quality. Values are always multiples of 25 milliseconds.
+
+    Type: int
+    Contains PII: maybe
+    Defined in OTEL: No
+    Aliases: connection.rtt
+    Example: 50
+    """
+
     # Path: model/attributes/browser/browser__name.json
     BROWSER_NAME: Literal["browser.name"] = "browser.name"
     """The name of the browser.
@@ -828,6 +840,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     DEPRECATED: Use code.function.name instead - code.function.name should include the namespace.
     Example: "http.handler"
+    """
+
+    # Path: model/attributes/connection/connection__rtt.json
+    CONNECTION_RTT: Literal["connection.rtt"] = "connection.rtt"
+    """The estimated request round trip time (RTT) in milliseconds based on the current connection's quality. Values are always multiples of 25 milliseconds.
+
+    Type: int
+    Contains PII: maybe
+    Defined in OTEL: No
+    Aliases: browser.connection.rtt
+    DEPRECATED: Use browser.connection.rtt instead - This attribute is being deprecated in favor of browser.connection.rtt
+    Example: 50
     """
 
     # Path: model/attributes/db/db__collection__name.json
@@ -5120,6 +5144,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example=True,
     ),
+    "browser.connection.rtt": AttributeMetadata(
+        brief="The estimated request round trip time (RTT) in milliseconds based on the current connection's quality. Values are always multiples of 25 milliseconds.",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=50,
+        aliases=["connection.rtt"],
+        sdks=["javascript-browser"],
+    ),
     "browser.name": AttributeMetadata(
         brief="The name of the browser.",
         type=AttributeType.STRING,
@@ -5314,6 +5347,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             replacement="code.function.name",
             reason="code.function.name should include the namespace.",
         ),
+    ),
+    "connection.rtt": AttributeMetadata(
+        brief="The estimated request round trip time (RTT) in milliseconds based on the current connection's quality. Values are always multiples of 25 milliseconds.",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=50,
+        deprecation=DeprecationInfo(
+            replacement="browser.connection.rtt",
+            reason="This attribute is being deprecated in favor of browser.connection.rtt",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["browser.connection.rtt"],
     ),
     "db.collection.name": AttributeMetadata(
         brief="The name of a collection (table, container) within the database.",
@@ -8169,6 +8215,7 @@ Attributes = TypedDict(
         "ai.warnings": List[str],
         "app_start_type": str,
         "blocked_main_thread": bool,
+        "browser.connection.rtt": int,
         "browser.name": str,
         "browser.report.type": str,
         "browser.script.invoker": str,
@@ -8193,6 +8240,7 @@ Attributes = TypedDict(
         "code.line.number": int,
         "code.lineno": int,
         "code.namespace": str,
+        "connection.rtt": int,
         "db.collection.name": str,
         "db.name": str,
         "db.namespace": str,

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -505,6 +505,22 @@
       }
     },
     {
+      "key": "connection.rtt",
+      "brief": "The estimated request round trip time (RTT) in milliseconds based on the current connection's quality. Values are always multiples of 25 milliseconds.",
+      "type": "integer",
+      "pii": {
+        "key": "maybe"
+      },
+      "is_in_otel": false,
+      "example": 50,
+      "deprecation": {
+        "_status": "backfill",
+        "replacement": "browser.connection.rtt",
+        "reason": "This attribute is being deprecated in favor of browser.connection.rtt"
+      },
+      "alias": ["browser.connection.rtt"]
+    },
+    {
       "key": "db.name",
       "brief": "The name of the database being accessed.",
       "type": "string",


### PR DESCRIPTION
Our JS SDK records a `connection.rtt` measurement, measuring the estimated request RTT based on the current connection quality. This is not really a performance indicator of made requests, but rather just an estimate how fast a request/response cycle will likely be handled. Anyway, we record this on the pageload and navigation spans (not sure about the value tbh but we do). 

For converting this measurement to an attribute, I for now decided to use the `browser` namespace due to this value being a coarse estimation.  We could use the `network` namespace and add something like `network.connection.rtt`. Just not sure if we want these estimations connected to the more general attribute. But tbh, LOGAF-L, so whatever reviewers prefer.