### PR TITLE
feat(attributes): add `gen_ai.function_id` attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3029,7 +3029,7 @@ export type GEN_AI_EMBEDDINGS_INPUT_TYPE = string;
 // Path: model/attributes/gen_ai/gen_ai__function_id.json
 
 /**
- * Framework-specific tracing label for the execution of a function or other unit of execution in a generative AI system.
+ * The function identifier associated with the AI operation. `gen_ai.function_id`
  *
  * Attribute Value Type: `string` {@link GEN_AI_FUNCTION_ID_TYPE}
  *

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3029,7 +3029,7 @@ export type GEN_AI_EMBEDDINGS_INPUT_TYPE = string;
 // Path: model/attributes/gen_ai/gen_ai__function_id.json
 
 /**
- * The function identifier associated with the AI operation. `gen_ai.function_id`
+ * Framework-specific tracing label for the execution of a function or other unit of execution in a generative AI system. `gen_ai.function_id`
  *
  * Attribute Value Type: `string` {@link GEN_AI_FUNCTION_ID_TYPE}
  *
@@ -13049,7 +13049,8 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     changelog: [{ version: '0.3.1', prs: [195] }],
   },
   [GEN_AI_FUNCTION_ID]: {
-    brief: 'The function identifier associated with the AI operation.',
+    brief:
+      'Framework-specific tracing label for the execution of a function or other unit of execution in a generative AI system.',
     type: 'string',
     pii: {
       isPii: 'maybe',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3026,6 +3026,26 @@ export const GEN_AI_EMBEDDINGS_INPUT = 'gen_ai.embeddings.input';
  */
 export type GEN_AI_EMBEDDINGS_INPUT_TYPE = string;
 
