### PR TITLE
doc: Remove extra `yarn run format` instruction

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 ## PR Checklist
 <!-- Check these to make sure the PR is ready for review -->
 - [ ] I have run `yarn test` and verified that the tests pass.
-- [ ] I have run `yarn generate && yarn format` to generate and format code and docs.
+- [ ] I have run `yarn generate` to generate and format code and docs.
 
 If an attribute was added:
 - [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Remember to run `yarn run generate` after editing or creating a `name` conventio
 
 ## Code and Docs Generation
 
-After you edit an attribute or add a new one, you should run `yarn run generate && yarn run format` to generate and format the code and docs, which are generated from the json files stored in the `model` directory.
+After you edit an attribute or add a new one, you should run `yarn run generate` to generate and format the code and docs, which are generated from the json files stored in the `model` directory.
 
 # Policies
 


### PR DESCRIPTION
## Description
`yarn run generate` [already runs](https://github.com/getsentry/sentry-conventions/blob/13e1f35b70ed40afcd50eb4b1b6e1a2ddebe6da0/package.json#L31) `yarn run format`, so there's no need to explicitly run format too.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate && yarn format` to generate and format code and docs.
