### PR TITLE
fix(sentry): Deprecate `sentry.trace.parent_span_id`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -15544,7 +15544,10 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: 'b0e6f15b45c36b12',
     deprecation: {},
-    changelog: [{ version: '0.1.0', prs: [116] }],
+    changelog: [
+      { version: 'next', prs: [287], description: 'Deprecate `sentry.trace.parent_span_id`' },
+      { version: '0.1.0', prs: [116] },
+    ],
   },
   [SENTRY_TRANSACTION]: {
     brief: 'The sentry transaction (segment name).',

--- a/model/attributes/sentry/sentry__trace__parent_span_id.json
+++ b/model/attributes/sentry/sentry__trace__parent_span_id.json
@@ -12,6 +12,11 @@
   },
   "changelog": [
     {
+      "version": "next",
+      "prs": [287],
+      "description": "Deprecate `sentry.trace.parent_span_id`"
+    },
+    {
       "version": "0.1.0",
       "prs": [116]
     }

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -10073,6 +10073,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="b0e6f15b45c36b12",
         deprecation=DeprecationInfo(),
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[287],
+                description="Deprecate `sentry.trace.parent_span_id`",
+            ),
             ChangelogEntry(version="0.1.0", prs=[116]),
         ],
     ),

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -2732,6 +2732,11 @@
       },
       "changelog": [
         {
+          "version": "next",
+          "prs": [287],
+          "description": "Deprecate `sentry.trace.parent_span_id`"
+        },
+        {
           "version": "0.1.0",
           "prs": [116]
         }


### PR DESCRIPTION
## Description
This attribute was [replaced](https://github.com/getsentry/sentry-docs/blob/c5c916e03d8e6dda9555836657043e2ecf984ef2/develop-docs/sdk/telemetry/logs.mdx?plain=1#L28-L30) with log's top level `span_id` field and should no longer be used. Because it was replaced with a field rather than a different attribute, I don't think there's a way to express the new location for this data in the attribute JSON.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate && yarn format` to generate and format code and docs.

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md)