+// Path: model/attributes/gen_ai/gen_ai__function_id.json
+
+/**
+ * The function identifier associated with the AI operation. `gen_ai.function_id`
+ *
+ * Attribute Value Type: `string` {@link GEN_AI_FUNCTION_ID_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "my-awesome-function"
+ */
+export const GEN_AI_FUNCTION_ID = 'gen_ai.function_id';
+
+/**
+ * Type for {@link GEN_AI_FUNCTION_ID} gen_ai.function_id
+ */
+export type GEN_AI_FUNCTION_ID_TYPE = string;
+
 // Path: model/attributes/gen_ai/gen_ai__input__messages.json
 
 /**
@@ -10360,6 +10380,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [GEN_AI_COST_OUTPUT_TOKENS]: 'double',
   [GEN_AI_COST_TOTAL_TOKENS]: 'double',
   [GEN_AI_EMBEDDINGS_INPUT]: 'string',
+  [GEN_AI_FUNCTION_ID]: 'string',
   [GEN_AI_INPUT_MESSAGES]: 'string',
   [GEN_AI_OPERATION_NAME]: 'string',
   [GEN_AI_OPERATION_TYPE]: 'string',
@@ -10848,6 +10869,7 @@ export type AttributeName =
   | typeof GEN_AI_COST_OUTPUT_TOKENS
   | typeof GEN_AI_COST_TOTAL_TOKENS
   | typeof GEN_AI_EMBEDDINGS_INPUT
+  | typeof GEN_AI_FUNCTION_ID
   | typeof GEN_AI_INPUT_MESSAGES
   | typeof GEN_AI_OPERATION_NAME
   | typeof GEN_AI_OPERATION_TYPE
@@ -13025,6 +13047,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: "What's the weather in Paris?",
     changelog: [{ version: '0.3.1', prs: [195] }],
+  },
+  [GEN_AI_FUNCTION_ID]: {
+    brief: 'The function identifier associated with the AI operation.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 'my-awesome-function',
+    changelog: [{ version: 'next', prs: [308], description: 'Added gen_ai.function_id attribute' }],
   },
   [GEN_AI_INPUT_MESSAGES]: {
     brief:
@@ -17239,6 +17271,7 @@ export type Attributes = {
   [GEN_AI_COST_OUTPUT_TOKENS]?: GEN_AI_COST_OUTPUT_TOKENS_TYPE;
   [GEN_AI_COST_TOTAL_TOKENS]?: GEN_AI_COST_TOTAL_TOKENS_TYPE;
   [GEN_AI_EMBEDDINGS_INPUT]?: GEN_AI_EMBEDDINGS_INPUT_TYPE;
+  [GEN_AI_FUNCTION_ID]?: GEN_AI_FUNCTION_ID_TYPE;
   [GEN_AI_INPUT_MESSAGES]?: GEN_AI_INPUT_MESSAGES_TYPE;
   [GEN_AI_OPERATION_NAME]?: GEN_AI_OPERATION_NAME_TYPE;
   [GEN_AI_OPERATION_TYPE]?: GEN_AI_OPERATION_TYPE_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3029,7 +3029,7 @@ export type GEN_AI_EMBEDDINGS_INPUT_TYPE = string;
 // Path: model/attributes/gen_ai/gen_ai__function_id.json
 
 /**
- * The function identifier associated with the AI operation. `gen_ai.function_id`
+ * Framework-specific tracing label for the execution of a function or other unit of execution in a generative AI system.
  *
  * Attribute Value Type: `string` {@link GEN_AI_FUNCTION_ID_TYPE}
  *

--- a/model/attributes/gen_ai/gen_ai__function_id.json
+++ b/model/attributes/gen_ai/gen_ai__function_id.json
@@ -1,0 +1,17 @@
+{
+  "key": "gen_ai.function_id",
+  "brief": "The function identifier associated with the AI operation.",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "my-awesome-function",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [308],
+      "description": "Added gen_ai.function_id attribute"
+    }
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__function_id.json
+++ b/model/attributes/gen_ai/gen_ai__function_id.json
@@ -1,6 +1,6 @@
 {
   "key": "gen_ai.function_id",
-  "brief": "The function identifier associated with the AI operation.",
+  "brief": "Framework-specific tracing label for the execution of a function or other unit of execution in a generative AI system.",
   "type": "string",
   "pii": {
     "key": "maybe"

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1829,6 +1829,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "What's the weather in Paris?"
     """
 
+    # Path: model/attributes/gen_ai/gen_ai__function_id.json
+    GEN_AI_FUNCTION_ID: Literal["gen_ai.function_id"] = "gen_ai.function_id"
+    """The function identifier associated with the AI operation.
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "my-awesome-function"
+    """
+
     # Path: model/attributes/gen_ai/gen_ai__input__messages.json
     GEN_AI_INPUT_MESSAGES: Literal["gen_ai.input.messages"] = "gen_ai.input.messages"
     """The messages passed to the model. It has to be a stringified version of an array of objects. The `role` attribute of each object must be `"user"`, `"assistant"`, `"tool"`, or `"system"`. For messages of the role `"tool"`, the `content` can be a string or an arbitrary object with information about the tool call. For other messages the `content` can be either a string or a list of objects in the format `{type: "text", text:"..."}`.
@@ -7465,6 +7475,20 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.3.1", prs=[195]),
         ],
     ),
+    "gen_ai.function_id": AttributeMetadata(
+        brief="The function identifier associated with the AI operation.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="my-awesome-function",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[308],
+                description="Added gen_ai.function_id attribute",
+            ),
+        ],
+    ),
     "gen_ai.input.messages": AttributeMetadata(
         brief='The messages passed to the model. It has to be a stringified version of an array of objects. The `role` attribute of each object must be `"user"`, `"assistant"`, `"tool"`, or `"system"`. For messages of the role `"tool"`, the `content` can be a string or an arbitrary object with information about the tool call. For other messages the `content` can be either a string or a list of objects in the format `{type: "text", text:"..."}`.',
         type=AttributeType.STRING,
@@ -11637,6 +11661,7 @@ Attributes = TypedDict(
         "gen_ai.cost.output_tokens": float,
         "gen_ai.cost.total_tokens": float,
         "gen_ai.embeddings.input": str,
+        "gen_ai.function_id": str,
         "gen_ai.input.messages": str,
         "gen_ai.operation.name": str,
         "gen_ai.operation.type": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1831,7 +1831,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/gen_ai/gen_ai__function_id.json
     GEN_AI_FUNCTION_ID: Literal["gen_ai.function_id"] = "gen_ai.function_id"
-    """The function identifier associated with the AI operation.
+    """Framework-specific tracing label for the execution of a function or other unit of execution in a generative AI system.
 
     Type: str
     Contains PII: maybe
@@ -7476,7 +7476,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "gen_ai.function_id": AttributeMetadata(
-        brief="The function identifier associated with the AI operation.",
+        brief="Framework-specific tracing label for the execution of a function or other unit of execution in a generative AI system.",
         type=AttributeType.STRING,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,


### PR DESCRIPTION
## Description

Add the `gen_ai.function_id` attribute. Currently only emitted by Vercel AI in the JS SDK.

Closes https://linear.app/getsentry/issue/TET-2181/add-gen-aifunction-id-to-sentry-conventions

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
