### PR TITLE
fix(gen_ai): input and output token description

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3028,7 +3028,7 @@ export type GEN_AI_USAGE_COMPLETION_TOKENS_TYPE = number;
 // Path: model/attributes/gen_ai/gen_ai__usage__input_tokens.json
 
 /**
- * The number of tokens used to process the AI input (prompt) without cached input tokens. `gen_ai.usage.input_tokens`
+ * The number of tokens used to process the AI input (prompt) including cached input tokens. `gen_ai.usage.input_tokens`
  *
  * Attribute Value Type: `number` {@link GEN_AI_USAGE_INPUT_TOKENS_TYPE}
  *
@@ -3090,7 +3090,7 @@ export type GEN_AI_USAGE_INPUT_TOKENS_CACHE_WRITE_TYPE = number;
 // Path: model/attributes/gen_ai/gen_ai__usage__output_tokens.json
 
 /**
- * The number of tokens used for creating the AI output (without reasoning tokens). `gen_ai.usage.output_tokens`
+ * The number of tokens used for creating the AI output (including reasoning tokens). `gen_ai.usage.output_tokens`
  *
  * Attribute Value Type: `number` {@link GEN_AI_USAGE_OUTPUT_TOKENS_TYPE}
  *
@@ -11278,7 +11278,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: [AI_COMPLETION_TOKENS_USED, GEN_AI_USAGE_OUTPUT_TOKENS],
   },
   [GEN_AI_USAGE_INPUT_TOKENS]: {
-    brief: 'The number of tokens used to process the AI input (prompt) without cached input tokens.',
+    brief: 'The number of tokens used to process the AI input (prompt) including cached input tokens.',
     type: 'integer',
     pii: {
       isPii: 'maybe',
@@ -11306,7 +11306,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 100,
   },
   [GEN_AI_USAGE_OUTPUT_TOKENS]: {
-    brief: 'The number of tokens used for creating the AI output (without reasoning tokens).',
+    brief: 'The number of tokens used for creating the AI output (including reasoning tokens).',
     type: 'integer',
     pii: {
       isPii: 'maybe',

--- a/model/attributes/gen_ai/gen_ai__usage__input_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__usage__input_tokens.json
@@ -1,6 +1,6 @@
 {
   "key": "gen_ai.usage.input_tokens",
-  "brief": "The number of tokens used to process the AI input (prompt) without cached input tokens.",
+  "brief": "The number of tokens used to process the AI input (prompt) including cached input tokens.",
   "type": "integer",
   "pii": {
     "key": "maybe"

--- a/model/attributes/gen_ai/gen_ai__usage__output_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__usage__output_tokens.json
@@ -1,6 +1,6 @@
 {
   "key": "gen_ai.usage.output_tokens",
-  "brief": "The number of tokens used for creating the AI output (without reasoning tokens).",
+  "brief": "The number of tokens used for creating the AI output (including reasoning tokens).",
   "type": "integer",
   "pii": {
     "key": "maybe"

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1772,7 +1772,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     GEN_AI_USAGE_INPUT_TOKENS: Literal["gen_ai.usage.input_tokens"] = (
         "gen_ai.usage.input_tokens"
     )
-    """The number of tokens used to process the AI input (prompt) without cached input tokens.
+    """The number of tokens used to process the AI input (prompt) including cached input tokens.
 
     Type: int
     Contains PII: maybe
@@ -1809,7 +1809,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     GEN_AI_USAGE_OUTPUT_TOKENS: Literal["gen_ai.usage.output_tokens"] = (
         "gen_ai.usage.output_tokens"
     )
-    """The number of tokens used for creating the AI output (without reasoning tokens).
+    """The number of tokens used for creating the AI output (including reasoning tokens).
 
     Type: int
     Contains PII: maybe
@@ -6000,7 +6000,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         aliases=["ai.completion_tokens.used", "gen_ai.usage.output_tokens"],
     ),
     "gen_ai.usage.input_tokens": AttributeMetadata(
-        brief="The number of tokens used to process the AI input (prompt) without cached input tokens.",
+        brief="The number of tokens used to process the AI input (prompt) including cached input tokens.",
         type=AttributeType.INTEGER,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
@@ -6022,7 +6022,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=50,
     ),
     "gen_ai.usage.output_tokens": AttributeMetadata(
-        brief="The number of tokens used for creating the AI output (without reasoning tokens).",
+        brief="The number of tokens used for creating the AI output (including reasoning tokens).",
         type=AttributeType.INTEGER,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,


### PR DESCRIPTION
## Description
- closes [TET-1986: Fix input and output token descriptions in sentry conventions](https://linear.app/getsentry/issue/TET-1986/fix-input-and-output-token-descriptions-in-sentry-conventions)

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate && yarn format` to generate and format code and docs.

If an attribute was added:
- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md)
