### PR TITLE
test: Fix python venv installation issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 
     "test": "yarn test:js && yarn test:python",
     "test:js": "vitest",
-    "test:python": "(cd python && uv venv && uv pip install -e . && uv run pytest)",
+    "test:python": "cd python && uv sync && uv pip install -e . && uv run pytest",
 
     "build": "yarn build:js && yarn build:python && yarn build:tarball",
     "build:js": "(cd javascript/sentry-conventions && yarn build)",


### PR DESCRIPTION
Looks like #231 accidentally broke `yarn test:python` in CI because by formatting when generating, the venv was already set up. Switching from `uv venv` to `uv sync` should fix this (CI will tell us).  