### PR TITLE
feat(attributes): Add `sentry.profiler_id` attribute

### DIFF
--- a/generated/attributes/all.md
+++ b/generated/attributes/all.md
@@ -4,7 +4,7 @@
 
 This page lists all available attributes across all categories.
 
-Total attributes: 423
+Total attributes: 424
 
 ## Stable Attributes
 
@@ -274,6 +274,7 @@ Total attributes: 423
 | [`sentry.origin`](./sentry.md#sentryorigin) | The origin of the instrumentation (e.g. span, log, etc.) |
 | [`sentry.platform`](./sentry.md#sentryplatform) | The sdk platform that generated the event. |
 | [`sentry.profile_id`](./sentry.md#sentryprofile_id) | The id of the sentry profile. |
+| [`sentry.profiler_id`](./sentry.md#sentryprofiler_id) | The id of the currently running profiler (continuous profiling) |
 | [`sentry.release`](./sentry.md#sentryrelease) | The sentry release. |
 | [`sentry.replay_id`](./sentry.md#sentryreplay_id) | The id of the sentry replay. |
 | [`sentry.replay_is_buffering`](./sentry.md#sentryreplay_is_buffering) | A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate). |

--- a/generated/attributes/sentry.md
+++ b/generated/attributes/sentry.md
@@ -38,6 +38,7 @@
   - [sentry.origin](#sentryorigin)
   - [sentry.platform](#sentryplatform)
   - [sentry.profile_id](#sentryprofile_id)
+  - [sentry.profiler_id](#sentryprofiler_id)
   - [sentry.release](#sentryrelease)
   - [sentry.replay_id](#sentryreplay_id)
   - [sentry.replay_is_buffering](#sentryreplay_is_buffering)
@@ -444,6 +445,17 @@ The id of the sentry profile.
 | Exists in OpenTelemetry | No |
 | Example | `123e4567e89b12d3a456426614174000` |
 | Aliases | `profile_id` |
+
+### sentry.profiler_id
+
+The id of the currently running profiler (continuous profiling)
+
+| Property | Value |
+| --- | --- |
+| Type | `string` |
+| Has PII | false |
+| Exists in OpenTelemetry | No |
+| Example | `18779b64dd35d1a538e7ce2dd2d3fad3` |
 
 ### sentry.release
 

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -7043,6 +7043,26 @@ export const SENTRY_PLATFORM = 'sentry.platform';
  */
 export type SENTRY_PLATFORM_TYPE = string;
 
+// Path: model/attributes/sentry/sentry__profiler_id.json
+
+/**
+ * The id of the currently running profiler (continuous profiling) `sentry.profiler_id`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_PROFILER_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "18779b64dd35d1a538e7ce2dd2d3fad3"
+ */
+export const SENTRY_PROFILER_ID = 'sentry.profiler_id';
+
+/**
+ * Type for {@link SENTRY_PROFILER_ID} sentry.profiler_id
+ */
+export type SENTRY_PROFILER_ID_TYPE = string;
+
 // Path: model/attributes/sentry/sentry__profile_id.json
 
 /**
@@ -9166,6 +9186,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SENTRY_OP]: 'string',
   [SENTRY_ORIGIN]: 'string',
   [SENTRY_PLATFORM]: 'string',
+  [SENTRY_PROFILER_ID]: 'string',
   [SENTRY_PROFILE_ID]: 'string',
   [SENTRY_RELEASE]: 'string',
   [SENTRY_REPLAY_ID]: 'string',
@@ -9592,6 +9613,7 @@ export type AttributeName =
   | typeof SENTRY_OP
   | typeof SENTRY_ORIGIN
   | typeof SENTRY_PLATFORM
+  | typeof SENTRY_PROFILER_ID
   | typeof SENTRY_PROFILE_ID
   | typeof SENTRY_RELEASE
   | typeof SENTRY_REPLAY_ID
@@ -13204,6 +13226,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: 'php',
   },
+  [SENTRY_PROFILER_ID]: {
+    brief: 'The id of the currently running profiler (continuous profiling)',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '18779b64dd35d1a538e7ce2dd2d3fad3',
+  },
   [SENTRY_PROFILE_ID]: {
     brief: 'The id of the sentry profile.',
     type: 'string',
@@ -14354,6 +14385,7 @@ export type Attributes = {
   [SENTRY_OP]?: SENTRY_OP_TYPE;
   [SENTRY_ORIGIN]?: SENTRY_ORIGIN_TYPE;
   [SENTRY_PLATFORM]?: SENTRY_PLATFORM_TYPE;
+  [SENTRY_PROFILER_ID]?: SENTRY_PROFILER_ID_TYPE;
   [SENTRY_PROFILE_ID]?: SENTRY_PROFILE_ID_TYPE;
   [SENTRY_RELEASE]?: SENTRY_RELEASE_TYPE;
   [SENTRY_REPLAY_ID]?: SENTRY_REPLAY_ID_TYPE;

--- a/model/attributes/sentry/sentry__profiler_id.json
+++ b/model/attributes/sentry/sentry__profiler_id.json
@@ -1,0 +1,10 @@
+{
+  "key": "sentry.profiler_id",
+  "brief": "The id of the currently running profiler (continuous profiling)",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "18779b64dd35d1a538e7ce2dd2d3fad3"
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3942,6 +3942,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "123e4567e89b12d3a456426614174000"
     """
 
+    # Path: model/attributes/sentry/sentry__profiler_id.json
+    SENTRY_PROFILER_ID: Literal["sentry.profiler_id"] = "sentry.profiler_id"
+    """The id of the currently running profiler (continuous profiling)
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "18779b64dd35d1a538e7ce2dd2d3fad3"
+    """
+
     # Path: model/attributes/sentry/sentry__release.json
     SENTRY_RELEASE: Literal["sentry.release"] = "sentry.release"
     """The sentry release.
@@ -7506,6 +7516,13 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="123e4567e89b12d3a456426614174000",
         aliases=["profile_id"],
     ),
+    "sentry.profiler_id": AttributeMetadata(
+        brief="The id of the currently running profiler (continuous profiling)",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="18779b64dd35d1a538e7ce2dd2d3fad3",
+    ),
     "sentry.release": AttributeMetadata(
         brief="The sentry release.",
         type=AttributeType.STRING,
@@ -8473,6 +8490,7 @@ Attributes = TypedDict(
         "sentry.origin": str,
         "sentry.platform": str,
         "sentry.profile_id": str,
+        "sentry.profiler_id": str,
         "sentry.release": str,
         "sentry.replay_id": str,
         "sentry.replay_is_buffering": bool,


### PR DESCRIPTION
This is the new attribute that span-first spans recorded during an active continuous profile will include. see https://github.com/getsentry/sentry-docs/pull/16051/