### PR TITLE
docs: Redirect from old `/generated` pages to new routes

### DIFF
--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -1,12 +1,13 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+
+const base = import.meta.env.BASE_URL;
 ---
 
 <BaseLayout title="Page Not Found">
-  <script is:inline>
+  <script is:inline define:vars={{ base }}>
     (function () {
       var path = window.location.pathname;
-      var base = '/sentry-conventions/';
       var oldPrefix = base + 'generated/';
       if (path.startsWith(oldPrefix)) {
         var newPath = base + path.slice(oldPrefix.length);


### PR DESCRIPTION
When we moved the Sentry Conventions docs page from Markdown to Astro, the URLs changed slightly. This is a bit unfortunate but I'd argue the new ones make a bit more sense. However, to avoid links (e.g. in code) leading to 404 pages, this PR adds a "client-side redirect" strategy to redirect anything from a previously `/sentry-conventions/generated/*` path to `/sentry-conventions/*`. SEO-wise this isn't ideal but since we host on GH pages, we can't define server-side redirects. We don't really care about SEO though since this is primarily an internal website, so I think it's a fine tradeoff.