### PR TITLE
feat(resource): add resource.deployment.environment

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -6273,6 +6273,27 @@ export const REPLAY_ID = 'replay_id';
  */
 export type REPLAY_ID_TYPE = string;
 
+// Path: model/attributes/resource/resource__deployment__environment.json
+
+/**
+ * The software deployment environment name. `resource.deployment.environment`
+ *
+ * Attribute Value Type: `string` {@link RESOURCE_DEPLOYMENT_ENVIRONMENT_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * @deprecated Use {@link SENTRY_ENVIRONMENT} (sentry.environment) instead
+ * @example "production"
+ */
+export const RESOURCE_DEPLOYMENT_ENVIRONMENT = 'resource.deployment.environment';
+
+/**
+ * Type for {@link RESOURCE_DEPLOYMENT_ENVIRONMENT} resource.deployment.environment
+ */
+export type RESOURCE_DEPLOYMENT_ENVIRONMENT_TYPE = string;
+
 // Path: model/attributes/resource/resource__deployment__environment__name.json
 
 /**
@@ -9186,6 +9207,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [RELEASE]: 'string',
   [REMIX_ACTION_FORM_DATA_KEY]: 'string',
   [REPLAY_ID]: 'string',
+  [RESOURCE_DEPLOYMENT_ENVIRONMENT]: 'string',
   [RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME]: 'string',
   [RESOURCE_RENDER_BLOCKING_STATUS]: 'string',
   [ROUTE]: 'string',
@@ -9615,6 +9637,7 @@ export type AttributeName =
   | typeof RELEASE
   | typeof REMIX_ACTION_FORM_DATA_KEY
   | typeof REPLAY_ID
+  | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT
   | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME
   | typeof RESOURCE_RENDER_BLOCKING_STATUS
   | typeof ROUTE
@@ -12898,6 +12921,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     aliases: [SENTRY_REPLAY_ID],
   },
+  [RESOURCE_DEPLOYMENT_ENVIRONMENT]: {
+    brief: 'The software deployment environment name.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: true,
+    example: 'production',
+    deprecation: {
+      replacement: 'sentry.environment',
+    },
+  },
   [RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME]: {
     brief: 'The software deployment environment name.',
     type: 'string',
@@ -14407,6 +14442,7 @@ export type Attributes = {
   [RELEASE]?: RELEASE_TYPE;
   [REMIX_ACTION_FORM_DATA_KEY]?: REMIX_ACTION_FORM_DATA_KEY_TYPE;
   [REPLAY_ID]?: REPLAY_ID_TYPE;
+  [RESOURCE_DEPLOYMENT_ENVIRONMENT]?: RESOURCE_DEPLOYMENT_ENVIRONMENT_TYPE;
   [RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME]?: RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME_TYPE;
   [RESOURCE_RENDER_BLOCKING_STATUS]?: RESOURCE_RENDER_BLOCKING_STATUS_TYPE;
   [ROUTE]?: ROUTE_TYPE;

--- a/model/attributes/resource/resource__deployment__environment.json
+++ b/model/attributes/resource/resource__deployment__environment.json
@@ -1,0 +1,14 @@
+{
+  "key": "resource.deployment.environment",
+  "brief": "The software deployment environment name.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": "production",
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "sentry.environment"
+  }
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -156,6 +156,7 @@ class _AttributeNamesMeta(type):
         "QUERY_KEY",
         "RELEASE",
         "REPLAY_ID",
+        "RESOURCE_DEPLOYMENT_ENVIRONMENT",
         "RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME",
         "ROUTE",
         "SENTRY_BROWSER_NAME",
@@ -3514,6 +3515,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Aliases: sentry.replay_id
     DEPRECATED: Use sentry.replay_id instead
     Example: "123e4567e89b12d3a456426614174000"
+    """
+
+    # Path: model/attributes/resource/resource__deployment__environment.json
+    RESOURCE_DEPLOYMENT_ENVIRONMENT: Literal["resource.deployment.environment"] = (
+        "resource.deployment.environment"
+    )
+    """The software deployment environment name.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: Yes
+    DEPRECATED: Use sentry.environment instead
+    Example: "production"
     """
 
     # Path: model/attributes/resource/resource__deployment__environment__name.json
@@ -7248,6 +7262,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(replacement="sentry.replay_id"),
         aliases=["sentry.replay_id"],
     ),
+    "resource.deployment.environment": AttributeMetadata(
+        brief="The software deployment environment name.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=True,
+        example="production",
+        deprecation=DeprecationInfo(
+            replacement="sentry.environment", status=DeprecationStatus.BACKFILL
+        ),
+    ),
     "resource.deployment.environment.name": AttributeMetadata(
         brief="The software deployment environment name.",
         type=AttributeType.STRING,
@@ -8483,6 +8507,7 @@ Attributes = TypedDict(
         "release": str,
         "remix.action_form_data.<key>": str,
         "replay_id": str,
+        "resource.deployment.environment": str,
         "resource.deployment.environment.name": str,
         "resource.render_blocking_status": str,
         "route": str,

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -1119,6 +1119,20 @@
       "example": "query.id='123'"
     },
     {
+      "key": "resource.deployment.environment",
+      "brief": "The software deployment environment name.",
+      "type": "string",
+      "pii": {
+        "key": "false"
+      },
+      "is_in_otel": true,
+      "example": "production",
+      "deprecation": {
+        "_status": "backfill",
+        "replacement": "sentry.environment"
+      }
+    },
+    {
       "key": "resource.deployment.environment.name",
       "brief": "The software deployment environment name.",
       "type": "string",


### PR DESCRIPTION
## Description
We currently have a definition for `resource.deployment.environment.name`, deprecated for `sentry.environment` with a `backfill` policy. That means that incoming spans using the OpenTelemetry conventional attribute `deployment.environment.name` in their span's `resource` will get the value copied to `sentry.environment` in Relay, which makes the environment filters work across the product. (see https://github.com/getsentry/sentry-conventions/pull/196)

`deployment.environment.name` was [introduced in OTel's semantic conventions v1.27.0 (Aug 2024)](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.27.0) as a replacement for `deployment.environment`, which was deprecated at that time. One of our customers is still using this deprecated attribute, and I'm sure they're not alone in that.  Define `resource.deployment.environment` as a deprecated, backfilled attribute so that clients using it, too will get working environment filters in the product.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate && yarn format` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)
    - `false` to match `sentry.environment` (presumably because the product depends on the exact given value)
