### PR TITLE
fix: Avoid changelog generation recursion

### DIFF
--- a/scripts/generate_attribute_changelog.ts
+++ b/scripts/generate_attribute_changelog.ts
@@ -17,7 +17,7 @@ function isCommitIgnored(hash: string): boolean {
   if (!h) return false;
   for (const ignored of IGNORED_COMMIT_HASHES) {
     const i = ignored.trim().toLowerCase();
-    if (h === i || h.startsWith(i) || i.startsWith(h)) return true;
+    if (h === i || h.startsWith(i)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Description

In #270, we introdued a changelog generation script that updates attributes' changelog entries. We missed an infinite recursion-like problem though where re-running this script would add #270 to the changelog of all attributes, because #270 added the changelog entries to all attribute JSON files. This would go on indefinitely 😅 

This PR:
- adds an ignore list of commit hashes and adds the commit hash of #270 to that list. Running the changelog script now, produces no changes to the existing JSON files.
- removes the changelog generaction script invocation from `yarn generate`. The reason is that I didn't think this through when suggesting that we run the script every on every PR. At this point in time, the script doesn't have a reliable way to determine the PR (said PR either doesn't exist yet, or wasn't merged). 
- Adds a little progress indicator to the generation script since it takes quite long to go through all attributes. 

If anyone is blocked by the current state on `main`, please feel free to merge this PR at any time :) I'll pick it up tomorrow morning VIE time otherwise.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate && yarn format` to generate and format code and docs.
