### PR TITLE
feat: Add `http.request.env.remote_address`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3978,6 +3978,26 @@ export const HTTP_REQUEST_DOMAIN_LOOKUP_START = 'http.request.domain_lookup_star
  */
 export type HTTP_REQUEST_DOMAIN_LOOKUP_START_TYPE = number;
 
+// Path: model/attributes/http/http__request__env__remote_address.json
+
+/**
+ * The remote IP address of the client, as reported by the server's request environment (e.g., REMOTE_ADDR). `http.request.env.remote_address`
+ *
+ * Attribute Value Type: `string` {@link HTTP_REQUEST_ENV_REMOTE_ADDRESS_TYPE}
+ *
+ * Contains PII: true
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "192.168.1.1"
+ */
+export const HTTP_REQUEST_ENV_REMOTE_ADDRESS = 'http.request.env.remote_address';
+
+/**
+ * Type for {@link HTTP_REQUEST_ENV_REMOTE_ADDRESS} http.request.env.remote_address
+ */
+export type HTTP_REQUEST_ENV_REMOTE_ADDRESS_TYPE = string;
+
 // Path: model/attributes/http/http__request__fetch_start.json
 
 /**
@@ -10029,6 +10049,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [HTTP_REQUEST_CONNECT_START]: 'double',
   [HTTP_REQUEST_DOMAIN_LOOKUP_END]: 'double',
   [HTTP_REQUEST_DOMAIN_LOOKUP_START]: 'double',
+  [HTTP_REQUEST_ENV_REMOTE_ADDRESS]: 'string',
   [HTTP_REQUEST_FETCH_START]: 'double',
   [HTTP_REQUEST_HEADER_KEY]: 'string[]',
   [HTTP_REQUEST_METHOD]: 'string',
@@ -10499,6 +10520,7 @@ export type AttributeName =
   | typeof HTTP_REQUEST_CONNECT_START
   | typeof HTTP_REQUEST_DOMAIN_LOOKUP_END
   | typeof HTTP_REQUEST_DOMAIN_LOOKUP_START
+  | typeof HTTP_REQUEST_ENV_REMOTE_ADDRESS
   | typeof HTTP_REQUEST_FETCH_START
   | typeof HTTP_REQUEST_HEADER_KEY
   | typeof HTTP_REQUEST_METHOD
@@ -13212,6 +13234,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 1732829555.322,
     sdks: ['javascript-browser'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
+  },
+  [HTTP_REQUEST_ENV_REMOTE_ADDRESS]: {
+    brief: "The remote IP address of the client, as reported by the server's request environment (e.g., REMOTE_ADDR).",
+    type: 'string',
+    pii: {
+      isPii: 'true',
+    },
+    isInOtel: false,
+    example: '192.168.1.1',
+    changelog: [{ version: '0.4.0' }],
   },
   [HTTP_REQUEST_FETCH_START]: {
     brief: 'The UNIX timestamp representing the time immediately before the browser starts to fetch the resource.',
@@ -16613,6 +16645,7 @@ export type Attributes = {
   [HTTP_REQUEST_CONNECT_START]?: HTTP_REQUEST_CONNECT_START_TYPE;
   [HTTP_REQUEST_DOMAIN_LOOKUP_END]?: HTTP_REQUEST_DOMAIN_LOOKUP_END_TYPE;
   [HTTP_REQUEST_DOMAIN_LOOKUP_START]?: HTTP_REQUEST_DOMAIN_LOOKUP_START_TYPE;
+  [HTTP_REQUEST_ENV_REMOTE_ADDRESS]?: HTTP_REQUEST_ENV_REMOTE_ADDRESS_TYPE;
   [HTTP_REQUEST_FETCH_START]?: HTTP_REQUEST_FETCH_START_TYPE;
   [HTTP_REQUEST_HEADER_KEY]?: HTTP_REQUEST_HEADER_KEY_TYPE;
   [HTTP_REQUEST_METHOD]?: HTTP_REQUEST_METHOD_TYPE;

--- a/model/attributes/http/http__request__env__remote_address.json
+++ b/model/attributes/http/http__request__env__remote_address.json
@@ -1,0 +1,15 @@
+{
+  "key": "http.request.env.remote_address",
+  "brief": "The remote IP address of the client, as reported by the server's request environment (e.g., REMOTE_ADDR).",
+  "type": "string",
+  "pii": {
+    "key": "true"
+  },
+  "is_in_otel": false,
+  "example": "192.168.1.1",
+  "changelog": [
+    {
+      "version": "0.4.0"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2367,6 +2367,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 1732829555.322
     """
 
+    # Path: model/attributes/http/http__request__env__remote_address.json
+    HTTP_REQUEST_ENV_REMOTE_ADDRESS: Literal["http.request.env.remote_address"] = (
+        "http.request.env.remote_address"
+    )
+    """The remote IP address of the client, as reported by the server's request environment (e.g., REMOTE_ADDR).
+
+    Type: str
+    Contains PII: true
+    Defined in OTEL: No
+    Example: "192.168.1.1"
+    """
+
     # Path: model/attributes/http/http__request__fetch_start.json
     HTTP_REQUEST_FETCH_START: Literal["http.request.fetch_start"] = (
         "http.request.fetch_start"
@@ -7733,6 +7745,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "http.request.env.remote_address": AttributeMetadata(
+        brief="The remote IP address of the client, as reported by the server's request environment (e.g., REMOTE_ADDR).",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.TRUE),
+        is_in_otel=False,
+        example="192.168.1.1",
+        changelog=[
+            ChangelogEntry(version="0.4.0"),
+        ],
+    ),
     "http.request.fetch_start": AttributeMetadata(
         brief="The UNIX timestamp representing the time immediately before the browser starts to fetch the resource.",
         type=AttributeType.DOUBLE,
@@ -11178,6 +11200,7 @@ Attributes = TypedDict(
         "http.request.connection_end": float,
         "http.request.domain_lookup_end": float,
         "http.request.domain_lookup_start": float,
+        "http.request.env.remote_address": str,
         "http.request.fetch_start": float,
         "http.request.header.<key>": List[str],
         "http.request.method": str,


### PR DESCRIPTION
## Description
Add an attributes based replacement for [`request.env.REMOTE_ADDR`](https://develop.sentry.dev/sdk/foundations/transport/event-payloads/request/).

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md)
