### PR TITLE
deprecate(attributes): Mark gen_ai.tool.type as deprecated

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -11,7 +11,7 @@
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated 
+ * @deprecated
  * @example ["Citation 1","Citation 2"]
  */
 export const AI_CITATIONS = 'ai.citations';
@@ -55,7 +55,7 @@ export type AI_COMPLETION_TOKENS_USED_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated 
+ * @deprecated
  * @example ["document1.txt","document2.pdf"]
  */
 export const AI_DOCUMENTS = 'ai.documents';
@@ -191,7 +191,7 @@ export type AI_INPUT_MESSAGES_TYPE = string;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated 
+ * @deprecated
  * @example false
  */
 export const AI_IS_SEARCH_REQUIRED = 'ai.is_search_required';
@@ -212,7 +212,7 @@ export type AI_IS_SEARCH_REQUIRED_TYPE = boolean;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated 
+ * @deprecated
  * @example "{\"user_id\": 123, \"session_id\": \"abc123\"}"
  */
 export const AI_METADATA = 'ai.metadata';
@@ -371,7 +371,7 @@ export type AI_PROMPT_TOKENS_USED_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated 
+ * @deprecated
  * @example true
  */
 export const AI_RAW_PROMPTING = 'ai.raw_prompting';
@@ -413,7 +413,7 @@ export type AI_RESPONSES_TYPE = Array<string>;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated 
+ * @deprecated
  * @example "json_object"
  */
 export const AI_RESPONSE_FORMAT = 'ai.response_format';
@@ -434,7 +434,7 @@ export type AI_RESPONSE_FORMAT_TYPE = string;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated 
+ * @deprecated
  * @example ["climate change effects","renewable energy"]
  */
 export const AI_SEARCH_QUERIES = 'ai.search_queries';
@@ -455,7 +455,7 @@ export type AI_SEARCH_QUERIES_TYPE = Array<string>;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated 
+ * @deprecated
  * @example ["search_result_1, search_result_2"]
  */
 export const AI_SEARCH_RESULTS = 'ai.search_results';
@@ -522,7 +522,7 @@ export type AI_STREAMING_TYPE = boolean;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated 
+ * @deprecated
  * @example "{\"executed_function\": \"add_integers\"}"
  */
 export const AI_TAGS = 'ai.tags';
@@ -723,7 +723,7 @@ export type AI_TOTAL_TOKENS_USED_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated 
+ * @deprecated
  * @example ["Token limit exceeded"]
  */
 export const AI_WARNINGS = 'ai.warnings';
@@ -8497,7 +8497,7 @@ export type SENTRY_TIMESTAMP_SEQUENCE_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated 
+ * @deprecated
  * @example "b0e6f15b45c36b12"
  */
 export const SENTRY_TRACE_PARENT_SPAN_ID = 'sentry.trace.parent_span_id';
@@ -10159,7 +10159,6 @@ export const VERCEL_STATUS_CODE = 'vercel.status_code';
  */
 export type VERCEL_STATUS_CODE_TYPE = number;
 
-
 export type AttributeType =
   | 'string'
   | 'boolean'
@@ -10171,10 +10170,7 @@ export type AttributeType =
   | 'double[]'
   | 'any';
 
-export type IsPii = 
-  | 'true'
-  | 'false'
-  | 'maybe';
+export type IsPii = 'true' | 'false' | 'maybe';
 
 export interface PiiInfo {
   /** Whether the attribute contains PII */
@@ -10710,6756 +10706,6394 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [VERCEL_STATUS_CODE]: 'integer',
 };
 
-export type AttributeName = typeof AI_CITATIONS | typeof AI_COMPLETION_TOKENS_USED | typeof AI_DOCUMENTS | typeof AI_FINISH_REASON | typeof AI_FREQUENCY_PENALTY | typeof AI_FUNCTION_CALL | typeof AI_GENERATION_ID | typeof AI_INPUT_MESSAGES | typeof AI_IS_SEARCH_REQUIRED | typeof AI_METADATA | typeof AI_MODEL_ID | typeof AI_MODEL_PROVIDER | typeof AI_PIPELINE_NAME | typeof AI_PREAMBLE | typeof AI_PRESENCE_PENALTY | typeof AI_PROMPT_TOKENS_USED | typeof AI_RAW_PROMPTING | typeof AI_RESPONSES | typeof AI_RESPONSE_FORMAT | typeof AI_SEARCH_QUERIES | typeof AI_SEARCH_RESULTS | typeof AI_SEED | typeof AI_STREAMING | typeof AI_TAGS | typeof AI_TEMPERATURE | typeof AI_TEXTS | typeof AI_TOOLS | typeof AI_TOOL_CALLS | typeof AI_TOP_K | typeof AI_TOP_P | typeof AI_TOTAL_COST | typeof AI_TOTAL_TOKENS_USED | typeof AI_WARNINGS | typeof APP_BUILD | typeof APP_IDENTIFIER | typeof APP_IN_FOREGROUND | typeof APP_NAME | typeof APP_START_TIME | typeof APP_START_TYPE | typeof APP_VERSION | typeof BLOCKED_MAIN_THREAD | typeof BROWSER_NAME | typeof BROWSER_REPORT_TYPE | typeof BROWSER_SCRIPT_INVOKER | typeof BROWSER_SCRIPT_INVOKER_TYPE | typeof BROWSER_SCRIPT_SOURCE_CHAR_POSITION | typeof BROWSER_VERSION | typeof BROWSER_WEB_VITAL_CLS_SOURCE_KEY | typeof BROWSER_WEB_VITAL_CLS_VALUE | typeof BROWSER_WEB_VITAL_FCP_VALUE | typeof BROWSER_WEB_VITAL_FP_VALUE | typeof BROWSER_WEB_VITAL_INP_VALUE | typeof BROWSER_WEB_VITAL_LCP_ELEMENT | typeof BROWSER_WEB_VITAL_LCP_ID | typeof BROWSER_WEB_VITAL_LCP_LOAD_TIME | typeof BROWSER_WEB_VITAL_LCP_RENDER_TIME | typeof BROWSER_WEB_VITAL_LCP_SIZE | typeof BROWSER_WEB_VITAL_LCP_URL | typeof BROWSER_WEB_VITAL_LCP_VALUE | typeof BROWSER_WEB_VITAL_TTFB_REQUEST_TIME | typeof BROWSER_WEB_VITAL_TTFB_VALUE | typeof CACHE_HIT | typeof CACHE_ITEM_SIZE | typeof CACHE_KEY | typeof CACHE_OPERATION | typeof CACHE_TTL | typeof CACHE_WRITE | typeof CHANNEL | typeof CLIENT_ADDRESS | typeof CLIENT_PORT | typeof CLOUDFLARE_D1_DURATION | typeof CLOUDFLARE_D1_ROWS_READ | typeof CLOUDFLARE_D1_ROWS_WRITTEN | typeof CLS | typeof CLS_SOURCE_KEY | typeof CODE_FILEPATH | typeof CODE_FILE_PATH | typeof CODE_FUNCTION | typeof CODE_FUNCTION_NAME | typeof CODE_LINENO | typeof CODE_LINE_NUMBER | typeof CODE_NAMESPACE | typeof CONNECTIONTYPE | typeof CONNECTION_RTT | typeof CULTURE_CALENDAR | typeof CULTURE_DISPLAY_NAME | typeof CULTURE_IS_24_HOUR_FORMAT | typeof CULTURE_LOCALE | typeof CULTURE_TIMEZONE | typeof DB_COLLECTION_NAME | typeof DB_NAME | typeof DB_NAMESPACE | typeof DB_OPERATION | typeof DB_OPERATION_NAME | typeof DB_QUERY_PARAMETER_KEY | typeof DB_QUERY_SUMMARY | typeof DB_QUERY_TEXT | typeof DB_REDIS_CONNECTION | typeof DB_REDIS_PARAMETERS | typeof DB_SQL_BINDINGS | typeof DB_STATEMENT | typeof DB_SYSTEM | typeof DB_SYSTEM_NAME | typeof DB_USER | typeof DEVICEMEMORY | typeof DEVICE_BRAND | typeof DEVICE_CLASS | typeof DEVICE_FAMILY | typeof DEVICE_FREE_MEMORY | typeof DEVICE_MEMORY_ESTIMATED_CAPACITY | typeof DEVICE_MEMORY_SIZE | typeof DEVICE_MODEL | typeof DEVICE_MODEL_ID | typeof DEVICE_PROCESSOR_COUNT | typeof DEVICE_SIMULATOR | typeof EFFECTIVECONNECTIONTYPE | typeof ENVIRONMENT | typeof ERROR_TYPE | typeof EVENT_ID | typeof EVENT_NAME | typeof EXCEPTION_ESCAPED | typeof EXCEPTION_MESSAGE | typeof EXCEPTION_STACKTRACE | typeof EXCEPTION_TYPE | typeof FAAS_COLDSTART | typeof FAAS_CRON | typeof FAAS_TIME | typeof FAAS_TRIGGER | typeof FCP | typeof FLAG_EVALUATION_KEY | typeof FP | typeof FRAMES_DELAY | typeof FRAMES_FROZEN | typeof FRAMES_SLOW | typeof FRAMES_TOTAL | typeof FS_ERROR | typeof GEN_AI_AGENT_NAME | typeof GEN_AI_CONVERSATION_ID | typeof GEN_AI_COST_INPUT_TOKENS | typeof GEN_AI_COST_OUTPUT_TOKENS | typeof GEN_AI_COST_TOTAL_TOKENS | typeof GEN_AI_EMBEDDINGS_INPUT | typeof GEN_AI_INPUT_MESSAGES | typeof GEN_AI_OPERATION_NAME | typeof GEN_AI_OPERATION_TYPE | typeof GEN_AI_OUTPUT_MESSAGES | typeof GEN_AI_PIPELINE_NAME | typeof GEN_AI_PROMPT | typeof GEN_AI_PROVIDER_NAME | typeof GEN_AI_REQUEST_AVAILABLE_TOOLS | typeof GEN_AI_REQUEST_FREQUENCY_PENALTY | typeof GEN_AI_REQUEST_MAX_TOKENS | typeof GEN_AI_REQUEST_MESSAGES | typeof GEN_AI_REQUEST_MODEL | typeof GEN_AI_REQUEST_PRESENCE_PENALTY | typeof GEN_AI_REQUEST_SEED | typeof GEN_AI_REQUEST_TEMPERATURE | typeof GEN_AI_REQUEST_TOP_K | typeof GEN_AI_REQUEST_TOP_P | typeof GEN_AI_RESPONSE_FINISH_REASONS | typeof GEN_AI_RESPONSE_ID | typeof GEN_AI_RESPONSE_MODEL | typeof GEN_AI_RESPONSE_STREAMING | typeof GEN_AI_RESPONSE_TEXT | typeof GEN_AI_RESPONSE_TIME_TO_FIRST_TOKEN | typeof GEN_AI_RESPONSE_TOKENS_PER_SECOND | typeof GEN_AI_RESPONSE_TOOL_CALLS | typeof GEN_AI_SYSTEM | typeof GEN_AI_SYSTEM_INSTRUCTIONS | typeof GEN_AI_SYSTEM_MESSAGE | typeof GEN_AI_TOOL_CALL_ARGUMENTS | typeof GEN_AI_TOOL_CALL_RESULT | typeof GEN_AI_TOOL_DEFINITIONS | typeof GEN_AI_TOOL_DESCRIPTION | typeof GEN_AI_TOOL_INPUT | typeof GEN_AI_TOOL_MESSAGE | typeof GEN_AI_TOOL_NAME | typeof GEN_AI_TOOL_OUTPUT | typeof GEN_AI_TOOL_TYPE | typeof GEN_AI_USAGE_COMPLETION_TOKENS | typeof GEN_AI_USAGE_INPUT_TOKENS | typeof GEN_AI_USAGE_INPUT_TOKENS_CACHED | typeof GEN_AI_USAGE_INPUT_TOKENS_CACHE_WRITE | typeof GEN_AI_USAGE_OUTPUT_TOKENS | typeof GEN_AI_USAGE_OUTPUT_TOKENS_REASONING | typeof GEN_AI_USAGE_PROMPT_TOKENS | typeof GEN_AI_USAGE_TOTAL_TOKENS | typeof GRAPHQL_OPERATION_NAME | typeof GRAPHQL_OPERATION_TYPE | typeof HARDWARECONCURRENCY | typeof HTTP_CLIENT_IP | typeof HTTP_DECODED_RESPONSE_CONTENT_LENGTH | typeof HTTP_FLAVOR | typeof HTTP_FRAGMENT | typeof HTTP_HOST | typeof HTTP_METHOD | typeof HTTP_QUERY | typeof HTTP_REQUEST_CONNECTION_END | typeof HTTP_REQUEST_CONNECT_START | typeof HTTP_REQUEST_DOMAIN_LOOKUP_END | typeof HTTP_REQUEST_DOMAIN_LOOKUP_START | typeof HTTP_REQUEST_FETCH_START | typeof HTTP_REQUEST_HEADER_KEY | typeof HTTP_REQUEST_METHOD | typeof HTTP_REQUEST_REDIRECT_END | typeof HTTP_REQUEST_REDIRECT_START | typeof HTTP_REQUEST_REQUEST_START | typeof HTTP_REQUEST_RESEND_COUNT | typeof HTTP_REQUEST_RESPONSE_END | typeof HTTP_REQUEST_RESPONSE_START | typeof HTTP_REQUEST_SECURE_CONNECTION_START | typeof HTTP_REQUEST_TIME_TO_FIRST_BYTE | typeof HTTP_REQUEST_WORKER_START | typeof HTTP_RESPONSE_BODY_SIZE | typeof HTTP_RESPONSE_CONTENT_LENGTH | typeof HTTP_RESPONSE_HEADER_CONTENT_LENGTH | typeof HTTP_RESPONSE_HEADER_KEY | typeof HTTP_RESPONSE_SIZE | typeof HTTP_RESPONSE_STATUS_CODE | typeof HTTP_RESPONSE_TRANSFER_SIZE | typeof HTTP_ROUTE | typeof HTTP_SCHEME | typeof HTTP_SERVER_NAME | typeof HTTP_SERVER_REQUEST_TIME_IN_QUEUE | typeof HTTP_STATUS_CODE | typeof HTTP_TARGET | typeof HTTP_URL | typeof HTTP_USER_AGENT | typeof ID | typeof INP | typeof JVM_GC_ACTION | typeof JVM_GC_NAME | typeof JVM_MEMORY_POOL_NAME | typeof JVM_MEMORY_TYPE | typeof JVM_THREAD_DAEMON | typeof JVM_THREAD_STATE | typeof LCP | typeof LCP_ELEMENT | typeof LCP_ID | typeof LCP_LOADTIME | typeof LCP_RENDERTIME | typeof LCP_SIZE | typeof LCP_URL | typeof LOGGER_NAME | typeof MCP_CANCELLED_REASON | typeof MCP_CANCELLED_REQUEST_ID | typeof MCP_CLIENT_NAME | typeof MCP_CLIENT_TITLE | typeof MCP_CLIENT_VERSION | typeof MCP_LIFECYCLE_PHASE | typeof MCP_LOGGING_DATA_TYPE | typeof MCP_LOGGING_LEVEL | typeof MCP_LOGGING_LOGGER | typeof MCP_LOGGING_MESSAGE | typeof MCP_METHOD_NAME | typeof MCP_PROGRESS_CURRENT | typeof MCP_PROGRESS_MESSAGE | typeof MCP_PROGRESS_PERCENTAGE | typeof MCP_PROGRESS_TOKEN | typeof MCP_PROGRESS_TOTAL | typeof MCP_PROMPT_NAME | typeof MCP_PROMPT_RESULT_DESCRIPTION | typeof MCP_PROMPT_RESULT_MESSAGE_CONTENT | typeof MCP_PROMPT_RESULT_MESSAGE_COUNT | typeof MCP_PROMPT_RESULT_MESSAGE_ROLE | typeof MCP_PROTOCOL_READY | typeof MCP_PROTOCOL_VERSION | typeof MCP_REQUEST_ARGUMENT_KEY | typeof MCP_REQUEST_ARGUMENT_NAME | typeof MCP_REQUEST_ARGUMENT_URI | typeof MCP_REQUEST_ID | typeof MCP_RESOURCE_PROTOCOL | typeof MCP_RESOURCE_URI | typeof MCP_SERVER_NAME | typeof MCP_SERVER_TITLE | typeof MCP_SERVER_VERSION | typeof MCP_SESSION_ID | typeof MCP_TOOL_NAME | typeof MCP_TOOL_RESULT_CONTENT | typeof MCP_TOOL_RESULT_CONTENT_COUNT | typeof MCP_TOOL_RESULT_IS_ERROR | typeof MCP_TRANSPORT | typeof MDC_KEY | typeof MESSAGING_DESTINATION_CONNECTION | typeof MESSAGING_DESTINATION_NAME | typeof MESSAGING_MESSAGE_BODY_SIZE | typeof MESSAGING_MESSAGE_ENVELOPE_SIZE | typeof MESSAGING_MESSAGE_ID | typeof MESSAGING_MESSAGE_RECEIVE_LATENCY | typeof MESSAGING_MESSAGE_RETRY_COUNT | typeof MESSAGING_OPERATION_TYPE | typeof MESSAGING_SYSTEM | typeof METHOD | typeof NAVIGATION_TYPE | typeof NEL_ELAPSED_TIME | typeof NEL_PHASE | typeof NEL_REFERRER | typeof NEL_SAMPLING_FUNCTION | typeof NEL_TYPE | typeof NETWORK_CONNECTION_EFFECTIVE_TYPE | typeof NETWORK_CONNECTION_RTT | typeof NETWORK_CONNECTION_TYPE | typeof NETWORK_LOCAL_ADDRESS | typeof NETWORK_LOCAL_PORT | typeof NETWORK_PEER_ADDRESS | typeof NETWORK_PEER_PORT | typeof NETWORK_PROTOCOL_NAME | typeof NETWORK_PROTOCOL_VERSION | typeof NETWORK_TRANSPORT | typeof NETWORK_TYPE | typeof NET_HOST_IP | typeof NET_HOST_NAME | typeof NET_HOST_PORT | typeof NET_PEER_IP | typeof NET_PEER_NAME | typeof NET_PEER_PORT | typeof NET_PROTOCOL_NAME | typeof NET_PROTOCOL_VERSION | typeof NET_SOCK_FAMILY | typeof NET_SOCK_HOST_ADDR | typeof NET_SOCK_HOST_PORT | typeof NET_SOCK_PEER_ADDR | typeof NET_SOCK_PEER_NAME | typeof NET_SOCK_PEER_PORT | typeof NET_TRANSPORT | typeof OS_BUILD_ID | typeof OS_DESCRIPTION | typeof OS_NAME | typeof OS_TYPE | typeof OS_VERSION | typeof OTEL_SCOPE_NAME | typeof OTEL_SCOPE_VERSION | typeof OTEL_STATUS_CODE | typeof OTEL_STATUS_DESCRIPTION | typeof PARAMS_KEY | typeof PREVIOUS_ROUTE | typeof PROCESS_EXECUTABLE_NAME | typeof PROCESS_PID | typeof PROCESS_RUNTIME_DESCRIPTION | typeof PROCESS_RUNTIME_NAME | typeof PROCESS_RUNTIME_VERSION | typeof QUERY_KEY | typeof RELEASE | typeof REMIX_ACTION_FORM_DATA_KEY | typeof REPLAY_ID | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME | typeof RESOURCE_RENDER_BLOCKING_STATUS | typeof ROUTE | typeof RPC_GRPC_STATUS_CODE | typeof RPC_SERVICE | typeof SENTRY_ACTION | typeof SENTRY_BROWSER_NAME | typeof SENTRY_BROWSER_VERSION | typeof SENTRY_CANCELLATION_REASON | typeof SENTRY_CATEGORY | typeof SENTRY_CLIENT_SAMPLE_RATE | typeof SENTRY_DESCRIPTION | typeof SENTRY_DIST | typeof SENTRY_DOMAIN | typeof SENTRY_DSC_ENVIRONMENT | typeof SENTRY_DSC_PUBLIC_KEY | typeof SENTRY_DSC_RELEASE | typeof SENTRY_DSC_SAMPLED | typeof SENTRY_DSC_SAMPLE_RATE | typeof SENTRY_DSC_TRACE_ID | typeof SENTRY_DSC_TRANSACTION | typeof SENTRY_ENVIRONMENT | typeof SENTRY_EXCLUSIVE_TIME | typeof SENTRY_GRAPHQL_OPERATION | typeof SENTRY_GROUP | typeof SENTRY_HTTP_PREFETCH | typeof SENTRY_IDLE_SPAN_FINISH_REASON | typeof SENTRY_IS_REMOTE | typeof SENTRY_KIND | typeof SENTRY_MESSAGE_PARAMETER_KEY | typeof SENTRY_MESSAGE_TEMPLATE | typeof SENTRY_MODULE_KEY | typeof SENTRY_NEXTJS_SSR_FUNCTION_ROUTE | typeof SENTRY_NEXTJS_SSR_FUNCTION_TYPE | typeof SENTRY_NORMALIZED_DB_QUERY | typeof SENTRY_NORMALIZED_DB_QUERY_HASH | typeof SENTRY_NORMALIZED_DESCRIPTION | typeof SENTRY_OBSERVED_TIMESTAMP_NANOS | typeof SENTRY_OP | typeof SENTRY_ORIGIN | typeof SENTRY_PLATFORM | typeof SENTRY_PROFILER_ID | typeof SENTRY_RELEASE | typeof SENTRY_REPLAY_ID | typeof SENTRY_REPLAY_IS_BUFFERING | typeof SENTRY_SDK_INTEGRATIONS | typeof SENTRY_SDK_NAME | typeof SENTRY_SDK_VERSION | typeof SENTRY_SEGMENT_ID | typeof _SENTRY_SEGMENT_ID | typeof SENTRY_SEGMENT_NAME | typeof SENTRY_SERVER_SAMPLE_RATE | typeof SENTRY_SOURCE | typeof SENTRY_SPAN_SOURCE | typeof SENTRY_STATUS_CODE | typeof SENTRY_STATUS_MESSAGE | typeof SENTRY_TIMESTAMP_SEQUENCE | typeof SENTRY_TRACE_PARENT_SPAN_ID | typeof SENTRY_TRANSACTION | typeof SERVER_ADDRESS | typeof SERVER_PORT | typeof SERVICE_NAME | typeof SERVICE_VERSION | typeof THREAD_ID | typeof THREAD_NAME | typeof TIMBER_TAG | typeof TRANSACTION | typeof TTFB | typeof TTFB_REQUESTTIME | typeof TYPE | typeof UI_COMPONENT_NAME | typeof UI_CONTRIBUTES_TO_TTFD | typeof UI_CONTRIBUTES_TO_TTID | typeof UI_ELEMENT_HEIGHT | typeof UI_ELEMENT_ID | typeof UI_ELEMENT_IDENTIFIER | typeof UI_ELEMENT_LOAD_TIME | typeof UI_ELEMENT_PAINT_TYPE | typeof UI_ELEMENT_RENDER_TIME | typeof UI_ELEMENT_TYPE | typeof UI_ELEMENT_URL | typeof UI_ELEMENT_WIDTH | typeof URL | typeof URL_DOMAIN | typeof URL_FRAGMENT | typeof URL_FULL | typeof URL_PATH | typeof URL_PATH_PARAMETER_KEY | typeof URL_PORT | typeof URL_QUERY | typeof URL_SCHEME | typeof URL_TEMPLATE | typeof USER_AGENT_ORIGINAL | typeof USER_EMAIL | typeof USER_FULL_NAME | typeof USER_GEO_CITY | typeof USER_GEO_COUNTRY_CODE | typeof USER_GEO_REGION | typeof USER_GEO_SUBDIVISION | typeof USER_HASH | typeof USER_ID | typeof USER_IP_ADDRESS | typeof USER_NAME | typeof USER_ROLES | typeof VERCEL_BRANCH | typeof VERCEL_BUILD_ID | typeof VERCEL_DEPLOYMENT_ID | typeof VERCEL_DESTINATION | typeof VERCEL_EDGE_TYPE | typeof VERCEL_ENTRYPOINT | typeof VERCEL_EXECUTION_REGION | typeof VERCEL_ID | typeof VERCEL_JA3_DIGEST | typeof VERCEL_JA4_DIGEST | typeof VERCEL_LOG_TYPE | typeof VERCEL_PROJECT_ID | typeof VERCEL_PROJECT_NAME | typeof VERCEL_PROXY_CACHE_ID | typeof VERCEL_PROXY_CLIENT_IP | typeof VERCEL_PROXY_HOST | typeof VERCEL_PROXY_LAMBDA_REGION | typeof VERCEL_PROXY_METHOD | typeof VERCEL_PROXY_PATH | typeof VERCEL_PROXY_PATH_TYPE | typeof VERCEL_PROXY_PATH_TYPE_VARIANT | typeof VERCEL_PROXY_REFERER | typeof VERCEL_PROXY_REGION | typeof VERCEL_PROXY_RESPONSE_BYTE_SIZE | typeof VERCEL_PROXY_SCHEME | typeof VERCEL_PROXY_STATUS_CODE | typeof VERCEL_PROXY_TIMESTAMP | typeof VERCEL_PROXY_USER_AGENT | typeof VERCEL_PROXY_VERCEL_CACHE | typeof VERCEL_PROXY_VERCEL_ID | typeof VERCEL_PROXY_WAF_ACTION | typeof VERCEL_PROXY_WAF_RULE_ID | typeof VERCEL_REQUEST_ID | typeof VERCEL_SOURCE | typeof VERCEL_STATUS_CODE;
+export type AttributeName =
+  | typeof AI_CITATIONS
+  | typeof AI_COMPLETION_TOKENS_USED
+  | typeof AI_DOCUMENTS
+  | typeof AI_FINISH_REASON
+  | typeof AI_FREQUENCY_PENALTY
+  | typeof AI_FUNCTION_CALL
+  | typeof AI_GENERATION_ID
+  | typeof AI_INPUT_MESSAGES
+  | typeof AI_IS_SEARCH_REQUIRED
+  | typeof AI_METADATA
+  | typeof AI_MODEL_ID
+  | typeof AI_MODEL_PROVIDER
+  | typeof AI_PIPELINE_NAME
+  | typeof AI_PREAMBLE
+  | typeof AI_PRESENCE_PENALTY
+  | typeof AI_PROMPT_TOKENS_USED
+  | typeof AI_RAW_PROMPTING
+  | typeof AI_RESPONSES
+  | typeof AI_RESPONSE_FORMAT
+  | typeof AI_SEARCH_QUERIES
+  | typeof AI_SEARCH_RESULTS
+  | typeof AI_SEED
+  | typeof AI_STREAMING
+  | typeof AI_TAGS
+  | typeof AI_TEMPERATURE
+  | typeof AI_TEXTS
+  | typeof AI_TOOLS
+  | typeof AI_TOOL_CALLS
+  | typeof AI_TOP_K
+  | typeof AI_TOP_P
+  | typeof AI_TOTAL_COST
+  | typeof AI_TOTAL_TOKENS_USED
+  | typeof AI_WARNINGS
+  | typeof APP_BUILD
+  | typeof APP_IDENTIFIER
+  | typeof APP_IN_FOREGROUND
+  | typeof APP_NAME
+  | typeof APP_START_TIME
+  | typeof APP_START_TYPE
+  | typeof APP_VERSION
+  | typeof BLOCKED_MAIN_THREAD
+  | typeof BROWSER_NAME
+  | typeof BROWSER_REPORT_TYPE
+  | typeof BROWSER_SCRIPT_INVOKER
+  | typeof BROWSER_SCRIPT_INVOKER_TYPE
+  | typeof BROWSER_SCRIPT_SOURCE_CHAR_POSITION
+  | typeof BROWSER_VERSION
+  | typeof BROWSER_WEB_VITAL_CLS_SOURCE_KEY
+  | typeof BROWSER_WEB_VITAL_CLS_VALUE
+  | typeof BROWSER_WEB_VITAL_FCP_VALUE
+  | typeof BROWSER_WEB_VITAL_FP_VALUE
+  | typeof BROWSER_WEB_VITAL_INP_VALUE
+  | typeof BROWSER_WEB_VITAL_LCP_ELEMENT
+  | typeof BROWSER_WEB_VITAL_LCP_ID
+  | typeof BROWSER_WEB_VITAL_LCP_LOAD_TIME
+  | typeof BROWSER_WEB_VITAL_LCP_RENDER_TIME
+  | typeof BROWSER_WEB_VITAL_LCP_SIZE
+  | typeof BROWSER_WEB_VITAL_LCP_URL
+  | typeof BROWSER_WEB_VITAL_LCP_VALUE
+  | typeof BROWSER_WEB_VITAL_TTFB_REQUEST_TIME
+  | typeof BROWSER_WEB_VITAL_TTFB_VALUE
+  | typeof CACHE_HIT
+  | typeof CACHE_ITEM_SIZE
+  | typeof CACHE_KEY
+  | typeof CACHE_OPERATION
+  | typeof CACHE_TTL
+  | typeof CACHE_WRITE
+  | typeof CHANNEL
+  | typeof CLIENT_ADDRESS
+  | typeof CLIENT_PORT
+  | typeof CLOUDFLARE_D1_DURATION
+  | typeof CLOUDFLARE_D1_ROWS_READ
+  | typeof CLOUDFLARE_D1_ROWS_WRITTEN
+  | typeof CLS
+  | typeof CLS_SOURCE_KEY
+  | typeof CODE_FILEPATH
+  | typeof CODE_FILE_PATH
+  | typeof CODE_FUNCTION
+  | typeof CODE_FUNCTION_NAME
+  | typeof CODE_LINENO
+  | typeof CODE_LINE_NUMBER
+  | typeof CODE_NAMESPACE
+  | typeof CONNECTIONTYPE
+  | typeof CONNECTION_RTT
+  | typeof CULTURE_CALENDAR
+  | typeof CULTURE_DISPLAY_NAME
+  | typeof CULTURE_IS_24_HOUR_FORMAT
+  | typeof CULTURE_LOCALE
+  | typeof CULTURE_TIMEZONE
+  | typeof DB_COLLECTION_NAME
+  | typeof DB_NAME
+  | typeof DB_NAMESPACE
+  | typeof DB_OPERATION
+  | typeof DB_OPERATION_NAME
+  | typeof DB_QUERY_PARAMETER_KEY
+  | typeof DB_QUERY_SUMMARY
+  | typeof DB_QUERY_TEXT
+  | typeof DB_REDIS_CONNECTION
+  | typeof DB_REDIS_PARAMETERS
+  | typeof DB_SQL_BINDINGS
+  | typeof DB_STATEMENT
+  | typeof DB_SYSTEM
+  | typeof DB_SYSTEM_NAME
+  | typeof DB_USER
+  | typeof DEVICEMEMORY
+  | typeof DEVICE_BRAND
+  | typeof DEVICE_CLASS
+  | typeof DEVICE_FAMILY
+  | typeof DEVICE_FREE_MEMORY
+  | typeof DEVICE_MEMORY_ESTIMATED_CAPACITY
+  | typeof DEVICE_MEMORY_SIZE
+  | typeof DEVICE_MODEL
+  | typeof DEVICE_MODEL_ID
+  | typeof DEVICE_PROCESSOR_COUNT
+  | typeof DEVICE_SIMULATOR
+  | typeof EFFECTIVECONNECTIONTYPE
+  | typeof ENVIRONMENT
+  | typeof ERROR_TYPE
+  | typeof EVENT_ID
+  | typeof EVENT_NAME
+  | typeof EXCEPTION_ESCAPED
+  | typeof EXCEPTION_MESSAGE
+  | typeof EXCEPTION_STACKTRACE
+  | typeof EXCEPTION_TYPE
+  | typeof FAAS_COLDSTART
+  | typeof FAAS_CRON
+  | typeof FAAS_TIME
+  | typeof FAAS_TRIGGER
+  | typeof FCP
+  | typeof FLAG_EVALUATION_KEY
+  | typeof FP
+  | typeof FRAMES_DELAY
+  | typeof FRAMES_FROZEN
+  | typeof FRAMES_SLOW
+  | typeof FRAMES_TOTAL
+  | typeof FS_ERROR
+  | typeof GEN_AI_AGENT_NAME
+  | typeof GEN_AI_CONVERSATION_ID
+  | typeof GEN_AI_COST_INPUT_TOKENS
+  | typeof GEN_AI_COST_OUTPUT_TOKENS
+  | typeof GEN_AI_COST_TOTAL_TOKENS
+  | typeof GEN_AI_EMBEDDINGS_INPUT
+  | typeof GEN_AI_INPUT_MESSAGES
+  | typeof GEN_AI_OPERATION_NAME
+  | typeof GEN_AI_OPERATION_TYPE
+  | typeof GEN_AI_OUTPUT_MESSAGES
+  | typeof GEN_AI_PIPELINE_NAME
+  | typeof GEN_AI_PROMPT
+  | typeof GEN_AI_PROVIDER_NAME
+  | typeof GEN_AI_REQUEST_AVAILABLE_TOOLS
+  | typeof GEN_AI_REQUEST_FREQUENCY_PENALTY
+  | typeof GEN_AI_REQUEST_MAX_TOKENS
+  | typeof GEN_AI_REQUEST_MESSAGES
+  | typeof GEN_AI_REQUEST_MODEL
+  | typeof GEN_AI_REQUEST_PRESENCE_PENALTY
+  | typeof GEN_AI_REQUEST_SEED
+  | typeof GEN_AI_REQUEST_TEMPERATURE
+  | typeof GEN_AI_REQUEST_TOP_K
+  | typeof GEN_AI_REQUEST_TOP_P
+  | typeof GEN_AI_RESPONSE_FINISH_REASONS
+  | typeof GEN_AI_RESPONSE_ID
+  | typeof GEN_AI_RESPONSE_MODEL
+  | typeof GEN_AI_RESPONSE_STREAMING
+  | typeof GEN_AI_RESPONSE_TEXT
+  | typeof GEN_AI_RESPONSE_TIME_TO_FIRST_TOKEN
+  | typeof GEN_AI_RESPONSE_TOKENS_PER_SECOND
+  | typeof GEN_AI_RESPONSE_TOOL_CALLS
+  | typeof GEN_AI_SYSTEM
+  | typeof GEN_AI_SYSTEM_INSTRUCTIONS
+  | typeof GEN_AI_SYSTEM_MESSAGE
+  | typeof GEN_AI_TOOL_CALL_ARGUMENTS
+  | typeof GEN_AI_TOOL_CALL_RESULT
+  | typeof GEN_AI_TOOL_DEFINITIONS
+  | typeof GEN_AI_TOOL_DESCRIPTION
+  | typeof GEN_AI_TOOL_INPUT
+  | typeof GEN_AI_TOOL_MESSAGE
+  | typeof GEN_AI_TOOL_NAME
+  | typeof GEN_AI_TOOL_OUTPUT
+  | typeof GEN_AI_TOOL_TYPE
+  | typeof GEN_AI_USAGE_COMPLETION_TOKENS
+  | typeof GEN_AI_USAGE_INPUT_TOKENS
+  | typeof GEN_AI_USAGE_INPUT_TOKENS_CACHED
+  | typeof GEN_AI_USAGE_INPUT_TOKENS_CACHE_WRITE
+  | typeof GEN_AI_USAGE_OUTPUT_TOKENS
+  | typeof GEN_AI_USAGE_OUTPUT_TOKENS_REASONING
+  | typeof GEN_AI_USAGE_PROMPT_TOKENS
+  | typeof GEN_AI_USAGE_TOTAL_TOKENS
+  | typeof GRAPHQL_OPERATION_NAME
+  | typeof GRAPHQL_OPERATION_TYPE
+  | typeof HARDWARECONCURRENCY
+  | typeof HTTP_CLIENT_IP
+  | typeof HTTP_DECODED_RESPONSE_CONTENT_LENGTH
+  | typeof HTTP_FLAVOR
+  | typeof HTTP_FRAGMENT
+  | typeof HTTP_HOST
+  | typeof HTTP_METHOD
+  | typeof HTTP_QUERY
+  | typeof HTTP_REQUEST_CONNECTION_END
+  | typeof HTTP_REQUEST_CONNECT_START
+  | typeof HTTP_REQUEST_DOMAIN_LOOKUP_END
+  | typeof HTTP_REQUEST_DOMAIN_LOOKUP_START
+  | typeof HTTP_REQUEST_FETCH_START
+  | typeof HTTP_REQUEST_HEADER_KEY
+  | typeof HTTP_REQUEST_METHOD
+  | typeof HTTP_REQUEST_REDIRECT_END
+  | typeof HTTP_REQUEST_REDIRECT_START
+  | typeof HTTP_REQUEST_REQUEST_START
+  | typeof HTTP_REQUEST_RESEND_COUNT
+  | typeof HTTP_REQUEST_RESPONSE_END
+  | typeof HTTP_REQUEST_RESPONSE_START
+  | typeof HTTP_REQUEST_SECURE_CONNECTION_START
+  | typeof HTTP_REQUEST_TIME_TO_FIRST_BYTE
+  | typeof HTTP_REQUEST_WORKER_START
+  | typeof HTTP_RESPONSE_BODY_SIZE
+  | typeof HTTP_RESPONSE_CONTENT_LENGTH
+  | typeof HTTP_RESPONSE_HEADER_CONTENT_LENGTH
+  | typeof HTTP_RESPONSE_HEADER_KEY
+  | typeof HTTP_RESPONSE_SIZE
+  | typeof HTTP_RESPONSE_STATUS_CODE
+  | typeof HTTP_RESPONSE_TRANSFER_SIZE
+  | typeof HTTP_ROUTE
+  | typeof HTTP_SCHEME
+  | typeof HTTP_SERVER_NAME
+  | typeof HTTP_SERVER_REQUEST_TIME_IN_QUEUE
+  | typeof HTTP_STATUS_CODE
+  | typeof HTTP_TARGET
+  | typeof HTTP_URL
+  | typeof HTTP_USER_AGENT
+  | typeof ID
+  | typeof INP
+  | typeof JVM_GC_ACTION
+  | typeof JVM_GC_NAME
+  | typeof JVM_MEMORY_POOL_NAME
+  | typeof JVM_MEMORY_TYPE
+  | typeof JVM_THREAD_DAEMON
+  | typeof JVM_THREAD_STATE
+  | typeof LCP
+  | typeof LCP_ELEMENT
+  | typeof LCP_ID
+  | typeof LCP_LOADTIME
+  | typeof LCP_RENDERTIME
+  | typeof LCP_SIZE
+  | typeof LCP_URL
+  | typeof LOGGER_NAME
+  | typeof MCP_CANCELLED_REASON
+  | typeof MCP_CANCELLED_REQUEST_ID
+  | typeof MCP_CLIENT_NAME
+  | typeof MCP_CLIENT_TITLE
+  | typeof MCP_CLIENT_VERSION
+  | typeof MCP_LIFECYCLE_PHASE
+  | typeof MCP_LOGGING_DATA_TYPE
+  | typeof MCP_LOGGING_LEVEL
+  | typeof MCP_LOGGING_LOGGER
+  | typeof MCP_LOGGING_MESSAGE
+  | typeof MCP_METHOD_NAME
+  | typeof MCP_PROGRESS_CURRENT
+  | typeof MCP_PROGRESS_MESSAGE
+  | typeof MCP_PROGRESS_PERCENTAGE
+  | typeof MCP_PROGRESS_TOKEN
+  | typeof MCP_PROGRESS_TOTAL
+  | typeof MCP_PROMPT_NAME
+  | typeof MCP_PROMPT_RESULT_DESCRIPTION
+  | typeof MCP_PROMPT_RESULT_MESSAGE_CONTENT
+  | typeof MCP_PROMPT_RESULT_MESSAGE_COUNT
+  | typeof MCP_PROMPT_RESULT_MESSAGE_ROLE
+  | typeof MCP_PROTOCOL_READY
+  | typeof MCP_PROTOCOL_VERSION
+  | typeof MCP_REQUEST_ARGUMENT_KEY
+  | typeof MCP_REQUEST_ARGUMENT_NAME
+  | typeof MCP_REQUEST_ARGUMENT_URI
+  | typeof MCP_REQUEST_ID
+  | typeof MCP_RESOURCE_PROTOCOL
+  | typeof MCP_RESOURCE_URI
+  | typeof MCP_SERVER_NAME
+  | typeof MCP_SERVER_TITLE
+  | typeof MCP_SERVER_VERSION
+  | typeof MCP_SESSION_ID
+  | typeof MCP_TOOL_NAME
+  | typeof MCP_TOOL_RESULT_CONTENT
+  | typeof MCP_TOOL_RESULT_CONTENT_COUNT
+  | typeof MCP_TOOL_RESULT_IS_ERROR
+  | typeof MCP_TRANSPORT
+  | typeof MDC_KEY
+  | typeof MESSAGING_DESTINATION_CONNECTION
+  | typeof MESSAGING_DESTINATION_NAME
+  | typeof MESSAGING_MESSAGE_BODY_SIZE
+  | typeof MESSAGING_MESSAGE_ENVELOPE_SIZE
+  | typeof MESSAGING_MESSAGE_ID
+  | typeof MESSAGING_MESSAGE_RECEIVE_LATENCY
+  | typeof MESSAGING_MESSAGE_RETRY_COUNT
+  | typeof MESSAGING_OPERATION_TYPE
+  | typeof MESSAGING_SYSTEM
+  | typeof METHOD
+  | typeof NAVIGATION_TYPE
+  | typeof NEL_ELAPSED_TIME
+  | typeof NEL_PHASE
+  | typeof NEL_REFERRER
+  | typeof NEL_SAMPLING_FUNCTION
+  | typeof NEL_TYPE
+  | typeof NETWORK_CONNECTION_EFFECTIVE_TYPE
+  | typeof NETWORK_CONNECTION_RTT
+  | typeof NETWORK_CONNECTION_TYPE
+  | typeof NETWORK_LOCAL_ADDRESS
+  | typeof NETWORK_LOCAL_PORT
+  | typeof NETWORK_PEER_ADDRESS
+  | typeof NETWORK_PEER_PORT
+  | typeof NETWORK_PROTOCOL_NAME
+  | typeof NETWORK_PROTOCOL_VERSION
+  | typeof NETWORK_TRANSPORT
+  | typeof NETWORK_TYPE
+  | typeof NET_HOST_IP
+  | typeof NET_HOST_NAME
+  | typeof NET_HOST_PORT
+  | typeof NET_PEER_IP
+  | typeof NET_PEER_NAME
+  | typeof NET_PEER_PORT
+  | typeof NET_PROTOCOL_NAME
+  | typeof NET_PROTOCOL_VERSION
+  | typeof NET_SOCK_FAMILY
+  | typeof NET_SOCK_HOST_ADDR
+  | typeof NET_SOCK_HOST_PORT
+  | typeof NET_SOCK_PEER_ADDR
+  | typeof NET_SOCK_PEER_NAME
+  | typeof NET_SOCK_PEER_PORT
+  | typeof NET_TRANSPORT
+  | typeof OS_BUILD_ID
+  | typeof OS_DESCRIPTION
+  | typeof OS_NAME
+  | typeof OS_TYPE
+  | typeof OS_VERSION
+  | typeof OTEL_SCOPE_NAME
+  | typeof OTEL_SCOPE_VERSION
+  | typeof OTEL_STATUS_CODE
+  | typeof OTEL_STATUS_DESCRIPTION
+  | typeof PARAMS_KEY
+  | typeof PREVIOUS_ROUTE
+  | typeof PROCESS_EXECUTABLE_NAME
+  | typeof PROCESS_PID
+  | typeof PROCESS_RUNTIME_DESCRIPTION
+  | typeof PROCESS_RUNTIME_NAME
+  | typeof PROCESS_RUNTIME_VERSION
+  | typeof QUERY_KEY
+  | typeof RELEASE
+  | typeof REMIX_ACTION_FORM_DATA_KEY
+  | typeof REPLAY_ID
+  | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT
+  | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME
+  | typeof RESOURCE_RENDER_BLOCKING_STATUS
+  | typeof ROUTE
+  | typeof RPC_GRPC_STATUS_CODE
+  | typeof RPC_SERVICE
+  | typeof SENTRY_ACTION
+  | typeof SENTRY_BROWSER_NAME
+  | typeof SENTRY_BROWSER_VERSION
+  | typeof SENTRY_CANCELLATION_REASON
+  | typeof SENTRY_CATEGORY
+  | typeof SENTRY_CLIENT_SAMPLE_RATE
+  | typeof SENTRY_DESCRIPTION
+  | typeof SENTRY_DIST
+  | typeof SENTRY_DOMAIN
+  | typeof SENTRY_DSC_ENVIRONMENT
+  | typeof SENTRY_DSC_PUBLIC_KEY
+  | typeof SENTRY_DSC_RELEASE
+  | typeof SENTRY_DSC_SAMPLED
+  | typeof SENTRY_DSC_SAMPLE_RATE
+  | typeof SENTRY_DSC_TRACE_ID
+  | typeof SENTRY_DSC_TRANSACTION
+  | typeof SENTRY_ENVIRONMENT
+  | typeof SENTRY_EXCLUSIVE_TIME
+  | typeof SENTRY_GRAPHQL_OPERATION
+  | typeof SENTRY_GROUP
+  | typeof SENTRY_HTTP_PREFETCH
+  | typeof SENTRY_IDLE_SPAN_FINISH_REASON
+  | typeof SENTRY_IS_REMOTE
+  | typeof SENTRY_KIND
+  | typeof SENTRY_MESSAGE_PARAMETER_KEY
+  | typeof SENTRY_MESSAGE_TEMPLATE
+  | typeof SENTRY_MODULE_KEY
+  | typeof SENTRY_NEXTJS_SSR_FUNCTION_ROUTE
+  | typeof SENTRY_NEXTJS_SSR_FUNCTION_TYPE
+  | typeof SENTRY_NORMALIZED_DB_QUERY
+  | typeof SENTRY_NORMALIZED_DB_QUERY_HASH
+  | typeof SENTRY_NORMALIZED_DESCRIPTION
+  | typeof SENTRY_OBSERVED_TIMESTAMP_NANOS
+  | typeof SENTRY_OP
+  | typeof SENTRY_ORIGIN
+  | typeof SENTRY_PLATFORM
+  | typeof SENTRY_PROFILER_ID
+  | typeof SENTRY_RELEASE
+  | typeof SENTRY_REPLAY_ID
+  | typeof SENTRY_REPLAY_IS_BUFFERING
+  | typeof SENTRY_SDK_INTEGRATIONS
+  | typeof SENTRY_SDK_NAME
+  | typeof SENTRY_SDK_VERSION
+  | typeof SENTRY_SEGMENT_ID
+  | typeof _SENTRY_SEGMENT_ID
+  | typeof SENTRY_SEGMENT_NAME
+  | typeof SENTRY_SERVER_SAMPLE_RATE
+  | typeof SENTRY_SOURCE
+  | typeof SENTRY_SPAN_SOURCE
+  | typeof SENTRY_STATUS_CODE
+  | typeof SENTRY_STATUS_MESSAGE
+  | typeof SENTRY_TIMESTAMP_SEQUENCE
+  | typeof SENTRY_TRACE_PARENT_SPAN_ID
+  | typeof SENTRY_TRANSACTION
+  | typeof SERVER_ADDRESS
+  | typeof SERVER_PORT
+  | typeof SERVICE_NAME
+  | typeof SERVICE_VERSION
+  | typeof THREAD_ID
+  | typeof THREAD_NAME
+  | typeof TIMBER_TAG
+  | typeof TRANSACTION
+  | typeof TTFB
+  | typeof TTFB_REQUESTTIME
+  | typeof TYPE
+  | typeof UI_COMPONENT_NAME
+  | typeof UI_CONTRIBUTES_TO_TTFD
+  | typeof UI_CONTRIBUTES_TO_TTID
+  | typeof UI_ELEMENT_HEIGHT
+  | typeof UI_ELEMENT_ID
+  | typeof UI_ELEMENT_IDENTIFIER
+  | typeof UI_ELEMENT_LOAD_TIME
+  | typeof UI_ELEMENT_PAINT_TYPE
+  | typeof UI_ELEMENT_RENDER_TIME
+  | typeof UI_ELEMENT_TYPE
+  | typeof UI_ELEMENT_URL
+  | typeof UI_ELEMENT_WIDTH
+  | typeof URL
+  | typeof URL_DOMAIN
+  | typeof URL_FRAGMENT
+  | typeof URL_FULL
+  | typeof URL_PATH
+  | typeof URL_PATH_PARAMETER_KEY
+  | typeof URL_PORT
+  | typeof URL_QUERY
+  | typeof URL_SCHEME
+  | typeof URL_TEMPLATE
+  | typeof USER_AGENT_ORIGINAL
+  | typeof USER_EMAIL
+  | typeof USER_FULL_NAME
+  | typeof USER_GEO_CITY
+  | typeof USER_GEO_COUNTRY_CODE
+  | typeof USER_GEO_REGION
+  | typeof USER_GEO_SUBDIVISION
+  | typeof USER_HASH
+  | typeof USER_ID
+  | typeof USER_IP_ADDRESS
+  | typeof USER_NAME
+  | typeof USER_ROLES
+  | typeof VERCEL_BRANCH
+  | typeof VERCEL_BUILD_ID
+  | typeof VERCEL_DEPLOYMENT_ID
+  | typeof VERCEL_DESTINATION
+  | typeof VERCEL_EDGE_TYPE
+  | typeof VERCEL_ENTRYPOINT
+  | typeof VERCEL_EXECUTION_REGION
+  | typeof VERCEL_ID
+  | typeof VERCEL_JA3_DIGEST
+  | typeof VERCEL_JA4_DIGEST
+  | typeof VERCEL_LOG_TYPE
+  | typeof VERCEL_PROJECT_ID
+  | typeof VERCEL_PROJECT_NAME
+  | typeof VERCEL_PROXY_CACHE_ID
+  | typeof VERCEL_PROXY_CLIENT_IP
+  | typeof VERCEL_PROXY_HOST
+  | typeof VERCEL_PROXY_LAMBDA_REGION
+  | typeof VERCEL_PROXY_METHOD
+  | typeof VERCEL_PROXY_PATH
+  | typeof VERCEL_PROXY_PATH_TYPE
+  | typeof VERCEL_PROXY_PATH_TYPE_VARIANT
+  | typeof VERCEL_PROXY_REFERER
+  | typeof VERCEL_PROXY_REGION
+  | typeof VERCEL_PROXY_RESPONSE_BYTE_SIZE
+  | typeof VERCEL_PROXY_SCHEME
+  | typeof VERCEL_PROXY_STATUS_CODE
+  | typeof VERCEL_PROXY_TIMESTAMP
+  | typeof VERCEL_PROXY_USER_AGENT
+  | typeof VERCEL_PROXY_VERCEL_CACHE
+  | typeof VERCEL_PROXY_VERCEL_ID
+  | typeof VERCEL_PROXY_WAF_ACTION
+  | typeof VERCEL_PROXY_WAF_RULE_ID
+  | typeof VERCEL_REQUEST_ID
+  | typeof VERCEL_SOURCE
+  | typeof VERCEL_STATUS_CODE;
 
 export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   [AI_CITATIONS]: {
-    brief: "References or sources cited by the AI model in its response.",
+    brief: 'References or sources cited by the AI model in its response.',
     type: 'string[]',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: ["Citation 1","Citation 2"],
+    example: ['Citation 1', 'Citation 2'],
     deprecation: {},
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.1.0", prs: [55] },
+      { version: 'next', prs: [264] },
+      { version: '0.1.0', prs: [55] },
     ],
   },
   [AI_COMPLETION_TOKENS_USED]: {
-    brief: "The number of tokens used to respond to the message.",
+    brief: 'The number of tokens used to respond to the message.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 10,
     deprecation: {
-      replacement: "gen_ai.usage.output_tokens"
+      replacement: 'gen_ai.usage.output_tokens',
     },
     aliases: [GEN_AI_USAGE_OUTPUT_TOKENS, GEN_AI_USAGE_COMPLETION_TOKENS],
-    sdks: ["python"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [57, 61] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['python'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [57, 61] }, { version: '0.0.0' }],
   },
   [AI_DOCUMENTS]: {
-    brief: "Documents or content chunks used as context for the AI model.",
+    brief: 'Documents or content chunks used as context for the AI model.',
     type: 'string[]',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: ["document1.txt","document2.pdf"],
+    example: ['document1.txt', 'document2.pdf'],
     deprecation: {},
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.1.0", prs: [55] },
+      { version: 'next', prs: [264] },
+      { version: '0.1.0', prs: [55] },
     ],
   },
   [AI_FINISH_REASON]: {
-    brief: "The reason why the model stopped generating.",
+    brief: 'The reason why the model stopped generating.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "COMPLETE",
+    example: 'COMPLETE',
     deprecation: {
-      replacement: "gen_ai.response.finish_reason"
+      replacement: 'gen_ai.response.finish_reason',
     },
     aliases: [GEN_AI_RESPONSE_FINISH_REASONS],
-    changelog: [
-      { version: "0.1.0", prs: [55, 57, 61, 108, 127] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [55, 57, 61, 108, 127] }],
   },
   [AI_FREQUENCY_PENALTY]: {
-    brief: "Used to reduce repetitiveness of generated tokens. The higher the value, the stronger a penalty is applied to previously present tokens, proportional to how many times they have already appeared in the prompt or prior generation.",
+    brief:
+      'Used to reduce repetitiveness of generated tokens. The higher the value, the stronger a penalty is applied to previously present tokens, proportional to how many times they have already appeared in the prompt or prior generation.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 0.5,
     deprecation: {
-      replacement: "gen_ai.request.frequency_penalty"
+      replacement: 'gen_ai.request.frequency_penalty',
     },
     aliases: [GEN_AI_REQUEST_FREQUENCY_PENALTY],
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [55, 57, 61, 108] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [55, 57, 61, 108] },
     ],
   },
   [AI_FUNCTION_CALL]: {
-    brief: "For an AI model call, the function that was called. This is deprecated for OpenAI, and replaced by tool_calls",
+    brief:
+      'For an AI model call, the function that was called. This is deprecated for OpenAI, and replaced by tool_calls',
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: "function_name",
+    example: 'function_name',
     deprecation: {
-      replacement: "gen_ai.tool.name"
+      replacement: 'gen_ai.tool.name',
     },
     aliases: [GEN_AI_TOOL_NAME],
-    changelog: [
-      { version: "0.1.0", prs: [55, 57, 61, 108] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [55, 57, 61, 108] }],
   },
   [AI_GENERATION_ID]: {
-    brief: "Unique identifier for the completion.",
+    brief: 'Unique identifier for the completion.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "gen_123abc",
+    example: 'gen_123abc',
     deprecation: {
-      replacement: "gen_ai.response.id"
+      replacement: 'gen_ai.response.id',
     },
     aliases: [GEN_AI_RESPONSE_ID],
-    changelog: [
-      { version: "0.1.0", prs: [55, 57, 61, 108, 127] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [55, 57, 61, 108, 127] }],
   },
   [AI_INPUT_MESSAGES]: {
-    brief: "The input messages sent to the model",
+    brief: 'The input messages sent to the model',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "[{\"role\": \"user\", \"message\": \"hello\"}]",
+    example: '[{"role": "user", "message": "hello"}]',
     deprecation: {
-      replacement: "gen_ai.request.messages"
+      replacement: 'gen_ai.request.messages',
     },
     aliases: [GEN_AI_REQUEST_MESSAGES],
-    sdks: ["python"],
-    changelog: [
-      { version: "0.1.0", prs: [65, 119] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['python'],
+    changelog: [{ version: '0.1.0', prs: [65, 119] }, { version: '0.0.0' }],
   },
   [AI_IS_SEARCH_REQUIRED]: {
-    brief: "Boolean indicating if the model needs to perform a search.",
+    brief: 'Boolean indicating if the model needs to perform a search.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: false,
     deprecation: {},
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.1.0", prs: [55] },
+      { version: 'next', prs: [264] },
+      { version: '0.1.0', prs: [55] },
     ],
   },
   [AI_METADATA]: {
-    brief: "Extra metadata passed to an AI pipeline step.",
+    brief: 'Extra metadata passed to an AI pipeline step.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "{\"user_id\": 123, \"session_id\": \"abc123\"}",
+    example: '{"user_id": 123, "session_id": "abc123"}',
     deprecation: {},
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.1.0", prs: [55, 127] },
+      { version: 'next', prs: [264] },
+      { version: '0.1.0', prs: [55, 127] },
     ],
   },
   [AI_MODEL_ID]: {
-    brief: "The vendor-specific ID of the model used.",
+    brief: 'The vendor-specific ID of the model used.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "gpt-4",
+    example: 'gpt-4',
     deprecation: {
-      replacement: "gen_ai.response.model"
+      replacement: 'gen_ai.response.model',
     },
     aliases: [GEN_AI_RESPONSE_MODEL],
-    sdks: ["python"],
-    changelog: [
-      { version: "0.1.0", prs: [57, 61, 127] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['python'],
+    changelog: [{ version: '0.1.0', prs: [57, 61, 127] }, { version: '0.0.0' }],
   },
   [AI_MODEL_PROVIDER]: {
-    brief: "The provider of the model.",
+    brief: 'The provider of the model.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "openai",
+    example: 'openai',
     deprecation: {
-      replacement: "gen_ai.provider.name"
+      replacement: 'gen_ai.provider.name',
     },
     aliases: [GEN_AI_PROVIDER_NAME, GEN_AI_SYSTEM],
     changelog: [
-      { version: "0.4.0", prs: [253] },
-      { version: "0.1.0", prs: [57, 61, 108, 127] },
+      { version: '0.4.0', prs: [253] },
+      { version: '0.1.0', prs: [57, 61, 108, 127] },
     ],
   },
   [AI_PIPELINE_NAME]: {
-    brief: "The name of the AI pipeline.",
+    brief: 'The name of the AI pipeline.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "Autofix Pipeline",
+    example: 'Autofix Pipeline',
     deprecation: {
-      replacement: "gen_ai.pipeline.name"
+      replacement: 'gen_ai.pipeline.name',
     },
     aliases: [GEN_AI_PIPELINE_NAME],
-    changelog: [
-      { version: "0.1.0", prs: [53, 76, 108, 127] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [53, 76, 108, 127] }],
   },
   [AI_PREAMBLE]: {
-    brief: "For an AI model call, the preamble parameter. Preambles are a part of the prompt used to adjust the model's overall behavior and conversation style.",
+    brief:
+      "For an AI model call, the preamble parameter. Preambles are a part of the prompt used to adjust the model's overall behavior and conversation style.",
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: "You are now a clown.",
+    example: 'You are now a clown.',
     deprecation: {
-      replacement: "gen_ai.system_instructions"
+      replacement: 'gen_ai.system_instructions',
     },
     aliases: [GEN_AI_SYSTEM_INSTRUCTIONS],
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.1.0", prs: [55] },
+      { version: 'next', prs: [264] },
+      { version: '0.1.0', prs: [55] },
     ],
   },
   [AI_PRESENCE_PENALTY]: {
-    brief: "Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.",
+    brief:
+      'Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 0.5,
     deprecation: {
-      replacement: "gen_ai.request.presence_penalty"
+      replacement: 'gen_ai.request.presence_penalty',
     },
     aliases: [GEN_AI_REQUEST_PRESENCE_PENALTY],
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [55, 57, 61, 108] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [55, 57, 61, 108] },
     ],
   },
   [AI_PROMPT_TOKENS_USED]: {
-    brief: "The number of tokens used to process just the prompt.",
+    brief: 'The number of tokens used to process just the prompt.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 20,
     deprecation: {
-      replacement: "gen_ai.usage.input_tokens"
+      replacement: 'gen_ai.usage.input_tokens',
     },
     aliases: [GEN_AI_USAGE_PROMPT_TOKENS, GEN_AI_USAGE_INPUT_TOKENS],
-    sdks: ["python"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [57, 61] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['python'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [57, 61] }, { version: '0.0.0' }],
   },
   [AI_RAW_PROMPTING]: {
-    brief: "When enabled, the user’s prompt will be sent to the model without any pre-processing.",
+    brief: 'When enabled, the user’s prompt will be sent to the model without any pre-processing.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,
     deprecation: {},
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.1.0", prs: [55] },
+      { version: 'next', prs: [264] },
+      { version: '0.1.0', prs: [55] },
     ],
   },
   [AI_RESPONSES]: {
-    brief: "The response messages sent back by the AI model.",
+    brief: 'The response messages sent back by the AI model.',
     type: 'string[]',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: ["hello","world"],
+    example: ['hello', 'world'],
     deprecation: {
-      replacement: "gen_ai.response.text"
+      replacement: 'gen_ai.response.text',
     },
-    sdks: ["python"],
-    changelog: [
-      { version: "0.1.0", prs: [65, 127] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['python'],
+    changelog: [{ version: '0.1.0', prs: [65, 127] }, { version: '0.0.0' }],
   },
   [AI_RESPONSE_FORMAT]: {
-    brief: "For an AI model call, the format of the response",
+    brief: 'For an AI model call, the format of the response',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "json_object",
+    example: 'json_object',
     deprecation: {},
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.1.0", prs: [55, 127] },
+      { version: 'next', prs: [264] },
+      { version: '0.1.0', prs: [55, 127] },
     ],
   },
   [AI_SEARCH_QUERIES]: {
-    brief: "Queries used to search for relevant context or documents.",
+    brief: 'Queries used to search for relevant context or documents.',
     type: 'string[]',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: ["climate change effects","renewable energy"],
+    example: ['climate change effects', 'renewable energy'],
     deprecation: {},
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.1.0", prs: [55] },
+      { version: 'next', prs: [264] },
+      { version: '0.1.0', prs: [55] },
     ],
   },
   [AI_SEARCH_RESULTS]: {
-    brief: "Results returned from search queries for context.",
+    brief: 'Results returned from search queries for context.',
     type: 'string[]',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: ["search_result_1, search_result_2"],
+    example: ['search_result_1, search_result_2'],
     deprecation: {},
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.1.0", prs: [55] },
+      { version: 'next', prs: [264] },
+      { version: '0.1.0', prs: [55] },
     ],
   },
   [AI_SEED]: {
-    brief: "The seed, ideally models given the same seed and same other parameters will produce the exact same output.",
+    brief: 'The seed, ideally models given the same seed and same other parameters will produce the exact same output.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "1234567890",
+    example: '1234567890',
     deprecation: {
-      replacement: "gen_ai.request.seed"
+      replacement: 'gen_ai.request.seed',
     },
     aliases: [GEN_AI_REQUEST_SEED],
-    changelog: [
-      { version: "0.1.0", prs: [55, 57, 61, 108, 127] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [55, 57, 61, 108, 127] }],
   },
   [AI_STREAMING]: {
-    brief: "Whether the request was streamed back.",
+    brief: 'Whether the request was streamed back.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,
     deprecation: {
-      replacement: "gen_ai.response.streaming"
+      replacement: 'gen_ai.response.streaming',
     },
     aliases: [GEN_AI_RESPONSE_STREAMING],
-    sdks: ["python"],
-    changelog: [
-      { version: "0.1.0", prs: [76, 108] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['python'],
+    changelog: [{ version: '0.1.0', prs: [76, 108] }, { version: '0.0.0' }],
   },
   [AI_TAGS]: {
-    brief: "Tags that describe an AI pipeline step.",
+    brief: 'Tags that describe an AI pipeline step.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "{\"executed_function\": \"add_integers\"}",
+    example: '{"executed_function": "add_integers"}',
     deprecation: {},
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.1.0", prs: [55, 127] },
+      { version: 'next', prs: [264] },
+      { version: '0.1.0', prs: [55, 127] },
     ],
   },
   [AI_TEMPERATURE]: {
-    brief: "For an AI model call, the temperature parameter. Temperature essentially means how random the output will be.",
+    brief:
+      'For an AI model call, the temperature parameter. Temperature essentially means how random the output will be.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 0.1,
     deprecation: {
-      replacement: "gen_ai.request.temperature"
+      replacement: 'gen_ai.request.temperature',
     },
     aliases: [GEN_AI_REQUEST_TEMPERATURE],
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [55, 57, 61, 108] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [55, 57, 61, 108] },
     ],
   },
   [AI_TEXTS]: {
-    brief: "Raw text inputs provided to the model.",
+    brief: 'Raw text inputs provided to the model.',
     type: 'string[]',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: ["Hello, how are you?","What is the capital of France?"],
+    example: ['Hello, how are you?', 'What is the capital of France?'],
     deprecation: {
-      replacement: "gen_ai.input.messages"
+      replacement: 'gen_ai.input.messages',
     },
     aliases: [GEN_AI_INPUT_MESSAGES],
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.1.0", prs: [55] },
+      { version: 'next', prs: [264] },
+      { version: '0.1.0', prs: [55] },
     ],
   },
   [AI_TOOLS]: {
-    brief: "For an AI model call, the functions that are available",
+    brief: 'For an AI model call, the functions that are available',
     type: 'string[]',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: ["function_1","function_2"],
+    example: ['function_1', 'function_2'],
     deprecation: {
-      replacement: "gen_ai.request.available_tools"
+      replacement: 'gen_ai.request.available_tools',
     },
-    changelog: [
-      { version: "0.1.0", prs: [55, 65, 127] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [55, 65, 127] }],
   },
   [AI_TOOL_CALLS]: {
-    brief: "For an AI model call, the tool calls that were made.",
+    brief: 'For an AI model call, the tool calls that were made.',
     type: 'string[]',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: ["tool_call_1","tool_call_2"],
+    example: ['tool_call_1', 'tool_call_2'],
     deprecation: {
-      replacement: "gen_ai.response.tool_calls"
+      replacement: 'gen_ai.response.tool_calls',
     },
-    changelog: [
-      { version: "0.1.0", prs: [55, 65] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [55, 65] }],
   },
   [AI_TOP_K]: {
-    brief: "Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).",
+    brief:
+      'Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 35,
     deprecation: {
-      replacement: "gen_ai.request.top_k"
+      replacement: 'gen_ai.request.top_k',
     },
     aliases: [GEN_AI_REQUEST_TOP_K],
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [55, 57, 61, 108] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [55, 57, 61, 108] },
     ],
   },
   [AI_TOP_P]: {
-    brief: "Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).",
+    brief:
+      'Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 0.7,
     deprecation: {
-      replacement: "gen_ai.request.top_p"
+      replacement: 'gen_ai.request.top_p',
     },
     aliases: [GEN_AI_REQUEST_TOP_P],
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [55, 57, 61, 108] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [55, 57, 61, 108] },
     ],
   },
   [AI_TOTAL_COST]: {
-    brief: "The total cost for the tokens used.",
+    brief: 'The total cost for the tokens used.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 12.34,
     deprecation: {
-      replacement: "gen_ai.cost.total_tokens"
+      replacement: 'gen_ai.cost.total_tokens',
     },
     aliases: [GEN_AI_COST_TOTAL_TOKENS],
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [53] },
+      { version: 'next', prs: [264] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [53] },
     ],
   },
   [AI_TOTAL_TOKENS_USED]: {
-    brief: "The total number of tokens used to process the prompt.",
+    brief: 'The total number of tokens used to process the prompt.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 30,
     deprecation: {
-      replacement: "gen_ai.usage.total_tokens"
+      replacement: 'gen_ai.usage.total_tokens',
     },
     aliases: [GEN_AI_USAGE_TOTAL_TOKENS],
-    sdks: ["python"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [57, 61, 108] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['python'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [57, 61, 108] }, { version: '0.0.0' }],
   },
   [AI_WARNINGS]: {
-    brief: "Warning messages generated during model execution.",
+    brief: 'Warning messages generated during model execution.',
     type: 'string[]',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: ["Token limit exceeded"],
+    example: ['Token limit exceeded'],
     deprecation: {},
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.1.0", prs: [55] },
+      { version: 'next', prs: [264] },
+      { version: '0.1.0', prs: [55] },
     ],
   },
   [APP_BUILD]: {
-    brief: "Internal build identifier, as it appears on the platform.",
+    brief: 'Internal build identifier, as it appears on the platform.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "1",
-    sdks: ["sentry.cocoa","sentry.java.android","sentry.javascript.react-native","sentry.dart.flutter"],
-    changelog: [
-      { version: "next", prs: [296], description: "Added app.build attribute" },
-    ],
+    example: '1',
+    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
+    changelog: [{ version: 'next', prs: [296], description: 'Added app.build attribute' }],
   },
   [APP_IDENTIFIER]: {
-    brief: "Version-independent application identifier, often a dotted bundle ID.",
+    brief: 'Version-independent application identifier, often a dotted bundle ID.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "com.example.myapp",
-    sdks: ["sentry.cocoa","sentry.java.android","sentry.javascript.react-native","sentry.dart.flutter"],
-    changelog: [
-      { version: "next", prs: [296], description: "Added app.identifier attribute" },
-    ],
+    example: 'com.example.myapp',
+    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
+    changelog: [{ version: 'next', prs: [296], description: 'Added app.identifier attribute' }],
   },
   [APP_IN_FOREGROUND]: {
-    brief: "Whether the application is currently in the foreground.",
+    brief: 'Whether the application is currently in the foreground.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,
-    sdks: ["sentry.cocoa","sentry.java.android","sentry.javascript.react-native","sentry.dart.flutter"],
-    changelog: [
-      { version: "next", prs: [296], description: "Added app.in_foreground attribute" },
-    ],
+    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
+    changelog: [{ version: 'next', prs: [296], description: 'Added app.in_foreground attribute' }],
   },
   [APP_NAME]: {
-    brief: "Human readable application name, as it appears on the platform.",
+    brief: 'Human readable application name, as it appears on the platform.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "My App",
-    sdks: ["sentry.cocoa","sentry.java.android","sentry.javascript.react-native","sentry.dart.flutter"],
-    changelog: [
-      { version: "next", prs: [296], description: "Added app.name attribute" },
-    ],
+    example: 'My App',
+    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
+    changelog: [{ version: 'next', prs: [296], description: 'Added app.name attribute' }],
   },
   [APP_START_TIME]: {
-    brief: "Formatted UTC timestamp when the user started the application.",
+    brief: 'Formatted UTC timestamp when the user started the application.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "2025-01-01T00:00:00.000Z",
-    sdks: ["sentry.cocoa","sentry.java.android","sentry.javascript.react-native","sentry.dart.flutter"],
-    changelog: [
-      { version: "next", prs: [296], description: "Added app.start_time attribute" },
-    ],
+    example: '2025-01-01T00:00:00.000Z',
+    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
+    changelog: [{ version: 'next', prs: [296], description: 'Added app.start_time attribute' }],
   },
   [APP_START_TYPE]: {
-    brief: "Mobile app start variant. Either cold or warm.",
+    brief: 'Mobile app start variant. Either cold or warm.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "cold",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'cold',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [APP_VERSION]: {
-    brief: "Human readable application version, as it appears on the platform.",
+    brief: 'Human readable application version, as it appears on the platform.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "1.0.0",
-    sdks: ["sentry.cocoa","sentry.java.android","sentry.javascript.react-native","sentry.dart.flutter"],
-    changelog: [
-      { version: "next", prs: [296], description: "Added app.version attribute" },
-    ],
+    example: '1.0.0',
+    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
+    changelog: [{ version: 'next', prs: [296], description: 'Added app.version attribute' }],
   },
   [BLOCKED_MAIN_THREAD]: {
-    brief: "Whether the main thread was blocked by the span.",
+    brief: 'Whether the main thread was blocked by the span.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.0.0' }],
   },
   [BROWSER_NAME]: {
-    brief: "The name of the browser.",
+    brief: 'The name of the browser.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "Chrome",
+    example: 'Chrome',
     aliases: [SENTRY_BROWSER_NAME],
-    changelog: [
-      { version: "0.1.0", prs: [127, 139] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127, 139] }, { version: '0.0.0' }],
   },
   [BROWSER_REPORT_TYPE]: {
-    brief: "A browser report sent via reporting API..",
+    brief: 'A browser report sent via reporting API..',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "network-error",
-    changelog: [
-      { version: "0.1.0", prs: [68, 127] },
-    ],
+    example: 'network-error',
+    changelog: [{ version: '0.1.0', prs: [68, 127] }],
   },
   [BROWSER_SCRIPT_INVOKER]: {
-    brief: "How a script was called in the browser.",
+    brief: 'How a script was called in the browser.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "Window.requestAnimationFrame",
-    sdks: ["browser"],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'Window.requestAnimationFrame',
+    sdks: ['browser'],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [BROWSER_SCRIPT_INVOKER_TYPE]: {
-    brief: "Browser script entry point type.",
+    brief: 'Browser script entry point type.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "event-listener",
-    sdks: ["browser"],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'event-listener',
+    sdks: ['browser'],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [BROWSER_SCRIPT_SOURCE_CHAR_POSITION]: {
-    brief: "A number representing the script character position of the script.",
+    brief: 'A number representing the script character position of the script.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 678,
-    sdks: ["browser"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['browser'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [BROWSER_VERSION]: {
-    brief: "The version of the browser.",
+    brief: 'The version of the browser.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "120.0.6099.130",
+    example: '120.0.6099.130',
     aliases: [SENTRY_BROWSER_VERSION],
-    changelog: [
-      { version: "0.1.0", prs: [59, 127, 139] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [59, 127, 139] }],
   },
   [BROWSER_WEB_VITAL_CLS_SOURCE_KEY]: {
-    brief: "The HTML elements or components responsible for the layout shift. <key> is a numeric index from 1 to N",
+    brief: 'The HTML elements or components responsible for the layout shift. <key> is a numeric index from 1 to N',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     hasDynamicSuffix: true,
-    example: "body > div#app",
+    example: 'body > div#app',
     aliases: [CLS_SOURCE_KEY],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [234] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [234] }],
   },
   [BROWSER_WEB_VITAL_CLS_VALUE]: {
-    brief: "The value of the recorded Cumulative Layout Shift (CLS) web vital",
+    brief: 'The value of the recorded Cumulative Layout Shift (CLS) web vital',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 0.2361,
     aliases: [CLS],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [229], description: "Added browser.web_vital.cls.value attribute" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [229], description: 'Added browser.web_vital.cls.value attribute' }],
   },
   [BROWSER_WEB_VITAL_FCP_VALUE]: {
-    brief: "The time it takes for the browser to render the first piece of meaningful content on the screen",
+    brief: 'The time it takes for the browser to render the first piece of meaningful content on the screen',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 547.6951,
     aliases: [FCP],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [235] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [235] }],
   },
   [BROWSER_WEB_VITAL_FP_VALUE]: {
-    brief: "The time in milliseconds it takes for the browser to render the first pixel on the screen",
+    brief: 'The time in milliseconds it takes for the browser to render the first pixel on the screen',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 477.1926,
     aliases: [FP],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [235] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [235] }],
   },
   [BROWSER_WEB_VITAL_INP_VALUE]: {
-    brief: "The value of the recorded Interaction to Next Paint (INP) web vital",
+    brief: 'The value of the recorded Interaction to Next Paint (INP) web vital',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 200,
     aliases: [INP],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [229], description: "Added browser.web_vital.inp.value attribute" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [229], description: 'Added browser.web_vital.inp.value attribute' }],
   },
   [BROWSER_WEB_VITAL_LCP_ELEMENT]: {
-    brief: "The HTML element selector or component name for which LCP was reported",
+    brief: 'The HTML element selector or component name for which LCP was reported',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "body > div#app > div#container > div",
+    example: 'body > div#app > div#container > div',
     aliases: [LCP_ELEMENT],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [233] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [233] }],
   },
   [BROWSER_WEB_VITAL_LCP_ID]: {
-    brief: "The id of the dom element responsible for the largest contentful paint",
+    brief: 'The id of the dom element responsible for the largest contentful paint',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "#gero",
+    example: '#gero',
     aliases: [LCP_ID],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [233] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [233] }],
   },
   [BROWSER_WEB_VITAL_LCP_LOAD_TIME]: {
-    brief: "The time it took for the LCP element to be loaded",
+    brief: 'The time it took for the LCP element to be loaded',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1402,
     aliases: [LCP_LOADTIME],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [233] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [233] }],
   },
   [BROWSER_WEB_VITAL_LCP_RENDER_TIME]: {
-    brief: "The time it took for the LCP element to be rendered",
+    brief: 'The time it took for the LCP element to be rendered',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1685,
     aliases: [LCP_RENDERTIME],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [233] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [233] }],
   },
   [BROWSER_WEB_VITAL_LCP_SIZE]: {
-    brief: "The size of the largest contentful paint element",
+    brief: 'The size of the largest contentful paint element',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1024,
     aliases: [LCP_SIZE],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [233] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [233] }],
   },
   [BROWSER_WEB_VITAL_LCP_URL]: {
-    brief: "The url of the dom element responsible for the largest contentful paint",
+    brief: 'The url of the dom element responsible for the largest contentful paint',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "https://example.com/static/img.png",
+    example: 'https://example.com/static/img.png',
     aliases: [LCP_URL],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [233] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [233] }],
   },
   [BROWSER_WEB_VITAL_LCP_VALUE]: {
-    brief: "The value of the recorded Largest Contentful Paint (LCP) web vital",
+    brief: 'The value of the recorded Largest Contentful Paint (LCP) web vital',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 2500,
     aliases: [LCP],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [229], description: "Added browser.web_vital.lcp.value attribute" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [229], description: 'Added browser.web_vital.lcp.value attribute' }],
   },
   [BROWSER_WEB_VITAL_TTFB_REQUEST_TIME]: {
-    brief: "The time it takes for the server to process the initial request and send the first byte of a response to the user's browser",
+    brief:
+      "The time it takes for the server to process the initial request and send the first byte of a response to the user's browser",
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1554.5814,
     aliases: [TTFB_REQUESTTIME],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [235] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [235] }],
   },
   [BROWSER_WEB_VITAL_TTFB_VALUE]: {
-    brief: "The value of the recorded Time To First Byte (TTFB) web vital in Milliseconds",
+    brief: 'The value of the recorded Time To First Byte (TTFB) web vital in Milliseconds',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 194.3322,
     aliases: [TTFB],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [235] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [235] }],
   },
   [CACHE_HIT]: {
-    brief: "If the cache was hit during this span.",
+    brief: 'If the cache was hit during this span.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.0.0' }],
   },
   [CACHE_ITEM_SIZE]: {
-    brief: "The size of the requested item in the cache. In bytes.",
+    brief: 'The size of the requested item in the cache. In bytes.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 58,
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [CACHE_KEY]: {
-    brief: "The key of the cache accessed.",
+    brief: 'The key of the cache accessed.',
     type: 'string[]',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: ["my-cache-key","my-other-cache-key"],
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: ['my-cache-key', 'my-other-cache-key'],
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.0.0' }],
   },
   [CACHE_OPERATION]: {
-    brief: "The operation being performed on the cache.",
+    brief: 'The operation being performed on the cache.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "get",
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'get',
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [CACHE_TTL]: {
-    brief: "The ttl of the cache in seconds",
+    brief: 'The ttl of the cache in seconds',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 120,
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [CACHE_WRITE]: {
-    brief: "If the cache operation resulted in a write to the cache.",
+    brief: 'If the cache operation resulted in a write to the cache.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,
-    sdks: ["java"],
-    changelog: [
-      { version: "next" },
-    ],
+    sdks: ['java'],
+    changelog: [{ version: 'next' }],
   },
   [CHANNEL]: {
-    brief: "The channel name that is being used.",
+    brief: 'The channel name that is being used.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "mail",
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'mail',
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [CLIENT_ADDRESS]: {
-    brief: "Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
+    brief:
+      'Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: true,
-    example: "example.com",
+    example: 'example.com',
     aliases: [HTTP_CLIENT_IP],
-    changelog: [
-      { version: "0.1.0", prs: [106, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [106, 127] }, { version: '0.0.0' }],
   },
   [CLIENT_PORT]: {
-    brief: "Client port number.",
+    brief: 'Client port number.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 5432,
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [CLOUDFLARE_D1_DURATION]: {
-    brief: "The duration of a Cloudflare D1 operation.",
+    brief: 'The duration of a Cloudflare D1 operation.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 543,
-    sdks: ["javascript-cloudflare"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-cloudflare'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [CLOUDFLARE_D1_ROWS_READ]: {
-    brief: "The number of rows read in a Cloudflare D1 operation.",
+    brief: 'The number of rows read in a Cloudflare D1 operation.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 12,
-    sdks: ["javascript-cloudflare"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-cloudflare'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [CLOUDFLARE_D1_ROWS_WRITTEN]: {
-    brief: "The number of rows written in a Cloudflare D1 operation.",
+    brief: 'The number of rows written in a Cloudflare D1 operation.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 12,
-    sdks: ["javascript-cloudflare"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-cloudflare'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [CLS]: {
-    brief: "The value of the recorded Cumulative Layout Shift (CLS) web vital",
+    brief: 'The value of the recorded Cumulative Layout Shift (CLS) web vital',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 0.2361,
     deprecation: {
-      replacement: "browser.web_vital.cls.value",
-      reason: "The CLS web vital is now recorded as a browser.web_vital.cls.value attribute."
+      replacement: 'browser.web_vital.cls.value',
+      reason: 'The CLS web vital is now recorded as a browser.web_vital.cls.value attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_CLS_VALUE],
-    sdks: ["javascript-browser"],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "next", prs: [229], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
+      {
+        version: 'next',
+        prs: [229],
+        description: "Added and deprecated attribute to document JS SDK's current behaviour",
+      },
     ],
   },
   [CLS_SOURCE_KEY]: {
-    brief: "The HTML elements or components responsible for the layout shift. <key> is a numeric index from 1 to N",
+    brief: 'The HTML elements or components responsible for the layout shift. <key> is a numeric index from 1 to N',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     hasDynamicSuffix: true,
-    example: "body > div#app",
+    example: 'body > div#app',
     deprecation: {
-      replacement: "browser.web_vital.cls.source.<key>",
-      reason: "The CLS source is now recorded as a browser.web_vital.cls.source.<key> attribute."
+      replacement: 'browser.web_vital.cls.source.<key>',
+      reason: 'The CLS source is now recorded as a browser.web_vital.cls.source.<key> attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_CLS_SOURCE_KEY],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [234] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [234] }],
   },
   [CODE_FILEPATH]: {
-    brief: "The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).",
+    brief:
+      'The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "/app/myapplication/http/handler/server.py",
+    example: '/app/myapplication/http/handler/server.py',
     deprecation: {
-      replacement: "code.file.path"
+      replacement: 'code.file.path',
     },
     aliases: [CODE_FILE_PATH],
-    changelog: [
-      { version: "0.1.0", prs: [61] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [CODE_FILE_PATH]: {
-    brief: "The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).",
+    brief:
+      'The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "/app/myapplication/http/handler/server.py",
+    example: '/app/myapplication/http/handler/server.py',
     aliases: [CODE_FILEPATH],
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.0.0' }],
   },
   [CODE_FUNCTION]: {
     brief: "The method or function name, or equivalent (usually rightmost part of the code unit's name).",
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "server_request",
+    example: 'server_request',
     deprecation: {
-      replacement: "code.function.name"
+      replacement: 'code.function.name',
     },
     aliases: [CODE_FUNCTION_NAME],
-    changelog: [
-      { version: "0.1.0", prs: [61, 74] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 74] }, { version: '0.0.0' }],
   },
   [CODE_FUNCTION_NAME]: {
     brief: "The method or function name, or equivalent (usually rightmost part of the code unit's name).",
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "server_request",
+    example: 'server_request',
     aliases: [CODE_FUNCTION],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [CODE_LINENO]: {
-    brief: "The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function",
+    brief:
+      'The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 42,
     deprecation: {
-      replacement: "code.line.number"
+      replacement: 'code.line.number',
     },
     aliases: [CODE_LINE_NUMBER],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [61, 108] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61, 108] }, { version: '0.0.0' }],
   },
   [CODE_LINE_NUMBER]: {
-    brief: "The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function",
+    brief:
+      'The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 42,
     aliases: [CODE_LINENO],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [CODE_NAMESPACE]: {
-    brief: "The 'namespace' within which code.function is defined. Usually the qualified class or module name, such that code.namespace + some separator + code.function form a unique identifier for the code unit.",
+    brief:
+      "The 'namespace' within which code.function is defined. Usually the qualified class or module name, such that code.namespace + some separator + code.function form a unique identifier for the code unit.",
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "http.handler",
+    example: 'http.handler',
     deprecation: {
-      replacement: "code.function.name",
-      reason: "code.function.name should include the namespace."
+      replacement: 'code.function.name',
+      reason: 'code.function.name should include the namespace.',
     },
-    changelog: [
-      { version: "0.1.0", prs: [61, 74] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 74] }, { version: '0.0.0' }],
   },
   [CONNECTIONTYPE]: {
-    brief: "Specifies the type of the current connection (e.g. wifi, ethernet, cellular , etc).",
+    brief: 'Specifies the type of the current connection (e.g. wifi, ethernet, cellular , etc).',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "wifi",
+    example: 'wifi',
     deprecation: {
-      replacement: "network.connection.type",
-      reason: "Old namespace-less attribute, to be replaced with network.connection.type for span-first future"
+      replacement: 'network.connection.type',
+      reason: 'Old namespace-less attribute, to be replaced with network.connection.type for span-first future',
     },
     aliases: [NETWORK_CONNECTION_TYPE],
-    sdks: ["javascript-browser"],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "next", prs: [279], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
+      {
+        version: 'next',
+        prs: [279],
+        description: "Added and deprecated attribute to document JS SDK's current behaviour",
+      },
     ],
   },
   [CONNECTION_RTT]: {
-    brief: "Specifies the estimated effective round-trip time of the current connection, in milliseconds.",
+    brief: 'Specifies the estimated effective round-trip time of the current connection, in milliseconds.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 100,
     deprecation: {
-      replacement: "network.connection.rtt",
-      reason: "Old attribute name (no official namespace), to be replaced with network.connection.rtt for span-first future"
+      replacement: 'network.connection.rtt',
+      reason:
+        'Old attribute name (no official namespace), to be replaced with network.connection.rtt for span-first future',
     },
     aliases: [NETWORK_CONNECTION_RTT],
-    sdks: ["javascript-browser"],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "next", prs: [279], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
+      {
+        version: 'next',
+        prs: [279],
+        description: "Added and deprecated attribute to document JS SDK's current behaviour",
+      },
     ],
   },
   [CULTURE_CALENDAR]: {
-    brief: "The calendar system used by the culture.",
+    brief: 'The calendar system used by the culture.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "GregorianCalendar",
-    changelog: [
-      { version: "0.4.0", prs: [243] },
-    ],
+    example: 'GregorianCalendar',
+    changelog: [{ version: '0.4.0', prs: [243] }],
   },
   [CULTURE_DISPLAY_NAME]: {
-    brief: "Human readable name of the culture.",
+    brief: 'Human readable name of the culture.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "English (United States)",
-    changelog: [
-      { version: "0.4.0", prs: [243] },
-    ],
+    example: 'English (United States)',
+    changelog: [{ version: '0.4.0', prs: [243] }],
   },
   [CULTURE_IS_24_HOUR_FORMAT]: {
-    brief: "Whether the culture uses 24-hour time format.",
+    brief: 'Whether the culture uses 24-hour time format.',
     type: 'boolean',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: true,
-    changelog: [
-      { version: "0.4.0", prs: [243] },
-    ],
+    changelog: [{ version: '0.4.0', prs: [243] }],
   },
   [CULTURE_LOCALE]: {
-    brief: "The locale identifier following RFC 4646.",
+    brief: 'The locale identifier following RFC 4646.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "en-US",
-    changelog: [
-      { version: "0.4.0", prs: [243] },
-    ],
+    example: 'en-US',
+    changelog: [{ version: '0.4.0', prs: [243] }],
   },
   [CULTURE_TIMEZONE]: {
-    brief: "The timezone of the culture, as a geographic timezone identifier.",
+    brief: 'The timezone of the culture, as a geographic timezone identifier.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "Europe/Vienna",
-    changelog: [
-      { version: "0.4.0", prs: [243] },
-    ],
+    example: 'Europe/Vienna',
+    changelog: [{ version: '0.4.0', prs: [243] }],
   },
   [DB_COLLECTION_NAME]: {
-    brief: "The name of a collection (table, container) within the database.",
+    brief: 'The name of a collection (table, container) within the database.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "users",
-    changelog: [
-      { version: "0.1.0", prs: [106, 127] },
-      { version: "0.0.0" },
-    ],
+    example: 'users',
+    changelog: [{ version: '0.1.0', prs: [106, 127] }, { version: '0.0.0' }],
   },
   [DB_NAME]: {
-    brief: "The name of the database being accessed.",
+    brief: 'The name of the database being accessed.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "customers",
+    example: 'customers',
     deprecation: {
-      replacement: "db.namespace"
+      replacement: 'db.namespace',
     },
     aliases: [DB_NAMESPACE],
-    changelog: [
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [DB_NAMESPACE]: {
-    brief: "The name of the database being accessed.",
+    brief: 'The name of the database being accessed.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "customers",
+    example: 'customers',
     aliases: [DB_NAME],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [DB_OPERATION]: {
-    brief: "The name of the operation being executed.",
+    brief: 'The name of the operation being executed.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "SELECT",
+    example: 'SELECT',
     deprecation: {
-      replacement: "db.operation.name"
+      replacement: 'db.operation.name',
     },
     aliases: [DB_OPERATION_NAME],
-    changelog: [
-      { version: "0.4.0", prs: [199] },
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [199] }, { version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [DB_OPERATION_NAME]: {
-    brief: "The name of the operation being executed.",
+    brief: 'The name of the operation being executed.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "SELECT",
+    example: 'SELECT',
     aliases: [DB_OPERATION],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [DB_QUERY_PARAMETER_KEY]: {
-    brief: "A query parameter used in db.query.text, with <key> being the parameter name, and the attribute value being a string representation of the parameter value.",
+    brief:
+      'A query parameter used in db.query.text, with <key> being the parameter name, and the attribute value being a string representation of the parameter value.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     hasDynamicSuffix: true,
     example: "db.query.parameter.foo='123'",
-    changelog: [
-      { version: "0.1.0", prs: [103, 127] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [103, 127] }],
   },
   [DB_QUERY_SUMMARY]: {
-    brief: "A shortened representation of operation(s) in the full query. This attribute must be low-cardinality and should only contain the operation table names.",
+    brief:
+      'A shortened representation of operation(s) in the full query. This attribute must be low-cardinality and should only contain the operation table names.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "SELECT users;",
-    changelog: [
-      { version: "0.4.0", prs: [208] },
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'SELECT users;',
+    changelog: [{ version: '0.4.0', prs: [208] }, { version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [DB_QUERY_TEXT]: {
-    brief: "The database parameterized query being executed. Any parameter values (filters, insertion values, etc) should be replaced with parameter placeholders. If applicable, use `db.query.parameter.<key>` to add the parameter value.",
+    brief:
+      'The database parameterized query being executed. Any parameter values (filters, insertion values, etc) should be replaced with parameter placeholders. If applicable, use `db.query.parameter.<key>` to add the parameter value.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "SELECT * FROM users WHERE id = $1",
+    example: 'SELECT * FROM users WHERE id = $1',
     aliases: [DB_STATEMENT],
-    changelog: [
-      { version: "0.4.0", prs: [208] },
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [208] }, { version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [DB_REDIS_CONNECTION]: {
-    brief: "The redis connection name.",
+    brief: 'The redis connection name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "my-redis-instance",
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'my-redis-instance',
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [DB_REDIS_PARAMETERS]: {
-    brief: "The array of command parameters given to a redis command.",
+    brief: 'The array of command parameters given to a redis command.',
     type: 'string[]',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: ["test","*"],
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: ['test', '*'],
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.0.0' }],
   },
   [DB_SQL_BINDINGS]: {
-    brief: "The array of query bindings.",
+    brief: 'The array of query bindings.',
     type: 'string[]',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: ["1","foo"],
+    example: ['1', 'foo'],
     deprecation: {
-      replacement: "db.query.parameter.<key>",
-      reason: "Instead of adding every binding in the db.sql.bindings attribute, add them as individual entires with db.query.parameter.<key>."
+      replacement: 'db.query.parameter.<key>',
+      reason:
+        'Instead of adding every binding in the db.sql.bindings attribute, add them as individual entires with db.query.parameter.<key>.',
     },
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.1.0", prs: [61] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [DB_STATEMENT]: {
-    brief: "The database statement being executed.",
+    brief: 'The database statement being executed.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "SELECT * FROM users",
+    example: 'SELECT * FROM users',
     deprecation: {
-      replacement: "db.query.text"
+      replacement: 'db.query.text',
     },
     aliases: [DB_QUERY_TEXT],
-    changelog: [
-      { version: "0.4.0", prs: [199] },
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [199] }, { version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [DB_SYSTEM]: {
-    brief: "An identifier for the database management system (DBMS) product being used. See [OpenTelemetry docs](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#notes-and-well-known-identifiers-for-dbsystem) for a list of well-known identifiers.",
+    brief:
+      'An identifier for the database management system (DBMS) product being used. See [OpenTelemetry docs](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#notes-and-well-known-identifiers-for-dbsystem) for a list of well-known identifiers.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "postgresql",
+    example: 'postgresql',
     deprecation: {
-      replacement: "db.system.name"
+      replacement: 'db.system.name',
     },
     aliases: [DB_SYSTEM_NAME],
-    changelog: [
-      { version: "0.4.0", prs: [199, 224] },
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [199, 224] }, { version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [DB_SYSTEM_NAME]: {
-    brief: "An identifier for the database management system (DBMS) product being used. See [OpenTelemetry docs](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#notes-and-well-known-identifiers-for-dbsystem) for a list of well-known identifiers.",
+    brief:
+      'An identifier for the database management system (DBMS) product being used. See [OpenTelemetry docs](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#notes-and-well-known-identifiers-for-dbsystem) for a list of well-known identifiers.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "postgresql",
+    example: 'postgresql',
     aliases: [DB_SYSTEM],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [DB_USER]: {
-    brief: "The database user.",
+    brief: 'The database user.',
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: true,
-    example: "fancy_user",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'fancy_user',
+    changelog: [{ version: '0.0.0' }],
   },
   [DEVICEMEMORY]: {
-    brief: "The estimated total memory capacity of the device, only a rough estimation in gigabytes.",
+    brief: 'The estimated total memory capacity of the device, only a rough estimation in gigabytes.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "8 GB",
+    example: '8 GB',
     deprecation: {
-      replacement: "device.memory.estimated_capacity",
-      reason: "Old namespace-less attribute, to be replaced with device.memory.estimated_capacity for span-first future"
+      replacement: 'device.memory.estimated_capacity',
+      reason:
+        'Old namespace-less attribute, to be replaced with device.memory.estimated_capacity for span-first future',
     },
     aliases: [DEVICE_MEMORY_ESTIMATED_CAPACITY],
-    sdks: ["javascript-browser"],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "next", prs: [281], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
+      {
+        version: 'next',
+        prs: [281],
+        description: "Added and deprecated attribute to document JS SDK's current behaviour",
+      },
     ],
   },
   [DEVICE_BRAND]: {
-    brief: "The brand of the device.",
+    brief: 'The brand of the device.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "Apple",
-    changelog: [
-      { version: "0.1.0", prs: [116, 127] },
-    ],
+    example: 'Apple',
+    changelog: [{ version: '0.1.0', prs: [116, 127] }],
   },
   [DEVICE_CLASS]: {
-    brief: "The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.",
+    brief:
+      'The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "medium",
-    changelog: [
-      { version: "next", prs: [300], description: "Added device.class attribute" },
-    ],
+    example: 'medium',
+    changelog: [{ version: 'next', prs: [300], description: 'Added device.class attribute' }],
   },
   [DEVICE_FAMILY]: {
-    brief: "The family of the device.",
+    brief: 'The family of the device.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "iPhone",
-    changelog: [
-      { version: "0.1.0", prs: [116, 127] },
-    ],
+    example: 'iPhone',
+    changelog: [{ version: '0.1.0', prs: [116, 127] }],
   },
   [DEVICE_FREE_MEMORY]: {
-    brief: "Free system memory in bytes.",
+    brief: 'Free system memory in bytes.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 2147483648,
-    changelog: [
-      { version: "next", prs: [300], description: "Added device.free_memory attribute" },
-    ],
+    changelog: [{ version: 'next', prs: [300], description: 'Added device.free_memory attribute' }],
   },
   [DEVICE_MEMORY_ESTIMATED_CAPACITY]: {
-    brief: "The estimated total memory capacity of the device, only a rough estimation in gigabytes. Browsers report estimations in buckets of powers of 2, mostly capped at 8 GB",
+    brief:
+      'The estimated total memory capacity of the device, only a rough estimation in gigabytes. Browsers report estimations in buckets of powers of 2, mostly capped at 8 GB',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 8,
     aliases: [DEVICEMEMORY],
-    sdks: ["javascript-browser"],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "next", prs: [281], description: "Added attribute device.memory.estimated_capacity to be used instead of deviceMemory" },
+      {
+        version: 'next',
+        prs: [281],
+        description: 'Added attribute device.memory.estimated_capacity to be used instead of deviceMemory',
+      },
     ],
   },
   [DEVICE_MEMORY_SIZE]: {
-    brief: "Total system memory available in bytes.",
+    brief: 'Total system memory available in bytes.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 17179869184,
-    changelog: [
-      { version: "next", prs: [300], description: "Added device.memory_size attribute" },
-    ],
+    changelog: [{ version: 'next', prs: [300], description: 'Added device.memory_size attribute' }],
   },
   [DEVICE_MODEL]: {
-    brief: "The model of the device.",
+    brief: 'The model of the device.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "iPhone 15 Pro Max",
-    changelog: [
-      { version: "0.1.0", prs: [116, 127] },
-    ],
+    example: 'iPhone 15 Pro Max',
+    changelog: [{ version: '0.1.0', prs: [116, 127] }],
   },
   [DEVICE_MODEL_ID]: {
-    brief: "An internal hardware revision to identify the device exactly.",
+    brief: 'An internal hardware revision to identify the device exactly.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "N861AP",
-    changelog: [
-      { version: "next", prs: [300], description: "Added device.model_id attribute" },
-    ],
+    example: 'N861AP',
+    changelog: [{ version: 'next', prs: [300], description: 'Added device.model_id attribute' }],
   },
   [DEVICE_PROCESSOR_COUNT]: {
-    brief: "Number of \"logical processors\".",
+    brief: 'Number of "logical processors".',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 8,
     aliases: [HARDWARECONCURRENCY],
     changelog: [
-      { version: "next", prs: [300], description: "Removed deprecation, device.processor_count is now the canonical attribute" },
-      { version: "next", prs: [300], description: "Added and deprecated attribute device.processor_count in favor of device.cpu.logical_core_count" },
+      {
+        version: 'next',
+        prs: [300],
+        description: 'Removed deprecation, device.processor_count is now the canonical attribute',
+      },
+      {
+        version: 'next',
+        prs: [300],
+        description: 'Added and deprecated attribute device.processor_count in favor of device.cpu.logical_core_count',
+      },
     ],
   },
   [DEVICE_SIMULATOR]: {
-    brief: "Whether the device is a simulator or an actual device.",
+    brief: 'Whether the device is a simulator or an actual device.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: false,
-    changelog: [
-      { version: "next", prs: [300], description: "Added device.simulator attribute" },
-    ],
+    changelog: [{ version: 'next', prs: [300], description: 'Added device.simulator attribute' }],
   },
   [EFFECTIVECONNECTIONTYPE]: {
-    brief: "Specifies the estimated effective type of the current connection (e.g. slow-2g, 2g, 3g, 4g).",
+    brief: 'Specifies the estimated effective type of the current connection (e.g. slow-2g, 2g, 3g, 4g).',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "4g",
+    example: '4g',
     deprecation: {
-      replacement: "network.connection.effective_type",
-      reason: "Old namespace-less attribute, to be replaced with network.connection.effective_type for span-first future"
+      replacement: 'network.connection.effective_type',
+      reason:
+        'Old namespace-less attribute, to be replaced with network.connection.effective_type for span-first future',
     },
     aliases: [NETWORK_CONNECTION_EFFECTIVE_TYPE],
-    sdks: ["javascript-browser"],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "next", prs: [279], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
+      {
+        version: 'next',
+        prs: [279],
+        description: "Added and deprecated attribute to document JS SDK's current behaviour",
+      },
     ],
   },
   [ENVIRONMENT]: {
-    brief: "The sentry environment.",
+    brief: 'The sentry environment.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "production",
+    example: 'production',
     deprecation: {
-      replacement: "sentry.environment"
+      replacement: 'sentry.environment',
     },
     aliases: [SENTRY_ENVIRONMENT],
-    changelog: [
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [ERROR_TYPE]: {
-    brief: "Describes a class of error the operation ended with.",
+    brief: 'Describes a class of error the operation ended with.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "timeout",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'timeout',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [EVENT_ID]: {
-    brief: "The unique identifier for this event (log record)",
+    brief: 'The unique identifier for this event (log record)',
     type: 'integer',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: 1234567890,
-    changelog: [
-      { version: "0.1.0", prs: [101] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [101] }],
   },
   [EVENT_NAME]: {
-    brief: "The name that uniquely identifies this event (log record)",
+    brief: 'The name that uniquely identifies this event (log record)',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "Process Payload",
-    changelog: [
-      { version: "0.1.0", prs: [101, 127] },
-    ],
+    example: 'Process Payload',
+    changelog: [{ version: '0.1.0', prs: [101, 127] }],
   },
   [EXCEPTION_ESCAPED]: {
-    brief: "SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span.",
+    brief:
+      'SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: true,
     example: true,
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.0.0' }],
   },
   [EXCEPTION_MESSAGE]: {
-    brief: "The error message.",
+    brief: 'The error message.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "ENOENT: no such file or directory",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'ENOENT: no such file or directory',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [EXCEPTION_STACKTRACE]: {
-    brief: "A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.",
+    brief:
+      'A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "Exception in thread \"main\" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example:
+      'Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [EXCEPTION_TYPE]: {
-    brief: "The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.",
+    brief:
+      'The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "OSError",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'OSError',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [FAAS_COLDSTART]: {
-    brief: "A boolean that is true if the serverless function is executed for the first time (aka cold-start).",
+    brief: 'A boolean that is true if the serverless function is executed for the first time (aka cold-start).',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: true,
     example: true,
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.0.0' }],
   },
   [FAAS_CRON]: {
-    brief: "A string containing the schedule period as Cron Expression.",
+    brief: 'A string containing the schedule period as Cron Expression.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "0/5 * * * ? *",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: '0/5 * * * ? *',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [FAAS_TIME]: {
-    brief: "A string containing the function invocation time in the ISO 8601 format expressed in UTC.",
+    brief: 'A string containing the function invocation time in the ISO 8601 format expressed in UTC.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "2020-01-23T13:47:06Z",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: '2020-01-23T13:47:06Z',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [FAAS_TRIGGER]: {
-    brief: "Type of the trigger which caused this function invocation.",
+    brief: 'Type of the trigger which caused this function invocation.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "timer",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'timer',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [FCP]: {
-    brief: "The time it takes for the browser to render the first piece of meaningful content on the screen",
+    brief: 'The time it takes for the browser to render the first piece of meaningful content on the screen',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 547.6951,
     deprecation: {
-      replacement: "browser.web_vital.fcp.value",
-      reason: "This attribute is being deprecated in favor of browser.web_vital.fcp.value"
+      replacement: 'browser.web_vital.fcp.value',
+      reason: 'This attribute is being deprecated in favor of browser.web_vital.fcp.value',
     },
     aliases: [BROWSER_WEB_VITAL_FCP_VALUE],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [235] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [235] }],
   },
   [FLAG_EVALUATION_KEY]: {
-    brief: "An instance of a feature flag evaluation. The value of this attribute is the boolean representing the evaluation result. The <key> suffix is the name of the feature flag.",
+    brief:
+      'An instance of a feature flag evaluation. The value of this attribute is the boolean representing the evaluation result. The <key> suffix is the name of the feature flag.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     hasDynamicSuffix: true,
-    example: "flag.evaluation.is_new_ui=true",
-    changelog: [
-      { version: "0.1.0", prs: [103] },
-    ],
+    example: 'flag.evaluation.is_new_ui=true',
+    changelog: [{ version: '0.1.0', prs: [103] }],
   },
   [FP]: {
-    brief: "The time it takes for the browser to render the first pixel on the screen",
+    brief: 'The time it takes for the browser to render the first pixel on the screen',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 477.1926,
     deprecation: {
-      replacement: "browser.web_vital.fp.value",
-      reason: "This attribute is being deprecated in favor of browser.web_vital.fp.value"
+      replacement: 'browser.web_vital.fp.value',
+      reason: 'This attribute is being deprecated in favor of browser.web_vital.fp.value',
     },
     aliases: [BROWSER_WEB_VITAL_FP_VALUE],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [235] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [235] }],
   },
   [FRAMES_DELAY]: {
-    brief: "The sum of all delayed frame durations in seconds during the lifetime of the span. For more information see [frames delay](https://develop.sentry.dev/sdk/performance/frames-delay/).",
+    brief:
+      'The sum of all delayed frame durations in seconds during the lifetime of the span. For more information see [frames delay](https://develop.sentry.dev/sdk/performance/frames-delay/).',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 5,
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [FRAMES_FROZEN]: {
-    brief: "The number of frozen frames rendered during the lifetime of the span.",
+    brief: 'The number of frozen frames rendered during the lifetime of the span.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 3,
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [FRAMES_SLOW]: {
-    brief: "The number of slow frames rendered during the lifetime of the span.",
+    brief: 'The number of slow frames rendered during the lifetime of the span.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1,
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [FRAMES_TOTAL]: {
-    brief: "The number of total frames rendered during the lifetime of the span.",
+    brief: 'The number of total frames rendered during the lifetime of the span.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 60,
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [FS_ERROR]: {
-    brief: "The error message of a file system error.",
+    brief: 'The error message of a file system error.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "ENOENT: no such file or directory",
+    example: 'ENOENT: no such file or directory',
     deprecation: {
-      replacement: "error.type",
-      reason: "This attribute is not part of the OpenTelemetry specification and error.type fits much better."
+      replacement: 'error.type',
+      reason: 'This attribute is not part of the OpenTelemetry specification and error.type fits much better.',
     },
-    sdks: ["javascript-node"],
-    changelog: [
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-node'],
+    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [GEN_AI_AGENT_NAME]: {
-    brief: "The name of the agent being used.",
+    brief: 'The name of the agent being used.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "ResearchAssistant",
-    changelog: [
-      { version: "0.1.0", prs: [62, 127] },
-    ],
+    example: 'ResearchAssistant',
+    changelog: [{ version: '0.1.0', prs: [62, 127] }],
   },
   [GEN_AI_CONVERSATION_ID]: {
-    brief: "The unique identifier for a conversation (session, thread), used to store and correlate messages within this conversation.",
+    brief:
+      'The unique identifier for a conversation (session, thread), used to store and correlate messages within this conversation.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "conv_5j66UpCpwteGg4YSxUnt7lPY",
-    changelog: [
-      { version: "0.4.0", prs: [250] },
-    ],
+    example: 'conv_5j66UpCpwteGg4YSxUnt7lPY',
+    changelog: [{ version: '0.4.0', prs: [250] }],
   },
   [GEN_AI_COST_INPUT_TOKENS]: {
-    brief: "The cost of tokens used to process the AI input (prompt) in USD (without cached input tokens).",
+    brief: 'The cost of tokens used to process the AI input (prompt) in USD (without cached input tokens).',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 123.45,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [112] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [112] },
     ],
   },
   [GEN_AI_COST_OUTPUT_TOKENS]: {
-    brief: "The cost of tokens used for creating the AI output in USD (without reasoning tokens).",
+    brief: 'The cost of tokens used for creating the AI output in USD (without reasoning tokens).',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 123.45,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [112] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [112] },
     ],
   },
   [GEN_AI_COST_TOTAL_TOKENS]: {
-    brief: "The total cost for the tokens used.",
+    brief: 'The total cost for the tokens used.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 12.34,
     aliases: [AI_TOTAL_COST],
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [126] },
+      { version: 'next', prs: [264] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [126] },
     ],
   },
   [GEN_AI_EMBEDDINGS_INPUT]: {
-    brief: "The input to the embeddings model.",
+    brief: 'The input to the embeddings model.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: "What's the weather in Paris?",
-    changelog: [
-      { version: "0.3.1", prs: [195] },
-    ],
+    changelog: [{ version: '0.3.1', prs: [195] }],
   },
   [GEN_AI_INPUT_MESSAGES]: {
-    brief: "The messages passed to the model. It has to be a stringified version of an array of objects. The `role` attribute of each object must be `\"user\"`, `\"assistant\"`, `\"tool\"`, or `\"system\"`. For messages of the role `\"tool\"`, the `content` can be a string or an arbitrary object with information about the tool call. For other messages the `content` can be either a string or a list of objects in the format `{type: \"text\", text:\"...\"}`.",
+    brief:
+      'The messages passed to the model. It has to be a stringified version of an array of objects. The `role` attribute of each object must be `"user"`, `"assistant"`, `"tool"`, or `"system"`. For messages of the role `"tool"`, the `content` can be a string or an arbitrary object with information about the tool call. For other messages the `content` can be either a string or a list of objects in the format `{type: "text", text:"..."}`.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "[{\"role\": \"user\", \"parts\": [{\"type\": \"text\", \"content\": \"Weather in Paris?\"}]}, {\"role\": \"assistant\", \"parts\": [{\"type\": \"tool_call\", \"id\": \"call_VSPygqKTWdrhaFErNvMV18Yl\", \"name\": \"get_weather\", \"arguments\": {\"location\": \"Paris\"}}]}, {\"role\": \"tool\", \"parts\": [{\"type\": \"tool_call_response\", \"id\": \"call_VSPygqKTWdrhaFErNvMV18Yl\", \"result\": \"rainy, 57°F\"}]}]",
+    example:
+      '[{"role": "user", "parts": [{"type": "text", "content": "Weather in Paris?"}]}, {"role": "assistant", "parts": [{"type": "tool_call", "id": "call_VSPygqKTWdrhaFErNvMV18Yl", "name": "get_weather", "arguments": {"location": "Paris"}}]}, {"role": "tool", "parts": [{"type": "tool_call_response", "id": "call_VSPygqKTWdrhaFErNvMV18Yl", "result": "rainy, 57°F"}]}]',
     aliases: [AI_TEXTS],
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.4.0", prs: [221] },
+      { version: 'next', prs: [264] },
+      { version: '0.4.0', prs: [221] },
     ],
   },
   [GEN_AI_OPERATION_NAME]: {
-    brief: "The name of the operation being performed. It has the following list of well-known values: 'chat', 'create_agent', 'embeddings', 'execute_tool', 'generate_content', 'invoke_agent', 'text_completion'. If one of them applies, then that value MUST be used. Otherwise a custom value MAY be used.",
+    brief:
+      "The name of the operation being performed. It has the following list of well-known values: 'chat', 'create_agent', 'embeddings', 'execute_tool', 'generate_content', 'invoke_agent', 'text_completion'. If one of them applies, then that value MUST be used. Otherwise a custom value MAY be used.",
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "chat",
+    example: 'chat',
     changelog: [
-      { version: "0.4.0", prs: [225] },
-      { version: "0.1.0", prs: [62, 127] },
+      { version: '0.4.0', prs: [225] },
+      { version: '0.1.0', prs: [62, 127] },
     ],
   },
   [GEN_AI_OPERATION_TYPE]: {
-    brief: "The type of AI operation. Must be one of 'agent' (invoke_agent and create_agent spans), 'ai_client' (any LLM call), 'tool' (execute_tool spans), 'handoff' (handoff spans), 'other' (input and output processors, skill loading, guardrails etc.) . Added during ingestion based on span.op and gen_ai.operation.type. Used to filter and aggregate data in the UI",
+    brief:
+      "The type of AI operation. Must be one of 'agent' (invoke_agent and create_agent spans), 'ai_client' (any LLM call), 'tool' (execute_tool spans), 'handoff' (handoff spans), 'other' (input and output processors, skill loading, guardrails etc.) . Added during ingestion based on span.op and gen_ai.operation.type. Used to filter and aggregate data in the UI",
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "tool",
+    example: 'tool',
     changelog: [
-      { version: "0.4.0", prs: [257] },
-      { version: "0.1.0", prs: [113, 127] },
+      { version: '0.4.0', prs: [257] },
+      { version: '0.1.0', prs: [113, 127] },
     ],
   },
   [GEN_AI_OUTPUT_MESSAGES]: {
-    brief: "The model's response messages. It has to be a stringified version of an array of message objects, which can include text responses and tool calls.",
+    brief:
+      "The model's response messages. It has to be a stringified version of an array of message objects, which can include text responses and tool calls.",
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "[{\"role\": \"assistant\", \"parts\": [{\"type\": \"text\", \"content\": \"The weather in Paris is currently rainy with a temperature of 57°F.\"}], \"finish_reason\": \"stop\"}]",
-    changelog: [
-      { version: "0.4.0", prs: [221] },
-    ],
+    example:
+      '[{"role": "assistant", "parts": [{"type": "text", "content": "The weather in Paris is currently rainy with a temperature of 57°F."}], "finish_reason": "stop"}]',
+    changelog: [{ version: '0.4.0', prs: [221] }],
   },
   [GEN_AI_PIPELINE_NAME]: {
-    brief: "Name of the AI pipeline or chain being executed.",
+    brief: 'Name of the AI pipeline or chain being executed.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "Autofix Pipeline",
+    example: 'Autofix Pipeline',
     aliases: [AI_PIPELINE_NAME],
-    changelog: [
-      { version: "0.1.0", prs: [76, 127] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [76, 127] }],
   },
   [GEN_AI_PROMPT]: {
-    brief: "The input messages sent to the model",
+    brief: 'The input messages sent to the model',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "[{\"role\": \"user\", \"message\": \"hello\"}]",
+    example: '[{"role": "user", "message": "hello"}]',
     deprecation: {
-      reason: "Deprecated from OTEL, use gen_ai.input.messages with the new format instead."
+      reason: 'Deprecated from OTEL, use gen_ai.input.messages with the new format instead.',
     },
-    changelog: [
-      { version: "0.1.0", prs: [74, 108, 119] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [74, 108, 119] }, { version: '0.0.0' }],
   },
   [GEN_AI_PROVIDER_NAME]: {
-    brief: "The Generative AI provider as identified by the client or server instrumentation.",
+    brief: 'The Generative AI provider as identified by the client or server instrumentation.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "openai",
+    example: 'openai',
     aliases: [AI_MODEL_PROVIDER, GEN_AI_SYSTEM],
-    changelog: [
-      { version: "0.4.0", prs: [253] },
-    ],
+    changelog: [{ version: '0.4.0', prs: [253] }],
   },
   [GEN_AI_REQUEST_AVAILABLE_TOOLS]: {
-    brief: "The available tools for the model. It has to be a stringified version of an array of objects.",
+    brief: 'The available tools for the model. It has to be a stringified version of an array of objects.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "[{\"name\": \"get_weather\", \"description\": \"Get the weather for a given location\"}, {\"name\": \"get_news\", \"description\": \"Get the news for a given topic\"}]",
+    example:
+      '[{"name": "get_weather", "description": "Get the weather for a given location"}, {"name": "get_news", "description": "Get the news for a given topic"}]',
     deprecation: {
-      replacement: "gen_ai.tool.definitions"
+      replacement: 'gen_ai.tool.definitions',
     },
     changelog: [
-      { version: "0.4.0", prs: [221] },
-      { version: "0.1.0", prs: [63, 127] },
+      { version: '0.4.0', prs: [221] },
+      { version: '0.1.0', prs: [63, 127] },
     ],
   },
   [GEN_AI_REQUEST_FREQUENCY_PENALTY]: {
-    brief: "Used to reduce repetitiveness of generated tokens. The higher the value, the stronger a penalty is applied to previously present tokens, proportional to how many times they have already appeared in the prompt or prior generation.",
+    brief:
+      'Used to reduce repetitiveness of generated tokens. The higher the value, the stronger a penalty is applied to previously present tokens, proportional to how many times they have already appeared in the prompt or prior generation.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 0.5,
     aliases: [AI_FREQUENCY_PENALTY],
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [57] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [57] },
     ],
   },
   [GEN_AI_REQUEST_MAX_TOKENS]: {
-    brief: "The maximum number of tokens to generate in the response.",
+    brief: 'The maximum number of tokens to generate in the response.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 2048,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [62] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [62] },
     ],
   },
   [GEN_AI_REQUEST_MESSAGES]: {
-    brief: "The messages passed to the model. It has to be a stringified version of an array of objects. The `role` attribute of each object must be `\"user\"`, `\"assistant\"`, `\"tool\"`, or `\"system\"`. For messages of the role `\"tool\"`, the `content` can be a string or an arbitrary object with information about the tool call. For other messages the `content` can be either a string or a list of objects in the format `{type: \"text\", text:\"...\"}`.",
+    brief:
+      'The messages passed to the model. It has to be a stringified version of an array of objects. The `role` attribute of each object must be `"user"`, `"assistant"`, `"tool"`, or `"system"`. For messages of the role `"tool"`, the `content` can be a string or an arbitrary object with information about the tool call. For other messages the `content` can be either a string or a list of objects in the format `{type: "text", text:"..."}`.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "[{\"role\": \"system\", \"content\": \"Generate a random number.\"}, {\"role\": \"user\", \"content\": [{\"text\": \"Generate a random number between 0 and 10.\", \"type\": \"text\"}]}, {\"role\": \"tool\", \"content\": {\"toolCallId\": \"1\", \"toolName\": \"Weather\", \"output\": \"rainy\"}}]",
+    example:
+      '[{"role": "system", "content": "Generate a random number."}, {"role": "user", "content": [{"text": "Generate a random number between 0 and 10.", "type": "text"}]}, {"role": "tool", "content": {"toolCallId": "1", "toolName": "Weather", "output": "rainy"}}]',
     deprecation: {
-      replacement: "gen_ai.input.messages"
+      replacement: 'gen_ai.input.messages',
     },
     aliases: [AI_INPUT_MESSAGES],
     changelog: [
-      { version: "0.4.0", prs: [221] },
-      { version: "0.1.0", prs: [63, 74, 108, 119, 122] },
+      { version: '0.4.0', prs: [221] },
+      { version: '0.1.0', prs: [63, 74, 108, 119, 122] },
     ],
   },
   [GEN_AI_REQUEST_MODEL]: {
-    brief: "The model identifier being used for the request.",
+    brief: 'The model identifier being used for the request.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "gpt-4-turbo-preview",
-    changelog: [
-      { version: "0.1.0", prs: [62, 127] },
-    ],
+    example: 'gpt-4-turbo-preview',
+    changelog: [{ version: '0.1.0', prs: [62, 127] }],
   },
   [GEN_AI_REQUEST_PRESENCE_PENALTY]: {
-    brief: "Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.",
+    brief:
+      'Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 0.5,
     aliases: [AI_PRESENCE_PENALTY],
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [57] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [57] },
     ],
   },
   [GEN_AI_REQUEST_SEED]: {
-    brief: "The seed, ideally models given the same seed and same other parameters will produce the exact same output.",
+    brief: 'The seed, ideally models given the same seed and same other parameters will produce the exact same output.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "1234567890",
+    example: '1234567890',
     aliases: [AI_SEED],
-    changelog: [
-      { version: "0.1.0", prs: [57, 127] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [57, 127] }],
   },
   [GEN_AI_REQUEST_TEMPERATURE]: {
-    brief: "For an AI model call, the temperature parameter. Temperature essentially means how random the output will be.",
+    brief:
+      'For an AI model call, the temperature parameter. Temperature essentially means how random the output will be.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 0.1,
     aliases: [AI_TEMPERATURE],
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [57] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [57] },
     ],
   },
   [GEN_AI_REQUEST_TOP_K]: {
-    brief: "Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).",
+    brief:
+      'Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 35,
     aliases: [AI_TOP_K],
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [57] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [57] },
     ],
   },
   [GEN_AI_REQUEST_TOP_P]: {
-    brief: "Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).",
+    brief:
+      'Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 0.7,
     aliases: [AI_TOP_P],
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [57] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [57] },
     ],
   },
   [GEN_AI_RESPONSE_FINISH_REASONS]: {
-    brief: "The reason why the model stopped generating.",
+    brief: 'The reason why the model stopped generating.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "COMPLETE",
+    example: 'COMPLETE',
     aliases: [AI_FINISH_REASON],
-    changelog: [
-      { version: "0.1.0", prs: [57, 127] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [57, 127] }],
   },
   [GEN_AI_RESPONSE_ID]: {
-    brief: "Unique identifier for the completion.",
+    brief: 'Unique identifier for the completion.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "gen_123abc",
+    example: 'gen_123abc',
     aliases: [AI_GENERATION_ID],
-    changelog: [
-      { version: "0.1.0", prs: [57, 127] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [57, 127] }],
   },
   [GEN_AI_RESPONSE_MODEL]: {
-    brief: "The vendor-specific ID of the model used.",
+    brief: 'The vendor-specific ID of the model used.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "gpt-4",
+    example: 'gpt-4',
     aliases: [AI_MODEL_ID],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [GEN_AI_RESPONSE_STREAMING]: {
     brief: "Whether or not the AI model call's response was streamed back asynchronously",
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,
     aliases: [AI_STREAMING],
-    changelog: [
-      { version: "0.1.0", prs: [76] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [76] }],
   },
   [GEN_AI_RESPONSE_TEXT]: {
-    brief: "The model's response text messages. It has to be a stringified version of an array of response text messages.",
+    brief:
+      "The model's response text messages. It has to be a stringified version of an array of response text messages.",
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "[\"The weather in Paris is rainy and overcast, with temperatures around 57°F\", \"The weather in London is sunny and warm, with temperatures around 65°F\"]",
+    example:
+      '["The weather in Paris is rainy and overcast, with temperatures around 57°F", "The weather in London is sunny and warm, with temperatures around 65°F"]',
     deprecation: {
-      replacement: "gen_ai.output.messages"
+      replacement: 'gen_ai.output.messages',
     },
     changelog: [
-      { version: "0.4.0", prs: [221] },
-      { version: "0.1.0", prs: [63, 74] },
+      { version: '0.4.0', prs: [221] },
+      { version: '0.1.0', prs: [63, 74] },
     ],
   },
   [GEN_AI_RESPONSE_TIME_TO_FIRST_TOKEN]: {
-    brief: "Time in seconds when the first response content chunk arrived in streaming responses.",
+    brief: 'Time in seconds when the first response content chunk arrived in streaming responses.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 0.6853435,
-    changelog: [
-      { version: "0.4.0", prs: [227] },
-    ],
+    changelog: [{ version: '0.4.0', prs: [227] }],
   },
   [GEN_AI_RESPONSE_TOKENS_PER_SECOND]: {
-    brief: "The total output tokens per seconds throughput",
+    brief: 'The total output tokens per seconds throughput',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 12345.67,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [66] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [66] },
     ],
   },
   [GEN_AI_RESPONSE_TOOL_CALLS]: {
     brief: "The tool calls in the model's response. It has to be a stringified version of an array of objects.",
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "[{\"name\": \"get_weather\", \"arguments\": {\"location\": \"Paris\"}}]",
+    example: '[{"name": "get_weather", "arguments": {"location": "Paris"}}]',
     deprecation: {
-      replacement: "gen_ai.output.messages"
+      replacement: 'gen_ai.output.messages',
     },
     changelog: [
-      { version: "0.4.0", prs: [221] },
-      { version: "0.1.0", prs: [63, 74] },
+      { version: '0.4.0', prs: [221] },
+      { version: '0.1.0', prs: [63, 74] },
     ],
   },
   [GEN_AI_SYSTEM]: {
-    brief: "The provider of the model.",
+    brief: 'The provider of the model.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "openai",
+    example: 'openai',
     deprecation: {
-      replacement: "gen_ai.provider.name"
+      replacement: 'gen_ai.provider.name',
     },
     aliases: [AI_MODEL_PROVIDER, GEN_AI_PROVIDER_NAME],
     changelog: [
-      { version: "0.4.0", prs: [253] },
-      { version: "0.1.0", prs: [57, 127] },
+      { version: '0.4.0', prs: [253] },
+      { version: '0.1.0', prs: [57, 127] },
     ],
   },
   [GEN_AI_SYSTEM_INSTRUCTIONS]: {
-    brief: "The system instructions passed to the model.",
+    brief: 'The system instructions passed to the model.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "You are a helpful assistant",
+    example: 'You are a helpful assistant',
     aliases: [AI_PREAMBLE],
     changelog: [
-      { version: "next", prs: [264] },
-      { version: "0.4.0", prs: [221] },
+      { version: 'next', prs: [264] },
+      { version: '0.4.0', prs: [221] },
     ],
   },
   [GEN_AI_SYSTEM_MESSAGE]: {
-    brief: "The system instructions passed to the model.",
+    brief: 'The system instructions passed to the model.',
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: "You are a helpful assistant",
+    example: 'You are a helpful assistant',
     deprecation: {
-      replacement: "gen_ai.system_instructions"
+      replacement: 'gen_ai.system_instructions',
     },
     changelog: [
-      { version: "0.4.0", prs: [221] },
-      { version: "0.1.0", prs: [62] },
+      { version: '0.4.0', prs: [221] },
+      { version: '0.1.0', prs: [62] },
     ],
   },
   [GEN_AI_TOOL_CALL_ARGUMENTS]: {
-    brief: "The arguments of the tool call. It has to be a stringified version of the arguments to the tool.",
+    brief: 'The arguments of the tool call. It has to be a stringified version of the arguments to the tool.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "{\"location\": \"Paris\"}",
+    example: '{"location": "Paris"}',
     aliases: [GEN_AI_TOOL_INPUT],
     changelog: [
-      { version: "next", prs: [265] },
-      { version: "0.4.0", prs: [221] },
+      { version: 'next', prs: [265] },
+      { version: '0.4.0', prs: [221] },
     ],
   },
   [GEN_AI_TOOL_CALL_RESULT]: {
-    brief: "The result of the tool call. It has to be a stringified version of the result of the tool.",
+    brief: 'The result of the tool call. It has to be a stringified version of the result of the tool.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "rainy, 57°F",
+    example: 'rainy, 57°F',
     aliases: [GEN_AI_TOOL_OUTPUT, GEN_AI_TOOL_MESSAGE],
     changelog: [
-      { version: "next", prs: [265] },
-      { version: "0.4.0", prs: [221] },
+      { version: 'next', prs: [265] },
+      { version: '0.4.0', prs: [221] },
     ],
   },
   [GEN_AI_TOOL_DEFINITIONS]: {
-    brief: "The list of source system tool definitions available to the GenAI agent or model.",
+    brief: 'The list of source system tool definitions available to the GenAI agent or model.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "[{\"type\": \"function\", \"name\": \"get_current_weather\", \"description\": \"Get the current weather in a given location\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\", \"description\": \"The city and state, e.g. San Francisco, CA\"}, \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]}}, \"required\": [\"location\", \"unit\"]}}]",
-    changelog: [
-      { version: "0.4.0", prs: [221] },
-    ],
+    example:
+      '[{"type": "function", "name": "get_current_weather", "description": "Get the current weather in a given location", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "The city and state, e.g. San Francisco, CA"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]}}]',
+    changelog: [{ version: '0.4.0', prs: [221] }],
   },
   [GEN_AI_TOOL_DESCRIPTION]: {
-    brief: "The description of the tool being used.",
+    brief: 'The description of the tool being used.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "Searches the web for current information about a topic",
-    changelog: [
-      { version: "0.1.0", prs: [62, 127] },
-    ],
+    example: 'Searches the web for current information about a topic',
+    changelog: [{ version: '0.1.0', prs: [62, 127] }],
   },
   [GEN_AI_TOOL_INPUT]: {
-    brief: "The input of the tool being used. It has to be a stringified version of the input to the tool.",
+    brief: 'The input of the tool being used. It has to be a stringified version of the input to the tool.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "{\"location\": \"Paris\"}",
+    example: '{"location": "Paris"}',
     deprecation: {
-      replacement: "gen_ai.tool.call.arguments"
+      replacement: 'gen_ai.tool.call.arguments',
     },
     aliases: [GEN_AI_TOOL_CALL_ARGUMENTS],
     changelog: [
-      { version: "next", prs: [265] },
-      { version: "0.1.0", prs: [63, 74] },
+      { version: 'next', prs: [265] },
+      { version: '0.1.0', prs: [63, 74] },
     ],
   },
   [GEN_AI_TOOL_MESSAGE]: {
-    brief: "The response from a tool or function call passed to the model.",
+    brief: 'The response from a tool or function call passed to the model.',
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: "rainy, 57°F",
+    example: 'rainy, 57°F',
     deprecation: {
-      replacement: "gen_ai.tool.call.result"
+      replacement: 'gen_ai.tool.call.result',
     },
     aliases: [GEN_AI_TOOL_CALL_RESULT, GEN_AI_TOOL_OUTPUT],
     changelog: [
-      { version: "next", prs: [265] },
-      { version: "0.1.0", prs: [62] },
+      { version: 'next', prs: [265] },
+      { version: '0.1.0', prs: [62] },
     ],
   },
   [GEN_AI_TOOL_NAME]: {
-    brief: "Name of the tool utilized by the agent.",
+    brief: 'Name of the tool utilized by the agent.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "Flights",
+    example: 'Flights',
     aliases: [AI_FUNCTION_CALL],
-    changelog: [
-      { version: "0.1.0", prs: [57, 127] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [57, 127] }],
   },
   [GEN_AI_TOOL_OUTPUT]: {
-    brief: "The output of the tool being used. It has to be a stringified version of the output of the tool.",
+    brief: 'The output of the tool being used. It has to be a stringified version of the output of the tool.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "rainy, 57°F",
+    example: 'rainy, 57°F',
     deprecation: {
-      replacement: "gen_ai.tool.call.result"
+      replacement: 'gen_ai.tool.call.result',
     },
     aliases: [GEN_AI_TOOL_CALL_RESULT, GEN_AI_TOOL_MESSAGE],
     changelog: [
-      { version: "next", prs: [265] },
-      { version: "0.1.0", prs: [63, 74] },
+      { version: 'next', prs: [265] },
+      { version: '0.1.0', prs: [63, 74] },
     ],
   },
   [GEN_AI_TOOL_TYPE]: {
-    brief: "The type of tool being used.",
+    brief: 'The type of tool being used.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "function",
+    example: 'function',
     deprecation: {
-      reason: "The gen_ai.tool.type attribute is deprecated and should no longer be set."
+      reason: 'The gen_ai.tool.type attribute is deprecated and should no longer be set.',
     },
-    changelog: [
-      { version: "0.1.0", prs: [62, 127] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [62, 127] }],
   },
   [GEN_AI_USAGE_COMPLETION_TOKENS]: {
-    brief: "The number of tokens used in the GenAI response (completion).",
+    brief: 'The number of tokens used in the GenAI response (completion).',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 10,
     deprecation: {
-      replacement: "gen_ai.usage.output_tokens"
+      replacement: 'gen_ai.usage.output_tokens',
     },
     aliases: [AI_COMPLETION_TOKENS_USED, GEN_AI_USAGE_OUTPUT_TOKENS],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [61] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [GEN_AI_USAGE_INPUT_TOKENS]: {
-    brief: "The number of tokens used to process the AI input (prompt) including cached input tokens.",
+    brief: 'The number of tokens used to process the AI input (prompt) including cached input tokens.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 10,
     aliases: [AI_PROMPT_TOKENS_USED, GEN_AI_USAGE_PROMPT_TOKENS],
     changelog: [
-      { version: "next", prs: [261] },
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [112] },
-      { version: "0.0.0" },
+      { version: 'next', prs: [261] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [112] },
+      { version: '0.0.0' },
     ],
   },
   [GEN_AI_USAGE_INPUT_TOKENS_CACHED]: {
-    brief: "The number of cached tokens used to process the AI input (prompt).",
+    brief: 'The number of cached tokens used to process the AI input (prompt).',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 50,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [62, 112] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [62, 112] },
     ],
   },
   [GEN_AI_USAGE_INPUT_TOKENS_CACHE_WRITE]: {
-    brief: "The number of tokens written to the cache when processing the AI input (prompt).",
+    brief: 'The number of tokens written to the cache when processing the AI input (prompt).',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 100,
-    changelog: [
-      { version: "0.4.0", prs: [217, 228] },
-    ],
+    changelog: [{ version: '0.4.0', prs: [217, 228] }],
   },
   [GEN_AI_USAGE_OUTPUT_TOKENS]: {
-    brief: "The number of tokens used for creating the AI output (including reasoning tokens).",
+    brief: 'The number of tokens used for creating the AI output (including reasoning tokens).',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 10,
     aliases: [AI_COMPLETION_TOKENS_USED, GEN_AI_USAGE_COMPLETION_TOKENS],
     changelog: [
-      { version: "next", prs: [261] },
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [112] },
-      { version: "0.0.0" },
+      { version: 'next', prs: [261] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [112] },
+      { version: '0.0.0' },
     ],
   },
   [GEN_AI_USAGE_OUTPUT_TOKENS_REASONING]: {
-    brief: "The number of tokens used for reasoning to create the AI output.",
+    brief: 'The number of tokens used for reasoning to create the AI output.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 75,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [62, 112] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [62, 112] },
     ],
   },
   [GEN_AI_USAGE_PROMPT_TOKENS]: {
-    brief: "The number of tokens used in the GenAI input (prompt).",
+    brief: 'The number of tokens used in the GenAI input (prompt).',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 20,
     deprecation: {
-      replacement: "gen_ai.usage.input_tokens"
+      replacement: 'gen_ai.usage.input_tokens',
     },
     aliases: [AI_PROMPT_TOKENS_USED, GEN_AI_USAGE_INPUT_TOKENS],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [61] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [GEN_AI_USAGE_TOTAL_TOKENS]: {
-    brief: "The total number of tokens used to process the prompt. (input tokens plus output todkens)",
+    brief: 'The total number of tokens used to process the prompt. (input tokens plus output todkens)',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 20,
     aliases: [AI_TOTAL_TOKENS_USED],
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [57] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [57] },
     ],
   },
   [GRAPHQL_OPERATION_NAME]: {
-    brief: "The name of the operation being executed.",
-    type: 'string',
-    pii: {
-      isPii: 'maybe'
-    },
-    isInOtel: true,
-    example: "findBookById",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
-  },
-  [GRAPHQL_OPERATION_TYPE]: {
-    brief: "The type of the operation being executed.",
-    type: 'string',
-    pii: {
-      isPii: 'maybe'
-    },
-    isInOtel: true,
-    example: "query",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
-  },
-  [HARDWARECONCURRENCY]: {
-    brief: "The number of logical CPU cores available.",
-    type: 'string',
-    pii: {
-      isPii: 'maybe'
-    },
-    isInOtel: false,
-    example: "14",
-    deprecation: {
-      replacement: "device.processor_count",
-      reason: "Old namespace-less attribute, to be replaced with device.processor_count for span-first future"
-    },
-    aliases: [DEVICE_PROCESSOR_COUNT],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [300], description: "Updated deprecation replacement from device.cpu.logical_core_count to device.processor_count" },
-      { version: "next", prs: [281], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
-    ],
-  },
-  [HTTP_CLIENT_IP]: {
-    brief: "Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
-    type: 'string',
-    pii: {
-      isPii: 'true'
-    },
-    isInOtel: true,
-    example: "example.com",
-    deprecation: {
-      replacement: "client.address"
-    },
-    aliases: [CLIENT_ADDRESS],
-    changelog: [
-      { version: "0.1.0", prs: [61, 106, 127] },
-      { version: "0.0.0" },
-    ],
-  },
-  [HTTP_DECODED_RESPONSE_CONTENT_LENGTH]: {
-    brief: "The decoded body size of the response (in bytes).",
-    type: 'integer',
-    pii: {
-      isPii: 'maybe'
-    },
-    isInOtel: false,
-    example: 456,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
-  },
-  [HTTP_FLAVOR]: {
-    brief: "The actual version of the protocol used for network communication.",
-    type: 'string',
-    pii: {
-      isPii: 'maybe'
-    },
-    isInOtel: true,
-    example: "1.1",
-    deprecation: {
-      replacement: "network.protocol.version"
-    },
-    aliases: [NETWORK_PROTOCOL_VERSION, NET_PROTOCOL_VERSION],
-    changelog: [
-      { version: "0.1.0", prs: [61, 108, 127] },
-      { version: "0.0.0" },
-    ],
-  },
-  [HTTP_FRAGMENT]: {
-    brief: "The fragments present in the URI. Note that this contains the leading # character, while the `url.fragment` attribute does not.",
-    type: 'string',
-    pii: {
-      isPii: 'maybe'
-    },
-    isInOtel: false,
-    example: "#details",
-    changelog: [
-      { version: "0.0.0" },
-    ],
-  },
-  [HTTP_HOST]: {
-    brief: "The domain name.",
-    type: 'string',
-    pii: {
-      isPii: 'maybe'
-    },
-    isInOtel: true,
-    example: "example.com",
-    deprecation: {
-      replacement: "server.address",
-      reason: "Deprecated, use one of `server.address` or `client.address`, depending on the usage"
-    },
-    aliases: [SERVER_ADDRESS, CLIENT_ADDRESS, HTTP_SERVER_NAME, NET_HOST_NAME],
-    changelog: [
-      { version: "0.1.0", prs: [61, 108, 127] },
-      { version: "0.0.0" },
-    ],
-  },
-  [HTTP_METHOD]: {
-    brief: "The HTTP method used.",
-    type: 'string',
-    pii: {
-      isPii: 'maybe'
-    },
-    isInOtel: true,
-    example: "GET",
-    deprecation: {
-      replacement: "http.request.method"
-    },
-    aliases: [HTTP_REQUEST_METHOD],
-    changelog: [
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
-  },
-  [HTTP_QUERY]: {
-    brief: "The query string present in the URL. Note that this contains the leading ? character, while the `url.query` attribute does not.",
+    brief: 'The name of the operation being executed.',
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason: "Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information."
+    },
+    isInOtel: true,
+    example: 'findBookById',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+  },
+  [GRAPHQL_OPERATION_TYPE]: {
+    brief: 'The type of the operation being executed.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: true,
+    example: 'query',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+  },
+  [HARDWARECONCURRENCY]: {
+    brief: 'The number of logical CPU cores available.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "?foo=bar&bar=baz",
+    example: '14',
+    deprecation: {
+      replacement: 'device.processor_count',
+      reason: 'Old namespace-less attribute, to be replaced with device.processor_count for span-first future',
+    },
+    aliases: [DEVICE_PROCESSOR_COUNT],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "0.0.0" },
+      {
+        version: 'next',
+        prs: [300],
+        description: 'Updated deprecation replacement from device.cpu.logical_core_count to device.processor_count',
+      },
+      {
+        version: 'next',
+        prs: [281],
+        description: "Added and deprecated attribute to document JS SDK's current behaviour",
+      },
     ],
   },
+  [HTTP_CLIENT_IP]: {
+    brief:
+      'Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
+    type: 'string',
+    pii: {
+      isPii: 'true',
+    },
+    isInOtel: true,
+    example: 'example.com',
+    deprecation: {
+      replacement: 'client.address',
+    },
+    aliases: [CLIENT_ADDRESS],
+    changelog: [{ version: '0.1.0', prs: [61, 106, 127] }, { version: '0.0.0' }],
+  },
+  [HTTP_DECODED_RESPONSE_CONTENT_LENGTH]: {
+    brief: 'The decoded body size of the response (in bytes).',
+    type: 'integer',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 456,
+    sdks: ['javascript-browser'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+  },
+  [HTTP_FLAVOR]: {
+    brief: 'The actual version of the protocol used for network communication.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: true,
+    example: '1.1',
+    deprecation: {
+      replacement: 'network.protocol.version',
+    },
+    aliases: [NETWORK_PROTOCOL_VERSION, NET_PROTOCOL_VERSION],
+    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+  },
+  [HTTP_FRAGMENT]: {
+    brief:
+      'The fragments present in the URI. Note that this contains the leading # character, while the `url.fragment` attribute does not.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: '#details',
+    changelog: [{ version: '0.0.0' }],
+  },
+  [HTTP_HOST]: {
+    brief: 'The domain name.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: true,
+    example: 'example.com',
+    deprecation: {
+      replacement: 'server.address',
+      reason: 'Deprecated, use one of `server.address` or `client.address`, depending on the usage',
+    },
+    aliases: [SERVER_ADDRESS, CLIENT_ADDRESS, HTTP_SERVER_NAME, NET_HOST_NAME],
+    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+  },
+  [HTTP_METHOD]: {
+    brief: 'The HTTP method used.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: true,
+    example: 'GET',
+    deprecation: {
+      replacement: 'http.request.method',
+    },
+    aliases: [HTTP_REQUEST_METHOD],
+    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+  },
+  [HTTP_QUERY]: {
+    brief:
+      'The query string present in the URL. Note that this contains the leading ? character, while the `url.query` attribute does not.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+      reason:
+        'Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.',
+    },
+    isInOtel: false,
+    example: '?foo=bar&bar=baz',
+    changelog: [{ version: '0.0.0' }],
+  },
   [HTTP_REQUEST_CONNECTION_END]: {
-    brief: "The UNIX timestamp representing the time immediately after the browser finishes establishing the connection to the server to retrieve the resource. The timestamp value includes the time interval to establish the transport connection, as well as other time intervals such as TLS handshake and SOCKS authentication.",
+    brief:
+      'The UNIX timestamp representing the time immediately after the browser finishes establishing the connection to the server to retrieve the resource. The timestamp value includes the time interval to establish the transport connection, as well as other time intervals such as TLS handshake and SOCKS authentication.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1732829555.15,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [134] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_CONNECT_START]: {
-    brief: "The UNIX timestamp representing the time immediately before the user agent starts establishing the connection to the server to retrieve the resource.",
+    brief:
+      'The UNIX timestamp representing the time immediately before the user agent starts establishing the connection to the server to retrieve the resource.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1732829555.111,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [134] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_DOMAIN_LOOKUP_END]: {
-    brief: "The UNIX timestamp representing the time immediately after the browser finishes the domain-name lookup for the resource.",
+    brief:
+      'The UNIX timestamp representing the time immediately after the browser finishes the domain-name lookup for the resource.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1732829555.201,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [134] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_DOMAIN_LOOKUP_START]: {
-    brief: "The UNIX timestamp representing the time immediately before the browser starts the domain name lookup for the resource.",
+    brief:
+      'The UNIX timestamp representing the time immediately before the browser starts the domain name lookup for the resource.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1732829555.322,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [134] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_FETCH_START]: {
-    brief: "The UNIX timestamp representing the time immediately before the browser starts to fetch the resource.",
+    brief: 'The UNIX timestamp representing the time immediately before the browser starts to fetch the resource.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1732829555.389,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [134] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_HEADER_KEY]: {
-    brief: "HTTP request headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.",
+    brief:
+      'HTTP request headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.',
     type: 'string[]',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     hasDynamicSuffix: true,
     example: "http.request.header.custom-header=['foo', 'bar']",
     changelog: [
-      { version: "0.4.0", prs: [201, 204] },
-      { version: "0.1.0", prs: [103] },
+      { version: '0.4.0', prs: [201, 204] },
+      { version: '0.1.0', prs: [103] },
     ],
   },
   [HTTP_REQUEST_METHOD]: {
-    brief: "The HTTP method used.",
+    brief: 'The HTTP method used.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "GET",
+    example: 'GET',
     aliases: [METHOD, HTTP_METHOD],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_REDIRECT_END]: {
-    brief: "The UNIX timestamp representing the timestamp immediately after receiving the last byte of the response of the last redirect",
+    brief:
+      'The UNIX timestamp representing the timestamp immediately after receiving the last byte of the response of the last redirect',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1732829558.502,
-    sdks: ["javascript-browser"],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [130, 134] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [130, 134] },
     ],
   },
   [HTTP_REQUEST_REDIRECT_START]: {
-    brief: "The UNIX timestamp representing the start time of the fetch which that initiates the redirect.",
+    brief: 'The UNIX timestamp representing the start time of the fetch which that initiates the redirect.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1732829555.495,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [134] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_REQUEST_START]: {
-    brief: "The UNIX timestamp representing the time immediately before the browser starts requesting the resource from the server, cache, or local resource. If the transport connection fails and the browser retires the request, the value returned will be the start of the retry request.",
+    brief:
+      'The UNIX timestamp representing the time immediately before the browser starts requesting the resource from the server, cache, or local resource. If the transport connection fails and the browser retires the request, the value returned will be the start of the retry request.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1732829555.51,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [134] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_RESEND_COUNT]: {
-    brief: "The ordinal number of request resending attempt (for any reason, including redirects).",
+    brief: 'The ordinal number of request resending attempt (for any reason, including redirects).',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 2,
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_RESPONSE_END]: {
-    brief: "The UNIX timestamp representing the time immediately after the browser receives the last byte of the resource or immediately before the transport connection is closed, whichever comes first.",
+    brief:
+      'The UNIX timestamp representing the time immediately after the browser receives the last byte of the resource or immediately before the transport connection is closed, whichever comes first.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1732829555.89,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [134] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_RESPONSE_START]: {
-    brief: "The UNIX timestamp representing the time immediately before the browser starts requesting the resource from the server, cache, or local resource. If the transport connection fails and the browser retires the request, the value returned will be the start of the retry request.",
+    brief:
+      'The UNIX timestamp representing the time immediately before the browser starts requesting the resource from the server, cache, or local resource. If the transport connection fails and the browser retires the request, the value returned will be the start of the retry request.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1732829555.7,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [134] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_SECURE_CONNECTION_START]: {
-    brief: "The UNIX timestamp representing the time immediately before the browser starts the handshake process to secure the current connection. If a secure connection is not used, the property returns zero.",
+    brief:
+      'The UNIX timestamp representing the time immediately before the browser starts the handshake process to secure the current connection. If a secure connection is not used, the property returns zero.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1732829555.73,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [134] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_TIME_TO_FIRST_BYTE]: {
-    brief: "The time in seconds from the browser's timeorigin to when the first byte of the request's response was received. See https://web.dev/articles/ttfb#measure-resource-requests",
+    brief:
+      "The time in seconds from the browser's timeorigin to when the first byte of the request's response was received. See https://web.dev/articles/ttfb#measure-resource-requests",
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1.032,
-    sdks: ["javascript-browser"],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [131] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [131] },
     ],
   },
   [HTTP_REQUEST_WORKER_START]: {
-    brief: "The UNIX timestamp representing the timestamp immediately before dispatching the FetchEvent if a Service Worker thread is already running, or immediately before starting the Service Worker thread if it is not already running.",
+    brief:
+      'The UNIX timestamp representing the timestamp immediately before dispatching the FetchEvent if a Service Worker thread is already running, or immediately before starting the Service Worker thread if it is not already running.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1732829553.68,
-    sdks: ["javascript-browser"],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [130, 134] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [130, 134] },
     ],
   },
   [HTTP_RESPONSE_BODY_SIZE]: {
-    brief: "The encoded body size of the response (in bytes).",
+    brief: 'The encoded body size of the response (in bytes).',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 123,
     aliases: [HTTP_RESPONSE_CONTENT_LENGTH, HTTP_RESPONSE_HEADER_CONTENT_LENGTH],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [106] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [106] }, { version: '0.0.0' }],
   },
   [HTTP_RESPONSE_CONTENT_LENGTH]: {
-    brief: "The encoded body size of the response (in bytes).",
+    brief: 'The encoded body size of the response (in bytes).',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 123,
     deprecation: {
-      replacement: "http.response.body.size"
+      replacement: 'http.response.body.size',
     },
     aliases: [HTTP_RESPONSE_BODY_SIZE, HTTP_RESPONSE_HEADER_CONTENT_LENGTH],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [61, 106] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61, 106] }, { version: '0.0.0' }],
   },
   [HTTP_RESPONSE_HEADER_CONTENT_LENGTH]: {
-    brief: "The size of the message body sent to the recipient (in bytes)",
+    brief: 'The size of the message body sent to the recipient (in bytes)',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: "http.response.header.custom-header=['foo', 'bar']",
     aliases: [HTTP_RESPONSE_CONTENT_LENGTH, HTTP_RESPONSE_BODY_SIZE],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [HTTP_RESPONSE_HEADER_KEY]: {
-    brief: "HTTP response headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.",
+    brief:
+      'HTTP response headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.',
     type: 'string[]',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     hasDynamicSuffix: true,
     example: "http.response.header.custom-header=['foo', 'bar']",
     changelog: [
-      { version: "0.4.0", prs: [201, 204] },
-      { version: "0.1.0", prs: [103] },
+      { version: '0.4.0', prs: [201, 204] },
+      { version: '0.1.0', prs: [103] },
     ],
   },
   [HTTP_RESPONSE_SIZE]: {
-    brief: "The transfer size of the response (in bytes).",
+    brief: 'The transfer size of the response (in bytes).',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 456,
     aliases: [HTTP_RESPONSE_TRANSFER_SIZE],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [HTTP_RESPONSE_STATUS_CODE]: {
-    brief: "The status code of the HTTP response.",
+    brief: 'The status code of the HTTP response.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 404,
     aliases: [HTTP_STATUS_CODE],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [HTTP_RESPONSE_TRANSFER_SIZE]: {
-    brief: "The transfer size of the response (in bytes).",
+    brief: 'The transfer size of the response (in bytes).',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 456,
     deprecation: {
-      replacement: "http.response.size"
+      replacement: 'http.response.size',
     },
     aliases: [HTTP_RESPONSE_SIZE],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [61] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [HTTP_ROUTE]: {
-    brief: "The matched route, that is, the path template in the format used by the respective server framework.",
+    brief: 'The matched route, that is, the path template in the format used by the respective server framework.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "/users/:id",
+    example: '/users/:id',
     aliases: [URL_TEMPLATE],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [HTTP_SCHEME]: {
-    brief: "The URI scheme component identifying the used protocol.",
+    brief: 'The URI scheme component identifying the used protocol.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "https",
+    example: 'https',
     deprecation: {
-      replacement: "url.scheme"
+      replacement: 'url.scheme',
     },
     aliases: [URL_SCHEME],
-    changelog: [
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [HTTP_SERVER_NAME]: {
-    brief: "The server domain name",
+    brief: 'The server domain name',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "example.com",
+    example: 'example.com',
     deprecation: {
-      replacement: "server.address"
+      replacement: 'server.address',
     },
     aliases: [SERVER_ADDRESS, NET_HOST_NAME, HTTP_HOST],
-    changelog: [
-      { version: "0.1.0", prs: [61, 108, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
   },
   [HTTP_SERVER_REQUEST_TIME_IN_QUEUE]: {
-    brief: "The time in milliseconds the request spent in the server queue before processing began. Measured from the X-Request-Start header set by reverse proxies (e.g., Nginx, HAProxy, Heroku) to when the application started handling the request.",
+    brief:
+      'The time in milliseconds the request spent in the server queue before processing began. Measured from the X-Request-Start header set by reverse proxies (e.g., Nginx, HAProxy, Heroku) to when the application started handling the request.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 50,
-    sdks: ["ruby"],
-    changelog: [
-      { version: "next", prs: [267] },
-    ],
+    sdks: ['ruby'],
+    changelog: [{ version: 'next', prs: [267] }],
   },
   [HTTP_STATUS_CODE]: {
-    brief: "The status code of the HTTP response.",
+    brief: 'The status code of the HTTP response.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 404,
     deprecation: {
-      replacement: "http.response.status_code"
+      replacement: 'http.response.status_code',
     },
     aliases: [HTTP_RESPONSE_STATUS_CODE],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [61] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [HTTP_TARGET]: {
-    brief: "The pathname and query string of the URL.",
+    brief: 'The pathname and query string of the URL.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "/test?foo=bar#buzz",
+    example: '/test?foo=bar#buzz',
     deprecation: {
-      replacement: "url.path",
-      reason: "This attribute is being deprecated in favor of url.path and url.query"
+      replacement: 'url.path',
+      reason: 'This attribute is being deprecated in favor of url.path and url.query',
     },
-    changelog: [
-      { version: "0.1.0", prs: [61] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [HTTP_URL]: {
-    brief: "The URL of the resource that was fetched.",
+    brief: 'The URL of the resource that was fetched.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "https://example.com/test?foo=bar#buzz",
+    example: 'https://example.com/test?foo=bar#buzz',
     deprecation: {
-      replacement: "url.full"
+      replacement: 'url.full',
     },
     aliases: [URL_FULL, URL],
-    changelog: [
-      { version: "0.1.0", prs: [61, 108] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 108] }, { version: '0.0.0' }],
   },
   [HTTP_USER_AGENT]: {
-    brief: "Value of the HTTP User-Agent header sent by the client.",
+    brief: 'Value of the HTTP User-Agent header sent by the client.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1",
+    example:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1',
     deprecation: {
-      replacement: "user_agent.original"
+      replacement: 'user_agent.original',
     },
     aliases: [USER_AGENT_ORIGINAL],
-    changelog: [
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [ID]: {
-    brief: "A unique identifier for the span.",
+    brief: 'A unique identifier for the span.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "f47ac10b58cc4372a5670e02b2c3d479",
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'f47ac10b58cc4372a5670e02b2c3d479',
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.0.0' }],
   },
   [INP]: {
-    brief: "The value of the recorded Interaction to Next Paint (INP) web vital",
+    brief: 'The value of the recorded Interaction to Next Paint (INP) web vital',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 200,
     deprecation: {
-      replacement: "browser.web_vital.inp.value",
-      reason: "The INP web vital is now recorded as a browser.web_vital.inp.value attribute."
+      replacement: 'browser.web_vital.inp.value',
+      reason: 'The INP web vital is now recorded as a browser.web_vital.inp.value attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_INP_VALUE],
-    sdks: ["javascript-browser"],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "next", prs: [229], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
+      {
+        version: 'next',
+        prs: [229],
+        description: "Added and deprecated attribute to document JS SDK's current behaviour",
+      },
     ],
   },
   [JVM_GC_ACTION]: {
-    brief: "Name of the garbage collector action.",
+    brief: 'Name of the garbage collector action.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "end of minor GC",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'end of minor GC',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [JVM_GC_NAME]: {
-    brief: "Name of the garbage collector.",
+    brief: 'Name of the garbage collector.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "G1 Young Generation",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'G1 Young Generation',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [JVM_MEMORY_POOL_NAME]: {
-    brief: "Name of the memory pool.",
+    brief: 'Name of the memory pool.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "G1 Old Gen",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'G1 Old Gen',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [JVM_MEMORY_TYPE]: {
-    brief: "Name of the memory pool.",
+    brief: 'Name of the memory pool.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "G1 Old Gen",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'G1 Old Gen',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [JVM_THREAD_DAEMON]: {
-    brief: "Whether the thread is daemon or not.",
+    brief: 'Whether the thread is daemon or not.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: true,
     example: true,
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.0.0' }],
   },
   [JVM_THREAD_STATE]: {
-    brief: "State of the thread.",
+    brief: 'State of the thread.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "blocked",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'blocked',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [LCP]: {
-    brief: "The value of the recorded Largest Contentful Paint (LCP) web vital",
+    brief: 'The value of the recorded Largest Contentful Paint (LCP) web vital',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 2500,
     deprecation: {
-      replacement: "browser.web_vital.lcp.value",
-      reason: "The LCP web vital is now recorded as a browser.web_vital.lcp.value attribute."
+      replacement: 'browser.web_vital.lcp.value',
+      reason: 'The LCP web vital is now recorded as a browser.web_vital.lcp.value attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_LCP_VALUE],
-    sdks: ["javascript-browser"],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "next", prs: [229], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
+      {
+        version: 'next',
+        prs: [229],
+        description: "Added and deprecated attribute to document JS SDK's current behaviour",
+      },
     ],
   },
   [LCP_ELEMENT]: {
-    brief: "The dom element responsible for the largest contentful paint.",
+    brief: 'The dom element responsible for the largest contentful paint.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "img",
+    example: 'img',
     deprecation: {
-      replacement: "browser.web_vital.lcp.element",
-      reason: "The LCP element is now recorded as a browser.web_vital.lcp.element attribute."
+      replacement: 'browser.web_vital.lcp.element',
+      reason: 'The LCP element is now recorded as a browser.web_vital.lcp.element attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_LCP_ELEMENT],
-    changelog: [
-      { version: "next", prs: [233] },
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: 'next', prs: [233] }, { version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [LCP_ID]: {
-    brief: "The id of the dom element responsible for the largest contentful paint.",
+    brief: 'The id of the dom element responsible for the largest contentful paint.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "#hero",
+    example: '#hero',
     deprecation: {
-      replacement: "browser.web_vital.lcp.id",
-      reason: "The LCP id is now recorded as a browser.web_vital.lcp.id attribute."
+      replacement: 'browser.web_vital.lcp.id',
+      reason: 'The LCP id is now recorded as a browser.web_vital.lcp.id attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_LCP_ID],
-    changelog: [
-      { version: "next", prs: [233] },
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: 'next', prs: [233] }, { version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [LCP_LOADTIME]: {
-    brief: "The time it took for the LCP element to be loaded",
+    brief: 'The time it took for the LCP element to be loaded',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1402,
     deprecation: {
-      replacement: "browser.web_vital.lcp.load_time",
-      reason: "The LCP load time is now recorded as a browser.web_vital.lcp.load_time attribute."
+      replacement: 'browser.web_vital.lcp.load_time',
+      reason: 'The LCP load time is now recorded as a browser.web_vital.lcp.load_time attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_LCP_LOAD_TIME],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [233] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [233] }],
   },
   [LCP_RENDERTIME]: {
-    brief: "The time it took for the LCP element to be rendered",
+    brief: 'The time it took for the LCP element to be rendered',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1685,
     deprecation: {
-      replacement: "browser.web_vital.lcp.render_time",
-      reason: "The LCP render time is now recorded as a browser.web_vital.lcp.render_time attribute."
+      replacement: 'browser.web_vital.lcp.render_time',
+      reason: 'The LCP render time is now recorded as a browser.web_vital.lcp.render_time attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_LCP_RENDER_TIME],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [233] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [233] }],
   },
   [LCP_SIZE]: {
-    brief: "The size of the largest contentful paint element.",
+    brief: 'The size of the largest contentful paint element.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1234,
     deprecation: {
-      replacement: "browser.web_vital.lcp.size",
-      reason: "The LCP size is now recorded as a browser.web_vital.lcp.size attribute."
+      replacement: 'browser.web_vital.lcp.size',
+      reason: 'The LCP size is now recorded as a browser.web_vital.lcp.size attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_LCP_SIZE],
-    changelog: [
-      { version: "next", prs: [233] },
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: 'next', prs: [233] }, { version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [LCP_URL]: {
-    brief: "The url of the dom element responsible for the largest contentful paint.",
+    brief: 'The url of the dom element responsible for the largest contentful paint.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "https://example.com",
+    example: 'https://example.com',
     deprecation: {
-      replacement: "browser.web_vital.lcp.url",
-      reason: "The LCP url is now recorded as a browser.web_vital.lcp.url attribute."
+      replacement: 'browser.web_vital.lcp.url',
+      reason: 'The LCP url is now recorded as a browser.web_vital.lcp.url attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_LCP_URL],
-    changelog: [
-      { version: "next", prs: [233] },
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: 'next', prs: [233] }, { version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [LOGGER_NAME]: {
-    brief: "The name of the logger that generated this event.",
+    brief: 'The name of the logger that generated this event.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "myLogger",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'myLogger',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [MCP_CANCELLED_REASON]: {
-    brief: "Reason for the cancellation of an MCP operation.",
+    brief: 'Reason for the cancellation of an MCP operation.',
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason: "Cancellation reasons may contain user-specific or sensitive information"
+      reason: 'Cancellation reasons may contain user-specific or sensitive information',
     },
     isInOtel: false,
-    example: "User cancelled the request",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'User cancelled the request',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_CANCELLED_REQUEST_ID]: {
-    brief: "Request ID of the cancelled MCP operation.",
+    brief: 'Request ID of the cancelled MCP operation.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "123",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: '123',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_CLIENT_NAME]: {
-    brief: "Name of the MCP client application.",
+    brief: 'Name of the MCP client application.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "claude-desktop",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'claude-desktop',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_CLIENT_TITLE]: {
-    brief: "Display title of the MCP client application.",
+    brief: 'Display title of the MCP client application.',
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason: "Client titles may reveal user-specific application configurations or custom setups"
+      reason: 'Client titles may reveal user-specific application configurations or custom setups',
     },
     isInOtel: false,
-    example: "Claude Desktop",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'Claude Desktop',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_CLIENT_VERSION]: {
-    brief: "Version of the MCP client application.",
+    brief: 'Version of the MCP client application.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "1.0.0",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: '1.0.0',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_LIFECYCLE_PHASE]: {
-    brief: "Lifecycle phase indicator for MCP operations.",
+    brief: 'Lifecycle phase indicator for MCP operations.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "initialization_complete",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'initialization_complete',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_LOGGING_DATA_TYPE]: {
-    brief: "Data type of the logged message content.",
+    brief: 'Data type of the logged message content.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "string",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'string',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_LOGGING_LEVEL]: {
-    brief: "Log level for MCP logging operations.",
+    brief: 'Log level for MCP logging operations.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "info",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'info',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_LOGGING_LOGGER]: {
-    brief: "Logger name for MCP logging operations.",
+    brief: 'Logger name for MCP logging operations.',
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason: "Logger names may be user-defined and could contain sensitive information"
+      reason: 'Logger names may be user-defined and could contain sensitive information',
     },
     isInOtel: false,
-    example: "mcp_server",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'mcp_server',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_LOGGING_MESSAGE]: {
-    brief: "Log message content from MCP logging operations.",
+    brief: 'Log message content from MCP logging operations.',
     type: 'string',
     pii: {
       isPii: 'true',
-      reason: "Log messages can contain user data"
+      reason: 'Log messages can contain user data',
     },
     isInOtel: false,
-    example: "Tool execution completed successfully",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'Tool execution completed successfully',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_METHOD_NAME]: {
-    brief: "The name of the MCP request or notification method being called.",
+    brief: 'The name of the MCP request or notification method being called.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "tools/call",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'tools/call',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_PROGRESS_CURRENT]: {
-    brief: "Current progress value of an MCP operation.",
+    brief: 'Current progress value of an MCP operation.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 50,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.3.0", prs: [171] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.3.0', prs: [171] },
     ],
   },
   [MCP_PROGRESS_MESSAGE]: {
-    brief: "Progress message describing the current state of an MCP operation.",
+    brief: 'Progress message describing the current state of an MCP operation.',
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason: "Progress messages may contain user-specific or sensitive information"
+      reason: 'Progress messages may contain user-specific or sensitive information',
     },
     isInOtel: false,
-    example: "Processing 50 of 100 items",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'Processing 50 of 100 items',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_PROGRESS_PERCENTAGE]: {
-    brief: "Calculated progress percentage of an MCP operation. Computed from current/total * 100.",
+    brief: 'Calculated progress percentage of an MCP operation. Computed from current/total * 100.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 50,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.3.0", prs: [171] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.3.0', prs: [171] },
     ],
   },
   [MCP_PROGRESS_TOKEN]: {
-    brief: "Token for tracking progress of an MCP operation.",
+    brief: 'Token for tracking progress of an MCP operation.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "progress-token-123",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'progress-token-123',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_PROGRESS_TOTAL]: {
-    brief: "Total progress target value of an MCP operation.",
+    brief: 'Total progress target value of an MCP operation.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 100,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.3.0", prs: [171] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.3.0', prs: [171] },
     ],
   },
   [MCP_PROMPT_NAME]: {
-    brief: "Name of the MCP prompt template being used.",
+    brief: 'Name of the MCP prompt template being used.',
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason: "Prompt names may reveal user behavior patterns or sensitive operations"
+      reason: 'Prompt names may reveal user behavior patterns or sensitive operations',
     },
     isInOtel: false,
-    example: "summarize",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'summarize',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_PROMPT_RESULT_DESCRIPTION]: {
-    brief: "Description of the prompt result.",
+    brief: 'Description of the prompt result.',
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: "A summary of the requested information",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'A summary of the requested information',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_PROMPT_RESULT_MESSAGE_CONTENT]: {
-    brief: "Content of the message in the prompt result. Used for single message results only.",
+    brief: 'Content of the message in the prompt result. Used for single message results only.',
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: "Please provide a summary of the document",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'Please provide a summary of the document',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_PROMPT_RESULT_MESSAGE_COUNT]: {
-    brief: "Number of messages in the prompt result.",
+    brief: 'Number of messages in the prompt result.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 3,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.3.0", prs: [171] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.3.0', prs: [171] },
     ],
   },
   [MCP_PROMPT_RESULT_MESSAGE_ROLE]: {
-    brief: "Role of the message in the prompt result. Used for single message results only.",
+    brief: 'Role of the message in the prompt result. Used for single message results only.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "user",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'user',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_PROTOCOL_READY]: {
-    brief: "Protocol readiness indicator for MCP session. Non-zero value indicates the protocol is ready.",
+    brief: 'Protocol readiness indicator for MCP session. Non-zero value indicates the protocol is ready.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.3.0", prs: [171] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.3.0', prs: [171] },
     ],
   },
   [MCP_PROTOCOL_VERSION]: {
-    brief: "MCP protocol version used in the session.",
+    brief: 'MCP protocol version used in the session.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "2024-11-05",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: '2024-11-05',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_REQUEST_ARGUMENT_KEY]: {
-    brief: "MCP request argument with dynamic key suffix. The <key> is replaced with the actual argument name. The value is a JSON-stringified representation of the argument value.",
+    brief:
+      'MCP request argument with dynamic key suffix. The <key> is replaced with the actual argument name. The value is a JSON-stringified representation of the argument value.',
     type: 'string',
     pii: {
       isPii: 'true',
-      reason: "Arguments contain user input"
+      reason: 'Arguments contain user input',
     },
     isInOtel: false,
     hasDynamicSuffix: true,
     example: "mcp.request.argument.query='weather in Paris'",
-    changelog: [
-      { version: "0.3.0", prs: [176] },
-    ],
+    changelog: [{ version: '0.3.0', prs: [176] }],
   },
   [MCP_REQUEST_ARGUMENT_NAME]: {
-    brief: "Name argument from prompts/get MCP request.",
+    brief: 'Name argument from prompts/get MCP request.',
     type: 'string',
     pii: {
       isPii: 'true',
-      reason: "Prompt names can contain user input"
+      reason: 'Prompt names can contain user input',
     },
     isInOtel: false,
-    example: "summarize",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'summarize',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_REQUEST_ARGUMENT_URI]: {
-    brief: "URI argument from resources/read MCP request.",
+    brief: 'URI argument from resources/read MCP request.',
     type: 'string',
     pii: {
       isPii: 'true',
-      reason: "URIs can contain user file paths"
+      reason: 'URIs can contain user file paths',
     },
     isInOtel: false,
-    example: "file:///path/to/resource",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'file:///path/to/resource',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_REQUEST_ID]: {
-    brief: "JSON-RPC request identifier for the MCP request. Unique within the MCP session.",
+    brief: 'JSON-RPC request identifier for the MCP request. Unique within the MCP session.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "1",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: '1',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_RESOURCE_PROTOCOL]: {
-    brief: "Protocol of the resource URI being accessed, extracted from the URI.",
+    brief: 'Protocol of the resource URI being accessed, extracted from the URI.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "file",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'file',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_RESOURCE_URI]: {
-    brief: "The resource URI being accessed in an MCP operation.",
+    brief: 'The resource URI being accessed in an MCP operation.',
     type: 'string',
     pii: {
       isPii: 'true',
-      reason: "URIs can contain sensitive file paths"
+      reason: 'URIs can contain sensitive file paths',
     },
     isInOtel: false,
-    example: "file:///path/to/file.txt",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'file:///path/to/file.txt',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_SERVER_NAME]: {
-    brief: "Name of the MCP server application.",
+    brief: 'Name of the MCP server application.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "sentry-mcp-server",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'sentry-mcp-server',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_SERVER_TITLE]: {
-    brief: "Display title of the MCP server application.",
+    brief: 'Display title of the MCP server application.',
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason: "Server titles may reveal user-specific application configurations or custom setups"
+      reason: 'Server titles may reveal user-specific application configurations or custom setups',
     },
     isInOtel: false,
-    example: "Sentry MCP Server",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'Sentry MCP Server',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_SERVER_VERSION]: {
-    brief: "Version of the MCP server application.",
+    brief: 'Version of the MCP server application.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "0.1.0",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: '0.1.0',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_SESSION_ID]: {
-    brief: "Identifier for the MCP session.",
+    brief: 'Identifier for the MCP session.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "550e8400-e29b-41d4-a716-446655440000",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_TOOL_NAME]: {
-    brief: "Name of the MCP tool being called.",
+    brief: 'Name of the MCP tool being called.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "calculator",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'calculator',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_TOOL_RESULT_CONTENT]: {
-    brief: "The content of the tool result.",
+    brief: 'The content of the tool result.',
     type: 'string',
     pii: {
       isPii: 'true',
-      reason: "Tool results can contain user data"
+      reason: 'Tool results can contain user data',
     },
     isInOtel: false,
-    example: "{\"output\": \"rainy\", \"toolCallId\": \"1\"}",
+    example: '{"output": "rainy", "toolCallId": "1"}',
     changelog: [
-      { version: "0.3.0", prs: [171] },
-      { version: "0.2.0", prs: [164] },
+      { version: '0.3.0', prs: [171] },
+      { version: '0.2.0', prs: [164] },
     ],
   },
   [MCP_TOOL_RESULT_CONTENT_COUNT]: {
-    brief: "Number of content items in the tool result.",
+    brief: 'Number of content items in the tool result.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.3.0", prs: [171] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.3.0', prs: [171] },
     ],
   },
   [MCP_TOOL_RESULT_IS_ERROR]: {
-    brief: "Whether a tool execution resulted in an error.",
+    brief: 'Whether a tool execution resulted in an error.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: false,
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MCP_TRANSPORT]: {
-    brief: "Transport method used for MCP communication.",
+    brief: 'Transport method used for MCP communication.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "stdio",
-    changelog: [
-      { version: "0.3.0", prs: [171] },
-    ],
+    example: 'stdio',
+    changelog: [{ version: '0.3.0', prs: [171] }],
   },
   [MDC_KEY]: {
-    brief: "Attributes from the Mapped Diagnostic Context (MDC) present at the moment the log record was created. The MDC is supported by all the most popular logging solutions in the Java ecosystem, and it's usually implemented as a thread-local map that stores context for e.g. a specific request.",
+    brief:
+      "Attributes from the Mapped Diagnostic Context (MDC) present at the moment the log record was created. The MDC is supported by all the most popular logging solutions in the Java ecosystem, and it's usually implemented as a thread-local map that stores context for e.g. a specific request.",
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     hasDynamicSuffix: true,
     example: "mdc.some_key='some_value'",
-    sdks: ["java","java.logback","java.jul","java.log4j2"],
-    changelog: [
-      { version: "0.3.0", prs: [176] },
-    ],
+    sdks: ['java', 'java.logback', 'java.jul', 'java.log4j2'],
+    changelog: [{ version: '0.3.0', prs: [176] }],
   },
   [MESSAGING_DESTINATION_CONNECTION]: {
-    brief: "The message destination connection.",
+    brief: 'The message destination connection.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "BestTopic",
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'BestTopic',
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [MESSAGING_DESTINATION_NAME]: {
-    brief: "The message destination name.",
+    brief: 'The message destination name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "BestTopic",
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'BestTopic',
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [MESSAGING_MESSAGE_BODY_SIZE]: {
-    brief: "The size of the message body in bytes.",
+    brief: 'The size of the message body in bytes.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 839,
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [MESSAGING_MESSAGE_ENVELOPE_SIZE]: {
-    brief: "The size of the message body and metadata in bytes.",
+    brief: 'The size of the message body and metadata in bytes.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 1045,
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [MESSAGING_MESSAGE_ID]: {
-    brief: "A value used by the messaging system as an identifier for the message, represented as a string.",
+    brief: 'A value used by the messaging system as an identifier for the message, represented as a string.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "f47ac10b58cc4372a5670e02b2c3d479",
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'f47ac10b58cc4372a5670e02b2c3d479',
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [MESSAGING_MESSAGE_RECEIVE_LATENCY]: {
-    brief: "The latency between when the message was published and received.",
+    brief: 'The latency between when the message was published and received.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1732847252,
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [MESSAGING_MESSAGE_RETRY_COUNT]: {
-    brief: "The amount of attempts to send the message.",
+    brief: 'The amount of attempts to send the message.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 2,
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [MESSAGING_OPERATION_TYPE]: {
-    brief: "A string identifying the type of the messaging operation",
+    brief: 'A string identifying the type of the messaging operation',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "create",
-    changelog: [
-      { version: "0.1.0", prs: [51, 127] },
-    ],
+    example: 'create',
+    changelog: [{ version: '0.1.0', prs: [51, 127] }],
   },
   [MESSAGING_SYSTEM]: {
-    brief: "The messaging system as identified by the client instrumentation.",
+    brief: 'The messaging system as identified by the client instrumentation.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "activemq",
-    sdks: ["php-laravel"],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'activemq',
+    sdks: ['php-laravel'],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [METHOD]: {
-    brief: "The HTTP method used.",
+    brief: 'The HTTP method used.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "GET",
+    example: 'GET',
     deprecation: {
-      replacement: "http.request.method"
+      replacement: 'http.request.method',
     },
     aliases: [HTTP_REQUEST_METHOD],
-    sdks: ["javascript-browser","javascript-node"],
-    changelog: [
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-browser', 'javascript-node'],
+    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [NAVIGATION_TYPE]: {
-    brief: "The type of navigation done by a client-side router.",
+    brief: 'The type of navigation done by a client-side router.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "router.push",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'router.push',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [NEL_ELAPSED_TIME]: {
-    brief: "The elapsed number of milliseconds between the start of the resource fetch and when it was completed or aborted by the user agent.",
+    brief:
+      'The elapsed number of milliseconds between the start of the resource fetch and when it was completed or aborted by the user agent.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 100,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [68] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [68] },
     ],
   },
   [NEL_PHASE]: {
-    brief: "If request failed, the phase of its network error. If request succeeded, \"application\".",
+    brief: 'If request failed, the phase of its network error. If request succeeded, "application".',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "application",
-    changelog: [
-      { version: "0.1.0", prs: [68, 127] },
-    ],
+    example: 'application',
+    changelog: [{ version: '0.1.0', prs: [68, 127] }],
   },
   [NEL_REFERRER]: {
     brief: "request's referrer, as determined by the referrer policy associated with its client.",
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "https://example.com/foo?bar=baz",
-    changelog: [
-      { version: "0.1.0", prs: [68, 127] },
-    ],
+    example: 'https://example.com/foo?bar=baz',
+    changelog: [{ version: '0.1.0', prs: [68, 127] }],
   },
   [NEL_SAMPLING_FUNCTION]: {
-    brief: "The sampling function used to determine if the request should be sampled.",
+    brief: 'The sampling function used to determine if the request should be sampled.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 0.5,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [68] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [68] },
     ],
   },
   [NEL_TYPE]: {
-    brief: "If request failed, the type of its network error. If request succeeded, \"ok\".",
+    brief: 'If request failed, the type of its network error. If request succeeded, "ok".',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "dns.unreachable",
-    changelog: [
-      { version: "0.1.0", prs: [68, 127] },
-    ],
+    example: 'dns.unreachable',
+    changelog: [{ version: '0.1.0', prs: [68, 127] }],
   },
   [NETWORK_CONNECTION_EFFECTIVE_TYPE]: {
-    brief: "Specifies the effective type of the current connection (e.g. slow-2g, 2g, 3g, 4g).",
+    brief: 'Specifies the effective type of the current connection (e.g. slow-2g, 2g, 3g, 4g).',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "4g",
+    example: '4g',
     aliases: [EFFECTIVECONNECTIONTYPE],
-    sdks: ["javascript-browser"],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "next", prs: [279], description: "Added attribute network.connection.effective_type to be used instead of effectiveConnectionType" },
+      {
+        version: 'next',
+        prs: [279],
+        description: 'Added attribute network.connection.effective_type to be used instead of effectiveConnectionType',
+      },
     ],
   },
   [NETWORK_CONNECTION_RTT]: {
-    brief: "Specifies the estimated effective round-trip time of the current connection, in milliseconds.",
+    brief: 'Specifies the estimated effective round-trip time of the current connection, in milliseconds.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 100,
     aliases: [CONNECTION_RTT],
-    sdks: ["javascript-browser"],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "next", prs: [279], description: "Added attribute network.connection.rtt to be used instead of connection.rtt" },
+      {
+        version: 'next',
+        prs: [279],
+        description: 'Added attribute network.connection.rtt to be used instead of connection.rtt',
+      },
     ],
   },
   [NETWORK_CONNECTION_TYPE]: {
-    brief: "Specifies the type of the current connection (e.g. wifi, ethernet, cellular , etc).",
+    brief: 'Specifies the type of the current connection (e.g. wifi, ethernet, cellular , etc).',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "wifi",
+    example: 'wifi',
     aliases: [CONNECTIONTYPE],
-    sdks: ["javascript-browser"],
+    sdks: ['javascript-browser'],
     changelog: [
-      { version: "next", prs: [279], description: "Added attribute network.connection.type to be used instead of connectionType" },
+      {
+        version: 'next',
+        prs: [279],
+        description: 'Added attribute network.connection.type to be used instead of connectionType',
+      },
     ],
   },
   [NETWORK_LOCAL_ADDRESS]: {
-    brief: "Local address of the network connection - IP address or Unix domain socket name.",
+    brief: 'Local address of the network connection - IP address or Unix domain socket name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "10.1.2.80",
+    example: '10.1.2.80',
     aliases: [NET_HOST_IP, NET_SOCK_HOST_ADDR],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [NETWORK_LOCAL_PORT]: {
-    brief: "Local port number of the network connection.",
+    brief: 'Local port number of the network connection.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 65400,
     aliases: [NET_SOCK_HOST_PORT],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [NETWORK_PEER_ADDRESS]: {
-    brief: "Peer address of the network connection - IP address or Unix domain socket name.",
+    brief: 'Peer address of the network connection - IP address or Unix domain socket name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "10.1.2.80",
+    example: '10.1.2.80',
     aliases: [NET_PEER_IP, NET_SOCK_PEER_ADDR],
-    changelog: [
-      { version: "0.1.0", prs: [108, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [108, 127] }, { version: '0.0.0' }],
   },
   [NETWORK_PEER_PORT]: {
-    brief: "Peer port number of the network connection.",
+    brief: 'Peer port number of the network connection.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 65400,
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [NETWORK_PROTOCOL_NAME]: {
-    brief: "OSI application layer or non-OSI equivalent.",
+    brief: 'OSI application layer or non-OSI equivalent.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "http",
+    example: 'http',
     aliases: [NET_PROTOCOL_NAME],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [NETWORK_PROTOCOL_VERSION]: {
-    brief: "The actual version of the protocol used for network communication.",
+    brief: 'The actual version of the protocol used for network communication.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "1.1",
+    example: '1.1',
     aliases: [HTTP_FLAVOR, NET_PROTOCOL_VERSION],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [NETWORK_TRANSPORT]: {
-    brief: "OSI transport layer or inter-process communication method.",
+    brief: 'OSI transport layer or inter-process communication method.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "tcp",
+    example: 'tcp',
     aliases: [NET_TRANSPORT],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [NETWORK_TYPE]: {
-    brief: "OSI network layer or non-OSI equivalent.",
+    brief: 'OSI network layer or non-OSI equivalent.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "ipv4",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'ipv4',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [NET_HOST_IP]: {
-    brief: "Local address of the network connection - IP address or Unix domain socket name.",
+    brief: 'Local address of the network connection - IP address or Unix domain socket name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "192.168.0.1",
+    example: '192.168.0.1',
     deprecation: {
-      replacement: "network.local.address"
+      replacement: 'network.local.address',
     },
     aliases: [NETWORK_LOCAL_ADDRESS, NET_SOCK_HOST_ADDR],
-    changelog: [
-      { version: "0.1.0", prs: [61, 108, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
   },
   [NET_HOST_NAME]: {
-    brief: "Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
+    brief:
+      'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "example.com",
+    example: 'example.com',
     deprecation: {
-      replacement: "server.address"
+      replacement: 'server.address',
     },
     aliases: [SERVER_ADDRESS, HTTP_SERVER_NAME, HTTP_HOST],
-    changelog: [
-      { version: "0.1.0", prs: [61, 108, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
   },
   [NET_HOST_PORT]: {
-    brief: "Server port number.",
+    brief: 'Server port number.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 1337,
     deprecation: {
-      replacement: "server.port"
+      replacement: 'server.port',
     },
     aliases: [SERVER_PORT],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [61] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [NET_PEER_IP]: {
-    brief: "Peer address of the network connection - IP address or Unix domain socket name.",
+    brief: 'Peer address of the network connection - IP address or Unix domain socket name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "192.168.0.1",
+    example: '192.168.0.1',
     deprecation: {
-      replacement: "network.peer.address"
+      replacement: 'network.peer.address',
     },
     aliases: [NETWORK_PEER_ADDRESS, NET_SOCK_PEER_ADDR],
-    changelog: [
-      { version: "0.1.0", prs: [61, 108, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
   },
   [NET_PEER_NAME]: {
-    brief: "Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
+    brief:
+      'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "example.com",
+    example: 'example.com',
     deprecation: {
-      replacement: "server.address",
-      reason: "Deprecated, use server.address on client spans and client.address on server spans."
+      replacement: 'server.address',
+      reason: 'Deprecated, use server.address on client spans and client.address on server spans.',
     },
-    changelog: [
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [NET_PEER_PORT]: {
-    brief: "Peer port number.",
+    brief: 'Peer port number.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 1337,
     deprecation: {
-      replacement: "server.port",
-      reason: "Deprecated, use server.port on client spans and client.port on server spans."
+      replacement: 'server.port',
+      reason: 'Deprecated, use server.port on client spans and client.port on server spans.',
     },
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [61] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [NET_PROTOCOL_NAME]: {
-    brief: "OSI application layer or non-OSI equivalent.",
+    brief: 'OSI application layer or non-OSI equivalent.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "http",
+    example: 'http',
     deprecation: {
-      replacement: "network.protocol.name"
+      replacement: 'network.protocol.name',
     },
     aliases: [NETWORK_PROTOCOL_NAME],
-    changelog: [
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [NET_PROTOCOL_VERSION]: {
-    brief: "The actual version of the protocol used for network communication.",
+    brief: 'The actual version of the protocol used for network communication.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "1.1",
+    example: '1.1',
     deprecation: {
-      replacement: "network.protocol.version"
+      replacement: 'network.protocol.version',
     },
     aliases: [NETWORK_PROTOCOL_VERSION, HTTP_FLAVOR],
-    changelog: [
-      { version: "0.1.0", prs: [61, 108, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
   },
   [NET_SOCK_FAMILY]: {
-    brief: "OSI transport and network layer",
+    brief: 'OSI transport and network layer',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "inet",
+    example: 'inet',
     deprecation: {
-      replacement: "network.transport",
-      reason: "Deprecated, use network.transport and network.type."
+      replacement: 'network.transport',
+      reason: 'Deprecated, use network.transport and network.type.',
     },
-    changelog: [
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [NET_SOCK_HOST_ADDR]: {
-    brief: "Local address of the network connection mapping to Unix domain socket name.",
+    brief: 'Local address of the network connection mapping to Unix domain socket name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "/var/my.sock",
+    example: '/var/my.sock',
     deprecation: {
-      replacement: "network.local.address"
+      replacement: 'network.local.address',
     },
     aliases: [NETWORK_LOCAL_ADDRESS, NET_HOST_IP],
-    changelog: [
-      { version: "0.1.0", prs: [61, 108, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
   },
   [NET_SOCK_HOST_PORT]: {
-    brief: "Local port number of the network connection.",
+    brief: 'Local port number of the network connection.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 8080,
     deprecation: {
-      replacement: "network.local.port"
+      replacement: 'network.local.port',
     },
     aliases: [NETWORK_LOCAL_PORT],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [61] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [NET_SOCK_PEER_ADDR]: {
-    brief: "Peer address of the network connection - IP address",
+    brief: 'Peer address of the network connection - IP address',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "192.168.0.1",
+    example: '192.168.0.1',
     deprecation: {
-      replacement: "network.peer.address"
+      replacement: 'network.peer.address',
     },
     aliases: [NETWORK_PEER_ADDRESS, NET_PEER_IP],
-    changelog: [
-      { version: "0.1.0", prs: [61, 108, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
   },
   [NET_SOCK_PEER_NAME]: {
-    brief: "Peer address of the network connection - Unix domain socket name",
+    brief: 'Peer address of the network connection - Unix domain socket name',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "/var/my.sock",
+    example: '/var/my.sock',
     deprecation: {
-      reason: "Deprecated from OTEL, no replacement at this time"
+      reason: 'Deprecated from OTEL, no replacement at this time',
     },
-    changelog: [
-      { version: "0.1.0", prs: [61, 119, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 119, 127] }, { version: '0.0.0' }],
   },
   [NET_SOCK_PEER_PORT]: {
-    brief: "Peer port number of the network connection.",
+    brief: 'Peer port number of the network connection.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 8080,
     deprecation: {
-      replacement: "network.peer.port"
+      replacement: 'network.peer.port',
     },
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.1.0", prs: [61] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [NET_TRANSPORT]: {
-    brief: "OSI transport layer or inter-process communication method.",
+    brief: 'OSI transport layer or inter-process communication method.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "tcp",
+    example: 'tcp',
     deprecation: {
-      replacement: "network.transport"
+      replacement: 'network.transport',
     },
     aliases: [NETWORK_TRANSPORT],
-    changelog: [
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [OS_BUILD_ID]: {
-    brief: "The build ID of the operating system.",
+    brief: 'The build ID of the operating system.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "1234567890",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: '1234567890',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [OS_DESCRIPTION]: {
-    brief: "Human readable (not intended to be parsed) OS version information, like e.g. reported by ver or lsb_release -a commands.",
+    brief:
+      'Human readable (not intended to be parsed) OS version information, like e.g. reported by ver or lsb_release -a commands.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "Ubuntu 18.04.1 LTS",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'Ubuntu 18.04.1 LTS',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [OS_NAME]: {
-    brief: "Human readable operating system name.",
+    brief: 'Human readable operating system name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "Ubuntu",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'Ubuntu',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [OS_TYPE]: {
-    brief: "The operating system type.",
+    brief: 'The operating system type.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "linux",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'linux',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [OS_VERSION]: {
-    brief: "The version of the operating system.",
+    brief: 'The version of the operating system.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "18.04.2",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: '18.04.2',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [OTEL_SCOPE_NAME]: {
-    brief: "The name of the instrumentation scope - (InstrumentationScope.Name in OTLP).",
+    brief: 'The name of the instrumentation scope - (InstrumentationScope.Name in OTLP).',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "io.opentelemetry.contrib.mongodb",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'io.opentelemetry.contrib.mongodb',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [OTEL_SCOPE_VERSION]: {
-    brief: "The version of the instrumentation scope - (InstrumentationScope.Version in OTLP).",
+    brief: 'The version of the instrumentation scope - (InstrumentationScope.Version in OTLP).',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "2.4.5",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: '2.4.5',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [OTEL_STATUS_CODE]: {
-    brief: "Name of the code, either “OK” or “ERROR”. MUST NOT be set if the status code is UNSET.",
+    brief: 'Name of the code, either “OK” or “ERROR”. MUST NOT be set if the status code is UNSET.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "OK",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'OK',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [OTEL_STATUS_DESCRIPTION]: {
-    brief: "Description of the Status if it has a value, otherwise not set.",
+    brief: 'Description of the Status if it has a value, otherwise not set.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "resource not found",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'resource not found',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [PARAMS_KEY]: {
-    brief: "Decoded parameters extracted from a URL path. Usually added by client-side routing frameworks like vue-router.",
+    brief:
+      'Decoded parameters extracted from a URL path. Usually added by client-side routing frameworks like vue-router.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     hasDynamicSuffix: true,
     example: "params.id='123'",
     aliases: [URL_PATH_PARAMETER_KEY],
-    changelog: [
-      { version: "0.1.0", prs: [103] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [103] }],
   },
   [PREVIOUS_ROUTE]: {
-    brief: "Also used by mobile SDKs to indicate the previous route in the application.",
+    brief: 'Also used by mobile SDKs to indicate the previous route in the application.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "HomeScreen",
-    sdks: ["javascript-reactnative"],
-    changelog: [
-      { version: "0.1.0", prs: [74] },
-      { version: "0.0.0" },
-    ],
+    example: 'HomeScreen',
+    sdks: ['javascript-reactnative'],
+    changelog: [{ version: '0.1.0', prs: [74] }, { version: '0.0.0' }],
   },
   [PROCESS_EXECUTABLE_NAME]: {
-    brief: "The name of the executable that started the process.",
+    brief: 'The name of the executable that started the process.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "getsentry",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'getsentry',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [PROCESS_PID]: {
-    brief: "The process ID of the running process.",
+    brief: 'The process ID of the running process.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 12345,
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [PROCESS_RUNTIME_DESCRIPTION]: {
-    brief: "An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment. Equivalent to `raw_description` in the Sentry runtime context.",
+    brief:
+      'An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment. Equivalent to `raw_description` in the Sentry runtime context.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "Eclipse OpenJ9 VM openj9-0.21.0",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'Eclipse OpenJ9 VM openj9-0.21.0',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [PROCESS_RUNTIME_NAME]: {
-    brief: "The name of the runtime. Equivalent to `name` in the Sentry runtime context.",
+    brief: 'The name of the runtime. Equivalent to `name` in the Sentry runtime context.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "node",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'node',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [PROCESS_RUNTIME_VERSION]: {
-    brief: "The version of the runtime of this process, as returned by the runtime without modification. Equivalent to `version` in the Sentry runtime context.",
+    brief:
+      'The version of the runtime of this process, as returned by the runtime without modification. Equivalent to `version` in the Sentry runtime context.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "18.04.2",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: '18.04.2',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [QUERY_KEY]: {
-    brief: "An item in a query string. Usually added by client-side routing frameworks like vue-router.",
+    brief: 'An item in a query string. Usually added by client-side routing frameworks like vue-router.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     hasDynamicSuffix: true,
     example: "query.id='123'",
     deprecation: {
-      replacement: "url.query",
-      reason: "Instead of sending items individually in query.<key>, they should be sent all together with url.query."
+      replacement: 'url.query',
+      reason: 'Instead of sending items individually in query.<key>, they should be sent all together with url.query.',
     },
-    changelog: [
-      { version: "0.1.0", prs: [103] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [103] }],
   },
   [RELEASE]: {
-    brief: "The sentry release.",
+    brief: 'The sentry release.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "production",
+    example: 'production',
     deprecation: {
-      replacement: "sentry.release"
+      replacement: 'sentry.release',
     },
     aliases: [SENTRY_RELEASE],
-    changelog: [
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [REMIX_ACTION_FORM_DATA_KEY]: {
-    brief: "Remix form data, <key> being the form data key, the value being the form data value.",
+    brief: 'Remix form data, <key> being the form data key, the value being the form data value.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     hasDynamicSuffix: true,
     example: "http.response.header.text='test'",
-    sdks: ["javascript-remix"],
-    changelog: [
-      { version: "0.1.0", prs: [103] },
-    ],
+    sdks: ['javascript-remix'],
+    changelog: [{ version: '0.1.0', prs: [103] }],
   },
   [REPLAY_ID]: {
-    brief: "The id of the sentry replay.",
+    brief: 'The id of the sentry replay.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "123e4567e89b12d3a456426614174000",
+    example: '123e4567e89b12d3a456426614174000',
     deprecation: {
-      replacement: "sentry.replay_id"
+      replacement: 'sentry.replay_id',
     },
     aliases: [SENTRY_REPLAY_ID],
-    changelog: [
-      { version: "0.1.0", prs: [61] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [RESOURCE_DEPLOYMENT_ENVIRONMENT]: {
-    brief: "The software deployment environment name.",
+    brief: 'The software deployment environment name.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: true,
-    example: "production",
+    example: 'production',
     deprecation: {
-      replacement: "sentry.environment"
+      replacement: 'sentry.environment',
     },
-    changelog: [
-      { version: "next", prs: [266] },
-    ],
+    changelog: [{ version: 'next', prs: [266] }],
   },
   [RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME]: {
-    brief: "The software deployment environment name.",
+    brief: 'The software deployment environment name.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: true,
-    example: "production",
+    example: 'production',
     deprecation: {
-      replacement: "sentry.environment"
+      replacement: 'sentry.environment',
     },
-    changelog: [
-      { version: "0.3.1", prs: [196] },
-    ],
+    changelog: [{ version: '0.3.1', prs: [196] }],
   },
   [RESOURCE_RENDER_BLOCKING_STATUS]: {
-    brief: "The render blocking status of the resource.",
+    brief: 'The render blocking status of the resource.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "non-blocking",
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'non-blocking',
+    sdks: ['javascript-browser'],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [ROUTE]: {
-    brief: "The matched route, that is, the path template in the format used by the respective server framework. Also used by mobile SDKs to indicate the current route in the application.",
+    brief:
+      'The matched route, that is, the path template in the format used by the respective server framework. Also used by mobile SDKs to indicate the current route in the application.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "App\\Controller::indexAction",
+    example: 'App\\Controller::indexAction',
     deprecation: {
-      replacement: "http.route"
+      replacement: 'http.route',
     },
     aliases: [HTTP_ROUTE],
-    sdks: ["php-laravel","javascript-reactnative"],
-    changelog: [
-      { version: "0.1.0", prs: [61, 74] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['php-laravel', 'javascript-reactnative'],
+    changelog: [{ version: '0.1.0', prs: [61, 74] }, { version: '0.0.0' }],
   },
   [RPC_GRPC_STATUS_CODE]: {
-    brief: "The numeric status code of the gRPC request.",
+    brief: 'The numeric status code of the gRPC request.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 2,
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [RPC_SERVICE]: {
-    brief: "The full (logical) name of the service being called, including its package name, if applicable.",
+    brief: 'The full (logical) name of the service being called, including its package name, if applicable.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "myService.BestService",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'myService.BestService',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [SENTRY_ACTION]: {
-    brief: "Used as a generic attribute representing the action depending on the type of span. For instance, this is the database query operation for DB spans, and the request method for HTTP spans.",
+    brief:
+      'Used as a generic attribute representing the action depending on the type of span. For instance, this is the database query operation for DB spans, and the request method for HTTP spans.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "SELECT",
-    changelog: [
-      { version: "0.4.0", prs: [212] },
-    ],
+    example: 'SELECT',
+    changelog: [{ version: '0.4.0', prs: [212] }],
   },
   [SENTRY_BROWSER_NAME]: {
-    brief: "The name of the browser.",
+    brief: 'The name of the browser.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "Chrome",
+    example: 'Chrome',
     deprecation: {
-      replacement: "browser.name"
+      replacement: 'browser.name',
     },
     aliases: [BROWSER_NAME],
-    changelog: [
-      { version: "0.1.0", prs: [139] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [139] }],
   },
   [SENTRY_BROWSER_VERSION]: {
-    brief: "The version of the browser.",
+    brief: 'The version of the browser.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "120.0.6099.130",
+    example: '120.0.6099.130',
     deprecation: {
-      replacement: "browser.version"
+      replacement: 'browser.version',
     },
     aliases: [BROWSER_VERSION],
-    changelog: [
-      { version: "0.1.0", prs: [139] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [139] }],
   },
   [SENTRY_CANCELLATION_REASON]: {
-    brief: "The reason why a span ended early.",
+    brief: 'The reason why a span ended early.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "document.hidden",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'document.hidden',
+    changelog: [{ version: '0.0.0' }],
   },
   [SENTRY_CATEGORY]: {
-    brief: "The high-level category of a span, derived from the span operation or span attributes. This categorizes spans by their general purpose (e.g., database, HTTP, UI). Known values include: 'ai', 'ai.pipeline', 'app', 'browser', 'cache', 'console', 'db', 'event', 'file', 'function.aws', 'function.azure', 'function.gcp', 'function.nextjs', 'function.remix', 'graphql', 'grpc', 'http', 'measure', 'middleware', 'navigation', 'pageload', 'queue', 'resource', 'rpc', 'serialize', 'subprocess', 'template', 'topic', 'ui', 'ui.angular', 'ui.ember', 'ui.react', 'ui.svelte', 'ui.vue', 'view', 'websocket'.",
+    brief:
+      "The high-level category of a span, derived from the span operation or span attributes. This categorizes spans by their general purpose (e.g., database, HTTP, UI). Known values include: 'ai', 'ai.pipeline', 'app', 'browser', 'cache', 'console', 'db', 'event', 'file', 'function.aws', 'function.azure', 'function.gcp', 'function.nextjs', 'function.remix', 'graphql', 'grpc', 'http', 'measure', 'middleware', 'navigation', 'pageload', 'queue', 'resource', 'rpc', 'serialize', 'subprocess', 'template', 'topic', 'ui', 'ui.angular', 'ui.ember', 'ui.react', 'ui.svelte', 'ui.vue', 'view', 'websocket'.",
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "db",
-    changelog: [
-      { version: "0.4.0", prs: [218] },
-    ],
+    example: 'db',
+    changelog: [{ version: '0.4.0', prs: [218] }],
   },
   [SENTRY_CLIENT_SAMPLE_RATE]: {
-    brief: "Rate at which a span was sampled in the SDK.",
+    brief: 'Rate at which a span was sampled in the SDK.',
     type: 'double',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: 0.5,
-    changelog: [
-      { version: "0.1.0", prs: [102] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [102] }],
   },
   [SENTRY_DESCRIPTION]: {
-    brief: "The human-readable description of a span.",
+    brief: 'The human-readable description of a span.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "index view query",
-    changelog: [
-      { version: "0.1.0", prs: [135] },
-    ],
+    example: 'index view query',
+    changelog: [{ version: '0.1.0', prs: [135] }],
   },
   [SENTRY_DIST]: {
-    brief: "The sentry dist.",
+    brief: 'The sentry dist.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "1.0",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: '1.0',
+    changelog: [{ version: '0.0.0' }],
   },
   [SENTRY_DOMAIN]: {
-    brief: "Used as a generic attribute representing the domain depending on the type of span. For instance, this is the collection/table name for database spans, and the server address for HTTP spans.",
+    brief:
+      'Used as a generic attribute representing the domain depending on the type of span. For instance, this is the collection/table name for database spans, and the server address for HTTP spans.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "example.com",
-    changelog: [
-      { version: "0.4.0", prs: [212] },
-    ],
+    example: 'example.com',
+    changelog: [{ version: '0.4.0', prs: [212] }],
   },
   [SENTRY_DSC_ENVIRONMENT]: {
-    brief: "The environment from the dynamic sampling context.",
+    brief: 'The environment from the dynamic sampling context.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "prod",
-    changelog: [
-      { version: "0.3.0", prs: [185] },
-    ],
+    example: 'prod',
+    changelog: [{ version: '0.3.0', prs: [185] }],
   },
   [SENTRY_DSC_PUBLIC_KEY]: {
-    brief: "The public key from the dynamic sampling context.",
+    brief: 'The public key from the dynamic sampling context.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "c51734c603c4430eb57cb0a5728a479d",
-    changelog: [
-      { version: "0.3.0", prs: [185] },
-    ],
+    example: 'c51734c603c4430eb57cb0a5728a479d',
+    changelog: [{ version: '0.3.0', prs: [185] }],
   },
   [SENTRY_DSC_RELEASE]: {
-    brief: "The release identifier from the dynamic sampling context.",
+    brief: 'The release identifier from the dynamic sampling context.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "frontend@e8211be71b214afab5b85de4b4c54be3714952bb",
-    changelog: [
-      { version: "0.3.0", prs: [185] },
-    ],
+    example: 'frontend@e8211be71b214afab5b85de4b4c54be3714952bb',
+    changelog: [{ version: '0.3.0', prs: [185] }],
   },
   [SENTRY_DSC_SAMPLED]: {
-    brief: "Whether the event was sampled according to the dynamic sampling context.",
+    brief: 'Whether the event was sampled according to the dynamic sampling context.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,
-    changelog: [
-      { version: "0.3.0", prs: [185] },
-    ],
+    changelog: [{ version: '0.3.0', prs: [185] }],
   },
   [SENTRY_DSC_SAMPLE_RATE]: {
-    brief: "The sample rate from the dynamic sampling context.",
+    brief: 'The sample rate from the dynamic sampling context.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "1.0",
-    changelog: [
-      { version: "0.3.0", prs: [185] },
-    ],
+    example: '1.0',
+    changelog: [{ version: '0.3.0', prs: [185] }],
   },
   [SENTRY_DSC_TRACE_ID]: {
-    brief: "The trace ID from the dynamic sampling context.",
+    brief: 'The trace ID from the dynamic sampling context.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "047372980460430cbc78d9779df33a46",
-    changelog: [
-      { version: "0.3.0", prs: [185] },
-    ],
+    example: '047372980460430cbc78d9779df33a46',
+    changelog: [{ version: '0.3.0', prs: [185] }],
   },
   [SENTRY_DSC_TRANSACTION]: {
-    brief: "The transaction name from the dynamic sampling context.",
+    brief: 'The transaction name from the dynamic sampling context.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "/issues/errors-outages/",
-    changelog: [
-      { version: "0.3.0", prs: [185] },
-    ],
+    example: '/issues/errors-outages/',
+    changelog: [{ version: '0.3.0', prs: [185] }],
   },
   [SENTRY_ENVIRONMENT]: {
-    brief: "The sentry environment.",
+    brief: 'The sentry environment.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "production",
+    example: 'production',
     aliases: [ENVIRONMENT],
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.0.0' }],
   },
   [SENTRY_EXCLUSIVE_TIME]: {
-    brief: "The exclusive time duration of the span in milliseconds.",
+    brief: 'The exclusive time duration of the span in milliseconds.',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1234,
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.3.0", prs: [160] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.3.0', prs: [160] }, { version: '0.0.0' }],
   },
   [SENTRY_GRAPHQL_OPERATION]: {
-    brief: "Indicates the type of graphql operation, emitted by the Javascript SDK.",
+    brief: 'Indicates the type of graphql operation, emitted by the Javascript SDK.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "getUserById",
-    changelog: [
-      { version: "0.3.1", prs: [190] },
-    ],
+    example: 'getUserById',
+    changelog: [{ version: '0.3.1', prs: [190] }],
   },
   [SENTRY_GROUP]: {
-    brief: "Stores the hash of `sentry.normalized_description`. This is primarily used for grouping spans in the product end.",
+    brief:
+      'Stores the hash of `sentry.normalized_description`. This is primarily used for grouping spans in the product end.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    changelog: [
-      { version: "0.4.0", prs: [212] },
-    ],
+    changelog: [{ version: '0.4.0', prs: [212] }],
   },
   [SENTRY_HTTP_PREFETCH]: {
-    brief: "If an http request was a prefetch request.",
+    brief: 'If an http request was a prefetch request.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.0.0' }],
   },
   [SENTRY_IDLE_SPAN_FINISH_REASON]: {
-    brief: "The reason why an idle span ended early.",
+    brief: 'The reason why an idle span ended early.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "idleTimeout",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'idleTimeout',
+    changelog: [{ version: '0.0.0' }],
   },
   [SENTRY_IS_REMOTE]: {
     brief: "Indicates whether a span's parent is remote.",
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,
-    changelog: [
-      { version: "0.3.1", prs: [190] },
-    ],
+    changelog: [{ version: '0.3.1', prs: [190] }],
   },
   [SENTRY_KIND]: {
-    brief: "Used to clarify the relationship between parents and children, or to distinguish between spans, e.g. a `server` and `client` span with the same name.",
+    brief:
+      'Used to clarify the relationship between parents and children, or to distinguish between spans, e.g. a `server` and `client` span with the same name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "server",
-    changelog: [
-      { version: "0.3.1", prs: [190] },
-    ],
+    example: 'server',
+    changelog: [{ version: '0.3.1', prs: [190] }],
   },
   [SENTRY_MESSAGE_PARAMETER_KEY]: {
-    brief: "A parameter used in the message template. <key> can either be the number that represent the parameter's position in the template string (sentry.message.parameter.0, sentry.message.parameter.1, etc) or the parameter's name (sentry.message.parameter.item_id, sentry.message.parameter.user_id, etc)",
+    brief:
+      "A parameter used in the message template. <key> can either be the number that represent the parameter's position in the template string (sentry.message.parameter.0, sentry.message.parameter.1, etc) or the parameter's name (sentry.message.parameter.item_id, sentry.message.parameter.user_id, etc)",
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: "sentry.message.parameter.0='123'",
-    changelog: [
-      { version: "0.1.0", prs: [116] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [116] }],
   },
   [SENTRY_MESSAGE_TEMPLATE]: {
-    brief: "The parameterized template string.",
+    brief: 'The parameterized template string.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "Hello, {name}!",
-    changelog: [
-      { version: "0.1.0", prs: [116] },
-    ],
+    example: 'Hello, {name}!',
+    changelog: [{ version: '0.1.0', prs: [116] }],
   },
   [SENTRY_MODULE_KEY]: {
-    brief: "A module that was loaded in the process. The key is the name of the module.",
+    brief: 'A module that was loaded in the process. The key is the name of the module.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     hasDynamicSuffix: true,
     example: "sentry.module.brianium/paratest='v7.7.0'",
-    changelog: [
-      { version: "0.1.0", prs: [103] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [103] }],
   },
   [SENTRY_NEXTJS_SSR_FUNCTION_ROUTE]: {
-    brief: "A parameterized route for a function in Next.js that contributes to Server-Side Rendering. Should be present on spans that track such functions when the file location of the function is known.",
+    brief:
+      'A parameterized route for a function in Next.js that contributes to Server-Side Rendering. Should be present on spans that track such functions when the file location of the function is known.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "/posts/[id]/layout",
-    sdks: ["javascript"],
-    changelog: [
-      { version: "0.1.0", prs: [54, 106] },
-    ],
+    example: '/posts/[id]/layout',
+    sdks: ['javascript'],
+    changelog: [{ version: '0.1.0', prs: [54, 106] }],
   },
   [SENTRY_NEXTJS_SSR_FUNCTION_TYPE]: {
-    brief: "A descriptor for a for a function in Next.js that contributes to Server-Side Rendering. Should be present on spans that track such functions.",
+    brief:
+      'A descriptor for a for a function in Next.js that contributes to Server-Side Rendering. Should be present on spans that track such functions.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "generateMetadata",
-    sdks: ["javascript"],
-    changelog: [
-      { version: "0.1.0", prs: [54, 106] },
-    ],
+    example: 'generateMetadata',
+    sdks: ['javascript'],
+    changelog: [{ version: '0.1.0', prs: [54, 106] }],
   },
   [SENTRY_NORMALIZED_DB_QUERY]: {
-    brief: "The normalized version of `db.query.text`.",
+    brief: 'The normalized version of `db.query.text`.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "SELECT .. FROM sentry_project WHERE (project_id = %s)",
-    changelog: [
-      { version: "0.3.1", prs: [194] },
-    ],
+    example: 'SELECT .. FROM sentry_project WHERE (project_id = %s)',
+    changelog: [{ version: '0.3.1', prs: [194] }],
   },
   [SENTRY_NORMALIZED_DB_QUERY_HASH]: {
-    brief: "The hash of `sentry.normalized_db_query`.",
+    brief: 'The hash of `sentry.normalized_db_query`.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    changelog: [
-      { version: "0.4.0", prs: [200] },
-    ],
+    changelog: [{ version: '0.4.0', prs: [200] }],
   },
   [SENTRY_NORMALIZED_DESCRIPTION]: {
-    brief: "Used as a generic attribute representing the normalized `sentry.description`. This refers to the legacy use case of `sentry.description` where it holds relevant data depending on the type of span (e.g. database query, resource url, http request description, etc).",
+    brief:
+      'Used as a generic attribute representing the normalized `sentry.description`. This refers to the legacy use case of `sentry.description` where it holds relevant data depending on the type of span (e.g. database query, resource url, http request description, etc).',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "SELECT .. FROM sentry_project WHERE (project_id = %s)",
-    changelog: [
-      { version: "0.4.0", prs: [212] },
-    ],
+    example: 'SELECT .. FROM sentry_project WHERE (project_id = %s)',
+    changelog: [{ version: '0.4.0', prs: [212] }],
   },
   [SENTRY_OBSERVED_TIMESTAMP_NANOS]: {
-    brief: "The timestamp at which an envelope was received by Relay, in nanoseconds.",
+    brief: 'The timestamp at which an envelope was received by Relay, in nanoseconds.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "1544712660300000000",
+    example: '1544712660300000000',
     changelog: [
-      { version: "0.3.0", prs: [174] },
-      { version: "0.2.0", prs: [137] },
+      { version: '0.3.0', prs: [174] },
+      { version: '0.2.0', prs: [137] },
     ],
   },
   [SENTRY_OP]: {
-    brief: "The operation of a span.",
+    brief: 'The operation of a span.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "http.client",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'http.client',
+    changelog: [{ version: '0.0.0' }],
   },
   [SENTRY_ORIGIN]: {
-    brief: "The origin of the instrumentation (e.g. span, log, etc.)",
+    brief: 'The origin of the instrumentation (e.g. span, log, etc.)',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "auto.http.otel.fastify",
-    changelog: [
-      { version: "0.1.0", prs: [68] },
-      { version: "0.0.0" },
-    ],
+    example: 'auto.http.otel.fastify',
+    changelog: [{ version: '0.1.0', prs: [68] }, { version: '0.0.0' }],
   },
   [SENTRY_PLATFORM]: {
-    brief: "The sdk platform that generated the event.",
+    brief: 'The sdk platform that generated the event.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "php",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'php',
+    changelog: [{ version: '0.0.0' }],
   },
   [SENTRY_PROFILER_ID]: {
-    brief: "The id of the currently running profiler (continuous profiling)",
+    brief: 'The id of the currently running profiler (continuous profiling)',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "18779b64dd35d1a538e7ce2dd2d3fad3",
-    changelog: [
-      { version: "0.4.0", prs: [242] },
-    ],
+    example: '18779b64dd35d1a538e7ce2dd2d3fad3',
+    changelog: [{ version: '0.4.0', prs: [242] }],
   },
   [SENTRY_RELEASE]: {
-    brief: "The sentry release.",
+    brief: 'The sentry release.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "7.0.0",
+    example: '7.0.0',
     aliases: [SERVICE_VERSION, RELEASE],
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.0.0' }],
   },
   [SENTRY_REPLAY_ID]: {
-    brief: "The id of the sentry replay.",
+    brief: 'The id of the sentry replay.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "123e4567e89b12d3a456426614174000",
+    example: '123e4567e89b12d3a456426614174000',
     aliases: [REPLAY_ID],
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.0.0' }],
   },
   [SENTRY_REPLAY_IS_BUFFERING]: {
-    brief: "A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate).",
+    brief:
+      'A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate).',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,
-    changelog: [
-      { version: "0.3.0", prs: [185] },
-    ],
+    changelog: [{ version: '0.3.0', prs: [185] }],
   },
   [SENTRY_SDK_INTEGRATIONS]: {
-    brief: "A list of names identifying enabled integrations. The list shouldhave all enabled integrations, including default integrations. Defaultintegrations are included because different SDK releases may contain differentdefault integrations.",
+    brief:
+      'A list of names identifying enabled integrations. The list shouldhave all enabled integrations, including default integrations. Defaultintegrations are included because different SDK releases may contain differentdefault integrations.',
     type: 'string[]',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: ["InboundFilters","FunctionToString","BrowserApiErrors","Breadcrumbs"],
-    changelog: [
-      { version: "0.0.0", prs: [42] },
-    ],
+    example: ['InboundFilters', 'FunctionToString', 'BrowserApiErrors', 'Breadcrumbs'],
+    changelog: [{ version: '0.0.0', prs: [42] }],
   },
   [SENTRY_SDK_NAME]: {
-    brief: "The sentry sdk name.",
+    brief: 'The sentry sdk name.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "@sentry/react",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: '@sentry/react',
+    changelog: [{ version: '0.0.0' }],
   },
   [SENTRY_SDK_VERSION]: {
-    brief: "The sentry sdk version.",
+    brief: 'The sentry sdk version.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "7.0.0",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: '7.0.0',
+    changelog: [{ version: '0.0.0' }],
   },
   [SENTRY_SEGMENT_ID]: {
-    brief: "The segment ID of a span",
+    brief: 'The segment ID of a span',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "051581bf3cb55c13",
+    example: '051581bf3cb55c13',
     aliases: [_SENTRY_SEGMENT_ID],
-    changelog: [
-      { version: "0.1.0", prs: [107, 124] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [107, 124] }],
   },
   [_SENTRY_SEGMENT_ID]: {
-    brief: "The segment ID of a span",
+    brief: 'The segment ID of a span',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "051581bf3cb55c13",
+    example: '051581bf3cb55c13',
     deprecation: {
-      replacement: "sentry.segment.id"
+      replacement: 'sentry.segment.id',
     },
     aliases: [SENTRY_SEGMENT_ID],
-    changelog: [
-      { version: "0.1.0", prs: [124] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [124] }],
   },
   [SENTRY_SEGMENT_NAME]: {
-    brief: "The segment name of a span",
+    brief: 'The segment name of a span',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "GET /user",
-    changelog: [
-      { version: "0.1.0", prs: [104] },
-    ],
+    example: 'GET /user',
+    changelog: [{ version: '0.1.0', prs: [104] }],
   },
   [SENTRY_SERVER_SAMPLE_RATE]: {
-    brief: "Rate at which a span was sampled in Relay.",
+    brief: 'Rate at which a span was sampled in Relay.',
     type: 'double',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: 0.5,
-    changelog: [
-      { version: "0.1.0", prs: [102] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [102] }],
   },
   [SENTRY_SOURCE]: {
-    brief: "The source of a span, also referred to as transaction source. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`. '`source`' describes a parametrized route, while `'url'` describes the full URL, potentially containing identifiers.",
+    brief:
+      "The source of a span, also referred to as transaction source. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`. '`source`' describes a parametrized route, while `'url'` describes the full URL, potentially containing identifiers.",
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "route",
+    example: 'route',
     deprecation: {
-      replacement: "sentry.span.source",
-      reason: "This attribute is being deprecated in favor of sentry.span.source"
+      replacement: 'sentry.span.source',
+      reason: 'This attribute is being deprecated in favor of sentry.span.source',
     },
-    changelog: [
-      { version: "next" },
-    ],
+    changelog: [{ version: 'next' }],
   },
   [SENTRY_SPAN_SOURCE]: {
-    brief: "The source of a span, also referred to as transaction source. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`. '`source`' describes a parametrized route, while `'url'` describes the full URL, potentially containing identifiers.",
+    brief:
+      "The source of a span, also referred to as transaction source. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`. '`source`' describes a parametrized route, while `'url'` describes the full URL, potentially containing identifiers.",
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "route",
-    changelog: [
-      { version: "0.4.0", prs: [214] },
-      { version: "0.0.0" },
-    ],
+    example: 'route',
+    changelog: [{ version: '0.4.0', prs: [214] }, { version: '0.0.0' }],
   },
   [SENTRY_STATUS_CODE]: {
-    brief: "The HTTP status code used in Sentry Insights. Typically set by Sentry during ingestion, rather than by clients.",
+    brief:
+      'The HTTP status code used in Sentry Insights. Typically set by Sentry during ingestion, rather than by clients.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 200,
-    changelog: [
-      { version: "0.4.0", prs: [223, 228] },
-    ],
+    changelog: [{ version: '0.4.0', prs: [223, 228] }],
   },
   [SENTRY_STATUS_MESSAGE]: {
-    brief: "The from OTLP extracted status message.",
+    brief: 'The from OTLP extracted status message.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "foobar",
-    changelog: [
-      { version: "0.3.1", prs: [190] },
-    ],
+    example: 'foobar',
+    changelog: [{ version: '0.3.1', prs: [190] }],
   },
   [SENTRY_TIMESTAMP_SEQUENCE]: {
-    brief: "A sequencing counter for deterministic ordering of logs or metrics when timestamps share the same integer millisecond. Starts at 0 on SDK initialization, increments by 1 for each captured item, and resets to 0 when the integer millisecond of the current item differs from the previous one.",
+    brief:
+      'A sequencing counter for deterministic ordering of logs or metrics when timestamps share the same integer millisecond. Starts at 0 on SDK initialization, increments by 1 for each captured item, and resets to 0 when the integer millisecond of the current item differs from the previous one.',
     type: 'integer',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: 0,
-    changelog: [
-      { version: "next", prs: [262] },
-    ],
+    changelog: [{ version: 'next', prs: [262] }],
   },
   [SENTRY_TRACE_PARENT_SPAN_ID]: {
-    brief: "The span id of the span that was active when the log was collected. This should not be set if there was no active span.",
+    brief:
+      'The span id of the span that was active when the log was collected. This should not be set if there was no active span.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "b0e6f15b45c36b12",
+    example: 'b0e6f15b45c36b12',
     deprecation: {},
     changelog: [
-      { version: "next", prs: [287], description: "Deprecate `sentry.trace.parent_span_id`" },
-      { version: "0.1.0", prs: [116] },
+      { version: 'next', prs: [287], description: 'Deprecate `sentry.trace.parent_span_id`' },
+      { version: '0.1.0', prs: [116] },
     ],
   },
   [SENTRY_TRANSACTION]: {
-    brief: "The sentry transaction (segment name).",
+    brief: 'The sentry transaction (segment name).',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "GET /",
+    example: 'GET /',
     aliases: [TRANSACTION],
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.0.0' }],
   },
   [SERVER_ADDRESS]: {
-    brief: "Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
+    brief:
+      'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "example.com",
+    example: 'example.com',
     aliases: [HTTP_SERVER_NAME, NET_HOST_NAME, HTTP_HOST],
-    changelog: [
-      { version: "0.1.0", prs: [108, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [108, 127] }, { version: '0.0.0' }],
   },
   [SERVER_PORT]: {
-    brief: "Server port number.",
+    brief: 'Server port number.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 1337,
     aliases: [NET_HOST_PORT],
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [SERVICE_NAME]: {
-    brief: "Logical name of the service.",
+    brief: 'Logical name of the service.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "omegastar",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'omegastar',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [SERVICE_VERSION]: {
-    brief: "The version string of the service API or implementation. The format is not defined by these conventions.",
+    brief: 'The version string of the service API or implementation. The format is not defined by these conventions.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "5.0.0",
+    example: '5.0.0',
     aliases: [SENTRY_RELEASE],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [THREAD_ID]: {
-    brief: "Current “managed” thread ID.",
+    brief: 'Current “managed” thread ID.',
     type: 'integer',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: true,
     example: 56,
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.0.0' }],
   },
   [THREAD_NAME]: {
-    brief: "Current thread name.",
+    brief: 'Current thread name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "main",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'main',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [TIMBER_TAG]: {
-    brief: "The log tag provided by the timber logging framework.",
+    brief: 'The log tag provided by the timber logging framework.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "MyTag",
-    sdks: ["sentry.java.android"],
-    changelog: [
-      { version: "0.3.0", prs: [183] },
-    ],
+    example: 'MyTag',
+    sdks: ['sentry.java.android'],
+    changelog: [{ version: '0.3.0', prs: [183] }],
   },
   [TRANSACTION]: {
-    brief: "The sentry transaction (segment name).",
+    brief: 'The sentry transaction (segment name).',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "GET /",
+    example: 'GET /',
     deprecation: {
-      replacement: "sentry.transaction"
+      replacement: 'sentry.transaction',
     },
     aliases: [SENTRY_TRANSACTION],
-    changelog: [
-      { version: "0.1.0", prs: [61, 127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [TTFB]: {
-    brief: "The value of the recorded Time To First Byte (TTFB) web vital in milliseconds",
+    brief: 'The value of the recorded Time To First Byte (TTFB) web vital in milliseconds',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 194,
     deprecation: {
-      replacement: "browser.web_vital.ttfb.value",
-      reason: "This attribute is being deprecated in favor of browser.web_vital.ttfb.value"
+      replacement: 'browser.web_vital.ttfb.value',
+      reason: 'This attribute is being deprecated in favor of browser.web_vital.ttfb.value',
     },
     aliases: [BROWSER_WEB_VITAL_TTFB_VALUE],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [235] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [235] }],
   },
   [TTFB_REQUESTTIME]: {
-    brief: "The time it takes for the server to process the initial request and send the first byte of a response to the user's browser",
+    brief:
+      "The time it takes for the server to process the initial request and send the first byte of a response to the user's browser",
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1554.5814,
     deprecation: {
-      replacement: "browser.web_vital.ttfb.request_time",
-      reason: "This attribute is being deprecated in favor of browser.web_vital.ttfb.request_time"
+      replacement: 'browser.web_vital.ttfb.request_time',
+      reason: 'This attribute is being deprecated in favor of browser.web_vital.ttfb.request_time',
     },
     aliases: [BROWSER_WEB_VITAL_TTFB_REQUEST_TIME],
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [235] },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [235] }],
   },
   [TYPE]: {
-    brief: "More granular type of the operation happening.",
+    brief: 'More granular type of the operation happening.',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "fetch",
-    sdks: ["javascript-browser","javascript-node"],
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'fetch',
+    sdks: ['javascript-browser', 'javascript-node'],
+    changelog: [{ version: '0.0.0' }],
   },
   [UI_COMPONENT_NAME]: {
-    brief: "The name of the associated component.",
+    brief: 'The name of the associated component.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "HomeButton",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'HomeButton',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [UI_CONTRIBUTES_TO_TTFD]: {
-    brief: "Whether the span execution contributed to the TTFD (time to fully drawn) metric.",
+    brief: 'Whether the span execution contributed to the TTFD (time to fully drawn) metric.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.0.0' }],
   },
   [UI_CONTRIBUTES_TO_TTID]: {
-    brief: "Whether the span execution contributed to the TTID (time to initial display) metric.",
+    brief: 'Whether the span execution contributed to the TTID (time to initial display) metric.',
     type: 'boolean',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.0.0' }],
   },
   [UI_ELEMENT_HEIGHT]: {
-    brief: "The height of the UI element (for Html in pixels)",
+    brief: 'The height of the UI element (for Html in pixels)',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 256,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [284], description: "Added ui.element.height attribute" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.height attribute' }],
   },
   [UI_ELEMENT_ID]: {
-    brief: "The id of the UI element",
+    brief: 'The id of the UI element',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "btn-login",
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [284], description: "Added ui.element.id attribute" },
-    ],
+    example: 'btn-login',
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.id attribute' }],
   },
   [UI_ELEMENT_IDENTIFIER]: {
-    brief: "The identifier used to measure the UI element timing",
+    brief: 'The identifier used to measure the UI element timing',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "heroImage",
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [284], description: "Added ui.element.identifier attribute" },
-    ],
+    example: 'heroImage',
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.identifier attribute' }],
   },
   [UI_ELEMENT_LOAD_TIME]: {
-    brief: "The loading time of a UI element (from time origin to finished loading)",
+    brief: 'The loading time of a UI element (from time origin to finished loading)',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 998.2234,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [284], description: "Added ui.element.load_time attribute" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.load_time attribute' }],
   },
   [UI_ELEMENT_PAINT_TYPE]: {
     brief: "The type of element paint. Can either be 'image-paint' or 'text-paint'",
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "image-paint",
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [284], description: "Added ui.element.paint_type attribute" },
-    ],
+    example: 'image-paint',
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.paint_type attribute' }],
   },
   [UI_ELEMENT_RENDER_TIME]: {
-    brief: "The rendering time of the UI element (from time origin to finished rendering)",
+    brief: 'The rendering time of the UI element (from time origin to finished rendering)',
     type: 'double',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1023.1124,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [284], description: "Added ui.element.render_time attribute" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.render_time attribute' }],
   },
   [UI_ELEMENT_TYPE]: {
-    brief: "type of the UI element",
+    brief: 'type of the UI element',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "img",
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [284], description: "Added ui.element.type attribute" },
-    ],
+    example: 'img',
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.type attribute' }],
   },
   [UI_ELEMENT_URL]: {
-    brief: "The URL of the UI element (e.g. an img src)",
+    brief: 'The URL of the UI element (e.g. an img src)',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "https://assets.myapp.com/hero.png",
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [284], description: "Added ui.element.url attribute" },
-    ],
+    example: 'https://assets.myapp.com/hero.png',
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.url attribute' }],
   },
   [UI_ELEMENT_WIDTH]: {
-    brief: "The width of the UI element (for HTML in pixels)",
+    brief: 'The width of the UI element (for HTML in pixels)',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 512,
-    sdks: ["javascript-browser"],
-    changelog: [
-      { version: "next", prs: [284], description: "Added ui.element.width attribute" },
-    ],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.width attribute' }],
   },
   [URL]: {
-    brief: "The URL of the resource that was fetched.",
+    brief: 'The URL of the resource that was fetched.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "https://example.com/test?foo=bar#buzz",
+    example: 'https://example.com/test?foo=bar#buzz',
     deprecation: {
-      replacement: "url.full"
+      replacement: 'url.full',
     },
     aliases: [URL_FULL, HTTP_URL],
-    sdks: ["javascript-browser","javascript-node"],
-    changelog: [
-      { version: "0.1.0", prs: [61] },
-      { version: "0.0.0" },
-    ],
+    sdks: ['javascript-browser', 'javascript-node'],
+    changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [URL_DOMAIN]: {
-    brief: "Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
+    brief:
+      'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "example.com",
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    example: 'example.com',
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [URL_FRAGMENT]: {
-    brief: "The fragments present in the URI. Note that this does not contain the leading # character, while the `http.fragment` attribute does.",
+    brief:
+      'The fragments present in the URI. Note that this does not contain the leading # character, while the `http.fragment` attribute does.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "details",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'details',
+    changelog: [{ version: '0.0.0' }],
   },
   [URL_FULL]: {
-    brief: "The URL of the resource that was fetched.",
+    brief: 'The URL of the resource that was fetched.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "https://example.com/test?foo=bar#buzz",
+    example: 'https://example.com/test?foo=bar#buzz',
     aliases: [HTTP_URL, URL],
-    changelog: [
-      { version: "0.1.0", prs: [108] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [108] }, { version: '0.0.0' }],
   },
   [URL_PATH]: {
-    brief: "The URI path component.",
+    brief: 'The URI path component.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "/foo",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: '/foo',
+    changelog: [{ version: '0.0.0' }],
   },
   [URL_PATH_PARAMETER_KEY]: {
-    brief: "Decoded parameters extracted from a URL path. Usually added by client-side routing frameworks like vue-router.",
+    brief:
+      'Decoded parameters extracted from a URL path. Usually added by client-side routing frameworks like vue-router.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     hasDynamicSuffix: true,
     example: "url.path.parameter.id='123'",
     aliases: [PARAMS_KEY],
-    changelog: [
-      { version: "0.1.0", prs: [103] },
-    ],
+    changelog: [{ version: '0.1.0', prs: [103] }],
   },
   [URL_PORT]: {
-    brief: "Server port number.",
+    brief: 'Server port number.',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 1337,
-    changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [URL_QUERY]: {
-    brief: "The query string present in the URL. Note that this does not contain the leading ? character, while the `http.query` attribute does.",
+    brief:
+      'The query string present in the URL. Note that this does not contain the leading ? character, while the `http.query` attribute does.',
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason: "Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information."
+      reason:
+        'Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.',
     },
     isInOtel: true,
-    example: "foo=bar&bar=baz",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'foo=bar&bar=baz',
+    changelog: [{ version: '0.0.0' }],
   },
   [URL_SCHEME]: {
-    brief: "The URI scheme component identifying the used protocol.",
+    brief: 'The URI scheme component identifying the used protocol.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "https",
+    example: 'https',
     aliases: [HTTP_SCHEME],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [URL_TEMPLATE]: {
-    brief: "The low-cardinality template of an absolute path reference.",
+    brief: 'The low-cardinality template of an absolute path reference.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "/users/:id",
+    example: '/users/:id',
     aliases: [HTTP_ROUTE],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [USER_AGENT_ORIGINAL]: {
-    brief: "Value of the HTTP User-Agent header sent by the client.",
+    brief: 'Value of the HTTP User-Agent header sent by the client.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: true,
-    example: "Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1",
+    example:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1',
     aliases: [HTTP_USER_AGENT],
-    changelog: [
-      { version: "0.1.0", prs: [127] },
-      { version: "0.0.0" },
-    ],
+    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [USER_EMAIL]: {
-    brief: "User email address.",
+    brief: 'User email address.',
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: true,
-    example: "test@example.com",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'test@example.com',
+    changelog: [{ version: '0.0.0' }],
   },
   [USER_FULL_NAME]: {
     brief: "User's full name.",
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: true,
-    example: "John Smith",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'John Smith',
+    changelog: [{ version: '0.0.0' }],
   },
   [USER_GEO_CITY]: {
-    brief: "Human readable city name.",
+    brief: 'Human readable city name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "Toronto",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'Toronto',
+    changelog: [{ version: '0.0.0' }],
   },
   [USER_GEO_COUNTRY_CODE]: {
-    brief: "Two-letter country code (ISO 3166-1 alpha-2).",
+    brief: 'Two-letter country code (ISO 3166-1 alpha-2).',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "CA",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'CA',
+    changelog: [{ version: '0.0.0' }],
   },
   [USER_GEO_REGION]: {
-    brief: "Human readable region name or code.",
+    brief: 'Human readable region name or code.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "Canada",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'Canada',
+    changelog: [{ version: '0.0.0' }],
   },
   [USER_GEO_SUBDIVISION]: {
-    brief: "Human readable subdivision name.",
+    brief: 'Human readable subdivision name.',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "Ontario",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'Ontario',
+    changelog: [{ version: '0.0.0' }],
   },
   [USER_HASH]: {
-    brief: "Unique user hash to correlate information for a user in anonymized form.",
+    brief: 'Unique user hash to correlate information for a user in anonymized form.',
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: true,
-    example: "8ae4c2993e0f4f3b8b2d1b1f3b5e8f4d",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: '8ae4c2993e0f4f3b8b2d1b1f3b5e8f4d',
+    changelog: [{ version: '0.0.0' }],
   },
   [USER_ID]: {
-    brief: "Unique identifier of the user.",
+    brief: 'Unique identifier of the user.',
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: true,
-    example: "S-1-5-21-202424912787-2692429404-2351956786-1000",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'S-1-5-21-202424912787-2692429404-2351956786-1000',
+    changelog: [{ version: '0.0.0' }],
   },
   [USER_IP_ADDRESS]: {
-    brief: "The IP address of the user.",
+    brief: 'The IP address of the user.',
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: "192.168.1.1",
-    changelog: [
-      { version: "0.1.0", prs: [75] },
-    ],
+    example: '192.168.1.1',
+    changelog: [{ version: '0.1.0', prs: [75] }],
   },
   [USER_NAME]: {
-    brief: "Short name or login/username of the user.",
+    brief: 'Short name or login/username of the user.',
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: true,
-    example: "j.smith",
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: 'j.smith',
+    changelog: [{ version: '0.0.0' }],
   },
   [USER_ROLES]: {
-    brief: "Array of user roles at the time of the event.",
+    brief: 'Array of user roles at the time of the event.',
     type: 'string[]',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: true,
-    example: ["admin","editor"],
-    changelog: [
-      { version: "0.0.0" },
-    ],
+    example: ['admin', 'editor'],
+    changelog: [{ version: '0.0.0' }],
   },
   [VERCEL_BRANCH]: {
-    brief: "Git branch name for Vercel project",
+    brief: 'Git branch name for Vercel project',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "main",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'main',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_BUILD_ID]: {
-    brief: "Identifier for the Vercel build (only present on build logs)",
+    brief: 'Identifier for the Vercel build (only present on build logs)',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "bld_cotnkcr76",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'bld_cotnkcr76',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_DEPLOYMENT_ID]: {
-    brief: "Identifier for the Vercel deployment",
+    brief: 'Identifier for the Vercel deployment',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "dpl_233NRGRjVZX1caZrXWtz5g1TAksD",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'dpl_233NRGRjVZX1caZrXWtz5g1TAksD',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_DESTINATION]: {
-    brief: "Origin of the external content in Vercel (only on external logs)",
+    brief: 'Origin of the external content in Vercel (only on external logs)',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "https://vitals.vercel-insights.com/v1",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'https://vitals.vercel-insights.com/v1',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_EDGE_TYPE]: {
-    brief: "Type of edge runtime in Vercel",
+    brief: 'Type of edge runtime in Vercel',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "edge-function",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'edge-function',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_ENTRYPOINT]: {
-    brief: "Entrypoint for the request in Vercel",
+    brief: 'Entrypoint for the request in Vercel',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "api/index.js",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'api/index.js',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_EXECUTION_REGION]: {
-    brief: "Region where the request is executed",
+    brief: 'Region where the request is executed',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "sfo1",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'sfo1',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_ID]: {
-    brief: "Unique identifier for the log entry in Vercel",
+    brief: 'Unique identifier for the log entry in Vercel',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "1573817187330377061717300000",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: '1573817187330377061717300000',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_JA3_DIGEST]: {
-    brief: "JA3 fingerprint digest of Vercel request",
+    brief: 'JA3 fingerprint digest of Vercel request',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: '769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_JA4_DIGEST]: {
-    brief: "JA4 fingerprint digest",
+    brief: 'JA4 fingerprint digest',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "t13d1516h2_8daaf6152771_02713d6af862",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 't13d1516h2_8daaf6152771_02713d6af862',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_LOG_TYPE]: {
-    brief: "Vercel log output type",
+    brief: 'Vercel log output type',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "stdout",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'stdout',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROJECT_ID]: {
-    brief: "Identifier for the Vercel project",
+    brief: 'Identifier for the Vercel project',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "gdufoJxB6b9b1fEqr1jUtFkyavUU",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'gdufoJxB6b9b1fEqr1jUtFkyavUU',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROJECT_NAME]: {
-    brief: "Name of the Vercel project",
+    brief: 'Name of the Vercel project',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "my-app",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'my-app',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_CACHE_ID]: {
-    brief: "Original request ID when request is served from cache",
+    brief: 'Original request ID when request is served from cache',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "pdx1::v8g4b-1744143786684-93dafbc0f70d",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'pdx1::v8g4b-1744143786684-93dafbc0f70d',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_CLIENT_IP]: {
-    brief: "Client IP address",
+    brief: 'Client IP address',
     type: 'string',
     pii: {
-      isPii: 'true'
+      isPii: 'true',
     },
     isInOtel: false,
-    example: "120.75.16.101",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: '120.75.16.101',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_HOST]: {
-    brief: "Hostname of the request",
+    brief: 'Hostname of the request',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "test.vercel.app",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'test.vercel.app',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_LAMBDA_REGION]: {
-    brief: "Region where lambda function executed",
+    brief: 'Region where lambda function executed',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "sfo1",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'sfo1',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_METHOD]: {
-    brief: "HTTP method of the request",
+    brief: 'HTTP method of the request',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "GET",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'GET',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_PATH]: {
-    brief: "Request path with query parameters",
+    brief: 'Request path with query parameters',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "/dynamic/some-value.json?route=some-value",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: '/dynamic/some-value.json?route=some-value',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_PATH_TYPE]: {
-    brief: "How the request was served based on its path and project configuration",
+    brief: 'How the request was served based on its path and project configuration',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "func",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'func',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_PATH_TYPE_VARIANT]: {
-    brief: "Variant of the path type",
+    brief: 'Variant of the path type',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "api",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'api',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_REFERER]: {
-    brief: "Referer of the request",
+    brief: 'Referer of the request',
     type: 'string',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: "*.vercel.app",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: '*.vercel.app',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_REGION]: {
-    brief: "Region where the request is processed",
+    brief: 'Region where the request is processed',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "sfo1",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'sfo1',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_RESPONSE_BYTE_SIZE]: {
-    brief: "Size of the response in bytes",
+    brief: 'Size of the response in bytes',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1024,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.2.0", prs: [163] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.2.0', prs: [163] },
     ],
   },
   [VERCEL_PROXY_SCHEME]: {
-    brief: "Protocol of the request",
+    brief: 'Protocol of the request',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "https",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'https',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_STATUS_CODE]: {
-    brief: "HTTP status code of the proxy request",
+    brief: 'HTTP status code of the proxy request',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 200,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.2.0", prs: [163] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.2.0', prs: [163] },
     ],
   },
   [VERCEL_PROXY_TIMESTAMP]: {
-    brief: "Unix timestamp when the proxy request was made",
+    brief: 'Unix timestamp when the proxy request was made',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1573817250172,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.2.0", prs: [163] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.2.0', prs: [163] },
     ],
   },
   [VERCEL_PROXY_USER_AGENT]: {
-    brief: "User agent strings of the request",
+    brief: 'User agent strings of the request',
     type: 'string[]',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
-    example: ["Mozilla/5.0..."],
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: ['Mozilla/5.0...'],
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_VERCEL_CACHE]: {
-    brief: "Cache status sent to the browser",
+    brief: 'Cache status sent to the browser',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "REVALIDATED",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'REVALIDATED',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_VERCEL_ID]: {
-    brief: "Vercel-specific identifier",
+    brief: 'Vercel-specific identifier',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "sfo1::abc123",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'sfo1::abc123',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_WAF_ACTION]: {
-    brief: "Action taken by firewall rules",
+    brief: 'Action taken by firewall rules',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "deny",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'deny',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_PROXY_WAF_RULE_ID]: {
-    brief: "ID of the firewall rule that matched",
+    brief: 'ID of the firewall rule that matched',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "rule_gAHz8jtSB1Gy",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'rule_gAHz8jtSB1Gy',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_REQUEST_ID]: {
-    brief: "Identifier of the Vercel request",
+    brief: 'Identifier of the Vercel request',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "643af4e3-975a-4cc7-9e7a-1eda11539d90",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: '643af4e3-975a-4cc7-9e7a-1eda11539d90',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_SOURCE]: {
-    brief: "Origin of the Vercel log (build, edge, lambda, static, external, or firewall)",
+    brief: 'Origin of the Vercel log (build, edge, lambda, static, external, or firewall)',
     type: 'string',
     pii: {
-      isPii: 'false'
+      isPii: 'false',
     },
     isInOtel: false,
-    example: "build",
-    changelog: [
-      { version: "0.2.0", prs: [163] },
-    ],
+    example: 'build',
+    changelog: [{ version: '0.2.0', prs: [163] }],
   },
   [VERCEL_STATUS_CODE]: {
-    brief: "HTTP status code of the request (-1 means no response returned and the lambda crashed)",
+    brief: 'HTTP status code of the request (-1 means no response returned and the lambda crashed)',
     type: 'integer',
     pii: {
-      isPii: 'maybe'
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 200,
     changelog: [
-      { version: "0.4.0", prs: [228] },
-      { version: "0.2.0", prs: [163] },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.2.0', prs: [163] },
     ],
   },
 };
@@ -17953,4 +17587,3 @@ export type Attributes = {
   [VERCEL_SOURCE]?: VERCEL_SOURCE_TYPE;
   [VERCEL_STATUS_CODE]?: VERCEL_STATUS_CODE_TYPE;
 } & Record<string, AttributeValue | undefined>;
-

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -11,7 +11,7 @@
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated
+ * @deprecated 
  * @example ["Citation 1","Citation 2"]
  */
 export const AI_CITATIONS = 'ai.citations';
@@ -55,7 +55,7 @@ export type AI_COMPLETION_TOKENS_USED_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated
+ * @deprecated 
  * @example ["document1.txt","document2.pdf"]
  */
 export const AI_DOCUMENTS = 'ai.documents';
@@ -191,7 +191,7 @@ export type AI_INPUT_MESSAGES_TYPE = string;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated
+ * @deprecated 
  * @example false
  */
 export const AI_IS_SEARCH_REQUIRED = 'ai.is_search_required';
@@ -212,7 +212,7 @@ export type AI_IS_SEARCH_REQUIRED_TYPE = boolean;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated
+ * @deprecated 
  * @example "{\"user_id\": 123, \"session_id\": \"abc123\"}"
  */
 export const AI_METADATA = 'ai.metadata';
@@ -371,7 +371,7 @@ export type AI_PROMPT_TOKENS_USED_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated
+ * @deprecated 
  * @example true
  */
 export const AI_RAW_PROMPTING = 'ai.raw_prompting';
@@ -413,7 +413,7 @@ export type AI_RESPONSES_TYPE = Array<string>;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated
+ * @deprecated 
  * @example "json_object"
  */
 export const AI_RESPONSE_FORMAT = 'ai.response_format';
@@ -434,7 +434,7 @@ export type AI_RESPONSE_FORMAT_TYPE = string;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated
+ * @deprecated 
  * @example ["climate change effects","renewable energy"]
  */
 export const AI_SEARCH_QUERIES = 'ai.search_queries';
@@ -455,7 +455,7 @@ export type AI_SEARCH_QUERIES_TYPE = Array<string>;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated
+ * @deprecated 
  * @example ["search_result_1, search_result_2"]
  */
 export const AI_SEARCH_RESULTS = 'ai.search_results';
@@ -522,7 +522,7 @@ export type AI_STREAMING_TYPE = boolean;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated
+ * @deprecated 
  * @example "{\"executed_function\": \"add_integers\"}"
  */
 export const AI_TAGS = 'ai.tags';
@@ -723,7 +723,7 @@ export type AI_TOTAL_TOKENS_USED_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated
+ * @deprecated 
  * @example ["Token limit exceeded"]
  */
 export const AI_WARNINGS = 'ai.warnings';
@@ -3811,6 +3811,7 @@ export type GEN_AI_TOOL_OUTPUT_TYPE = string;
  *
  * Attribute defined in OTEL: Yes
  *
+ * @deprecated  - The gen_ai.tool.type attribute is deprecated and should no longer be set.
  * @example "function"
  */
 export const GEN_AI_TOOL_TYPE = 'gen_ai.tool.type';
@@ -8496,7 +8497,7 @@ export type SENTRY_TIMESTAMP_SEQUENCE_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated
+ * @deprecated 
  * @example "b0e6f15b45c36b12"
  */
 export const SENTRY_TRACE_PARENT_SPAN_ID = 'sentry.trace.parent_span_id';
@@ -10158,6 +10159,7 @@ export const VERCEL_STATUS_CODE = 'vercel.status_code';
  */
 export type VERCEL_STATUS_CODE_TYPE = number;
 
+
 export type AttributeType =
   | 'string'
   | 'boolean'
@@ -10169,7 +10171,10 @@ export type AttributeType =
   | 'double[]'
   | 'any';
 
-export type IsPii = 'true' | 'false' | 'maybe';
+export type IsPii = 
+  | 'true'
+  | 'false'
+  | 'maybe';
 
 export interface PiiInfo {
   /** Whether the attribute contains PII */
@@ -10705,6391 +10710,6756 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [VERCEL_STATUS_CODE]: 'integer',
 };
 
-export type AttributeName =
-  | typeof AI_CITATIONS
-  | typeof AI_COMPLETION_TOKENS_USED
-  | typeof AI_DOCUMENTS
-  | typeof AI_FINISH_REASON
-  | typeof AI_FREQUENCY_PENALTY
-  | typeof AI_FUNCTION_CALL
-  | typeof AI_GENERATION_ID
-  | typeof AI_INPUT_MESSAGES
-  | typeof AI_IS_SEARCH_REQUIRED
-  | typeof AI_METADATA
-  | typeof AI_MODEL_ID
-  | typeof AI_MODEL_PROVIDER
-  | typeof AI_PIPELINE_NAME
-  | typeof AI_PREAMBLE
-  | typeof AI_PRESENCE_PENALTY
-  | typeof AI_PROMPT_TOKENS_USED
-  | typeof AI_RAW_PROMPTING
-  | typeof AI_RESPONSES
-  | typeof AI_RESPONSE_FORMAT
-  | typeof AI_SEARCH_QUERIES
-  | typeof AI_SEARCH_RESULTS
-  | typeof AI_SEED
-  | typeof AI_STREAMING
-  | typeof AI_TAGS
-  | typeof AI_TEMPERATURE
-  | typeof AI_TEXTS
-  | typeof AI_TOOLS
-  | typeof AI_TOOL_CALLS
-  | typeof AI_TOP_K
-  | typeof AI_TOP_P
-  | typeof AI_TOTAL_COST
-  | typeof AI_TOTAL_TOKENS_USED
-  | typeof AI_WARNINGS
-  | typeof APP_BUILD
-  | typeof APP_IDENTIFIER
-  | typeof APP_IN_FOREGROUND
-  | typeof APP_NAME
-  | typeof APP_START_TIME
-  | typeof APP_START_TYPE
-  | typeof APP_VERSION
-  | typeof BLOCKED_MAIN_THREAD
-  | typeof BROWSER_NAME
-  | typeof BROWSER_REPORT_TYPE
-  | typeof BROWSER_SCRIPT_INVOKER
-  | typeof BROWSER_SCRIPT_INVOKER_TYPE
-  | typeof BROWSER_SCRIPT_SOURCE_CHAR_POSITION
-  | typeof BROWSER_VERSION
-  | typeof BROWSER_WEB_VITAL_CLS_SOURCE_KEY
-  | typeof BROWSER_WEB_VITAL_CLS_VALUE
-  | typeof BROWSER_WEB_VITAL_FCP_VALUE
-  | typeof BROWSER_WEB_VITAL_FP_VALUE
-  | typeof BROWSER_WEB_VITAL_INP_VALUE
-  | typeof BROWSER_WEB_VITAL_LCP_ELEMENT
-  | typeof BROWSER_WEB_VITAL_LCP_ID
-  | typeof BROWSER_WEB_VITAL_LCP_LOAD_TIME
-  | typeof BROWSER_WEB_VITAL_LCP_RENDER_TIME
-  | typeof BROWSER_WEB_VITAL_LCP_SIZE
-  | typeof BROWSER_WEB_VITAL_LCP_URL
-  | typeof BROWSER_WEB_VITAL_LCP_VALUE
-  | typeof BROWSER_WEB_VITAL_TTFB_REQUEST_TIME
-  | typeof BROWSER_WEB_VITAL_TTFB_VALUE
-  | typeof CACHE_HIT
-  | typeof CACHE_ITEM_SIZE
-  | typeof CACHE_KEY
-  | typeof CACHE_OPERATION
-  | typeof CACHE_TTL
-  | typeof CACHE_WRITE
-  | typeof CHANNEL
-  | typeof CLIENT_ADDRESS
-  | typeof CLIENT_PORT
-  | typeof CLOUDFLARE_D1_DURATION
-  | typeof CLOUDFLARE_D1_ROWS_READ
-  | typeof CLOUDFLARE_D1_ROWS_WRITTEN
-  | typeof CLS
-  | typeof CLS_SOURCE_KEY
-  | typeof CODE_FILEPATH
-  | typeof CODE_FILE_PATH
-  | typeof CODE_FUNCTION
-  | typeof CODE_FUNCTION_NAME
-  | typeof CODE_LINENO
-  | typeof CODE_LINE_NUMBER
-  | typeof CODE_NAMESPACE
-  | typeof CONNECTIONTYPE
-  | typeof CONNECTION_RTT
-  | typeof CULTURE_CALENDAR
-  | typeof CULTURE_DISPLAY_NAME
-  | typeof CULTURE_IS_24_HOUR_FORMAT
-  | typeof CULTURE_LOCALE
-  | typeof CULTURE_TIMEZONE
-  | typeof DB_COLLECTION_NAME
-  | typeof DB_NAME
-  | typeof DB_NAMESPACE
-  | typeof DB_OPERATION
-  | typeof DB_OPERATION_NAME
-  | typeof DB_QUERY_PARAMETER_KEY
-  | typeof DB_QUERY_SUMMARY
-  | typeof DB_QUERY_TEXT
-  | typeof DB_REDIS_CONNECTION
-  | typeof DB_REDIS_PARAMETERS
-  | typeof DB_SQL_BINDINGS
-  | typeof DB_STATEMENT
-  | typeof DB_SYSTEM
-  | typeof DB_SYSTEM_NAME
-  | typeof DB_USER
-  | typeof DEVICEMEMORY
-  | typeof DEVICE_BRAND
-  | typeof DEVICE_CLASS
-  | typeof DEVICE_FAMILY
-  | typeof DEVICE_FREE_MEMORY
-  | typeof DEVICE_MEMORY_ESTIMATED_CAPACITY
-  | typeof DEVICE_MEMORY_SIZE
-  | typeof DEVICE_MODEL
-  | typeof DEVICE_MODEL_ID
-  | typeof DEVICE_PROCESSOR_COUNT
-  | typeof DEVICE_SIMULATOR
-  | typeof EFFECTIVECONNECTIONTYPE
-  | typeof ENVIRONMENT
-  | typeof ERROR_TYPE
-  | typeof EVENT_ID
-  | typeof EVENT_NAME
-  | typeof EXCEPTION_ESCAPED
-  | typeof EXCEPTION_MESSAGE
-  | typeof EXCEPTION_STACKTRACE
-  | typeof EXCEPTION_TYPE
-  | typeof FAAS_COLDSTART
-  | typeof FAAS_CRON
-  | typeof FAAS_TIME
-  | typeof FAAS_TRIGGER
-  | typeof FCP
-  | typeof FLAG_EVALUATION_KEY
-  | typeof FP
-  | typeof FRAMES_DELAY
-  | typeof FRAMES_FROZEN
-  | typeof FRAMES_SLOW
-  | typeof FRAMES_TOTAL
-  | typeof FS_ERROR
-  | typeof GEN_AI_AGENT_NAME
-  | typeof GEN_AI_CONVERSATION_ID
-  | typeof GEN_AI_COST_INPUT_TOKENS
-  | typeof GEN_AI_COST_OUTPUT_TOKENS
-  | typeof GEN_AI_COST_TOTAL_TOKENS
-  | typeof GEN_AI_EMBEDDINGS_INPUT
-  | typeof GEN_AI_INPUT_MESSAGES
-  | typeof GEN_AI_OPERATION_NAME
-  | typeof GEN_AI_OPERATION_TYPE
-  | typeof GEN_AI_OUTPUT_MESSAGES
-  | typeof GEN_AI_PIPELINE_NAME
-  | typeof GEN_AI_PROMPT
-  | typeof GEN_AI_PROVIDER_NAME
-  | typeof GEN_AI_REQUEST_AVAILABLE_TOOLS
-  | typeof GEN_AI_REQUEST_FREQUENCY_PENALTY
-  | typeof GEN_AI_REQUEST_MAX_TOKENS
-  | typeof GEN_AI_REQUEST_MESSAGES
-  | typeof GEN_AI_REQUEST_MODEL
-  | typeof GEN_AI_REQUEST_PRESENCE_PENALTY
-  | typeof GEN_AI_REQUEST_SEED
-  | typeof GEN_AI_REQUEST_TEMPERATURE
-  | typeof GEN_AI_REQUEST_TOP_K
-  | typeof GEN_AI_REQUEST_TOP_P
-  | typeof GEN_AI_RESPONSE_FINISH_REASONS
-  | typeof GEN_AI_RESPONSE_ID
-  | typeof GEN_AI_RESPONSE_MODEL
-  | typeof GEN_AI_RESPONSE_STREAMING
-  | typeof GEN_AI_RESPONSE_TEXT
-  | typeof GEN_AI_RESPONSE_TIME_TO_FIRST_TOKEN
-  | typeof GEN_AI_RESPONSE_TOKENS_PER_SECOND
-  | typeof GEN_AI_RESPONSE_TOOL_CALLS
-  | typeof GEN_AI_SYSTEM
-  | typeof GEN_AI_SYSTEM_INSTRUCTIONS
-  | typeof GEN_AI_SYSTEM_MESSAGE
-  | typeof GEN_AI_TOOL_CALL_ARGUMENTS
-  | typeof GEN_AI_TOOL_CALL_RESULT
-  | typeof GEN_AI_TOOL_DEFINITIONS
-  | typeof GEN_AI_TOOL_DESCRIPTION
-  | typeof GEN_AI_TOOL_INPUT
-  | typeof GEN_AI_TOOL_MESSAGE
-  | typeof GEN_AI_TOOL_NAME
-  | typeof GEN_AI_TOOL_OUTPUT
-  | typeof GEN_AI_TOOL_TYPE
-  | typeof GEN_AI_USAGE_COMPLETION_TOKENS
-  | typeof GEN_AI_USAGE_INPUT_TOKENS
-  | typeof GEN_AI_USAGE_INPUT_TOKENS_CACHED
-  | typeof GEN_AI_USAGE_INPUT_TOKENS_CACHE_WRITE
-  | typeof GEN_AI_USAGE_OUTPUT_TOKENS
-  | typeof GEN_AI_USAGE_OUTPUT_TOKENS_REASONING
-  | typeof GEN_AI_USAGE_PROMPT_TOKENS
-  | typeof GEN_AI_USAGE_TOTAL_TOKENS
-  | typeof GRAPHQL_OPERATION_NAME
-  | typeof GRAPHQL_OPERATION_TYPE
-  | typeof HARDWARECONCURRENCY
-  | typeof HTTP_CLIENT_IP
-  | typeof HTTP_DECODED_RESPONSE_CONTENT_LENGTH
-  | typeof HTTP_FLAVOR
-  | typeof HTTP_FRAGMENT
-  | typeof HTTP_HOST
-  | typeof HTTP_METHOD
-  | typeof HTTP_QUERY
-  | typeof HTTP_REQUEST_CONNECTION_END
-  | typeof HTTP_REQUEST_CONNECT_START
-  | typeof HTTP_REQUEST_DOMAIN_LOOKUP_END
-  | typeof HTTP_REQUEST_DOMAIN_LOOKUP_START
-  | typeof HTTP_REQUEST_FETCH_START
-  | typeof HTTP_REQUEST_HEADER_KEY
-  | typeof HTTP_REQUEST_METHOD
-  | typeof HTTP_REQUEST_REDIRECT_END
-  | typeof HTTP_REQUEST_REDIRECT_START
-  | typeof HTTP_REQUEST_REQUEST_START
-  | typeof HTTP_REQUEST_RESEND_COUNT
-  | typeof HTTP_REQUEST_RESPONSE_END
-  | typeof HTTP_REQUEST_RESPONSE_START
-  | typeof HTTP_REQUEST_SECURE_CONNECTION_START
-  | typeof HTTP_REQUEST_TIME_TO_FIRST_BYTE
-  | typeof HTTP_REQUEST_WORKER_START
-  | typeof HTTP_RESPONSE_BODY_SIZE
-  | typeof HTTP_RESPONSE_CONTENT_LENGTH
-  | typeof HTTP_RESPONSE_HEADER_CONTENT_LENGTH
-  | typeof HTTP_RESPONSE_HEADER_KEY
-  | typeof HTTP_RESPONSE_SIZE
-  | typeof HTTP_RESPONSE_STATUS_CODE
-  | typeof HTTP_RESPONSE_TRANSFER_SIZE
-  | typeof HTTP_ROUTE
-  | typeof HTTP_SCHEME
-  | typeof HTTP_SERVER_NAME
-  | typeof HTTP_SERVER_REQUEST_TIME_IN_QUEUE
-  | typeof HTTP_STATUS_CODE
-  | typeof HTTP_TARGET
-  | typeof HTTP_URL
-  | typeof HTTP_USER_AGENT
-  | typeof ID
-  | typeof INP
-  | typeof JVM_GC_ACTION
-  | typeof JVM_GC_NAME
-  | typeof JVM_MEMORY_POOL_NAME
-  | typeof JVM_MEMORY_TYPE
-  | typeof JVM_THREAD_DAEMON
-  | typeof JVM_THREAD_STATE
-  | typeof LCP
-  | typeof LCP_ELEMENT
-  | typeof LCP_ID
-  | typeof LCP_LOADTIME
-  | typeof LCP_RENDERTIME
-  | typeof LCP_SIZE
-  | typeof LCP_URL
-  | typeof LOGGER_NAME
-  | typeof MCP_CANCELLED_REASON
-  | typeof MCP_CANCELLED_REQUEST_ID
-  | typeof MCP_CLIENT_NAME
-  | typeof MCP_CLIENT_TITLE
-  | typeof MCP_CLIENT_VERSION
-  | typeof MCP_LIFECYCLE_PHASE
-  | typeof MCP_LOGGING_DATA_TYPE
-  | typeof MCP_LOGGING_LEVEL
-  | typeof MCP_LOGGING_LOGGER
-  | typeof MCP_LOGGING_MESSAGE
-  | typeof MCP_METHOD_NAME
-  | typeof MCP_PROGRESS_CURRENT
-  | typeof MCP_PROGRESS_MESSAGE
-  | typeof MCP_PROGRESS_PERCENTAGE
-  | typeof MCP_PROGRESS_TOKEN
-  | typeof MCP_PROGRESS_TOTAL
-  | typeof MCP_PROMPT_NAME
-  | typeof MCP_PROMPT_RESULT_DESCRIPTION
-  | typeof MCP_PROMPT_RESULT_MESSAGE_CONTENT
-  | typeof MCP_PROMPT_RESULT_MESSAGE_COUNT
-  | typeof MCP_PROMPT_RESULT_MESSAGE_ROLE
-  | typeof MCP_PROTOCOL_READY
-  | typeof MCP_PROTOCOL_VERSION
-  | typeof MCP_REQUEST_ARGUMENT_KEY
-  | typeof MCP_REQUEST_ARGUMENT_NAME
-  | typeof MCP_REQUEST_ARGUMENT_URI
-  | typeof MCP_REQUEST_ID
-  | typeof MCP_RESOURCE_PROTOCOL
-  | typeof MCP_RESOURCE_URI
-  | typeof MCP_SERVER_NAME
-  | typeof MCP_SERVER_TITLE
-  | typeof MCP_SERVER_VERSION
-  | typeof MCP_SESSION_ID
-  | typeof MCP_TOOL_NAME
-  | typeof MCP_TOOL_RESULT_CONTENT
-  | typeof MCP_TOOL_RESULT_CONTENT_COUNT
-  | typeof MCP_TOOL_RESULT_IS_ERROR
-  | typeof MCP_TRANSPORT
-  | typeof MDC_KEY
-  | typeof MESSAGING_DESTINATION_CONNECTION
-  | typeof MESSAGING_DESTINATION_NAME
-  | typeof MESSAGING_MESSAGE_BODY_SIZE
-  | typeof MESSAGING_MESSAGE_ENVELOPE_SIZE
-  | typeof MESSAGING_MESSAGE_ID
-  | typeof MESSAGING_MESSAGE_RECEIVE_LATENCY
-  | typeof MESSAGING_MESSAGE_RETRY_COUNT
-  | typeof MESSAGING_OPERATION_TYPE
-  | typeof MESSAGING_SYSTEM
-  | typeof METHOD
-  | typeof NAVIGATION_TYPE
-  | typeof NEL_ELAPSED_TIME
-  | typeof NEL_PHASE
-  | typeof NEL_REFERRER
-  | typeof NEL_SAMPLING_FUNCTION
-  | typeof NEL_TYPE
-  | typeof NETWORK_CONNECTION_EFFECTIVE_TYPE
-  | typeof NETWORK_CONNECTION_RTT
-  | typeof NETWORK_CONNECTION_TYPE
-  | typeof NETWORK_LOCAL_ADDRESS
-  | typeof NETWORK_LOCAL_PORT
-  | typeof NETWORK_PEER_ADDRESS
-  | typeof NETWORK_PEER_PORT
-  | typeof NETWORK_PROTOCOL_NAME
-  | typeof NETWORK_PROTOCOL_VERSION
-  | typeof NETWORK_TRANSPORT
-  | typeof NETWORK_TYPE
-  | typeof NET_HOST_IP
-  | typeof NET_HOST_NAME
-  | typeof NET_HOST_PORT
-  | typeof NET_PEER_IP
-  | typeof NET_PEER_NAME
-  | typeof NET_PEER_PORT
-  | typeof NET_PROTOCOL_NAME
-  | typeof NET_PROTOCOL_VERSION
-  | typeof NET_SOCK_FAMILY
-  | typeof NET_SOCK_HOST_ADDR
-  | typeof NET_SOCK_HOST_PORT
-  | typeof NET_SOCK_PEER_ADDR
-  | typeof NET_SOCK_PEER_NAME
-  | typeof NET_SOCK_PEER_PORT
-  | typeof NET_TRANSPORT
-  | typeof OS_BUILD_ID
-  | typeof OS_DESCRIPTION
-  | typeof OS_NAME
-  | typeof OS_TYPE
-  | typeof OS_VERSION
-  | typeof OTEL_SCOPE_NAME
-  | typeof OTEL_SCOPE_VERSION
-  | typeof OTEL_STATUS_CODE
-  | typeof OTEL_STATUS_DESCRIPTION
-  | typeof PARAMS_KEY
-  | typeof PREVIOUS_ROUTE
-  | typeof PROCESS_EXECUTABLE_NAME
-  | typeof PROCESS_PID
-  | typeof PROCESS_RUNTIME_DESCRIPTION
-  | typeof PROCESS_RUNTIME_NAME
-  | typeof PROCESS_RUNTIME_VERSION
-  | typeof QUERY_KEY
-  | typeof RELEASE
-  | typeof REMIX_ACTION_FORM_DATA_KEY
-  | typeof REPLAY_ID
-  | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT
-  | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME
-  | typeof RESOURCE_RENDER_BLOCKING_STATUS
-  | typeof ROUTE
-  | typeof RPC_GRPC_STATUS_CODE
-  | typeof RPC_SERVICE
-  | typeof SENTRY_ACTION
-  | typeof SENTRY_BROWSER_NAME
-  | typeof SENTRY_BROWSER_VERSION
-  | typeof SENTRY_CANCELLATION_REASON
-  | typeof SENTRY_CATEGORY
-  | typeof SENTRY_CLIENT_SAMPLE_RATE
-  | typeof SENTRY_DESCRIPTION
-  | typeof SENTRY_DIST
-  | typeof SENTRY_DOMAIN
-  | typeof SENTRY_DSC_ENVIRONMENT
-  | typeof SENTRY_DSC_PUBLIC_KEY
-  | typeof SENTRY_DSC_RELEASE
-  | typeof SENTRY_DSC_SAMPLED
-  | typeof SENTRY_DSC_SAMPLE_RATE
-  | typeof SENTRY_DSC_TRACE_ID
-  | typeof SENTRY_DSC_TRANSACTION
-  | typeof SENTRY_ENVIRONMENT
-  | typeof SENTRY_EXCLUSIVE_TIME
-  | typeof SENTRY_GRAPHQL_OPERATION
-  | typeof SENTRY_GROUP
-  | typeof SENTRY_HTTP_PREFETCH
-  | typeof SENTRY_IDLE_SPAN_FINISH_REASON
-  | typeof SENTRY_IS_REMOTE
-  | typeof SENTRY_KIND
-  | typeof SENTRY_MESSAGE_PARAMETER_KEY
-  | typeof SENTRY_MESSAGE_TEMPLATE
-  | typeof SENTRY_MODULE_KEY
-  | typeof SENTRY_NEXTJS_SSR_FUNCTION_ROUTE
-  | typeof SENTRY_NEXTJS_SSR_FUNCTION_TYPE
-  | typeof SENTRY_NORMALIZED_DB_QUERY
-  | typeof SENTRY_NORMALIZED_DB_QUERY_HASH
-  | typeof SENTRY_NORMALIZED_DESCRIPTION
-  | typeof SENTRY_OBSERVED_TIMESTAMP_NANOS
-  | typeof SENTRY_OP
-  | typeof SENTRY_ORIGIN
-  | typeof SENTRY_PLATFORM
-  | typeof SENTRY_PROFILER_ID
-  | typeof SENTRY_RELEASE
-  | typeof SENTRY_REPLAY_ID
-  | typeof SENTRY_REPLAY_IS_BUFFERING
-  | typeof SENTRY_SDK_INTEGRATIONS
-  | typeof SENTRY_SDK_NAME
-  | typeof SENTRY_SDK_VERSION
-  | typeof SENTRY_SEGMENT_ID
-  | typeof _SENTRY_SEGMENT_ID
-  | typeof SENTRY_SEGMENT_NAME
-  | typeof SENTRY_SERVER_SAMPLE_RATE
-  | typeof SENTRY_SOURCE
-  | typeof SENTRY_SPAN_SOURCE
-  | typeof SENTRY_STATUS_CODE
-  | typeof SENTRY_STATUS_MESSAGE
-  | typeof SENTRY_TIMESTAMP_SEQUENCE
-  | typeof SENTRY_TRACE_PARENT_SPAN_ID
-  | typeof SENTRY_TRANSACTION
-  | typeof SERVER_ADDRESS
-  | typeof SERVER_PORT
-  | typeof SERVICE_NAME
-  | typeof SERVICE_VERSION
-  | typeof THREAD_ID
-  | typeof THREAD_NAME
-  | typeof TIMBER_TAG
-  | typeof TRANSACTION
-  | typeof TTFB
-  | typeof TTFB_REQUESTTIME
-  | typeof TYPE
-  | typeof UI_COMPONENT_NAME
-  | typeof UI_CONTRIBUTES_TO_TTFD
-  | typeof UI_CONTRIBUTES_TO_TTID
-  | typeof UI_ELEMENT_HEIGHT
-  | typeof UI_ELEMENT_ID
-  | typeof UI_ELEMENT_IDENTIFIER
-  | typeof UI_ELEMENT_LOAD_TIME
-  | typeof UI_ELEMENT_PAINT_TYPE
-  | typeof UI_ELEMENT_RENDER_TIME
-  | typeof UI_ELEMENT_TYPE
-  | typeof UI_ELEMENT_URL
-  | typeof UI_ELEMENT_WIDTH
-  | typeof URL
-  | typeof URL_DOMAIN
-  | typeof URL_FRAGMENT
-  | typeof URL_FULL
-  | typeof URL_PATH
-  | typeof URL_PATH_PARAMETER_KEY
-  | typeof URL_PORT
-  | typeof URL_QUERY
-  | typeof URL_SCHEME
-  | typeof URL_TEMPLATE
-  | typeof USER_AGENT_ORIGINAL
-  | typeof USER_EMAIL
-  | typeof USER_FULL_NAME
-  | typeof USER_GEO_CITY
-  | typeof USER_GEO_COUNTRY_CODE
-  | typeof USER_GEO_REGION
-  | typeof USER_GEO_SUBDIVISION
-  | typeof USER_HASH
-  | typeof USER_ID
-  | typeof USER_IP_ADDRESS
-  | typeof USER_NAME
-  | typeof USER_ROLES
-  | typeof VERCEL_BRANCH
-  | typeof VERCEL_BUILD_ID
-  | typeof VERCEL_DEPLOYMENT_ID
-  | typeof VERCEL_DESTINATION
-  | typeof VERCEL_EDGE_TYPE
-  | typeof VERCEL_ENTRYPOINT
-  | typeof VERCEL_EXECUTION_REGION
-  | typeof VERCEL_ID
-  | typeof VERCEL_JA3_DIGEST
-  | typeof VERCEL_JA4_DIGEST
-  | typeof VERCEL_LOG_TYPE
-  | typeof VERCEL_PROJECT_ID
-  | typeof VERCEL_PROJECT_NAME
-  | typeof VERCEL_PROXY_CACHE_ID
-  | typeof VERCEL_PROXY_CLIENT_IP
-  | typeof VERCEL_PROXY_HOST
-  | typeof VERCEL_PROXY_LAMBDA_REGION
-  | typeof VERCEL_PROXY_METHOD
-  | typeof VERCEL_PROXY_PATH
-  | typeof VERCEL_PROXY_PATH_TYPE
-  | typeof VERCEL_PROXY_PATH_TYPE_VARIANT
-  | typeof VERCEL_PROXY_REFERER
-  | typeof VERCEL_PROXY_REGION
-  | typeof VERCEL_PROXY_RESPONSE_BYTE_SIZE
-  | typeof VERCEL_PROXY_SCHEME
-  | typeof VERCEL_PROXY_STATUS_CODE
-  | typeof VERCEL_PROXY_TIMESTAMP
-  | typeof VERCEL_PROXY_USER_AGENT
-  | typeof VERCEL_PROXY_VERCEL_CACHE
-  | typeof VERCEL_PROXY_VERCEL_ID
-  | typeof VERCEL_PROXY_WAF_ACTION
-  | typeof VERCEL_PROXY_WAF_RULE_ID
-  | typeof VERCEL_REQUEST_ID
-  | typeof VERCEL_SOURCE
-  | typeof VERCEL_STATUS_CODE;
+export type AttributeName = typeof AI_CITATIONS | typeof AI_COMPLETION_TOKENS_USED | typeof AI_DOCUMENTS | typeof AI_FINISH_REASON | typeof AI_FREQUENCY_PENALTY | typeof AI_FUNCTION_CALL | typeof AI_GENERATION_ID | typeof AI_INPUT_MESSAGES | typeof AI_IS_SEARCH_REQUIRED | typeof AI_METADATA | typeof AI_MODEL_ID | typeof AI_MODEL_PROVIDER | typeof AI_PIPELINE_NAME | typeof AI_PREAMBLE | typeof AI_PRESENCE_PENALTY | typeof AI_PROMPT_TOKENS_USED | typeof AI_RAW_PROMPTING | typeof AI_RESPONSES | typeof AI_RESPONSE_FORMAT | typeof AI_SEARCH_QUERIES | typeof AI_SEARCH_RESULTS | typeof AI_SEED | typeof AI_STREAMING | typeof AI_TAGS | typeof AI_TEMPERATURE | typeof AI_TEXTS | typeof AI_TOOLS | typeof AI_TOOL_CALLS | typeof AI_TOP_K | typeof AI_TOP_P | typeof AI_TOTAL_COST | typeof AI_TOTAL_TOKENS_USED | typeof AI_WARNINGS | typeof APP_BUILD | typeof APP_IDENTIFIER | typeof APP_IN_FOREGROUND | typeof APP_NAME | typeof APP_START_TIME | typeof APP_START_TYPE | typeof APP_VERSION | typeof BLOCKED_MAIN_THREAD | typeof BROWSER_NAME | typeof BROWSER_REPORT_TYPE | typeof BROWSER_SCRIPT_INVOKER | typeof BROWSER_SCRIPT_INVOKER_TYPE | typeof BROWSER_SCRIPT_SOURCE_CHAR_POSITION | typeof BROWSER_VERSION | typeof BROWSER_WEB_VITAL_CLS_SOURCE_KEY | typeof BROWSER_WEB_VITAL_CLS_VALUE | typeof BROWSER_WEB_VITAL_FCP_VALUE | typeof BROWSER_WEB_VITAL_FP_VALUE | typeof BROWSER_WEB_VITAL_INP_VALUE | typeof BROWSER_WEB_VITAL_LCP_ELEMENT | typeof BROWSER_WEB_VITAL_LCP_ID | typeof BROWSER_WEB_VITAL_LCP_LOAD_TIME | typeof BROWSER_WEB_VITAL_LCP_RENDER_TIME | typeof BROWSER_WEB_VITAL_LCP_SIZE | typeof BROWSER_WEB_VITAL_LCP_URL | typeof BROWSER_WEB_VITAL_LCP_VALUE | typeof BROWSER_WEB_VITAL_TTFB_REQUEST_TIME | typeof BROWSER_WEB_VITAL_TTFB_VALUE | typeof CACHE_HIT | typeof CACHE_ITEM_SIZE | typeof CACHE_KEY | typeof CACHE_OPERATION | typeof CACHE_TTL | typeof CACHE_WRITE | typeof CHANNEL | typeof CLIENT_ADDRESS | typeof CLIENT_PORT | typeof CLOUDFLARE_D1_DURATION | typeof CLOUDFLARE_D1_ROWS_READ | typeof CLOUDFLARE_D1_ROWS_WRITTEN | typeof CLS | typeof CLS_SOURCE_KEY | typeof CODE_FILEPATH | typeof CODE_FILE_PATH | typeof CODE_FUNCTION | typeof CODE_FUNCTION_NAME | typeof CODE_LINENO | typeof CODE_LINE_NUMBER | typeof CODE_NAMESPACE | typeof CONNECTIONTYPE | typeof CONNECTION_RTT | typeof CULTURE_CALENDAR | typeof CULTURE_DISPLAY_NAME | typeof CULTURE_IS_24_HOUR_FORMAT | typeof CULTURE_LOCALE | typeof CULTURE_TIMEZONE | typeof DB_COLLECTION_NAME | typeof DB_NAME | typeof DB_NAMESPACE | typeof DB_OPERATION | typeof DB_OPERATION_NAME | typeof DB_QUERY_PARAMETER_KEY | typeof DB_QUERY_SUMMARY | typeof DB_QUERY_TEXT | typeof DB_REDIS_CONNECTION | typeof DB_REDIS_PARAMETERS | typeof DB_SQL_BINDINGS | typeof DB_STATEMENT | typeof DB_SYSTEM | typeof DB_SYSTEM_NAME | typeof DB_USER | typeof DEVICEMEMORY | typeof DEVICE_BRAND | typeof DEVICE_CLASS | typeof DEVICE_FAMILY | typeof DEVICE_FREE_MEMORY | typeof DEVICE_MEMORY_ESTIMATED_CAPACITY | typeof DEVICE_MEMORY_SIZE | typeof DEVICE_MODEL | typeof DEVICE_MODEL_ID | typeof DEVICE_PROCESSOR_COUNT | typeof DEVICE_SIMULATOR | typeof EFFECTIVECONNECTIONTYPE | typeof ENVIRONMENT | typeof ERROR_TYPE | typeof EVENT_ID | typeof EVENT_NAME | typeof EXCEPTION_ESCAPED | typeof EXCEPTION_MESSAGE | typeof EXCEPTION_STACKTRACE | typeof EXCEPTION_TYPE | typeof FAAS_COLDSTART | typeof FAAS_CRON | typeof FAAS_TIME | typeof FAAS_TRIGGER | typeof FCP | typeof FLAG_EVALUATION_KEY | typeof FP | typeof FRAMES_DELAY | typeof FRAMES_FROZEN | typeof FRAMES_SLOW | typeof FRAMES_TOTAL | typeof FS_ERROR | typeof GEN_AI_AGENT_NAME | typeof GEN_AI_CONVERSATION_ID | typeof GEN_AI_COST_INPUT_TOKENS | typeof GEN_AI_COST_OUTPUT_TOKENS | typeof GEN_AI_COST_TOTAL_TOKENS | typeof GEN_AI_EMBEDDINGS_INPUT | typeof GEN_AI_INPUT_MESSAGES | typeof GEN_AI_OPERATION_NAME | typeof GEN_AI_OPERATION_TYPE | typeof GEN_AI_OUTPUT_MESSAGES | typeof GEN_AI_PIPELINE_NAME | typeof GEN_AI_PROMPT | typeof GEN_AI_PROVIDER_NAME | typeof GEN_AI_REQUEST_AVAILABLE_TOOLS | typeof GEN_AI_REQUEST_FREQUENCY_PENALTY | typeof GEN_AI_REQUEST_MAX_TOKENS | typeof GEN_AI_REQUEST_MESSAGES | typeof GEN_AI_REQUEST_MODEL | typeof GEN_AI_REQUEST_PRESENCE_PENALTY | typeof GEN_AI_REQUEST_SEED | typeof GEN_AI_REQUEST_TEMPERATURE | typeof GEN_AI_REQUEST_TOP_K | typeof GEN_AI_REQUEST_TOP_P | typeof GEN_AI_RESPONSE_FINISH_REASONS | typeof GEN_AI_RESPONSE_ID | typeof GEN_AI_RESPONSE_MODEL | typeof GEN_AI_RESPONSE_STREAMING | typeof GEN_AI_RESPONSE_TEXT | typeof GEN_AI_RESPONSE_TIME_TO_FIRST_TOKEN | typeof GEN_AI_RESPONSE_TOKENS_PER_SECOND | typeof GEN_AI_RESPONSE_TOOL_CALLS | typeof GEN_AI_SYSTEM | typeof GEN_AI_SYSTEM_INSTRUCTIONS | typeof GEN_AI_SYSTEM_MESSAGE | typeof GEN_AI_TOOL_CALL_ARGUMENTS | typeof GEN_AI_TOOL_CALL_RESULT | typeof GEN_AI_TOOL_DEFINITIONS | typeof GEN_AI_TOOL_DESCRIPTION | typeof GEN_AI_TOOL_INPUT | typeof GEN_AI_TOOL_MESSAGE | typeof GEN_AI_TOOL_NAME | typeof GEN_AI_TOOL_OUTPUT | typeof GEN_AI_TOOL_TYPE | typeof GEN_AI_USAGE_COMPLETION_TOKENS | typeof GEN_AI_USAGE_INPUT_TOKENS | typeof GEN_AI_USAGE_INPUT_TOKENS_CACHED | typeof GEN_AI_USAGE_INPUT_TOKENS_CACHE_WRITE | typeof GEN_AI_USAGE_OUTPUT_TOKENS | typeof GEN_AI_USAGE_OUTPUT_TOKENS_REASONING | typeof GEN_AI_USAGE_PROMPT_TOKENS | typeof GEN_AI_USAGE_TOTAL_TOKENS | typeof GRAPHQL_OPERATION_NAME | typeof GRAPHQL_OPERATION_TYPE | typeof HARDWARECONCURRENCY | typeof HTTP_CLIENT_IP | typeof HTTP_DECODED_RESPONSE_CONTENT_LENGTH | typeof HTTP_FLAVOR | typeof HTTP_FRAGMENT | typeof HTTP_HOST | typeof HTTP_METHOD | typeof HTTP_QUERY | typeof HTTP_REQUEST_CONNECTION_END | typeof HTTP_REQUEST_CONNECT_START | typeof HTTP_REQUEST_DOMAIN_LOOKUP_END | typeof HTTP_REQUEST_DOMAIN_LOOKUP_START | typeof HTTP_REQUEST_FETCH_START | typeof HTTP_REQUEST_HEADER_KEY | typeof HTTP_REQUEST_METHOD | typeof HTTP_REQUEST_REDIRECT_END | typeof HTTP_REQUEST_REDIRECT_START | typeof HTTP_REQUEST_REQUEST_START | typeof HTTP_REQUEST_RESEND_COUNT | typeof HTTP_REQUEST_RESPONSE_END | typeof HTTP_REQUEST_RESPONSE_START | typeof HTTP_REQUEST_SECURE_CONNECTION_START | typeof HTTP_REQUEST_TIME_TO_FIRST_BYTE | typeof HTTP_REQUEST_WORKER_START | typeof HTTP_RESPONSE_BODY_SIZE | typeof HTTP_RESPONSE_CONTENT_LENGTH | typeof HTTP_RESPONSE_HEADER_CONTENT_LENGTH | typeof HTTP_RESPONSE_HEADER_KEY | typeof HTTP_RESPONSE_SIZE | typeof HTTP_RESPONSE_STATUS_CODE | typeof HTTP_RESPONSE_TRANSFER_SIZE | typeof HTTP_ROUTE | typeof HTTP_SCHEME | typeof HTTP_SERVER_NAME | typeof HTTP_SERVER_REQUEST_TIME_IN_QUEUE | typeof HTTP_STATUS_CODE | typeof HTTP_TARGET | typeof HTTP_URL | typeof HTTP_USER_AGENT | typeof ID | typeof INP | typeof JVM_GC_ACTION | typeof JVM_GC_NAME | typeof JVM_MEMORY_POOL_NAME | typeof JVM_MEMORY_TYPE | typeof JVM_THREAD_DAEMON | typeof JVM_THREAD_STATE | typeof LCP | typeof LCP_ELEMENT | typeof LCP_ID | typeof LCP_LOADTIME | typeof LCP_RENDERTIME | typeof LCP_SIZE | typeof LCP_URL | typeof LOGGER_NAME | typeof MCP_CANCELLED_REASON | typeof MCP_CANCELLED_REQUEST_ID | typeof MCP_CLIENT_NAME | typeof MCP_CLIENT_TITLE | typeof MCP_CLIENT_VERSION | typeof MCP_LIFECYCLE_PHASE | typeof MCP_LOGGING_DATA_TYPE | typeof MCP_LOGGING_LEVEL | typeof MCP_LOGGING_LOGGER | typeof MCP_LOGGING_MESSAGE | typeof MCP_METHOD_NAME | typeof MCP_PROGRESS_CURRENT | typeof MCP_PROGRESS_MESSAGE | typeof MCP_PROGRESS_PERCENTAGE | typeof MCP_PROGRESS_TOKEN | typeof MCP_PROGRESS_TOTAL | typeof MCP_PROMPT_NAME | typeof MCP_PROMPT_RESULT_DESCRIPTION | typeof MCP_PROMPT_RESULT_MESSAGE_CONTENT | typeof MCP_PROMPT_RESULT_MESSAGE_COUNT | typeof MCP_PROMPT_RESULT_MESSAGE_ROLE | typeof MCP_PROTOCOL_READY | typeof MCP_PROTOCOL_VERSION | typeof MCP_REQUEST_ARGUMENT_KEY | typeof MCP_REQUEST_ARGUMENT_NAME | typeof MCP_REQUEST_ARGUMENT_URI | typeof MCP_REQUEST_ID | typeof MCP_RESOURCE_PROTOCOL | typeof MCP_RESOURCE_URI | typeof MCP_SERVER_NAME | typeof MCP_SERVER_TITLE | typeof MCP_SERVER_VERSION | typeof MCP_SESSION_ID | typeof MCP_TOOL_NAME | typeof MCP_TOOL_RESULT_CONTENT | typeof MCP_TOOL_RESULT_CONTENT_COUNT | typeof MCP_TOOL_RESULT_IS_ERROR | typeof MCP_TRANSPORT | typeof MDC_KEY | typeof MESSAGING_DESTINATION_CONNECTION | typeof MESSAGING_DESTINATION_NAME | typeof MESSAGING_MESSAGE_BODY_SIZE | typeof MESSAGING_MESSAGE_ENVELOPE_SIZE | typeof MESSAGING_MESSAGE_ID | typeof MESSAGING_MESSAGE_RECEIVE_LATENCY | typeof MESSAGING_MESSAGE_RETRY_COUNT | typeof MESSAGING_OPERATION_TYPE | typeof MESSAGING_SYSTEM | typeof METHOD | typeof NAVIGATION_TYPE | typeof NEL_ELAPSED_TIME | typeof NEL_PHASE | typeof NEL_REFERRER | typeof NEL_SAMPLING_FUNCTION | typeof NEL_TYPE | typeof NETWORK_CONNECTION_EFFECTIVE_TYPE | typeof NETWORK_CONNECTION_RTT | typeof NETWORK_CONNECTION_TYPE | typeof NETWORK_LOCAL_ADDRESS | typeof NETWORK_LOCAL_PORT | typeof NETWORK_PEER_ADDRESS | typeof NETWORK_PEER_PORT | typeof NETWORK_PROTOCOL_NAME | typeof NETWORK_PROTOCOL_VERSION | typeof NETWORK_TRANSPORT | typeof NETWORK_TYPE | typeof NET_HOST_IP | typeof NET_HOST_NAME | typeof NET_HOST_PORT | typeof NET_PEER_IP | typeof NET_PEER_NAME | typeof NET_PEER_PORT | typeof NET_PROTOCOL_NAME | typeof NET_PROTOCOL_VERSION | typeof NET_SOCK_FAMILY | typeof NET_SOCK_HOST_ADDR | typeof NET_SOCK_HOST_PORT | typeof NET_SOCK_PEER_ADDR | typeof NET_SOCK_PEER_NAME | typeof NET_SOCK_PEER_PORT | typeof NET_TRANSPORT | typeof OS_BUILD_ID | typeof OS_DESCRIPTION | typeof OS_NAME | typeof OS_TYPE | typeof OS_VERSION | typeof OTEL_SCOPE_NAME | typeof OTEL_SCOPE_VERSION | typeof OTEL_STATUS_CODE | typeof OTEL_STATUS_DESCRIPTION | typeof PARAMS_KEY | typeof PREVIOUS_ROUTE | typeof PROCESS_EXECUTABLE_NAME | typeof PROCESS_PID | typeof PROCESS_RUNTIME_DESCRIPTION | typeof PROCESS_RUNTIME_NAME | typeof PROCESS_RUNTIME_VERSION | typeof QUERY_KEY | typeof RELEASE | typeof REMIX_ACTION_FORM_DATA_KEY | typeof REPLAY_ID | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME | typeof RESOURCE_RENDER_BLOCKING_STATUS | typeof ROUTE | typeof RPC_GRPC_STATUS_CODE | typeof RPC_SERVICE | typeof SENTRY_ACTION | typeof SENTRY_BROWSER_NAME | typeof SENTRY_BROWSER_VERSION | typeof SENTRY_CANCELLATION_REASON | typeof SENTRY_CATEGORY | typeof SENTRY_CLIENT_SAMPLE_RATE | typeof SENTRY_DESCRIPTION | typeof SENTRY_DIST | typeof SENTRY_DOMAIN | typeof SENTRY_DSC_ENVIRONMENT | typeof SENTRY_DSC_PUBLIC_KEY | typeof SENTRY_DSC_RELEASE | typeof SENTRY_DSC_SAMPLED | typeof SENTRY_DSC_SAMPLE_RATE | typeof SENTRY_DSC_TRACE_ID | typeof SENTRY_DSC_TRANSACTION | typeof SENTRY_ENVIRONMENT | typeof SENTRY_EXCLUSIVE_TIME | typeof SENTRY_GRAPHQL_OPERATION | typeof SENTRY_GROUP | typeof SENTRY_HTTP_PREFETCH | typeof SENTRY_IDLE_SPAN_FINISH_REASON | typeof SENTRY_IS_REMOTE | typeof SENTRY_KIND | typeof SENTRY_MESSAGE_PARAMETER_KEY | typeof SENTRY_MESSAGE_TEMPLATE | typeof SENTRY_MODULE_KEY | typeof SENTRY_NEXTJS_SSR_FUNCTION_ROUTE | typeof SENTRY_NEXTJS_SSR_FUNCTION_TYPE | typeof SENTRY_NORMALIZED_DB_QUERY | typeof SENTRY_NORMALIZED_DB_QUERY_HASH | typeof SENTRY_NORMALIZED_DESCRIPTION | typeof SENTRY_OBSERVED_TIMESTAMP_NANOS | typeof SENTRY_OP | typeof SENTRY_ORIGIN | typeof SENTRY_PLATFORM | typeof SENTRY_PROFILER_ID | typeof SENTRY_RELEASE | typeof SENTRY_REPLAY_ID | typeof SENTRY_REPLAY_IS_BUFFERING | typeof SENTRY_SDK_INTEGRATIONS | typeof SENTRY_SDK_NAME | typeof SENTRY_SDK_VERSION | typeof SENTRY_SEGMENT_ID | typeof _SENTRY_SEGMENT_ID | typeof SENTRY_SEGMENT_NAME | typeof SENTRY_SERVER_SAMPLE_RATE | typeof SENTRY_SOURCE | typeof SENTRY_SPAN_SOURCE | typeof SENTRY_STATUS_CODE | typeof SENTRY_STATUS_MESSAGE | typeof SENTRY_TIMESTAMP_SEQUENCE | typeof SENTRY_TRACE_PARENT_SPAN_ID | typeof SENTRY_TRANSACTION | typeof SERVER_ADDRESS | typeof SERVER_PORT | typeof SERVICE_NAME | typeof SERVICE_VERSION | typeof THREAD_ID | typeof THREAD_NAME | typeof TIMBER_TAG | typeof TRANSACTION | typeof TTFB | typeof TTFB_REQUESTTIME | typeof TYPE | typeof UI_COMPONENT_NAME | typeof UI_CONTRIBUTES_TO_TTFD | typeof UI_CONTRIBUTES_TO_TTID | typeof UI_ELEMENT_HEIGHT | typeof UI_ELEMENT_ID | typeof UI_ELEMENT_IDENTIFIER | typeof UI_ELEMENT_LOAD_TIME | typeof UI_ELEMENT_PAINT_TYPE | typeof UI_ELEMENT_RENDER_TIME | typeof UI_ELEMENT_TYPE | typeof UI_ELEMENT_URL | typeof UI_ELEMENT_WIDTH | typeof URL | typeof URL_DOMAIN | typeof URL_FRAGMENT | typeof URL_FULL | typeof URL_PATH | typeof URL_PATH_PARAMETER_KEY | typeof URL_PORT | typeof URL_QUERY | typeof URL_SCHEME | typeof URL_TEMPLATE | typeof USER_AGENT_ORIGINAL | typeof USER_EMAIL | typeof USER_FULL_NAME | typeof USER_GEO_CITY | typeof USER_GEO_COUNTRY_CODE | typeof USER_GEO_REGION | typeof USER_GEO_SUBDIVISION | typeof USER_HASH | typeof USER_ID | typeof USER_IP_ADDRESS | typeof USER_NAME | typeof USER_ROLES | typeof VERCEL_BRANCH | typeof VERCEL_BUILD_ID | typeof VERCEL_DEPLOYMENT_ID | typeof VERCEL_DESTINATION | typeof VERCEL_EDGE_TYPE | typeof VERCEL_ENTRYPOINT | typeof VERCEL_EXECUTION_REGION | typeof VERCEL_ID | typeof VERCEL_JA3_DIGEST | typeof VERCEL_JA4_DIGEST | typeof VERCEL_LOG_TYPE | typeof VERCEL_PROJECT_ID | typeof VERCEL_PROJECT_NAME | typeof VERCEL_PROXY_CACHE_ID | typeof VERCEL_PROXY_CLIENT_IP | typeof VERCEL_PROXY_HOST | typeof VERCEL_PROXY_LAMBDA_REGION | typeof VERCEL_PROXY_METHOD | typeof VERCEL_PROXY_PATH | typeof VERCEL_PROXY_PATH_TYPE | typeof VERCEL_PROXY_PATH_TYPE_VARIANT | typeof VERCEL_PROXY_REFERER | typeof VERCEL_PROXY_REGION | typeof VERCEL_PROXY_RESPONSE_BYTE_SIZE | typeof VERCEL_PROXY_SCHEME | typeof VERCEL_PROXY_STATUS_CODE | typeof VERCEL_PROXY_TIMESTAMP | typeof VERCEL_PROXY_USER_AGENT | typeof VERCEL_PROXY_VERCEL_CACHE | typeof VERCEL_PROXY_VERCEL_ID | typeof VERCEL_PROXY_WAF_ACTION | typeof VERCEL_PROXY_WAF_RULE_ID | typeof VERCEL_REQUEST_ID | typeof VERCEL_SOURCE | typeof VERCEL_STATUS_CODE;
 
 export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   [AI_CITATIONS]: {
-    brief: 'References or sources cited by the AI model in its response.',
+    brief: "References or sources cited by the AI model in its response.",
     type: 'string[]',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: ['Citation 1', 'Citation 2'],
+    example: ["Citation 1","Citation 2"],
     deprecation: {},
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.1.0', prs: [55] },
+      { version: "next", prs: [264] },
+      { version: "0.1.0", prs: [55] },
     ],
   },
   [AI_COMPLETION_TOKENS_USED]: {
-    brief: 'The number of tokens used to respond to the message.',
+    brief: "The number of tokens used to respond to the message.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 10,
     deprecation: {
-      replacement: 'gen_ai.usage.output_tokens',
+      replacement: "gen_ai.usage.output_tokens"
     },
     aliases: [GEN_AI_USAGE_OUTPUT_TOKENS, GEN_AI_USAGE_COMPLETION_TOKENS],
-    sdks: ['python'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [57, 61] }, { version: '0.0.0' }],
+    sdks: ["python"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [57, 61] },
+      { version: "0.0.0" },
+    ],
   },
   [AI_DOCUMENTS]: {
-    brief: 'Documents or content chunks used as context for the AI model.',
+    brief: "Documents or content chunks used as context for the AI model.",
     type: 'string[]',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: ['document1.txt', 'document2.pdf'],
+    example: ["document1.txt","document2.pdf"],
     deprecation: {},
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.1.0', prs: [55] },
+      { version: "next", prs: [264] },
+      { version: "0.1.0", prs: [55] },
     ],
   },
   [AI_FINISH_REASON]: {
-    brief: 'The reason why the model stopped generating.',
+    brief: "The reason why the model stopped generating.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'COMPLETE',
+    example: "COMPLETE",
     deprecation: {
-      replacement: 'gen_ai.response.finish_reason',
+      replacement: "gen_ai.response.finish_reason"
     },
     aliases: [GEN_AI_RESPONSE_FINISH_REASONS],
-    changelog: [{ version: '0.1.0', prs: [55, 57, 61, 108, 127] }],
+    changelog: [
+      { version: "0.1.0", prs: [55, 57, 61, 108, 127] },
+    ],
   },
   [AI_FREQUENCY_PENALTY]: {
-    brief:
-      'Used to reduce repetitiveness of generated tokens. The higher the value, the stronger a penalty is applied to previously present tokens, proportional to how many times they have already appeared in the prompt or prior generation.',
+    brief: "Used to reduce repetitiveness of generated tokens. The higher the value, the stronger a penalty is applied to previously present tokens, proportional to how many times they have already appeared in the prompt or prior generation.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 0.5,
     deprecation: {
-      replacement: 'gen_ai.request.frequency_penalty',
+      replacement: "gen_ai.request.frequency_penalty"
     },
     aliases: [GEN_AI_REQUEST_FREQUENCY_PENALTY],
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [55, 57, 61, 108] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [55, 57, 61, 108] },
     ],
   },
   [AI_FUNCTION_CALL]: {
-    brief:
-      'For an AI model call, the function that was called. This is deprecated for OpenAI, and replaced by tool_calls',
+    brief: "For an AI model call, the function that was called. This is deprecated for OpenAI, and replaced by tool_calls",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: 'function_name',
+    example: "function_name",
     deprecation: {
-      replacement: 'gen_ai.tool.name',
+      replacement: "gen_ai.tool.name"
     },
     aliases: [GEN_AI_TOOL_NAME],
-    changelog: [{ version: '0.1.0', prs: [55, 57, 61, 108] }],
+    changelog: [
+      { version: "0.1.0", prs: [55, 57, 61, 108] },
+    ],
   },
   [AI_GENERATION_ID]: {
-    brief: 'Unique identifier for the completion.',
+    brief: "Unique identifier for the completion.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'gen_123abc',
+    example: "gen_123abc",
     deprecation: {
-      replacement: 'gen_ai.response.id',
+      replacement: "gen_ai.response.id"
     },
     aliases: [GEN_AI_RESPONSE_ID],
-    changelog: [{ version: '0.1.0', prs: [55, 57, 61, 108, 127] }],
+    changelog: [
+      { version: "0.1.0", prs: [55, 57, 61, 108, 127] },
+    ],
   },
   [AI_INPUT_MESSAGES]: {
-    brief: 'The input messages sent to the model',
+    brief: "The input messages sent to the model",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '[{"role": "user", "message": "hello"}]',
+    example: "[{\"role\": \"user\", \"message\": \"hello\"}]",
     deprecation: {
-      replacement: 'gen_ai.request.messages',
+      replacement: "gen_ai.request.messages"
     },
     aliases: [GEN_AI_REQUEST_MESSAGES],
-    sdks: ['python'],
-    changelog: [{ version: '0.1.0', prs: [65, 119] }, { version: '0.0.0' }],
+    sdks: ["python"],
+    changelog: [
+      { version: "0.1.0", prs: [65, 119] },
+      { version: "0.0.0" },
+    ],
   },
   [AI_IS_SEARCH_REQUIRED]: {
-    brief: 'Boolean indicating if the model needs to perform a search.',
+    brief: "Boolean indicating if the model needs to perform a search.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: false,
     deprecation: {},
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.1.0', prs: [55] },
+      { version: "next", prs: [264] },
+      { version: "0.1.0", prs: [55] },
     ],
   },
   [AI_METADATA]: {
-    brief: 'Extra metadata passed to an AI pipeline step.',
+    brief: "Extra metadata passed to an AI pipeline step.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '{"user_id": 123, "session_id": "abc123"}',
+    example: "{\"user_id\": 123, \"session_id\": \"abc123\"}",
     deprecation: {},
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.1.0', prs: [55, 127] },
+      { version: "next", prs: [264] },
+      { version: "0.1.0", prs: [55, 127] },
     ],
   },
   [AI_MODEL_ID]: {
-    brief: 'The vendor-specific ID of the model used.',
+    brief: "The vendor-specific ID of the model used.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'gpt-4',
+    example: "gpt-4",
     deprecation: {
-      replacement: 'gen_ai.response.model',
+      replacement: "gen_ai.response.model"
     },
     aliases: [GEN_AI_RESPONSE_MODEL],
-    sdks: ['python'],
-    changelog: [{ version: '0.1.0', prs: [57, 61, 127] }, { version: '0.0.0' }],
+    sdks: ["python"],
+    changelog: [
+      { version: "0.1.0", prs: [57, 61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [AI_MODEL_PROVIDER]: {
-    brief: 'The provider of the model.',
+    brief: "The provider of the model.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'openai',
+    example: "openai",
     deprecation: {
-      replacement: 'gen_ai.provider.name',
+      replacement: "gen_ai.provider.name"
     },
     aliases: [GEN_AI_PROVIDER_NAME, GEN_AI_SYSTEM],
     changelog: [
-      { version: '0.4.0', prs: [253] },
-      { version: '0.1.0', prs: [57, 61, 108, 127] },
+      { version: "0.4.0", prs: [253] },
+      { version: "0.1.0", prs: [57, 61, 108, 127] },
     ],
   },
   [AI_PIPELINE_NAME]: {
-    brief: 'The name of the AI pipeline.',
+    brief: "The name of the AI pipeline.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'Autofix Pipeline',
+    example: "Autofix Pipeline",
     deprecation: {
-      replacement: 'gen_ai.pipeline.name',
+      replacement: "gen_ai.pipeline.name"
     },
     aliases: [GEN_AI_PIPELINE_NAME],
-    changelog: [{ version: '0.1.0', prs: [53, 76, 108, 127] }],
+    changelog: [
+      { version: "0.1.0", prs: [53, 76, 108, 127] },
+    ],
   },
   [AI_PREAMBLE]: {
-    brief:
-      "For an AI model call, the preamble parameter. Preambles are a part of the prompt used to adjust the model's overall behavior and conversation style.",
+    brief: "For an AI model call, the preamble parameter. Preambles are a part of the prompt used to adjust the model's overall behavior and conversation style.",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: 'You are now a clown.',
+    example: "You are now a clown.",
     deprecation: {
-      replacement: 'gen_ai.system_instructions',
+      replacement: "gen_ai.system_instructions"
     },
     aliases: [GEN_AI_SYSTEM_INSTRUCTIONS],
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.1.0', prs: [55] },
+      { version: "next", prs: [264] },
+      { version: "0.1.0", prs: [55] },
     ],
   },
   [AI_PRESENCE_PENALTY]: {
-    brief:
-      'Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.',
+    brief: "Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 0.5,
     deprecation: {
-      replacement: 'gen_ai.request.presence_penalty',
+      replacement: "gen_ai.request.presence_penalty"
     },
     aliases: [GEN_AI_REQUEST_PRESENCE_PENALTY],
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [55, 57, 61, 108] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [55, 57, 61, 108] },
     ],
   },
   [AI_PROMPT_TOKENS_USED]: {
-    brief: 'The number of tokens used to process just the prompt.',
+    brief: "The number of tokens used to process just the prompt.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 20,
     deprecation: {
-      replacement: 'gen_ai.usage.input_tokens',
+      replacement: "gen_ai.usage.input_tokens"
     },
     aliases: [GEN_AI_USAGE_PROMPT_TOKENS, GEN_AI_USAGE_INPUT_TOKENS],
-    sdks: ['python'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [57, 61] }, { version: '0.0.0' }],
+    sdks: ["python"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [57, 61] },
+      { version: "0.0.0" },
+    ],
   },
   [AI_RAW_PROMPTING]: {
-    brief: 'When enabled, the user’s prompt will be sent to the model without any pre-processing.',
+    brief: "When enabled, the user’s prompt will be sent to the model without any pre-processing.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: true,
     deprecation: {},
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.1.0', prs: [55] },
+      { version: "next", prs: [264] },
+      { version: "0.1.0", prs: [55] },
     ],
   },
   [AI_RESPONSES]: {
-    brief: 'The response messages sent back by the AI model.',
+    brief: "The response messages sent back by the AI model.",
     type: 'string[]',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: ['hello', 'world'],
+    example: ["hello","world"],
     deprecation: {
-      replacement: 'gen_ai.response.text',
+      replacement: "gen_ai.response.text"
     },
-    sdks: ['python'],
-    changelog: [{ version: '0.1.0', prs: [65, 127] }, { version: '0.0.0' }],
+    sdks: ["python"],
+    changelog: [
+      { version: "0.1.0", prs: [65, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [AI_RESPONSE_FORMAT]: {
-    brief: 'For an AI model call, the format of the response',
+    brief: "For an AI model call, the format of the response",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'json_object',
+    example: "json_object",
     deprecation: {},
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.1.0', prs: [55, 127] },
+      { version: "next", prs: [264] },
+      { version: "0.1.0", prs: [55, 127] },
     ],
   },
   [AI_SEARCH_QUERIES]: {
-    brief: 'Queries used to search for relevant context or documents.',
+    brief: "Queries used to search for relevant context or documents.",
     type: 'string[]',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: ['climate change effects', 'renewable energy'],
+    example: ["climate change effects","renewable energy"],
     deprecation: {},
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.1.0', prs: [55] },
+      { version: "next", prs: [264] },
+      { version: "0.1.0", prs: [55] },
     ],
   },
   [AI_SEARCH_RESULTS]: {
-    brief: 'Results returned from search queries for context.',
+    brief: "Results returned from search queries for context.",
     type: 'string[]',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: ['search_result_1, search_result_2'],
+    example: ["search_result_1, search_result_2"],
     deprecation: {},
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.1.0', prs: [55] },
+      { version: "next", prs: [264] },
+      { version: "0.1.0", prs: [55] },
     ],
   },
   [AI_SEED]: {
-    brief: 'The seed, ideally models given the same seed and same other parameters will produce the exact same output.',
+    brief: "The seed, ideally models given the same seed and same other parameters will produce the exact same output.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '1234567890',
+    example: "1234567890",
     deprecation: {
-      replacement: 'gen_ai.request.seed',
+      replacement: "gen_ai.request.seed"
     },
     aliases: [GEN_AI_REQUEST_SEED],
-    changelog: [{ version: '0.1.0', prs: [55, 57, 61, 108, 127] }],
+    changelog: [
+      { version: "0.1.0", prs: [55, 57, 61, 108, 127] },
+    ],
   },
   [AI_STREAMING]: {
-    brief: 'Whether the request was streamed back.',
+    brief: "Whether the request was streamed back.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: true,
     deprecation: {
-      replacement: 'gen_ai.response.streaming',
+      replacement: "gen_ai.response.streaming"
     },
     aliases: [GEN_AI_RESPONSE_STREAMING],
-    sdks: ['python'],
-    changelog: [{ version: '0.1.0', prs: [76, 108] }, { version: '0.0.0' }],
+    sdks: ["python"],
+    changelog: [
+      { version: "0.1.0", prs: [76, 108] },
+      { version: "0.0.0" },
+    ],
   },
   [AI_TAGS]: {
-    brief: 'Tags that describe an AI pipeline step.',
+    brief: "Tags that describe an AI pipeline step.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '{"executed_function": "add_integers"}',
+    example: "{\"executed_function\": \"add_integers\"}",
     deprecation: {},
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.1.0', prs: [55, 127] },
+      { version: "next", prs: [264] },
+      { version: "0.1.0", prs: [55, 127] },
     ],
   },
   [AI_TEMPERATURE]: {
-    brief:
-      'For an AI model call, the temperature parameter. Temperature essentially means how random the output will be.',
+    brief: "For an AI model call, the temperature parameter. Temperature essentially means how random the output will be.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 0.1,
     deprecation: {
-      replacement: 'gen_ai.request.temperature',
+      replacement: "gen_ai.request.temperature"
     },
     aliases: [GEN_AI_REQUEST_TEMPERATURE],
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [55, 57, 61, 108] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [55, 57, 61, 108] },
     ],
   },
   [AI_TEXTS]: {
-    brief: 'Raw text inputs provided to the model.',
+    brief: "Raw text inputs provided to the model.",
     type: 'string[]',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: ['Hello, how are you?', 'What is the capital of France?'],
+    example: ["Hello, how are you?","What is the capital of France?"],
     deprecation: {
-      replacement: 'gen_ai.input.messages',
+      replacement: "gen_ai.input.messages"
     },
     aliases: [GEN_AI_INPUT_MESSAGES],
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.1.0', prs: [55] },
+      { version: "next", prs: [264] },
+      { version: "0.1.0", prs: [55] },
     ],
   },
   [AI_TOOLS]: {
-    brief: 'For an AI model call, the functions that are available',
+    brief: "For an AI model call, the functions that are available",
     type: 'string[]',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: ['function_1', 'function_2'],
+    example: ["function_1","function_2"],
     deprecation: {
-      replacement: 'gen_ai.request.available_tools',
+      replacement: "gen_ai.request.available_tools"
     },
-    changelog: [{ version: '0.1.0', prs: [55, 65, 127] }],
+    changelog: [
+      { version: "0.1.0", prs: [55, 65, 127] },
+    ],
   },
   [AI_TOOL_CALLS]: {
-    brief: 'For an AI model call, the tool calls that were made.',
+    brief: "For an AI model call, the tool calls that were made.",
     type: 'string[]',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: ['tool_call_1', 'tool_call_2'],
+    example: ["tool_call_1","tool_call_2"],
     deprecation: {
-      replacement: 'gen_ai.response.tool_calls',
+      replacement: "gen_ai.response.tool_calls"
     },
-    changelog: [{ version: '0.1.0', prs: [55, 65] }],
+    changelog: [
+      { version: "0.1.0", prs: [55, 65] },
+    ],
   },
   [AI_TOP_K]: {
-    brief:
-      'Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).',
+    brief: "Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 35,
     deprecation: {
-      replacement: 'gen_ai.request.top_k',
+      replacement: "gen_ai.request.top_k"
     },
     aliases: [GEN_AI_REQUEST_TOP_K],
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [55, 57, 61, 108] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [55, 57, 61, 108] },
     ],
   },
   [AI_TOP_P]: {
-    brief:
-      'Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).',
+    brief: "Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 0.7,
     deprecation: {
-      replacement: 'gen_ai.request.top_p',
+      replacement: "gen_ai.request.top_p"
     },
     aliases: [GEN_AI_REQUEST_TOP_P],
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [55, 57, 61, 108] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [55, 57, 61, 108] },
     ],
   },
   [AI_TOTAL_COST]: {
-    brief: 'The total cost for the tokens used.',
+    brief: "The total cost for the tokens used.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 12.34,
     deprecation: {
-      replacement: 'gen_ai.cost.total_tokens',
+      replacement: "gen_ai.cost.total_tokens"
     },
     aliases: [GEN_AI_COST_TOTAL_TOKENS],
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [53] },
+      { version: "next", prs: [264] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [53] },
     ],
   },
   [AI_TOTAL_TOKENS_USED]: {
-    brief: 'The total number of tokens used to process the prompt.',
+    brief: "The total number of tokens used to process the prompt.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 30,
     deprecation: {
-      replacement: 'gen_ai.usage.total_tokens',
+      replacement: "gen_ai.usage.total_tokens"
     },
     aliases: [GEN_AI_USAGE_TOTAL_TOKENS],
-    sdks: ['python'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [57, 61, 108] }, { version: '0.0.0' }],
+    sdks: ["python"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [57, 61, 108] },
+      { version: "0.0.0" },
+    ],
   },
   [AI_WARNINGS]: {
-    brief: 'Warning messages generated during model execution.',
+    brief: "Warning messages generated during model execution.",
     type: 'string[]',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: ['Token limit exceeded'],
+    example: ["Token limit exceeded"],
     deprecation: {},
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.1.0', prs: [55] },
+      { version: "next", prs: [264] },
+      { version: "0.1.0", prs: [55] },
     ],
   },
   [APP_BUILD]: {
-    brief: 'Internal build identifier, as it appears on the platform.',
+    brief: "Internal build identifier, as it appears on the platform.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '1',
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
-    changelog: [{ version: 'next', prs: [296], description: 'Added app.build attribute' }],
+    example: "1",
+    sdks: ["sentry.cocoa","sentry.java.android","sentry.javascript.react-native","sentry.dart.flutter"],
+    changelog: [
+      { version: "next", prs: [296], description: "Added app.build attribute" },
+    ],
   },
   [APP_IDENTIFIER]: {
-    brief: 'Version-independent application identifier, often a dotted bundle ID.',
+    brief: "Version-independent application identifier, often a dotted bundle ID.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'com.example.myapp',
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
-    changelog: [{ version: 'next', prs: [296], description: 'Added app.identifier attribute' }],
+    example: "com.example.myapp",
+    sdks: ["sentry.cocoa","sentry.java.android","sentry.javascript.react-native","sentry.dart.flutter"],
+    changelog: [
+      { version: "next", prs: [296], description: "Added app.identifier attribute" },
+    ],
   },
   [APP_IN_FOREGROUND]: {
-    brief: 'Whether the application is currently in the foreground.',
+    brief: "Whether the application is currently in the foreground.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: true,
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
-    changelog: [{ version: 'next', prs: [296], description: 'Added app.in_foreground attribute' }],
+    sdks: ["sentry.cocoa","sentry.java.android","sentry.javascript.react-native","sentry.dart.flutter"],
+    changelog: [
+      { version: "next", prs: [296], description: "Added app.in_foreground attribute" },
+    ],
   },
   [APP_NAME]: {
-    brief: 'Human readable application name, as it appears on the platform.',
+    brief: "Human readable application name, as it appears on the platform.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'My App',
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
-    changelog: [{ version: 'next', prs: [296], description: 'Added app.name attribute' }],
+    example: "My App",
+    sdks: ["sentry.cocoa","sentry.java.android","sentry.javascript.react-native","sentry.dart.flutter"],
+    changelog: [
+      { version: "next", prs: [296], description: "Added app.name attribute" },
+    ],
   },
   [APP_START_TIME]: {
-    brief: 'Formatted UTC timestamp when the user started the application.',
+    brief: "Formatted UTC timestamp when the user started the application.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '2025-01-01T00:00:00.000Z',
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
-    changelog: [{ version: 'next', prs: [296], description: 'Added app.start_time attribute' }],
+    example: "2025-01-01T00:00:00.000Z",
+    sdks: ["sentry.cocoa","sentry.java.android","sentry.javascript.react-native","sentry.dart.flutter"],
+    changelog: [
+      { version: "next", prs: [296], description: "Added app.start_time attribute" },
+    ],
   },
   [APP_START_TYPE]: {
-    brief: 'Mobile app start variant. Either cold or warm.',
+    brief: "Mobile app start variant. Either cold or warm.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'cold',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "cold",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [APP_VERSION]: {
-    brief: 'Human readable application version, as it appears on the platform.',
+    brief: "Human readable application version, as it appears on the platform.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '1.0.0',
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
-    changelog: [{ version: 'next', prs: [296], description: 'Added app.version attribute' }],
+    example: "1.0.0",
+    sdks: ["sentry.cocoa","sentry.java.android","sentry.javascript.react-native","sentry.dart.flutter"],
+    changelog: [
+      { version: "next", prs: [296], description: "Added app.version attribute" },
+    ],
   },
   [BLOCKED_MAIN_THREAD]: {
-    brief: 'Whether the main thread was blocked by the span.',
+    brief: "Whether the main thread was blocked by the span.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: true,
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [BROWSER_NAME]: {
-    brief: 'The name of the browser.',
+    brief: "The name of the browser.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'Chrome',
+    example: "Chrome",
     aliases: [SENTRY_BROWSER_NAME],
-    changelog: [{ version: '0.1.0', prs: [127, 139] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127, 139] },
+      { version: "0.0.0" },
+    ],
   },
   [BROWSER_REPORT_TYPE]: {
-    brief: 'A browser report sent via reporting API..',
+    brief: "A browser report sent via reporting API..",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'network-error',
-    changelog: [{ version: '0.1.0', prs: [68, 127] }],
+    example: "network-error",
+    changelog: [
+      { version: "0.1.0", prs: [68, 127] },
+    ],
   },
   [BROWSER_SCRIPT_INVOKER]: {
-    brief: 'How a script was called in the browser.',
+    brief: "How a script was called in the browser.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'Window.requestAnimationFrame',
-    sdks: ['browser'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "Window.requestAnimationFrame",
+    sdks: ["browser"],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [BROWSER_SCRIPT_INVOKER_TYPE]: {
-    brief: 'Browser script entry point type.',
+    brief: "Browser script entry point type.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'event-listener',
-    sdks: ['browser'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "event-listener",
+    sdks: ["browser"],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [BROWSER_SCRIPT_SOURCE_CHAR_POSITION]: {
-    brief: 'A number representing the script character position of the script.',
+    brief: "A number representing the script character position of the script.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 678,
-    sdks: ['browser'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    sdks: ["browser"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [BROWSER_VERSION]: {
-    brief: 'The version of the browser.',
+    brief: "The version of the browser.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '120.0.6099.130',
+    example: "120.0.6099.130",
     aliases: [SENTRY_BROWSER_VERSION],
-    changelog: [{ version: '0.1.0', prs: [59, 127, 139] }],
+    changelog: [
+      { version: "0.1.0", prs: [59, 127, 139] },
+    ],
   },
   [BROWSER_WEB_VITAL_CLS_SOURCE_KEY]: {
-    brief: 'The HTML elements or components responsible for the layout shift. <key> is a numeric index from 1 to N',
+    brief: "The HTML elements or components responsible for the layout shift. <key> is a numeric index from 1 to N",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     hasDynamicSuffix: true,
-    example: 'body > div#app',
+    example: "body > div#app",
     aliases: [CLS_SOURCE_KEY],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [234] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [234] },
+    ],
   },
   [BROWSER_WEB_VITAL_CLS_VALUE]: {
-    brief: 'The value of the recorded Cumulative Layout Shift (CLS) web vital',
+    brief: "The value of the recorded Cumulative Layout Shift (CLS) web vital",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 0.2361,
     aliases: [CLS],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [229], description: 'Added browser.web_vital.cls.value attribute' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [229], description: "Added browser.web_vital.cls.value attribute" },
+    ],
   },
   [BROWSER_WEB_VITAL_FCP_VALUE]: {
-    brief: 'The time it takes for the browser to render the first piece of meaningful content on the screen',
+    brief: "The time it takes for the browser to render the first piece of meaningful content on the screen",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 547.6951,
     aliases: [FCP],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [235] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [235] },
+    ],
   },
   [BROWSER_WEB_VITAL_FP_VALUE]: {
-    brief: 'The time in milliseconds it takes for the browser to render the first pixel on the screen',
+    brief: "The time in milliseconds it takes for the browser to render the first pixel on the screen",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 477.1926,
     aliases: [FP],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [235] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [235] },
+    ],
   },
   [BROWSER_WEB_VITAL_INP_VALUE]: {
-    brief: 'The value of the recorded Interaction to Next Paint (INP) web vital',
+    brief: "The value of the recorded Interaction to Next Paint (INP) web vital",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 200,
     aliases: [INP],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [229], description: 'Added browser.web_vital.inp.value attribute' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [229], description: "Added browser.web_vital.inp.value attribute" },
+    ],
   },
   [BROWSER_WEB_VITAL_LCP_ELEMENT]: {
-    brief: 'The HTML element selector or component name for which LCP was reported',
+    brief: "The HTML element selector or component name for which LCP was reported",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'body > div#app > div#container > div',
+    example: "body > div#app > div#container > div",
     aliases: [LCP_ELEMENT],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [233] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [233] },
+    ],
   },
   [BROWSER_WEB_VITAL_LCP_ID]: {
-    brief: 'The id of the dom element responsible for the largest contentful paint',
+    brief: "The id of the dom element responsible for the largest contentful paint",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '#gero',
+    example: "#gero",
     aliases: [LCP_ID],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [233] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [233] },
+    ],
   },
   [BROWSER_WEB_VITAL_LCP_LOAD_TIME]: {
-    brief: 'The time it took for the LCP element to be loaded',
+    brief: "The time it took for the LCP element to be loaded",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1402,
     aliases: [LCP_LOADTIME],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [233] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [233] },
+    ],
   },
   [BROWSER_WEB_VITAL_LCP_RENDER_TIME]: {
-    brief: 'The time it took for the LCP element to be rendered',
+    brief: "The time it took for the LCP element to be rendered",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1685,
     aliases: [LCP_RENDERTIME],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [233] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [233] },
+    ],
   },
   [BROWSER_WEB_VITAL_LCP_SIZE]: {
-    brief: 'The size of the largest contentful paint element',
+    brief: "The size of the largest contentful paint element",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1024,
     aliases: [LCP_SIZE],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [233] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [233] },
+    ],
   },
   [BROWSER_WEB_VITAL_LCP_URL]: {
-    brief: 'The url of the dom element responsible for the largest contentful paint',
+    brief: "The url of the dom element responsible for the largest contentful paint",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'https://example.com/static/img.png',
+    example: "https://example.com/static/img.png",
     aliases: [LCP_URL],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [233] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [233] },
+    ],
   },
   [BROWSER_WEB_VITAL_LCP_VALUE]: {
-    brief: 'The value of the recorded Largest Contentful Paint (LCP) web vital',
+    brief: "The value of the recorded Largest Contentful Paint (LCP) web vital",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 2500,
     aliases: [LCP],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [229], description: 'Added browser.web_vital.lcp.value attribute' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [229], description: "Added browser.web_vital.lcp.value attribute" },
+    ],
   },
   [BROWSER_WEB_VITAL_TTFB_REQUEST_TIME]: {
-    brief:
-      "The time it takes for the server to process the initial request and send the first byte of a response to the user's browser",
+    brief: "The time it takes for the server to process the initial request and send the first byte of a response to the user's browser",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1554.5814,
     aliases: [TTFB_REQUESTTIME],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [235] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [235] },
+    ],
   },
   [BROWSER_WEB_VITAL_TTFB_VALUE]: {
-    brief: 'The value of the recorded Time To First Byte (TTFB) web vital in Milliseconds',
+    brief: "The value of the recorded Time To First Byte (TTFB) web vital in Milliseconds",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 194.3322,
     aliases: [TTFB],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [235] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [235] },
+    ],
   },
   [CACHE_HIT]: {
-    brief: 'If the cache was hit during this span.',
+    brief: "If the cache was hit during this span.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: true,
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.0.0' }],
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [CACHE_ITEM_SIZE]: {
-    brief: 'The size of the requested item in the cache. In bytes.',
+    brief: "The size of the requested item in the cache. In bytes.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 58,
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [CACHE_KEY]: {
-    brief: 'The key of the cache accessed.',
+    brief: "The key of the cache accessed.",
     type: 'string[]',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: ['my-cache-key', 'my-other-cache-key'],
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.0.0' }],
+    example: ["my-cache-key","my-other-cache-key"],
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [CACHE_OPERATION]: {
-    brief: 'The operation being performed on the cache.',
+    brief: "The operation being performed on the cache.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'get',
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "get",
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [CACHE_TTL]: {
-    brief: 'The ttl of the cache in seconds',
+    brief: "The ttl of the cache in seconds",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 120,
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [CACHE_WRITE]: {
-    brief: 'If the cache operation resulted in a write to the cache.',
+    brief: "If the cache operation resulted in a write to the cache.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: true,
-    sdks: ['java'],
-    changelog: [{ version: 'next' }],
+    sdks: ["java"],
+    changelog: [
+      { version: "next" },
+    ],
   },
   [CHANNEL]: {
-    brief: 'The channel name that is being used.',
+    brief: "The channel name that is being used.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'mail',
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "mail",
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [CLIENT_ADDRESS]: {
-    brief:
-      'Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
+    brief: "Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: true,
-    example: 'example.com',
+    example: "example.com",
     aliases: [HTTP_CLIENT_IP],
-    changelog: [{ version: '0.1.0', prs: [106, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [106, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [CLIENT_PORT]: {
-    brief: 'Client port number.',
+    brief: "Client port number.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 5432,
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [CLOUDFLARE_D1_DURATION]: {
-    brief: 'The duration of a Cloudflare D1 operation.',
+    brief: "The duration of a Cloudflare D1 operation.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 543,
-    sdks: ['javascript-cloudflare'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    sdks: ["javascript-cloudflare"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [CLOUDFLARE_D1_ROWS_READ]: {
-    brief: 'The number of rows read in a Cloudflare D1 operation.',
+    brief: "The number of rows read in a Cloudflare D1 operation.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 12,
-    sdks: ['javascript-cloudflare'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    sdks: ["javascript-cloudflare"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [CLOUDFLARE_D1_ROWS_WRITTEN]: {
-    brief: 'The number of rows written in a Cloudflare D1 operation.',
+    brief: "The number of rows written in a Cloudflare D1 operation.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 12,
-    sdks: ['javascript-cloudflare'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    sdks: ["javascript-cloudflare"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [CLS]: {
-    brief: 'The value of the recorded Cumulative Layout Shift (CLS) web vital',
+    brief: "The value of the recorded Cumulative Layout Shift (CLS) web vital",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 0.2361,
     deprecation: {
-      replacement: 'browser.web_vital.cls.value',
-      reason: 'The CLS web vital is now recorded as a browser.web_vital.cls.value attribute.',
+      replacement: "browser.web_vital.cls.value",
+      reason: "The CLS web vital is now recorded as a browser.web_vital.cls.value attribute."
     },
     aliases: [BROWSER_WEB_VITAL_CLS_VALUE],
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      {
-        version: 'next',
-        prs: [229],
-        description: "Added and deprecated attribute to document JS SDK's current behaviour",
-      },
+      { version: "next", prs: [229], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
     ],
   },
   [CLS_SOURCE_KEY]: {
-    brief: 'The HTML elements or components responsible for the layout shift. <key> is a numeric index from 1 to N',
+    brief: "The HTML elements or components responsible for the layout shift. <key> is a numeric index from 1 to N",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     hasDynamicSuffix: true,
-    example: 'body > div#app',
+    example: "body > div#app",
     deprecation: {
-      replacement: 'browser.web_vital.cls.source.<key>',
-      reason: 'The CLS source is now recorded as a browser.web_vital.cls.source.<key> attribute.',
+      replacement: "browser.web_vital.cls.source.<key>",
+      reason: "The CLS source is now recorded as a browser.web_vital.cls.source.<key> attribute."
     },
     aliases: [BROWSER_WEB_VITAL_CLS_SOURCE_KEY],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [234] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [234] },
+    ],
   },
   [CODE_FILEPATH]: {
-    brief:
-      'The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).',
+    brief: "The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '/app/myapplication/http/handler/server.py',
+    example: "/app/myapplication/http/handler/server.py",
     deprecation: {
-      replacement: 'code.file.path',
+      replacement: "code.file.path"
     },
     aliases: [CODE_FILE_PATH],
-    changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61] },
+      { version: "0.0.0" },
+    ],
   },
   [CODE_FILE_PATH]: {
-    brief:
-      'The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).',
+    brief: "The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '/app/myapplication/http/handler/server.py',
+    example: "/app/myapplication/http/handler/server.py",
     aliases: [CODE_FILEPATH],
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [CODE_FUNCTION]: {
     brief: "The method or function name, or equivalent (usually rightmost part of the code unit's name).",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'server_request',
+    example: "server_request",
     deprecation: {
-      replacement: 'code.function.name',
+      replacement: "code.function.name"
     },
     aliases: [CODE_FUNCTION_NAME],
-    changelog: [{ version: '0.1.0', prs: [61, 74] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 74] },
+      { version: "0.0.0" },
+    ],
   },
   [CODE_FUNCTION_NAME]: {
     brief: "The method or function name, or equivalent (usually rightmost part of the code unit's name).",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'server_request',
+    example: "server_request",
     aliases: [CODE_FUNCTION],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [CODE_LINENO]: {
-    brief:
-      'The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function',
+    brief: "The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 42,
     deprecation: {
-      replacement: 'code.line.number',
+      replacement: "code.line.number"
     },
     aliases: [CODE_LINE_NUMBER],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61, 108] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [61, 108] },
+      { version: "0.0.0" },
+    ],
   },
   [CODE_LINE_NUMBER]: {
-    brief:
-      'The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function',
+    brief: "The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 42,
     aliases: [CODE_LINENO],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [CODE_NAMESPACE]: {
-    brief:
-      "The 'namespace' within which code.function is defined. Usually the qualified class or module name, such that code.namespace + some separator + code.function form a unique identifier for the code unit.",
+    brief: "The 'namespace' within which code.function is defined. Usually the qualified class or module name, such that code.namespace + some separator + code.function form a unique identifier for the code unit.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'http.handler',
+    example: "http.handler",
     deprecation: {
-      replacement: 'code.function.name',
-      reason: 'code.function.name should include the namespace.',
+      replacement: "code.function.name",
+      reason: "code.function.name should include the namespace."
     },
-    changelog: [{ version: '0.1.0', prs: [61, 74] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 74] },
+      { version: "0.0.0" },
+    ],
   },
   [CONNECTIONTYPE]: {
-    brief: 'Specifies the type of the current connection (e.g. wifi, ethernet, cellular , etc).',
+    brief: "Specifies the type of the current connection (e.g. wifi, ethernet, cellular , etc).",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'wifi',
+    example: "wifi",
     deprecation: {
-      replacement: 'network.connection.type',
-      reason: 'Old namespace-less attribute, to be replaced with network.connection.type for span-first future',
+      replacement: "network.connection.type",
+      reason: "Old namespace-less attribute, to be replaced with network.connection.type for span-first future"
     },
     aliases: [NETWORK_CONNECTION_TYPE],
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      {
-        version: 'next',
-        prs: [279],
-        description: "Added and deprecated attribute to document JS SDK's current behaviour",
-      },
+      { version: "next", prs: [279], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
     ],
   },
   [CONNECTION_RTT]: {
-    brief: 'Specifies the estimated effective round-trip time of the current connection, in milliseconds.',
+    brief: "Specifies the estimated effective round-trip time of the current connection, in milliseconds.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 100,
     deprecation: {
-      replacement: 'network.connection.rtt',
-      reason:
-        'Old attribute name (no official namespace), to be replaced with network.connection.rtt for span-first future',
+      replacement: "network.connection.rtt",
+      reason: "Old attribute name (no official namespace), to be replaced with network.connection.rtt for span-first future"
     },
     aliases: [NETWORK_CONNECTION_RTT],
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      {
-        version: 'next',
-        prs: [279],
-        description: "Added and deprecated attribute to document JS SDK's current behaviour",
-      },
+      { version: "next", prs: [279], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
     ],
   },
   [CULTURE_CALENDAR]: {
-    brief: 'The calendar system used by the culture.',
+    brief: "The calendar system used by the culture.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'GregorianCalendar',
-    changelog: [{ version: '0.4.0', prs: [243] }],
+    example: "GregorianCalendar",
+    changelog: [
+      { version: "0.4.0", prs: [243] },
+    ],
   },
   [CULTURE_DISPLAY_NAME]: {
-    brief: 'Human readable name of the culture.',
+    brief: "Human readable name of the culture.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'English (United States)',
-    changelog: [{ version: '0.4.0', prs: [243] }],
+    example: "English (United States)",
+    changelog: [
+      { version: "0.4.0", prs: [243] },
+    ],
   },
   [CULTURE_IS_24_HOUR_FORMAT]: {
-    brief: 'Whether the culture uses 24-hour time format.',
+    brief: "Whether the culture uses 24-hour time format.",
     type: 'boolean',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: true,
-    changelog: [{ version: '0.4.0', prs: [243] }],
+    changelog: [
+      { version: "0.4.0", prs: [243] },
+    ],
   },
   [CULTURE_LOCALE]: {
-    brief: 'The locale identifier following RFC 4646.',
+    brief: "The locale identifier following RFC 4646.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'en-US',
-    changelog: [{ version: '0.4.0', prs: [243] }],
+    example: "en-US",
+    changelog: [
+      { version: "0.4.0", prs: [243] },
+    ],
   },
   [CULTURE_TIMEZONE]: {
-    brief: 'The timezone of the culture, as a geographic timezone identifier.',
+    brief: "The timezone of the culture, as a geographic timezone identifier.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'Europe/Vienna',
-    changelog: [{ version: '0.4.0', prs: [243] }],
+    example: "Europe/Vienna",
+    changelog: [
+      { version: "0.4.0", prs: [243] },
+    ],
   },
   [DB_COLLECTION_NAME]: {
-    brief: 'The name of a collection (table, container) within the database.',
+    brief: "The name of a collection (table, container) within the database.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'users',
-    changelog: [{ version: '0.1.0', prs: [106, 127] }, { version: '0.0.0' }],
+    example: "users",
+    changelog: [
+      { version: "0.1.0", prs: [106, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [DB_NAME]: {
-    brief: 'The name of the database being accessed.',
+    brief: "The name of the database being accessed.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'customers',
+    example: "customers",
     deprecation: {
-      replacement: 'db.namespace',
+      replacement: "db.namespace"
     },
     aliases: [DB_NAMESPACE],
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [DB_NAMESPACE]: {
-    brief: 'The name of the database being accessed.',
+    brief: "The name of the database being accessed.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'customers',
+    example: "customers",
     aliases: [DB_NAME],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [DB_OPERATION]: {
-    brief: 'The name of the operation being executed.',
+    brief: "The name of the operation being executed.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'SELECT',
+    example: "SELECT",
     deprecation: {
-      replacement: 'db.operation.name',
+      replacement: "db.operation.name"
     },
     aliases: [DB_OPERATION_NAME],
-    changelog: [{ version: '0.4.0', prs: [199] }, { version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [199] },
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [DB_OPERATION_NAME]: {
-    brief: 'The name of the operation being executed.',
+    brief: "The name of the operation being executed.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'SELECT',
+    example: "SELECT",
     aliases: [DB_OPERATION],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [DB_QUERY_PARAMETER_KEY]: {
-    brief:
-      'A query parameter used in db.query.text, with <key> being the parameter name, and the attribute value being a string representation of the parameter value.',
+    brief: "A query parameter used in db.query.text, with <key> being the parameter name, and the attribute value being a string representation of the parameter value.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     hasDynamicSuffix: true,
     example: "db.query.parameter.foo='123'",
-    changelog: [{ version: '0.1.0', prs: [103, 127] }],
+    changelog: [
+      { version: "0.1.0", prs: [103, 127] },
+    ],
   },
   [DB_QUERY_SUMMARY]: {
-    brief:
-      'A shortened representation of operation(s) in the full query. This attribute must be low-cardinality and should only contain the operation table names.',
+    brief: "A shortened representation of operation(s) in the full query. This attribute must be low-cardinality and should only contain the operation table names.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'SELECT users;',
-    changelog: [{ version: '0.4.0', prs: [208] }, { version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "SELECT users;",
+    changelog: [
+      { version: "0.4.0", prs: [208] },
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [DB_QUERY_TEXT]: {
-    brief:
-      'The database parameterized query being executed. Any parameter values (filters, insertion values, etc) should be replaced with parameter placeholders. If applicable, use `db.query.parameter.<key>` to add the parameter value.',
+    brief: "The database parameterized query being executed. Any parameter values (filters, insertion values, etc) should be replaced with parameter placeholders. If applicable, use `db.query.parameter.<key>` to add the parameter value.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'SELECT * FROM users WHERE id = $1',
+    example: "SELECT * FROM users WHERE id = $1",
     aliases: [DB_STATEMENT],
-    changelog: [{ version: '0.4.0', prs: [208] }, { version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [208] },
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [DB_REDIS_CONNECTION]: {
-    brief: 'The redis connection name.',
+    brief: "The redis connection name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'my-redis-instance',
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "my-redis-instance",
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [DB_REDIS_PARAMETERS]: {
-    brief: 'The array of command parameters given to a redis command.',
+    brief: "The array of command parameters given to a redis command.",
     type: 'string[]',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: ['test', '*'],
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.0.0' }],
+    example: ["test","*"],
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [DB_SQL_BINDINGS]: {
-    brief: 'The array of query bindings.',
+    brief: "The array of query bindings.",
     type: 'string[]',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: ['1', 'foo'],
+    example: ["1","foo"],
     deprecation: {
-      replacement: 'db.query.parameter.<key>',
-      reason:
-        'Instead of adding every binding in the db.sql.bindings attribute, add them as individual entires with db.query.parameter.<key>.',
+      replacement: "db.query.parameter.<key>",
+      reason: "Instead of adding every binding in the db.sql.bindings attribute, add them as individual entires with db.query.parameter.<key>."
     },
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.1.0", prs: [61] },
+      { version: "0.0.0" },
+    ],
   },
   [DB_STATEMENT]: {
-    brief: 'The database statement being executed.',
+    brief: "The database statement being executed.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'SELECT * FROM users',
+    example: "SELECT * FROM users",
     deprecation: {
-      replacement: 'db.query.text',
+      replacement: "db.query.text"
     },
     aliases: [DB_QUERY_TEXT],
-    changelog: [{ version: '0.4.0', prs: [199] }, { version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [199] },
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [DB_SYSTEM]: {
-    brief:
-      'An identifier for the database management system (DBMS) product being used. See [OpenTelemetry docs](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#notes-and-well-known-identifiers-for-dbsystem) for a list of well-known identifiers.',
+    brief: "An identifier for the database management system (DBMS) product being used. See [OpenTelemetry docs](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#notes-and-well-known-identifiers-for-dbsystem) for a list of well-known identifiers.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'postgresql',
+    example: "postgresql",
     deprecation: {
-      replacement: 'db.system.name',
+      replacement: "db.system.name"
     },
     aliases: [DB_SYSTEM_NAME],
-    changelog: [{ version: '0.4.0', prs: [199, 224] }, { version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [199, 224] },
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [DB_SYSTEM_NAME]: {
-    brief:
-      'An identifier for the database management system (DBMS) product being used. See [OpenTelemetry docs](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#notes-and-well-known-identifiers-for-dbsystem) for a list of well-known identifiers.',
+    brief: "An identifier for the database management system (DBMS) product being used. See [OpenTelemetry docs](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#notes-and-well-known-identifiers-for-dbsystem) for a list of well-known identifiers.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'postgresql',
+    example: "postgresql",
     aliases: [DB_SYSTEM],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [DB_USER]: {
-    brief: 'The database user.',
+    brief: "The database user.",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: true,
-    example: 'fancy_user',
-    changelog: [{ version: '0.0.0' }],
+    example: "fancy_user",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [DEVICEMEMORY]: {
-    brief: 'The estimated total memory capacity of the device, only a rough estimation in gigabytes.',
+    brief: "The estimated total memory capacity of the device, only a rough estimation in gigabytes.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '8 GB',
+    example: "8 GB",
     deprecation: {
-      replacement: 'device.memory.estimated_capacity',
-      reason:
-        'Old namespace-less attribute, to be replaced with device.memory.estimated_capacity for span-first future',
+      replacement: "device.memory.estimated_capacity",
+      reason: "Old namespace-less attribute, to be replaced with device.memory.estimated_capacity for span-first future"
     },
     aliases: [DEVICE_MEMORY_ESTIMATED_CAPACITY],
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      {
-        version: 'next',
-        prs: [281],
-        description: "Added and deprecated attribute to document JS SDK's current behaviour",
-      },
+      { version: "next", prs: [281], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
     ],
   },
   [DEVICE_BRAND]: {
-    brief: 'The brand of the device.',
+    brief: "The brand of the device.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'Apple',
-    changelog: [{ version: '0.1.0', prs: [116, 127] }],
+    example: "Apple",
+    changelog: [
+      { version: "0.1.0", prs: [116, 127] },
+    ],
   },
   [DEVICE_CLASS]: {
-    brief:
-      'The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.',
+    brief: "The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'medium',
-    changelog: [{ version: 'next', prs: [300], description: 'Added device.class attribute' }],
+    example: "medium",
+    changelog: [
+      { version: "next", prs: [300], description: "Added device.class attribute" },
+    ],
   },
   [DEVICE_FAMILY]: {
-    brief: 'The family of the device.',
+    brief: "The family of the device.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'iPhone',
-    changelog: [{ version: '0.1.0', prs: [116, 127] }],
+    example: "iPhone",
+    changelog: [
+      { version: "0.1.0", prs: [116, 127] },
+    ],
   },
   [DEVICE_FREE_MEMORY]: {
-    brief: 'Free system memory in bytes.',
+    brief: "Free system memory in bytes.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 2147483648,
-    changelog: [{ version: 'next', prs: [300], description: 'Added device.free_memory attribute' }],
+    changelog: [
+      { version: "next", prs: [300], description: "Added device.free_memory attribute" },
+    ],
   },
   [DEVICE_MEMORY_ESTIMATED_CAPACITY]: {
-    brief:
-      'The estimated total memory capacity of the device, only a rough estimation in gigabytes. Browsers report estimations in buckets of powers of 2, mostly capped at 8 GB',
+    brief: "The estimated total memory capacity of the device, only a rough estimation in gigabytes. Browsers report estimations in buckets of powers of 2, mostly capped at 8 GB",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 8,
     aliases: [DEVICEMEMORY],
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      {
-        version: 'next',
-        prs: [281],
-        description: 'Added attribute device.memory.estimated_capacity to be used instead of deviceMemory',
-      },
+      { version: "next", prs: [281], description: "Added attribute device.memory.estimated_capacity to be used instead of deviceMemory" },
     ],
   },
   [DEVICE_MEMORY_SIZE]: {
-    brief: 'Total system memory available in bytes.',
+    brief: "Total system memory available in bytes.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 17179869184,
-    changelog: [{ version: 'next', prs: [300], description: 'Added device.memory_size attribute' }],
+    changelog: [
+      { version: "next", prs: [300], description: "Added device.memory_size attribute" },
+    ],
   },
   [DEVICE_MODEL]: {
-    brief: 'The model of the device.',
+    brief: "The model of the device.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'iPhone 15 Pro Max',
-    changelog: [{ version: '0.1.0', prs: [116, 127] }],
+    example: "iPhone 15 Pro Max",
+    changelog: [
+      { version: "0.1.0", prs: [116, 127] },
+    ],
   },
   [DEVICE_MODEL_ID]: {
-    brief: 'An internal hardware revision to identify the device exactly.',
+    brief: "An internal hardware revision to identify the device exactly.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'N861AP',
-    changelog: [{ version: 'next', prs: [300], description: 'Added device.model_id attribute' }],
+    example: "N861AP",
+    changelog: [
+      { version: "next", prs: [300], description: "Added device.model_id attribute" },
+    ],
   },
   [DEVICE_PROCESSOR_COUNT]: {
-    brief: 'Number of "logical processors".',
+    brief: "Number of \"logical processors\".",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 8,
     aliases: [HARDWARECONCURRENCY],
     changelog: [
-      {
-        version: 'next',
-        prs: [300],
-        description: 'Removed deprecation, device.processor_count is now the canonical attribute',
-      },
-      {
-        version: 'next',
-        prs: [300],
-        description: 'Added and deprecated attribute device.processor_count in favor of device.cpu.logical_core_count',
-      },
+      { version: "next", prs: [300], description: "Removed deprecation, device.processor_count is now the canonical attribute" },
+      { version: "next", prs: [300], description: "Added and deprecated attribute device.processor_count in favor of device.cpu.logical_core_count" },
     ],
   },
   [DEVICE_SIMULATOR]: {
-    brief: 'Whether the device is a simulator or an actual device.',
+    brief: "Whether the device is a simulator or an actual device.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: false,
-    changelog: [{ version: 'next', prs: [300], description: 'Added device.simulator attribute' }],
+    changelog: [
+      { version: "next", prs: [300], description: "Added device.simulator attribute" },
+    ],
   },
   [EFFECTIVECONNECTIONTYPE]: {
-    brief: 'Specifies the estimated effective type of the current connection (e.g. slow-2g, 2g, 3g, 4g).',
+    brief: "Specifies the estimated effective type of the current connection (e.g. slow-2g, 2g, 3g, 4g).",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '4g',
+    example: "4g",
     deprecation: {
-      replacement: 'network.connection.effective_type',
-      reason:
-        'Old namespace-less attribute, to be replaced with network.connection.effective_type for span-first future',
+      replacement: "network.connection.effective_type",
+      reason: "Old namespace-less attribute, to be replaced with network.connection.effective_type for span-first future"
     },
     aliases: [NETWORK_CONNECTION_EFFECTIVE_TYPE],
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      {
-        version: 'next',
-        prs: [279],
-        description: "Added and deprecated attribute to document JS SDK's current behaviour",
-      },
+      { version: "next", prs: [279], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
     ],
   },
   [ENVIRONMENT]: {
-    brief: 'The sentry environment.',
+    brief: "The sentry environment.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'production',
+    example: "production",
     deprecation: {
-      replacement: 'sentry.environment',
+      replacement: "sentry.environment"
     },
     aliases: [SENTRY_ENVIRONMENT],
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [ERROR_TYPE]: {
-    brief: 'Describes a class of error the operation ended with.',
+    brief: "Describes a class of error the operation ended with.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'timeout',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "timeout",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [EVENT_ID]: {
-    brief: 'The unique identifier for this event (log record)',
+    brief: "The unique identifier for this event (log record)",
     type: 'integer',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: 1234567890,
-    changelog: [{ version: '0.1.0', prs: [101] }],
+    changelog: [
+      { version: "0.1.0", prs: [101] },
+    ],
   },
   [EVENT_NAME]: {
-    brief: 'The name that uniquely identifies this event (log record)',
+    brief: "The name that uniquely identifies this event (log record)",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'Process Payload',
-    changelog: [{ version: '0.1.0', prs: [101, 127] }],
+    example: "Process Payload",
+    changelog: [
+      { version: "0.1.0", prs: [101, 127] },
+    ],
   },
   [EXCEPTION_ESCAPED]: {
-    brief:
-      'SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span.',
+    brief: "SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: true,
     example: true,
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [EXCEPTION_MESSAGE]: {
-    brief: 'The error message.',
+    brief: "The error message.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'ENOENT: no such file or directory',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "ENOENT: no such file or directory",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [EXCEPTION_STACKTRACE]: {
-    brief:
-      'A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.',
+    brief: "A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example:
-      'Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "Exception in thread \"main\" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [EXCEPTION_TYPE]: {
-    brief:
-      'The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.',
+    brief: "The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'OSError',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "OSError",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [FAAS_COLDSTART]: {
-    brief: 'A boolean that is true if the serverless function is executed for the first time (aka cold-start).',
+    brief: "A boolean that is true if the serverless function is executed for the first time (aka cold-start).",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: true,
     example: true,
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [FAAS_CRON]: {
-    brief: 'A string containing the schedule period as Cron Expression.',
+    brief: "A string containing the schedule period as Cron Expression.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '0/5 * * * ? *',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "0/5 * * * ? *",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [FAAS_TIME]: {
-    brief: 'A string containing the function invocation time in the ISO 8601 format expressed in UTC.',
+    brief: "A string containing the function invocation time in the ISO 8601 format expressed in UTC.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '2020-01-23T13:47:06Z',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "2020-01-23T13:47:06Z",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [FAAS_TRIGGER]: {
-    brief: 'Type of the trigger which caused this function invocation.',
+    brief: "Type of the trigger which caused this function invocation.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'timer',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "timer",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [FCP]: {
-    brief: 'The time it takes for the browser to render the first piece of meaningful content on the screen',
+    brief: "The time it takes for the browser to render the first piece of meaningful content on the screen",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 547.6951,
     deprecation: {
-      replacement: 'browser.web_vital.fcp.value',
-      reason: 'This attribute is being deprecated in favor of browser.web_vital.fcp.value',
+      replacement: "browser.web_vital.fcp.value",
+      reason: "This attribute is being deprecated in favor of browser.web_vital.fcp.value"
     },
     aliases: [BROWSER_WEB_VITAL_FCP_VALUE],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [235] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [235] },
+    ],
   },
   [FLAG_EVALUATION_KEY]: {
-    brief:
-      'An instance of a feature flag evaluation. The value of this attribute is the boolean representing the evaluation result. The <key> suffix is the name of the feature flag.',
+    brief: "An instance of a feature flag evaluation. The value of this attribute is the boolean representing the evaluation result. The <key> suffix is the name of the feature flag.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     hasDynamicSuffix: true,
-    example: 'flag.evaluation.is_new_ui=true',
-    changelog: [{ version: '0.1.0', prs: [103] }],
+    example: "flag.evaluation.is_new_ui=true",
+    changelog: [
+      { version: "0.1.0", prs: [103] },
+    ],
   },
   [FP]: {
-    brief: 'The time it takes for the browser to render the first pixel on the screen',
+    brief: "The time it takes for the browser to render the first pixel on the screen",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 477.1926,
     deprecation: {
-      replacement: 'browser.web_vital.fp.value',
-      reason: 'This attribute is being deprecated in favor of browser.web_vital.fp.value',
+      replacement: "browser.web_vital.fp.value",
+      reason: "This attribute is being deprecated in favor of browser.web_vital.fp.value"
     },
     aliases: [BROWSER_WEB_VITAL_FP_VALUE],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [235] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [235] },
+    ],
   },
   [FRAMES_DELAY]: {
-    brief:
-      'The sum of all delayed frame durations in seconds during the lifetime of the span. For more information see [frames delay](https://develop.sentry.dev/sdk/performance/frames-delay/).',
+    brief: "The sum of all delayed frame durations in seconds during the lifetime of the span. For more information see [frames delay](https://develop.sentry.dev/sdk/performance/frames-delay/).",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 5,
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [FRAMES_FROZEN]: {
-    brief: 'The number of frozen frames rendered during the lifetime of the span.',
+    brief: "The number of frozen frames rendered during the lifetime of the span.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 3,
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [FRAMES_SLOW]: {
-    brief: 'The number of slow frames rendered during the lifetime of the span.',
+    brief: "The number of slow frames rendered during the lifetime of the span.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1,
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [FRAMES_TOTAL]: {
-    brief: 'The number of total frames rendered during the lifetime of the span.',
+    brief: "The number of total frames rendered during the lifetime of the span.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 60,
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [FS_ERROR]: {
-    brief: 'The error message of a file system error.',
+    brief: "The error message of a file system error.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'ENOENT: no such file or directory',
+    example: "ENOENT: no such file or directory",
     deprecation: {
-      replacement: 'error.type',
-      reason: 'This attribute is not part of the OpenTelemetry specification and error.type fits much better.',
+      replacement: "error.type",
+      reason: "This attribute is not part of the OpenTelemetry specification and error.type fits much better."
     },
-    sdks: ['javascript-node'],
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    sdks: ["javascript-node"],
+    changelog: [
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [GEN_AI_AGENT_NAME]: {
-    brief: 'The name of the agent being used.',
+    brief: "The name of the agent being used.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'ResearchAssistant',
-    changelog: [{ version: '0.1.0', prs: [62, 127] }],
+    example: "ResearchAssistant",
+    changelog: [
+      { version: "0.1.0", prs: [62, 127] },
+    ],
   },
   [GEN_AI_CONVERSATION_ID]: {
-    brief:
-      'The unique identifier for a conversation (session, thread), used to store and correlate messages within this conversation.',
+    brief: "The unique identifier for a conversation (session, thread), used to store and correlate messages within this conversation.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'conv_5j66UpCpwteGg4YSxUnt7lPY',
-    changelog: [{ version: '0.4.0', prs: [250] }],
+    example: "conv_5j66UpCpwteGg4YSxUnt7lPY",
+    changelog: [
+      { version: "0.4.0", prs: [250] },
+    ],
   },
   [GEN_AI_COST_INPUT_TOKENS]: {
-    brief: 'The cost of tokens used to process the AI input (prompt) in USD (without cached input tokens).',
+    brief: "The cost of tokens used to process the AI input (prompt) in USD (without cached input tokens).",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 123.45,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [112] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [112] },
     ],
   },
   [GEN_AI_COST_OUTPUT_TOKENS]: {
-    brief: 'The cost of tokens used for creating the AI output in USD (without reasoning tokens).',
+    brief: "The cost of tokens used for creating the AI output in USD (without reasoning tokens).",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 123.45,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [112] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [112] },
     ],
   },
   [GEN_AI_COST_TOTAL_TOKENS]: {
-    brief: 'The total cost for the tokens used.',
+    brief: "The total cost for the tokens used.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 12.34,
     aliases: [AI_TOTAL_COST],
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [126] },
+      { version: "next", prs: [264] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [126] },
     ],
   },
   [GEN_AI_EMBEDDINGS_INPUT]: {
-    brief: 'The input to the embeddings model.',
+    brief: "The input to the embeddings model.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: "What's the weather in Paris?",
-    changelog: [{ version: '0.3.1', prs: [195] }],
+    changelog: [
+      { version: "0.3.1", prs: [195] },
+    ],
   },
   [GEN_AI_INPUT_MESSAGES]: {
-    brief:
-      'The messages passed to the model. It has to be a stringified version of an array of objects. The `role` attribute of each object must be `"user"`, `"assistant"`, `"tool"`, or `"system"`. For messages of the role `"tool"`, the `content` can be a string or an arbitrary object with information about the tool call. For other messages the `content` can be either a string or a list of objects in the format `{type: "text", text:"..."}`.',
+    brief: "The messages passed to the model. It has to be a stringified version of an array of objects. The `role` attribute of each object must be `\"user\"`, `\"assistant\"`, `\"tool\"`, or `\"system\"`. For messages of the role `\"tool\"`, the `content` can be a string or an arbitrary object with information about the tool call. For other messages the `content` can be either a string or a list of objects in the format `{type: \"text\", text:\"...\"}`.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example:
-      '[{"role": "user", "parts": [{"type": "text", "content": "Weather in Paris?"}]}, {"role": "assistant", "parts": [{"type": "tool_call", "id": "call_VSPygqKTWdrhaFErNvMV18Yl", "name": "get_weather", "arguments": {"location": "Paris"}}]}, {"role": "tool", "parts": [{"type": "tool_call_response", "id": "call_VSPygqKTWdrhaFErNvMV18Yl", "result": "rainy, 57°F"}]}]',
+    example: "[{\"role\": \"user\", \"parts\": [{\"type\": \"text\", \"content\": \"Weather in Paris?\"}]}, {\"role\": \"assistant\", \"parts\": [{\"type\": \"tool_call\", \"id\": \"call_VSPygqKTWdrhaFErNvMV18Yl\", \"name\": \"get_weather\", \"arguments\": {\"location\": \"Paris\"}}]}, {\"role\": \"tool\", \"parts\": [{\"type\": \"tool_call_response\", \"id\": \"call_VSPygqKTWdrhaFErNvMV18Yl\", \"result\": \"rainy, 57°F\"}]}]",
     aliases: [AI_TEXTS],
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.4.0', prs: [221] },
+      { version: "next", prs: [264] },
+      { version: "0.4.0", prs: [221] },
     ],
   },
   [GEN_AI_OPERATION_NAME]: {
-    brief:
-      "The name of the operation being performed. It has the following list of well-known values: 'chat', 'create_agent', 'embeddings', 'execute_tool', 'generate_content', 'invoke_agent', 'text_completion'. If one of them applies, then that value MUST be used. Otherwise a custom value MAY be used.",
+    brief: "The name of the operation being performed. It has the following list of well-known values: 'chat', 'create_agent', 'embeddings', 'execute_tool', 'generate_content', 'invoke_agent', 'text_completion'. If one of them applies, then that value MUST be used. Otherwise a custom value MAY be used.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'chat',
+    example: "chat",
     changelog: [
-      { version: '0.4.0', prs: [225] },
-      { version: '0.1.0', prs: [62, 127] },
+      { version: "0.4.0", prs: [225] },
+      { version: "0.1.0", prs: [62, 127] },
     ],
   },
   [GEN_AI_OPERATION_TYPE]: {
-    brief:
-      "The type of AI operation. Must be one of 'agent' (invoke_agent and create_agent spans), 'ai_client' (any LLM call), 'tool' (execute_tool spans), 'handoff' (handoff spans), 'other' (input and output processors, skill loading, guardrails etc.) . Added during ingestion based on span.op and gen_ai.operation.type. Used to filter and aggregate data in the UI",
+    brief: "The type of AI operation. Must be one of 'agent' (invoke_agent and create_agent spans), 'ai_client' (any LLM call), 'tool' (execute_tool spans), 'handoff' (handoff spans), 'other' (input and output processors, skill loading, guardrails etc.) . Added during ingestion based on span.op and gen_ai.operation.type. Used to filter and aggregate data in the UI",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'tool',
+    example: "tool",
     changelog: [
-      { version: '0.4.0', prs: [257] },
-      { version: '0.1.0', prs: [113, 127] },
+      { version: "0.4.0", prs: [257] },
+      { version: "0.1.0", prs: [113, 127] },
     ],
   },
   [GEN_AI_OUTPUT_MESSAGES]: {
-    brief:
-      "The model's response messages. It has to be a stringified version of an array of message objects, which can include text responses and tool calls.",
+    brief: "The model's response messages. It has to be a stringified version of an array of message objects, which can include text responses and tool calls.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example:
-      '[{"role": "assistant", "parts": [{"type": "text", "content": "The weather in Paris is currently rainy with a temperature of 57°F."}], "finish_reason": "stop"}]',
-    changelog: [{ version: '0.4.0', prs: [221] }],
+    example: "[{\"role\": \"assistant\", \"parts\": [{\"type\": \"text\", \"content\": \"The weather in Paris is currently rainy with a temperature of 57°F.\"}], \"finish_reason\": \"stop\"}]",
+    changelog: [
+      { version: "0.4.0", prs: [221] },
+    ],
   },
   [GEN_AI_PIPELINE_NAME]: {
-    brief: 'Name of the AI pipeline or chain being executed.',
+    brief: "Name of the AI pipeline or chain being executed.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'Autofix Pipeline',
+    example: "Autofix Pipeline",
     aliases: [AI_PIPELINE_NAME],
-    changelog: [{ version: '0.1.0', prs: [76, 127] }],
+    changelog: [
+      { version: "0.1.0", prs: [76, 127] },
+    ],
   },
   [GEN_AI_PROMPT]: {
-    brief: 'The input messages sent to the model',
+    brief: "The input messages sent to the model",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '[{"role": "user", "message": "hello"}]',
+    example: "[{\"role\": \"user\", \"message\": \"hello\"}]",
     deprecation: {
-      reason: 'Deprecated from OTEL, use gen_ai.input.messages with the new format instead.',
-    },
-    changelog: [{ version: '0.1.0', prs: [74, 108, 119] }, { version: '0.0.0' }],
-  },
-  [GEN_AI_PROVIDER_NAME]: {
-    brief: 'The Generative AI provider as identified by the client or server instrumentation.',
-    type: 'string',
-    pii: {
-      isPii: 'maybe',
-    },
-    isInOtel: true,
-    example: 'openai',
-    aliases: [AI_MODEL_PROVIDER, GEN_AI_SYSTEM],
-    changelog: [{ version: '0.4.0', prs: [253] }],
-  },
-  [GEN_AI_REQUEST_AVAILABLE_TOOLS]: {
-    brief: 'The available tools for the model. It has to be a stringified version of an array of objects.',
-    type: 'string',
-    pii: {
-      isPii: 'maybe',
-    },
-    isInOtel: false,
-    example:
-      '[{"name": "get_weather", "description": "Get the weather for a given location"}, {"name": "get_news", "description": "Get the news for a given topic"}]',
-    deprecation: {
-      replacement: 'gen_ai.tool.definitions',
+      reason: "Deprecated from OTEL, use gen_ai.input.messages with the new format instead."
     },
     changelog: [
-      { version: '0.4.0', prs: [221] },
-      { version: '0.1.0', prs: [63, 127] },
+      { version: "0.1.0", prs: [74, 108, 119] },
+      { version: "0.0.0" },
+    ],
+  },
+  [GEN_AI_PROVIDER_NAME]: {
+    brief: "The Generative AI provider as identified by the client or server instrumentation.",
+    type: 'string',
+    pii: {
+      isPii: 'maybe'
+    },
+    isInOtel: true,
+    example: "openai",
+    aliases: [AI_MODEL_PROVIDER, GEN_AI_SYSTEM],
+    changelog: [
+      { version: "0.4.0", prs: [253] },
+    ],
+  },
+  [GEN_AI_REQUEST_AVAILABLE_TOOLS]: {
+    brief: "The available tools for the model. It has to be a stringified version of an array of objects.",
+    type: 'string',
+    pii: {
+      isPii: 'maybe'
+    },
+    isInOtel: false,
+    example: "[{\"name\": \"get_weather\", \"description\": \"Get the weather for a given location\"}, {\"name\": \"get_news\", \"description\": \"Get the news for a given topic\"}]",
+    deprecation: {
+      replacement: "gen_ai.tool.definitions"
+    },
+    changelog: [
+      { version: "0.4.0", prs: [221] },
+      { version: "0.1.0", prs: [63, 127] },
     ],
   },
   [GEN_AI_REQUEST_FREQUENCY_PENALTY]: {
-    brief:
-      'Used to reduce repetitiveness of generated tokens. The higher the value, the stronger a penalty is applied to previously present tokens, proportional to how many times they have already appeared in the prompt or prior generation.',
+    brief: "Used to reduce repetitiveness of generated tokens. The higher the value, the stronger a penalty is applied to previously present tokens, proportional to how many times they have already appeared in the prompt or prior generation.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 0.5,
     aliases: [AI_FREQUENCY_PENALTY],
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [57] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [57] },
     ],
   },
   [GEN_AI_REQUEST_MAX_TOKENS]: {
-    brief: 'The maximum number of tokens to generate in the response.',
+    brief: "The maximum number of tokens to generate in the response.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 2048,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [62] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [62] },
     ],
   },
   [GEN_AI_REQUEST_MESSAGES]: {
-    brief:
-      'The messages passed to the model. It has to be a stringified version of an array of objects. The `role` attribute of each object must be `"user"`, `"assistant"`, `"tool"`, or `"system"`. For messages of the role `"tool"`, the `content` can be a string or an arbitrary object with information about the tool call. For other messages the `content` can be either a string or a list of objects in the format `{type: "text", text:"..."}`.',
+    brief: "The messages passed to the model. It has to be a stringified version of an array of objects. The `role` attribute of each object must be `\"user\"`, `\"assistant\"`, `\"tool\"`, or `\"system\"`. For messages of the role `\"tool\"`, the `content` can be a string or an arbitrary object with information about the tool call. For other messages the `content` can be either a string or a list of objects in the format `{type: \"text\", text:\"...\"}`.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example:
-      '[{"role": "system", "content": "Generate a random number."}, {"role": "user", "content": [{"text": "Generate a random number between 0 and 10.", "type": "text"}]}, {"role": "tool", "content": {"toolCallId": "1", "toolName": "Weather", "output": "rainy"}}]',
+    example: "[{\"role\": \"system\", \"content\": \"Generate a random number.\"}, {\"role\": \"user\", \"content\": [{\"text\": \"Generate a random number between 0 and 10.\", \"type\": \"text\"}]}, {\"role\": \"tool\", \"content\": {\"toolCallId\": \"1\", \"toolName\": \"Weather\", \"output\": \"rainy\"}}]",
     deprecation: {
-      replacement: 'gen_ai.input.messages',
+      replacement: "gen_ai.input.messages"
     },
     aliases: [AI_INPUT_MESSAGES],
     changelog: [
-      { version: '0.4.0', prs: [221] },
-      { version: '0.1.0', prs: [63, 74, 108, 119, 122] },
+      { version: "0.4.0", prs: [221] },
+      { version: "0.1.0", prs: [63, 74, 108, 119, 122] },
     ],
   },
   [GEN_AI_REQUEST_MODEL]: {
-    brief: 'The model identifier being used for the request.',
+    brief: "The model identifier being used for the request.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'gpt-4-turbo-preview',
-    changelog: [{ version: '0.1.0', prs: [62, 127] }],
+    example: "gpt-4-turbo-preview",
+    changelog: [
+      { version: "0.1.0", prs: [62, 127] },
+    ],
   },
   [GEN_AI_REQUEST_PRESENCE_PENALTY]: {
-    brief:
-      'Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.',
+    brief: "Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 0.5,
     aliases: [AI_PRESENCE_PENALTY],
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [57] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [57] },
     ],
   },
   [GEN_AI_REQUEST_SEED]: {
-    brief: 'The seed, ideally models given the same seed and same other parameters will produce the exact same output.',
+    brief: "The seed, ideally models given the same seed and same other parameters will produce the exact same output.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '1234567890',
+    example: "1234567890",
     aliases: [AI_SEED],
-    changelog: [{ version: '0.1.0', prs: [57, 127] }],
+    changelog: [
+      { version: "0.1.0", prs: [57, 127] },
+    ],
   },
   [GEN_AI_REQUEST_TEMPERATURE]: {
-    brief:
-      'For an AI model call, the temperature parameter. Temperature essentially means how random the output will be.',
+    brief: "For an AI model call, the temperature parameter. Temperature essentially means how random the output will be.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 0.1,
     aliases: [AI_TEMPERATURE],
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [57] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [57] },
     ],
   },
   [GEN_AI_REQUEST_TOP_K]: {
-    brief:
-      'Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).',
+    brief: "Limits the model to only consider the K most likely next tokens, where K is an integer (e.g., top_k=20 means only the 20 highest probability tokens are considered).",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 35,
     aliases: [AI_TOP_K],
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [57] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [57] },
     ],
   },
   [GEN_AI_REQUEST_TOP_P]: {
-    brief:
-      'Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).',
+    brief: "Limits the model to only consider tokens whose cumulative probability mass adds up to p, where p is a float between 0 and 1 (e.g., top_p=0.7 means only tokens that sum up to 70% of the probability mass are considered).",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 0.7,
     aliases: [AI_TOP_P],
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [57] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [57] },
     ],
   },
   [GEN_AI_RESPONSE_FINISH_REASONS]: {
-    brief: 'The reason why the model stopped generating.',
+    brief: "The reason why the model stopped generating.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'COMPLETE',
+    example: "COMPLETE",
     aliases: [AI_FINISH_REASON],
-    changelog: [{ version: '0.1.0', prs: [57, 127] }],
+    changelog: [
+      { version: "0.1.0", prs: [57, 127] },
+    ],
   },
   [GEN_AI_RESPONSE_ID]: {
-    brief: 'Unique identifier for the completion.',
+    brief: "Unique identifier for the completion.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'gen_123abc',
+    example: "gen_123abc",
     aliases: [AI_GENERATION_ID],
-    changelog: [{ version: '0.1.0', prs: [57, 127] }],
+    changelog: [
+      { version: "0.1.0", prs: [57, 127] },
+    ],
   },
   [GEN_AI_RESPONSE_MODEL]: {
-    brief: 'The vendor-specific ID of the model used.',
+    brief: "The vendor-specific ID of the model used.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'gpt-4',
+    example: "gpt-4",
     aliases: [AI_MODEL_ID],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [GEN_AI_RESPONSE_STREAMING]: {
     brief: "Whether or not the AI model call's response was streamed back asynchronously",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: true,
     aliases: [AI_STREAMING],
-    changelog: [{ version: '0.1.0', prs: [76] }],
+    changelog: [
+      { version: "0.1.0", prs: [76] },
+    ],
   },
   [GEN_AI_RESPONSE_TEXT]: {
-    brief:
-      "The model's response text messages. It has to be a stringified version of an array of response text messages.",
+    brief: "The model's response text messages. It has to be a stringified version of an array of response text messages.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example:
-      '["The weather in Paris is rainy and overcast, with temperatures around 57°F", "The weather in London is sunny and warm, with temperatures around 65°F"]',
+    example: "[\"The weather in Paris is rainy and overcast, with temperatures around 57°F\", \"The weather in London is sunny and warm, with temperatures around 65°F\"]",
     deprecation: {
-      replacement: 'gen_ai.output.messages',
+      replacement: "gen_ai.output.messages"
     },
     changelog: [
-      { version: '0.4.0', prs: [221] },
-      { version: '0.1.0', prs: [63, 74] },
+      { version: "0.4.0", prs: [221] },
+      { version: "0.1.0", prs: [63, 74] },
     ],
   },
   [GEN_AI_RESPONSE_TIME_TO_FIRST_TOKEN]: {
-    brief: 'Time in seconds when the first response content chunk arrived in streaming responses.',
+    brief: "Time in seconds when the first response content chunk arrived in streaming responses.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 0.6853435,
-    changelog: [{ version: '0.4.0', prs: [227] }],
+    changelog: [
+      { version: "0.4.0", prs: [227] },
+    ],
   },
   [GEN_AI_RESPONSE_TOKENS_PER_SECOND]: {
-    brief: 'The total output tokens per seconds throughput',
+    brief: "The total output tokens per seconds throughput",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 12345.67,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [66] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [66] },
     ],
   },
   [GEN_AI_RESPONSE_TOOL_CALLS]: {
     brief: "The tool calls in the model's response. It has to be a stringified version of an array of objects.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '[{"name": "get_weather", "arguments": {"location": "Paris"}}]',
+    example: "[{\"name\": \"get_weather\", \"arguments\": {\"location\": \"Paris\"}}]",
     deprecation: {
-      replacement: 'gen_ai.output.messages',
+      replacement: "gen_ai.output.messages"
     },
     changelog: [
-      { version: '0.4.0', prs: [221] },
-      { version: '0.1.0', prs: [63, 74] },
+      { version: "0.4.0", prs: [221] },
+      { version: "0.1.0", prs: [63, 74] },
     ],
   },
   [GEN_AI_SYSTEM]: {
-    brief: 'The provider of the model.',
+    brief: "The provider of the model.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'openai',
+    example: "openai",
     deprecation: {
-      replacement: 'gen_ai.provider.name',
+      replacement: "gen_ai.provider.name"
     },
     aliases: [AI_MODEL_PROVIDER, GEN_AI_PROVIDER_NAME],
     changelog: [
-      { version: '0.4.0', prs: [253] },
-      { version: '0.1.0', prs: [57, 127] },
+      { version: "0.4.0", prs: [253] },
+      { version: "0.1.0", prs: [57, 127] },
     ],
   },
   [GEN_AI_SYSTEM_INSTRUCTIONS]: {
-    brief: 'The system instructions passed to the model.',
+    brief: "The system instructions passed to the model.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'You are a helpful assistant',
+    example: "You are a helpful assistant",
     aliases: [AI_PREAMBLE],
     changelog: [
-      { version: 'next', prs: [264] },
-      { version: '0.4.0', prs: [221] },
+      { version: "next", prs: [264] },
+      { version: "0.4.0", prs: [221] },
     ],
   },
   [GEN_AI_SYSTEM_MESSAGE]: {
-    brief: 'The system instructions passed to the model.',
+    brief: "The system instructions passed to the model.",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: 'You are a helpful assistant',
+    example: "You are a helpful assistant",
     deprecation: {
-      replacement: 'gen_ai.system_instructions',
+      replacement: "gen_ai.system_instructions"
     },
     changelog: [
-      { version: '0.4.0', prs: [221] },
-      { version: '0.1.0', prs: [62] },
+      { version: "0.4.0", prs: [221] },
+      { version: "0.1.0", prs: [62] },
     ],
   },
   [GEN_AI_TOOL_CALL_ARGUMENTS]: {
-    brief: 'The arguments of the tool call. It has to be a stringified version of the arguments to the tool.',
+    brief: "The arguments of the tool call. It has to be a stringified version of the arguments to the tool.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '{"location": "Paris"}',
+    example: "{\"location\": \"Paris\"}",
     aliases: [GEN_AI_TOOL_INPUT],
     changelog: [
-      { version: 'next', prs: [265] },
-      { version: '0.4.0', prs: [221] },
+      { version: "next", prs: [265] },
+      { version: "0.4.0", prs: [221] },
     ],
   },
   [GEN_AI_TOOL_CALL_RESULT]: {
-    brief: 'The result of the tool call. It has to be a stringified version of the result of the tool.',
+    brief: "The result of the tool call. It has to be a stringified version of the result of the tool.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'rainy, 57°F',
+    example: "rainy, 57°F",
     aliases: [GEN_AI_TOOL_OUTPUT, GEN_AI_TOOL_MESSAGE],
     changelog: [
-      { version: 'next', prs: [265] },
-      { version: '0.4.0', prs: [221] },
+      { version: "next", prs: [265] },
+      { version: "0.4.0", prs: [221] },
     ],
   },
   [GEN_AI_TOOL_DEFINITIONS]: {
-    brief: 'The list of source system tool definitions available to the GenAI agent or model.',
+    brief: "The list of source system tool definitions available to the GenAI agent or model.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example:
-      '[{"type": "function", "name": "get_current_weather", "description": "Get the current weather in a given location", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "The city and state, e.g. San Francisco, CA"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]}}]',
-    changelog: [{ version: '0.4.0', prs: [221] }],
+    example: "[{\"type\": \"function\", \"name\": \"get_current_weather\", \"description\": \"Get the current weather in a given location\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\", \"description\": \"The city and state, e.g. San Francisco, CA\"}, \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]}}, \"required\": [\"location\", \"unit\"]}}]",
+    changelog: [
+      { version: "0.4.0", prs: [221] },
+    ],
   },
   [GEN_AI_TOOL_DESCRIPTION]: {
-    brief: 'The description of the tool being used.',
+    brief: "The description of the tool being used.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'Searches the web for current information about a topic',
-    changelog: [{ version: '0.1.0', prs: [62, 127] }],
+    example: "Searches the web for current information about a topic",
+    changelog: [
+      { version: "0.1.0", prs: [62, 127] },
+    ],
   },
   [GEN_AI_TOOL_INPUT]: {
-    brief: 'The input of the tool being used. It has to be a stringified version of the input to the tool.',
+    brief: "The input of the tool being used. It has to be a stringified version of the input to the tool.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '{"location": "Paris"}',
+    example: "{\"location\": \"Paris\"}",
     deprecation: {
-      replacement: 'gen_ai.tool.call.arguments',
+      replacement: "gen_ai.tool.call.arguments"
     },
     aliases: [GEN_AI_TOOL_CALL_ARGUMENTS],
     changelog: [
-      { version: 'next', prs: [265] },
-      { version: '0.1.0', prs: [63, 74] },
+      { version: "next", prs: [265] },
+      { version: "0.1.0", prs: [63, 74] },
     ],
   },
   [GEN_AI_TOOL_MESSAGE]: {
-    brief: 'The response from a tool or function call passed to the model.',
+    brief: "The response from a tool or function call passed to the model.",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: 'rainy, 57°F',
+    example: "rainy, 57°F",
     deprecation: {
-      replacement: 'gen_ai.tool.call.result',
+      replacement: "gen_ai.tool.call.result"
     },
     aliases: [GEN_AI_TOOL_CALL_RESULT, GEN_AI_TOOL_OUTPUT],
     changelog: [
-      { version: 'next', prs: [265] },
-      { version: '0.1.0', prs: [62] },
+      { version: "next", prs: [265] },
+      { version: "0.1.0", prs: [62] },
     ],
   },
   [GEN_AI_TOOL_NAME]: {
-    brief: 'Name of the tool utilized by the agent.',
+    brief: "Name of the tool utilized by the agent.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'Flights',
+    example: "Flights",
     aliases: [AI_FUNCTION_CALL],
-    changelog: [{ version: '0.1.0', prs: [57, 127] }],
+    changelog: [
+      { version: "0.1.0", prs: [57, 127] },
+    ],
   },
   [GEN_AI_TOOL_OUTPUT]: {
-    brief: 'The output of the tool being used. It has to be a stringified version of the output of the tool.',
+    brief: "The output of the tool being used. It has to be a stringified version of the output of the tool.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'rainy, 57°F',
+    example: "rainy, 57°F",
     deprecation: {
-      replacement: 'gen_ai.tool.call.result',
+      replacement: "gen_ai.tool.call.result"
     },
     aliases: [GEN_AI_TOOL_CALL_RESULT, GEN_AI_TOOL_MESSAGE],
     changelog: [
-      { version: 'next', prs: [265] },
-      { version: '0.1.0', prs: [63, 74] },
+      { version: "next", prs: [265] },
+      { version: "0.1.0", prs: [63, 74] },
     ],
   },
   [GEN_AI_TOOL_TYPE]: {
-    brief: 'The type of tool being used.',
+    brief: "The type of tool being used.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'function',
-    changelog: [{ version: '0.1.0', prs: [62, 127] }],
+    example: "function",
+    deprecation: {
+      reason: "The gen_ai.tool.type attribute is deprecated and should no longer be set."
+    },
+    changelog: [
+      { version: "0.1.0", prs: [62, 127] },
+    ],
   },
   [GEN_AI_USAGE_COMPLETION_TOKENS]: {
-    brief: 'The number of tokens used in the GenAI response (completion).',
+    brief: "The number of tokens used in the GenAI response (completion).",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 10,
     deprecation: {
-      replacement: 'gen_ai.usage.output_tokens',
+      replacement: "gen_ai.usage.output_tokens"
     },
     aliases: [AI_COMPLETION_TOKENS_USED, GEN_AI_USAGE_OUTPUT_TOKENS],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [61] },
+      { version: "0.0.0" },
+    ],
   },
   [GEN_AI_USAGE_INPUT_TOKENS]: {
-    brief: 'The number of tokens used to process the AI input (prompt) including cached input tokens.',
+    brief: "The number of tokens used to process the AI input (prompt) including cached input tokens.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 10,
     aliases: [AI_PROMPT_TOKENS_USED, GEN_AI_USAGE_PROMPT_TOKENS],
     changelog: [
-      { version: 'next', prs: [261] },
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [112] },
-      { version: '0.0.0' },
+      { version: "next", prs: [261] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [112] },
+      { version: "0.0.0" },
     ],
   },
   [GEN_AI_USAGE_INPUT_TOKENS_CACHED]: {
-    brief: 'The number of cached tokens used to process the AI input (prompt).',
+    brief: "The number of cached tokens used to process the AI input (prompt).",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 50,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [62, 112] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [62, 112] },
     ],
   },
   [GEN_AI_USAGE_INPUT_TOKENS_CACHE_WRITE]: {
-    brief: 'The number of tokens written to the cache when processing the AI input (prompt).',
+    brief: "The number of tokens written to the cache when processing the AI input (prompt).",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 100,
-    changelog: [{ version: '0.4.0', prs: [217, 228] }],
+    changelog: [
+      { version: "0.4.0", prs: [217, 228] },
+    ],
   },
   [GEN_AI_USAGE_OUTPUT_TOKENS]: {
-    brief: 'The number of tokens used for creating the AI output (including reasoning tokens).',
+    brief: "The number of tokens used for creating the AI output (including reasoning tokens).",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 10,
     aliases: [AI_COMPLETION_TOKENS_USED, GEN_AI_USAGE_COMPLETION_TOKENS],
     changelog: [
-      { version: 'next', prs: [261] },
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [112] },
-      { version: '0.0.0' },
+      { version: "next", prs: [261] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [112] },
+      { version: "0.0.0" },
     ],
   },
   [GEN_AI_USAGE_OUTPUT_TOKENS_REASONING]: {
-    brief: 'The number of tokens used for reasoning to create the AI output.',
+    brief: "The number of tokens used for reasoning to create the AI output.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 75,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [62, 112] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [62, 112] },
     ],
   },
   [GEN_AI_USAGE_PROMPT_TOKENS]: {
-    brief: 'The number of tokens used in the GenAI input (prompt).',
+    brief: "The number of tokens used in the GenAI input (prompt).",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 20,
     deprecation: {
-      replacement: 'gen_ai.usage.input_tokens',
+      replacement: "gen_ai.usage.input_tokens"
     },
     aliases: [AI_PROMPT_TOKENS_USED, GEN_AI_USAGE_INPUT_TOKENS],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [61] },
+      { version: "0.0.0" },
+    ],
   },
   [GEN_AI_USAGE_TOTAL_TOKENS]: {
-    brief: 'The total number of tokens used to process the prompt. (input tokens plus output todkens)',
+    brief: "The total number of tokens used to process the prompt. (input tokens plus output todkens)",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 20,
     aliases: [AI_TOTAL_TOKENS_USED],
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [57] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [57] },
     ],
   },
   [GRAPHQL_OPERATION_NAME]: {
-    brief: 'The name of the operation being executed.',
+    brief: "The name of the operation being executed.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'findBookById',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "findBookById",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [GRAPHQL_OPERATION_TYPE]: {
-    brief: 'The type of the operation being executed.',
+    brief: "The type of the operation being executed.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'query',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "query",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [HARDWARECONCURRENCY]: {
-    brief: 'The number of logical CPU cores available.',
+    brief: "The number of logical CPU cores available.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '14',
+    example: "14",
     deprecation: {
-      replacement: 'device.processor_count',
-      reason: 'Old namespace-less attribute, to be replaced with device.processor_count for span-first future',
+      replacement: "device.processor_count",
+      reason: "Old namespace-less attribute, to be replaced with device.processor_count for span-first future"
     },
     aliases: [DEVICE_PROCESSOR_COUNT],
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      {
-        version: 'next',
-        prs: [300],
-        description: 'Updated deprecation replacement from device.cpu.logical_core_count to device.processor_count',
-      },
-      {
-        version: 'next',
-        prs: [281],
-        description: "Added and deprecated attribute to document JS SDK's current behaviour",
-      },
+      { version: "next", prs: [300], description: "Updated deprecation replacement from device.cpu.logical_core_count to device.processor_count" },
+      { version: "next", prs: [281], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
     ],
   },
   [HTTP_CLIENT_IP]: {
-    brief:
-      'Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
+    brief: "Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: true,
-    example: 'example.com',
+    example: "example.com",
     deprecation: {
-      replacement: 'client.address',
+      replacement: "client.address"
     },
     aliases: [CLIENT_ADDRESS],
-    changelog: [{ version: '0.1.0', prs: [61, 106, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 106, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_DECODED_RESPONSE_CONTENT_LENGTH]: {
-    brief: 'The decoded body size of the response (in bytes).',
+    brief: "The decoded body size of the response (in bytes).",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 456,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_FLAVOR]: {
-    brief: 'The actual version of the protocol used for network communication.',
+    brief: "The actual version of the protocol used for network communication.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '1.1',
+    example: "1.1",
     deprecation: {
-      replacement: 'network.protocol.version',
+      replacement: "network.protocol.version"
     },
     aliases: [NETWORK_PROTOCOL_VERSION, NET_PROTOCOL_VERSION],
-    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 108, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_FRAGMENT]: {
-    brief:
-      'The fragments present in the URI. Note that this contains the leading # character, while the `url.fragment` attribute does not.',
+    brief: "The fragments present in the URI. Note that this contains the leading # character, while the `url.fragment` attribute does not.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '#details',
-    changelog: [{ version: '0.0.0' }],
+    example: "#details",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_HOST]: {
-    brief: 'The domain name.',
+    brief: "The domain name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'example.com',
+    example: "example.com",
     deprecation: {
-      replacement: 'server.address',
-      reason: 'Deprecated, use one of `server.address` or `client.address`, depending on the usage',
+      replacement: "server.address",
+      reason: "Deprecated, use one of `server.address` or `client.address`, depending on the usage"
     },
     aliases: [SERVER_ADDRESS, CLIENT_ADDRESS, HTTP_SERVER_NAME, NET_HOST_NAME],
-    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 108, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_METHOD]: {
-    brief: 'The HTTP method used.',
+    brief: "The HTTP method used.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'GET',
+    example: "GET",
     deprecation: {
-      replacement: 'http.request.method',
+      replacement: "http.request.method"
     },
     aliases: [HTTP_REQUEST_METHOD],
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_QUERY]: {
-    brief:
-      'The query string present in the URL. Note that this contains the leading ? character, while the `url.query` attribute does not.',
+    brief: "The query string present in the URL. Note that this contains the leading ? character, while the `url.query` attribute does not.",
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason:
-        'Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.',
+      reason: "Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information."
     },
     isInOtel: false,
-    example: '?foo=bar&bar=baz',
-    changelog: [{ version: '0.0.0' }],
+    example: "?foo=bar&bar=baz",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_REQUEST_CONNECTION_END]: {
-    brief:
-      'The UNIX timestamp representing the time immediately after the browser finishes establishing the connection to the server to retrieve the resource. The timestamp value includes the time interval to establish the transport connection, as well as other time intervals such as TLS handshake and SOCKS authentication.',
+    brief: "The UNIX timestamp representing the time immediately after the browser finishes establishing the connection to the server to retrieve the resource. The timestamp value includes the time interval to establish the transport connection, as well as other time intervals such as TLS handshake and SOCKS authentication.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1732829555.15,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [134] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_REQUEST_CONNECT_START]: {
-    brief:
-      'The UNIX timestamp representing the time immediately before the user agent starts establishing the connection to the server to retrieve the resource.',
+    brief: "The UNIX timestamp representing the time immediately before the user agent starts establishing the connection to the server to retrieve the resource.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1732829555.111,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [134] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_REQUEST_DOMAIN_LOOKUP_END]: {
-    brief:
-      'The UNIX timestamp representing the time immediately after the browser finishes the domain-name lookup for the resource.',
+    brief: "The UNIX timestamp representing the time immediately after the browser finishes the domain-name lookup for the resource.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1732829555.201,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [134] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_REQUEST_DOMAIN_LOOKUP_START]: {
-    brief:
-      'The UNIX timestamp representing the time immediately before the browser starts the domain name lookup for the resource.',
+    brief: "The UNIX timestamp representing the time immediately before the browser starts the domain name lookup for the resource.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1732829555.322,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [134] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_REQUEST_FETCH_START]: {
-    brief: 'The UNIX timestamp representing the time immediately before the browser starts to fetch the resource.',
+    brief: "The UNIX timestamp representing the time immediately before the browser starts to fetch the resource.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1732829555.389,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [134] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_REQUEST_HEADER_KEY]: {
-    brief:
-      'HTTP request headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.',
+    brief: "HTTP request headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.",
     type: 'string[]',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     hasDynamicSuffix: true,
     example: "http.request.header.custom-header=['foo', 'bar']",
     changelog: [
-      { version: '0.4.0', prs: [201, 204] },
-      { version: '0.1.0', prs: [103] },
+      { version: "0.4.0", prs: [201, 204] },
+      { version: "0.1.0", prs: [103] },
     ],
   },
   [HTTP_REQUEST_METHOD]: {
-    brief: 'The HTTP method used.',
+    brief: "The HTTP method used.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'GET',
+    example: "GET",
     aliases: [METHOD, HTTP_METHOD],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_REQUEST_REDIRECT_END]: {
-    brief:
-      'The UNIX timestamp representing the timestamp immediately after receiving the last byte of the response of the last redirect',
+    brief: "The UNIX timestamp representing the timestamp immediately after receiving the last byte of the response of the last redirect",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1732829558.502,
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [130, 134] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [130, 134] },
     ],
   },
   [HTTP_REQUEST_REDIRECT_START]: {
-    brief: 'The UNIX timestamp representing the start time of the fetch which that initiates the redirect.',
+    brief: "The UNIX timestamp representing the start time of the fetch which that initiates the redirect.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1732829555.495,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [134] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_REQUEST_REQUEST_START]: {
-    brief:
-      'The UNIX timestamp representing the time immediately before the browser starts requesting the resource from the server, cache, or local resource. If the transport connection fails and the browser retires the request, the value returned will be the start of the retry request.',
+    brief: "The UNIX timestamp representing the time immediately before the browser starts requesting the resource from the server, cache, or local resource. If the transport connection fails and the browser retires the request, the value returned will be the start of the retry request.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1732829555.51,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [134] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_REQUEST_RESEND_COUNT]: {
-    brief: 'The ordinal number of request resending attempt (for any reason, including redirects).',
+    brief: "The ordinal number of request resending attempt (for any reason, including redirects).",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 2,
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_REQUEST_RESPONSE_END]: {
-    brief:
-      'The UNIX timestamp representing the time immediately after the browser receives the last byte of the resource or immediately before the transport connection is closed, whichever comes first.',
+    brief: "The UNIX timestamp representing the time immediately after the browser receives the last byte of the resource or immediately before the transport connection is closed, whichever comes first.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1732829555.89,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [134] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_REQUEST_RESPONSE_START]: {
-    brief:
-      'The UNIX timestamp representing the time immediately before the browser starts requesting the resource from the server, cache, or local resource. If the transport connection fails and the browser retires the request, the value returned will be the start of the retry request.',
+    brief: "The UNIX timestamp representing the time immediately before the browser starts requesting the resource from the server, cache, or local resource. If the transport connection fails and the browser retires the request, the value returned will be the start of the retry request.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1732829555.7,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [134] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_REQUEST_SECURE_CONNECTION_START]: {
-    brief:
-      'The UNIX timestamp representing the time immediately before the browser starts the handshake process to secure the current connection. If a secure connection is not used, the property returns zero.',
+    brief: "The UNIX timestamp representing the time immediately before the browser starts the handshake process to secure the current connection. If a secure connection is not used, the property returns zero.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1732829555.73,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [134] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_REQUEST_TIME_TO_FIRST_BYTE]: {
-    brief:
-      "The time in seconds from the browser's timeorigin to when the first byte of the request's response was received. See https://web.dev/articles/ttfb#measure-resource-requests",
+    brief: "The time in seconds from the browser's timeorigin to when the first byte of the request's response was received. See https://web.dev/articles/ttfb#measure-resource-requests",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1.032,
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [131] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [131] },
     ],
   },
   [HTTP_REQUEST_WORKER_START]: {
-    brief:
-      'The UNIX timestamp representing the timestamp immediately before dispatching the FetchEvent if a Service Worker thread is already running, or immediately before starting the Service Worker thread if it is not already running.',
+    brief: "The UNIX timestamp representing the timestamp immediately before dispatching the FetchEvent if a Service Worker thread is already running, or immediately before starting the Service Worker thread if it is not already running.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1732829553.68,
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [130, 134] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [130, 134] },
     ],
   },
   [HTTP_RESPONSE_BODY_SIZE]: {
-    brief: 'The encoded body size of the response (in bytes).',
+    brief: "The encoded body size of the response (in bytes).",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 123,
     aliases: [HTTP_RESPONSE_CONTENT_LENGTH, HTTP_RESPONSE_HEADER_CONTENT_LENGTH],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [106] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [106] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_RESPONSE_CONTENT_LENGTH]: {
-    brief: 'The encoded body size of the response (in bytes).',
+    brief: "The encoded body size of the response (in bytes).",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 123,
     deprecation: {
-      replacement: 'http.response.body.size',
+      replacement: "http.response.body.size"
     },
     aliases: [HTTP_RESPONSE_BODY_SIZE, HTTP_RESPONSE_HEADER_CONTENT_LENGTH],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61, 106] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [61, 106] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_RESPONSE_HEADER_CONTENT_LENGTH]: {
-    brief: 'The size of the message body sent to the recipient (in bytes)',
+    brief: "The size of the message body sent to the recipient (in bytes)",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: "http.response.header.custom-header=['foo', 'bar']",
     aliases: [HTTP_RESPONSE_CONTENT_LENGTH, HTTP_RESPONSE_BODY_SIZE],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_RESPONSE_HEADER_KEY]: {
-    brief:
-      'HTTP response headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.',
+    brief: "HTTP response headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.",
     type: 'string[]',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     hasDynamicSuffix: true,
     example: "http.response.header.custom-header=['foo', 'bar']",
     changelog: [
-      { version: '0.4.0', prs: [201, 204] },
-      { version: '0.1.0', prs: [103] },
+      { version: "0.4.0", prs: [201, 204] },
+      { version: "0.1.0", prs: [103] },
     ],
   },
   [HTTP_RESPONSE_SIZE]: {
-    brief: 'The transfer size of the response (in bytes).',
+    brief: "The transfer size of the response (in bytes).",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 456,
     aliases: [HTTP_RESPONSE_TRANSFER_SIZE],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_RESPONSE_STATUS_CODE]: {
-    brief: 'The status code of the HTTP response.',
+    brief: "The status code of the HTTP response.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 404,
     aliases: [HTTP_STATUS_CODE],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_RESPONSE_TRANSFER_SIZE]: {
-    brief: 'The transfer size of the response (in bytes).',
+    brief: "The transfer size of the response (in bytes).",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 456,
     deprecation: {
-      replacement: 'http.response.size',
+      replacement: "http.response.size"
     },
     aliases: [HTTP_RESPONSE_SIZE],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [61] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_ROUTE]: {
-    brief: 'The matched route, that is, the path template in the format used by the respective server framework.',
+    brief: "The matched route, that is, the path template in the format used by the respective server framework.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '/users/:id',
+    example: "/users/:id",
     aliases: [URL_TEMPLATE],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_SCHEME]: {
-    brief: 'The URI scheme component identifying the used protocol.',
+    brief: "The URI scheme component identifying the used protocol.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'https',
+    example: "https",
     deprecation: {
-      replacement: 'url.scheme',
+      replacement: "url.scheme"
     },
     aliases: [URL_SCHEME],
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_SERVER_NAME]: {
-    brief: 'The server domain name',
+    brief: "The server domain name",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'example.com',
+    example: "example.com",
     deprecation: {
-      replacement: 'server.address',
+      replacement: "server.address"
     },
     aliases: [SERVER_ADDRESS, NET_HOST_NAME, HTTP_HOST],
-    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 108, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_SERVER_REQUEST_TIME_IN_QUEUE]: {
-    brief:
-      'The time in milliseconds the request spent in the server queue before processing began. Measured from the X-Request-Start header set by reverse proxies (e.g., Nginx, HAProxy, Heroku) to when the application started handling the request.',
+    brief: "The time in milliseconds the request spent in the server queue before processing began. Measured from the X-Request-Start header set by reverse proxies (e.g., Nginx, HAProxy, Heroku) to when the application started handling the request.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 50,
-    sdks: ['ruby'],
-    changelog: [{ version: 'next', prs: [267] }],
+    sdks: ["ruby"],
+    changelog: [
+      { version: "next", prs: [267] },
+    ],
   },
   [HTTP_STATUS_CODE]: {
-    brief: 'The status code of the HTTP response.',
+    brief: "The status code of the HTTP response.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 404,
     deprecation: {
-      replacement: 'http.response.status_code',
+      replacement: "http.response.status_code"
     },
     aliases: [HTTP_RESPONSE_STATUS_CODE],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [61] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_TARGET]: {
-    brief: 'The pathname and query string of the URL.',
+    brief: "The pathname and query string of the URL.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '/test?foo=bar#buzz',
+    example: "/test?foo=bar#buzz",
     deprecation: {
-      replacement: 'url.path',
-      reason: 'This attribute is being deprecated in favor of url.path and url.query',
+      replacement: "url.path",
+      reason: "This attribute is being deprecated in favor of url.path and url.query"
     },
-    changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_URL]: {
-    brief: 'The URL of the resource that was fetched.',
+    brief: "The URL of the resource that was fetched.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'https://example.com/test?foo=bar#buzz',
+    example: "https://example.com/test?foo=bar#buzz",
     deprecation: {
-      replacement: 'url.full',
+      replacement: "url.full"
     },
     aliases: [URL_FULL, URL],
-    changelog: [{ version: '0.1.0', prs: [61, 108] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 108] },
+      { version: "0.0.0" },
+    ],
   },
   [HTTP_USER_AGENT]: {
-    brief: 'Value of the HTTP User-Agent header sent by the client.',
+    brief: "Value of the HTTP User-Agent header sent by the client.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example:
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1',
+    example: "Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1",
     deprecation: {
-      replacement: 'user_agent.original',
+      replacement: "user_agent.original"
     },
     aliases: [USER_AGENT_ORIGINAL],
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [ID]: {
-    brief: 'A unique identifier for the span.',
+    brief: "A unique identifier for the span.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'f47ac10b58cc4372a5670e02b2c3d479',
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.0.0' }],
+    example: "f47ac10b58cc4372a5670e02b2c3d479",
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [INP]: {
-    brief: 'The value of the recorded Interaction to Next Paint (INP) web vital',
+    brief: "The value of the recorded Interaction to Next Paint (INP) web vital",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 200,
     deprecation: {
-      replacement: 'browser.web_vital.inp.value',
-      reason: 'The INP web vital is now recorded as a browser.web_vital.inp.value attribute.',
+      replacement: "browser.web_vital.inp.value",
+      reason: "The INP web vital is now recorded as a browser.web_vital.inp.value attribute."
     },
     aliases: [BROWSER_WEB_VITAL_INP_VALUE],
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      {
-        version: 'next',
-        prs: [229],
-        description: "Added and deprecated attribute to document JS SDK's current behaviour",
-      },
+      { version: "next", prs: [229], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
     ],
   },
   [JVM_GC_ACTION]: {
-    brief: 'Name of the garbage collector action.',
+    brief: "Name of the garbage collector action.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'end of minor GC',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "end of minor GC",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [JVM_GC_NAME]: {
-    brief: 'Name of the garbage collector.',
+    brief: "Name of the garbage collector.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'G1 Young Generation',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "G1 Young Generation",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [JVM_MEMORY_POOL_NAME]: {
-    brief: 'Name of the memory pool.',
+    brief: "Name of the memory pool.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'G1 Old Gen',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "G1 Old Gen",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [JVM_MEMORY_TYPE]: {
-    brief: 'Name of the memory pool.',
+    brief: "Name of the memory pool.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'G1 Old Gen',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "G1 Old Gen",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [JVM_THREAD_DAEMON]: {
-    brief: 'Whether the thread is daemon or not.',
+    brief: "Whether the thread is daemon or not.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: true,
     example: true,
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [JVM_THREAD_STATE]: {
-    brief: 'State of the thread.',
+    brief: "State of the thread.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'blocked',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "blocked",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [LCP]: {
-    brief: 'The value of the recorded Largest Contentful Paint (LCP) web vital',
+    brief: "The value of the recorded Largest Contentful Paint (LCP) web vital",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 2500,
     deprecation: {
-      replacement: 'browser.web_vital.lcp.value',
-      reason: 'The LCP web vital is now recorded as a browser.web_vital.lcp.value attribute.',
+      replacement: "browser.web_vital.lcp.value",
+      reason: "The LCP web vital is now recorded as a browser.web_vital.lcp.value attribute."
     },
     aliases: [BROWSER_WEB_VITAL_LCP_VALUE],
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      {
-        version: 'next',
-        prs: [229],
-        description: "Added and deprecated attribute to document JS SDK's current behaviour",
-      },
+      { version: "next", prs: [229], description: "Added and deprecated attribute to document JS SDK's current behaviour" },
     ],
   },
   [LCP_ELEMENT]: {
-    brief: 'The dom element responsible for the largest contentful paint.',
+    brief: "The dom element responsible for the largest contentful paint.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'img',
+    example: "img",
     deprecation: {
-      replacement: 'browser.web_vital.lcp.element',
-      reason: 'The LCP element is now recorded as a browser.web_vital.lcp.element attribute.',
+      replacement: "browser.web_vital.lcp.element",
+      reason: "The LCP element is now recorded as a browser.web_vital.lcp.element attribute."
     },
     aliases: [BROWSER_WEB_VITAL_LCP_ELEMENT],
-    changelog: [{ version: 'next', prs: [233] }, { version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "next", prs: [233] },
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [LCP_ID]: {
-    brief: 'The id of the dom element responsible for the largest contentful paint.',
+    brief: "The id of the dom element responsible for the largest contentful paint.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '#hero',
+    example: "#hero",
     deprecation: {
-      replacement: 'browser.web_vital.lcp.id',
-      reason: 'The LCP id is now recorded as a browser.web_vital.lcp.id attribute.',
+      replacement: "browser.web_vital.lcp.id",
+      reason: "The LCP id is now recorded as a browser.web_vital.lcp.id attribute."
     },
     aliases: [BROWSER_WEB_VITAL_LCP_ID],
-    changelog: [{ version: 'next', prs: [233] }, { version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "next", prs: [233] },
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [LCP_LOADTIME]: {
-    brief: 'The time it took for the LCP element to be loaded',
+    brief: "The time it took for the LCP element to be loaded",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1402,
     deprecation: {
-      replacement: 'browser.web_vital.lcp.load_time',
-      reason: 'The LCP load time is now recorded as a browser.web_vital.lcp.load_time attribute.',
+      replacement: "browser.web_vital.lcp.load_time",
+      reason: "The LCP load time is now recorded as a browser.web_vital.lcp.load_time attribute."
     },
     aliases: [BROWSER_WEB_VITAL_LCP_LOAD_TIME],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [233] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [233] },
+    ],
   },
   [LCP_RENDERTIME]: {
-    brief: 'The time it took for the LCP element to be rendered',
+    brief: "The time it took for the LCP element to be rendered",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1685,
     deprecation: {
-      replacement: 'browser.web_vital.lcp.render_time',
-      reason: 'The LCP render time is now recorded as a browser.web_vital.lcp.render_time attribute.',
+      replacement: "browser.web_vital.lcp.render_time",
+      reason: "The LCP render time is now recorded as a browser.web_vital.lcp.render_time attribute."
     },
     aliases: [BROWSER_WEB_VITAL_LCP_RENDER_TIME],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [233] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [233] },
+    ],
   },
   [LCP_SIZE]: {
-    brief: 'The size of the largest contentful paint element.',
+    brief: "The size of the largest contentful paint element.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1234,
     deprecation: {
-      replacement: 'browser.web_vital.lcp.size',
-      reason: 'The LCP size is now recorded as a browser.web_vital.lcp.size attribute.',
+      replacement: "browser.web_vital.lcp.size",
+      reason: "The LCP size is now recorded as a browser.web_vital.lcp.size attribute."
     },
     aliases: [BROWSER_WEB_VITAL_LCP_SIZE],
-    changelog: [{ version: 'next', prs: [233] }, { version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "next", prs: [233] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [LCP_URL]: {
-    brief: 'The url of the dom element responsible for the largest contentful paint.',
+    brief: "The url of the dom element responsible for the largest contentful paint.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'https://example.com',
+    example: "https://example.com",
     deprecation: {
-      replacement: 'browser.web_vital.lcp.url',
-      reason: 'The LCP url is now recorded as a browser.web_vital.lcp.url attribute.',
+      replacement: "browser.web_vital.lcp.url",
+      reason: "The LCP url is now recorded as a browser.web_vital.lcp.url attribute."
     },
     aliases: [BROWSER_WEB_VITAL_LCP_URL],
-    changelog: [{ version: 'next', prs: [233] }, { version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "next", prs: [233] },
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [LOGGER_NAME]: {
-    brief: 'The name of the logger that generated this event.',
+    brief: "The name of the logger that generated this event.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'myLogger',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "myLogger",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [MCP_CANCELLED_REASON]: {
-    brief: 'Reason for the cancellation of an MCP operation.',
+    brief: "Reason for the cancellation of an MCP operation.",
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason: 'Cancellation reasons may contain user-specific or sensitive information',
+      reason: "Cancellation reasons may contain user-specific or sensitive information"
     },
     isInOtel: false,
-    example: 'User cancelled the request',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "User cancelled the request",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_CANCELLED_REQUEST_ID]: {
-    brief: 'Request ID of the cancelled MCP operation.',
+    brief: "Request ID of the cancelled MCP operation.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '123',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "123",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_CLIENT_NAME]: {
-    brief: 'Name of the MCP client application.',
+    brief: "Name of the MCP client application.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'claude-desktop',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "claude-desktop",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_CLIENT_TITLE]: {
-    brief: 'Display title of the MCP client application.',
+    brief: "Display title of the MCP client application.",
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason: 'Client titles may reveal user-specific application configurations or custom setups',
+      reason: "Client titles may reveal user-specific application configurations or custom setups"
     },
     isInOtel: false,
-    example: 'Claude Desktop',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "Claude Desktop",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_CLIENT_VERSION]: {
-    brief: 'Version of the MCP client application.',
+    brief: "Version of the MCP client application.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '1.0.0',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "1.0.0",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_LIFECYCLE_PHASE]: {
-    brief: 'Lifecycle phase indicator for MCP operations.',
+    brief: "Lifecycle phase indicator for MCP operations.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'initialization_complete',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "initialization_complete",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_LOGGING_DATA_TYPE]: {
-    brief: 'Data type of the logged message content.',
+    brief: "Data type of the logged message content.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'string',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "string",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_LOGGING_LEVEL]: {
-    brief: 'Log level for MCP logging operations.',
+    brief: "Log level for MCP logging operations.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'info',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "info",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_LOGGING_LOGGER]: {
-    brief: 'Logger name for MCP logging operations.',
+    brief: "Logger name for MCP logging operations.",
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason: 'Logger names may be user-defined and could contain sensitive information',
+      reason: "Logger names may be user-defined and could contain sensitive information"
     },
     isInOtel: false,
-    example: 'mcp_server',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "mcp_server",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_LOGGING_MESSAGE]: {
-    brief: 'Log message content from MCP logging operations.',
+    brief: "Log message content from MCP logging operations.",
     type: 'string',
     pii: {
       isPii: 'true',
-      reason: 'Log messages can contain user data',
+      reason: "Log messages can contain user data"
     },
     isInOtel: false,
-    example: 'Tool execution completed successfully',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "Tool execution completed successfully",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_METHOD_NAME]: {
-    brief: 'The name of the MCP request or notification method being called.',
+    brief: "The name of the MCP request or notification method being called.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'tools/call',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "tools/call",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_PROGRESS_CURRENT]: {
-    brief: 'Current progress value of an MCP operation.',
+    brief: "Current progress value of an MCP operation.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 50,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.3.0', prs: [171] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.3.0", prs: [171] },
     ],
   },
   [MCP_PROGRESS_MESSAGE]: {
-    brief: 'Progress message describing the current state of an MCP operation.',
+    brief: "Progress message describing the current state of an MCP operation.",
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason: 'Progress messages may contain user-specific or sensitive information',
+      reason: "Progress messages may contain user-specific or sensitive information"
     },
     isInOtel: false,
-    example: 'Processing 50 of 100 items',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "Processing 50 of 100 items",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_PROGRESS_PERCENTAGE]: {
-    brief: 'Calculated progress percentage of an MCP operation. Computed from current/total * 100.',
+    brief: "Calculated progress percentage of an MCP operation. Computed from current/total * 100.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 50,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.3.0', prs: [171] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.3.0", prs: [171] },
     ],
   },
   [MCP_PROGRESS_TOKEN]: {
-    brief: 'Token for tracking progress of an MCP operation.',
+    brief: "Token for tracking progress of an MCP operation.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'progress-token-123',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "progress-token-123",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_PROGRESS_TOTAL]: {
-    brief: 'Total progress target value of an MCP operation.',
+    brief: "Total progress target value of an MCP operation.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 100,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.3.0', prs: [171] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.3.0", prs: [171] },
     ],
   },
   [MCP_PROMPT_NAME]: {
-    brief: 'Name of the MCP prompt template being used.',
+    brief: "Name of the MCP prompt template being used.",
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason: 'Prompt names may reveal user behavior patterns or sensitive operations',
+      reason: "Prompt names may reveal user behavior patterns or sensitive operations"
     },
     isInOtel: false,
-    example: 'summarize',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "summarize",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_PROMPT_RESULT_DESCRIPTION]: {
-    brief: 'Description of the prompt result.',
+    brief: "Description of the prompt result.",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: 'A summary of the requested information',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "A summary of the requested information",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_PROMPT_RESULT_MESSAGE_CONTENT]: {
-    brief: 'Content of the message in the prompt result. Used for single message results only.',
+    brief: "Content of the message in the prompt result. Used for single message results only.",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: 'Please provide a summary of the document',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "Please provide a summary of the document",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_PROMPT_RESULT_MESSAGE_COUNT]: {
-    brief: 'Number of messages in the prompt result.',
+    brief: "Number of messages in the prompt result.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 3,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.3.0', prs: [171] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.3.0", prs: [171] },
     ],
   },
   [MCP_PROMPT_RESULT_MESSAGE_ROLE]: {
-    brief: 'Role of the message in the prompt result. Used for single message results only.',
+    brief: "Role of the message in the prompt result. Used for single message results only.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'user',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "user",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_PROTOCOL_READY]: {
-    brief: 'Protocol readiness indicator for MCP session. Non-zero value indicates the protocol is ready.',
+    brief: "Protocol readiness indicator for MCP session. Non-zero value indicates the protocol is ready.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.3.0', prs: [171] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.3.0", prs: [171] },
     ],
   },
   [MCP_PROTOCOL_VERSION]: {
-    brief: 'MCP protocol version used in the session.',
+    brief: "MCP protocol version used in the session.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '2024-11-05',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "2024-11-05",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_REQUEST_ARGUMENT_KEY]: {
-    brief:
-      'MCP request argument with dynamic key suffix. The <key> is replaced with the actual argument name. The value is a JSON-stringified representation of the argument value.',
+    brief: "MCP request argument with dynamic key suffix. The <key> is replaced with the actual argument name. The value is a JSON-stringified representation of the argument value.",
     type: 'string',
     pii: {
       isPii: 'true',
-      reason: 'Arguments contain user input',
+      reason: "Arguments contain user input"
     },
     isInOtel: false,
     hasDynamicSuffix: true,
     example: "mcp.request.argument.query='weather in Paris'",
-    changelog: [{ version: '0.3.0', prs: [176] }],
+    changelog: [
+      { version: "0.3.0", prs: [176] },
+    ],
   },
   [MCP_REQUEST_ARGUMENT_NAME]: {
-    brief: 'Name argument from prompts/get MCP request.',
+    brief: "Name argument from prompts/get MCP request.",
     type: 'string',
     pii: {
       isPii: 'true',
-      reason: 'Prompt names can contain user input',
+      reason: "Prompt names can contain user input"
     },
     isInOtel: false,
-    example: 'summarize',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "summarize",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_REQUEST_ARGUMENT_URI]: {
-    brief: 'URI argument from resources/read MCP request.',
+    brief: "URI argument from resources/read MCP request.",
     type: 'string',
     pii: {
       isPii: 'true',
-      reason: 'URIs can contain user file paths',
+      reason: "URIs can contain user file paths"
     },
     isInOtel: false,
-    example: 'file:///path/to/resource',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "file:///path/to/resource",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_REQUEST_ID]: {
-    brief: 'JSON-RPC request identifier for the MCP request. Unique within the MCP session.',
+    brief: "JSON-RPC request identifier for the MCP request. Unique within the MCP session.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '1',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "1",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_RESOURCE_PROTOCOL]: {
-    brief: 'Protocol of the resource URI being accessed, extracted from the URI.',
+    brief: "Protocol of the resource URI being accessed, extracted from the URI.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'file',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "file",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_RESOURCE_URI]: {
-    brief: 'The resource URI being accessed in an MCP operation.',
+    brief: "The resource URI being accessed in an MCP operation.",
     type: 'string',
     pii: {
       isPii: 'true',
-      reason: 'URIs can contain sensitive file paths',
+      reason: "URIs can contain sensitive file paths"
     },
     isInOtel: false,
-    example: 'file:///path/to/file.txt',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "file:///path/to/file.txt",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_SERVER_NAME]: {
-    brief: 'Name of the MCP server application.',
+    brief: "Name of the MCP server application.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'sentry-mcp-server',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "sentry-mcp-server",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_SERVER_TITLE]: {
-    brief: 'Display title of the MCP server application.',
+    brief: "Display title of the MCP server application.",
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason: 'Server titles may reveal user-specific application configurations or custom setups',
+      reason: "Server titles may reveal user-specific application configurations or custom setups"
     },
     isInOtel: false,
-    example: 'Sentry MCP Server',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "Sentry MCP Server",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_SERVER_VERSION]: {
-    brief: 'Version of the MCP server application.',
+    brief: "Version of the MCP server application.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '0.1.0',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "0.1.0",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_SESSION_ID]: {
-    brief: 'Identifier for the MCP session.',
+    brief: "Identifier for the MCP session.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '550e8400-e29b-41d4-a716-446655440000',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "550e8400-e29b-41d4-a716-446655440000",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_TOOL_NAME]: {
-    brief: 'Name of the MCP tool being called.',
+    brief: "Name of the MCP tool being called.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'calculator',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "calculator",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_TOOL_RESULT_CONTENT]: {
-    brief: 'The content of the tool result.',
+    brief: "The content of the tool result.",
     type: 'string',
     pii: {
       isPii: 'true',
-      reason: 'Tool results can contain user data',
+      reason: "Tool results can contain user data"
     },
     isInOtel: false,
-    example: '{"output": "rainy", "toolCallId": "1"}',
+    example: "{\"output\": \"rainy\", \"toolCallId\": \"1\"}",
     changelog: [
-      { version: '0.3.0', prs: [171] },
-      { version: '0.2.0', prs: [164] },
+      { version: "0.3.0", prs: [171] },
+      { version: "0.2.0", prs: [164] },
     ],
   },
   [MCP_TOOL_RESULT_CONTENT_COUNT]: {
-    brief: 'Number of content items in the tool result.',
+    brief: "Number of content items in the tool result.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.3.0', prs: [171] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.3.0", prs: [171] },
     ],
   },
   [MCP_TOOL_RESULT_IS_ERROR]: {
-    brief: 'Whether a tool execution resulted in an error.',
+    brief: "Whether a tool execution resulted in an error.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: false,
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MCP_TRANSPORT]: {
-    brief: 'Transport method used for MCP communication.',
+    brief: "Transport method used for MCP communication.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'stdio',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    example: "stdio",
+    changelog: [
+      { version: "0.3.0", prs: [171] },
+    ],
   },
   [MDC_KEY]: {
-    brief:
-      "Attributes from the Mapped Diagnostic Context (MDC) present at the moment the log record was created. The MDC is supported by all the most popular logging solutions in the Java ecosystem, and it's usually implemented as a thread-local map that stores context for e.g. a specific request.",
+    brief: "Attributes from the Mapped Diagnostic Context (MDC) present at the moment the log record was created. The MDC is supported by all the most popular logging solutions in the Java ecosystem, and it's usually implemented as a thread-local map that stores context for e.g. a specific request.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     hasDynamicSuffix: true,
     example: "mdc.some_key='some_value'",
-    sdks: ['java', 'java.logback', 'java.jul', 'java.log4j2'],
-    changelog: [{ version: '0.3.0', prs: [176] }],
+    sdks: ["java","java.logback","java.jul","java.log4j2"],
+    changelog: [
+      { version: "0.3.0", prs: [176] },
+    ],
   },
   [MESSAGING_DESTINATION_CONNECTION]: {
-    brief: 'The message destination connection.',
+    brief: "The message destination connection.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'BestTopic',
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "BestTopic",
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [MESSAGING_DESTINATION_NAME]: {
-    brief: 'The message destination name.',
+    brief: "The message destination name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'BestTopic',
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "BestTopic",
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [MESSAGING_MESSAGE_BODY_SIZE]: {
-    brief: 'The size of the message body in bytes.',
+    brief: "The size of the message body in bytes.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 839,
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [MESSAGING_MESSAGE_ENVELOPE_SIZE]: {
-    brief: 'The size of the message body and metadata in bytes.',
+    brief: "The size of the message body and metadata in bytes.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 1045,
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [MESSAGING_MESSAGE_ID]: {
-    brief: 'A value used by the messaging system as an identifier for the message, represented as a string.',
+    brief: "A value used by the messaging system as an identifier for the message, represented as a string.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'f47ac10b58cc4372a5670e02b2c3d479',
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "f47ac10b58cc4372a5670e02b2c3d479",
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [MESSAGING_MESSAGE_RECEIVE_LATENCY]: {
-    brief: 'The latency between when the message was published and received.',
+    brief: "The latency between when the message was published and received.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1732847252,
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [MESSAGING_MESSAGE_RETRY_COUNT]: {
-    brief: 'The amount of attempts to send the message.',
+    brief: "The amount of attempts to send the message.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 2,
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [MESSAGING_OPERATION_TYPE]: {
-    brief: 'A string identifying the type of the messaging operation',
+    brief: "A string identifying the type of the messaging operation",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'create',
-    changelog: [{ version: '0.1.0', prs: [51, 127] }],
+    example: "create",
+    changelog: [
+      { version: "0.1.0", prs: [51, 127] },
+    ],
   },
   [MESSAGING_SYSTEM]: {
-    brief: 'The messaging system as identified by the client instrumentation.',
+    brief: "The messaging system as identified by the client instrumentation.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'activemq',
-    sdks: ['php-laravel'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "activemq",
+    sdks: ["php-laravel"],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [METHOD]: {
-    brief: 'The HTTP method used.',
+    brief: "The HTTP method used.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'GET',
+    example: "GET",
     deprecation: {
-      replacement: 'http.request.method',
+      replacement: "http.request.method"
     },
     aliases: [HTTP_REQUEST_METHOD],
-    sdks: ['javascript-browser', 'javascript-node'],
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    sdks: ["javascript-browser","javascript-node"],
+    changelog: [
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [NAVIGATION_TYPE]: {
-    brief: 'The type of navigation done by a client-side router.',
+    brief: "The type of navigation done by a client-side router.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'router.push',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "router.push",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [NEL_ELAPSED_TIME]: {
-    brief:
-      'The elapsed number of milliseconds between the start of the resource fetch and when it was completed or aborted by the user agent.',
+    brief: "The elapsed number of milliseconds between the start of the resource fetch and when it was completed or aborted by the user agent.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 100,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [68] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [68] },
     ],
   },
   [NEL_PHASE]: {
-    brief: 'If request failed, the phase of its network error. If request succeeded, "application".',
+    brief: "If request failed, the phase of its network error. If request succeeded, \"application\".",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'application',
-    changelog: [{ version: '0.1.0', prs: [68, 127] }],
+    example: "application",
+    changelog: [
+      { version: "0.1.0", prs: [68, 127] },
+    ],
   },
   [NEL_REFERRER]: {
     brief: "request's referrer, as determined by the referrer policy associated with its client.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'https://example.com/foo?bar=baz',
-    changelog: [{ version: '0.1.0', prs: [68, 127] }],
+    example: "https://example.com/foo?bar=baz",
+    changelog: [
+      { version: "0.1.0", prs: [68, 127] },
+    ],
   },
   [NEL_SAMPLING_FUNCTION]: {
-    brief: 'The sampling function used to determine if the request should be sampled.',
+    brief: "The sampling function used to determine if the request should be sampled.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 0.5,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.1.0', prs: [68] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [68] },
     ],
   },
   [NEL_TYPE]: {
-    brief: 'If request failed, the type of its network error. If request succeeded, "ok".',
+    brief: "If request failed, the type of its network error. If request succeeded, \"ok\".",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'dns.unreachable',
-    changelog: [{ version: '0.1.0', prs: [68, 127] }],
+    example: "dns.unreachable",
+    changelog: [
+      { version: "0.1.0", prs: [68, 127] },
+    ],
   },
   [NETWORK_CONNECTION_EFFECTIVE_TYPE]: {
-    brief: 'Specifies the effective type of the current connection (e.g. slow-2g, 2g, 3g, 4g).',
+    brief: "Specifies the effective type of the current connection (e.g. slow-2g, 2g, 3g, 4g).",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '4g',
+    example: "4g",
     aliases: [EFFECTIVECONNECTIONTYPE],
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      {
-        version: 'next',
-        prs: [279],
-        description: 'Added attribute network.connection.effective_type to be used instead of effectiveConnectionType',
-      },
+      { version: "next", prs: [279], description: "Added attribute network.connection.effective_type to be used instead of effectiveConnectionType" },
     ],
   },
   [NETWORK_CONNECTION_RTT]: {
-    brief: 'Specifies the estimated effective round-trip time of the current connection, in milliseconds.',
+    brief: "Specifies the estimated effective round-trip time of the current connection, in milliseconds.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 100,
     aliases: [CONNECTION_RTT],
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      {
-        version: 'next',
-        prs: [279],
-        description: 'Added attribute network.connection.rtt to be used instead of connection.rtt',
-      },
+      { version: "next", prs: [279], description: "Added attribute network.connection.rtt to be used instead of connection.rtt" },
     ],
   },
   [NETWORK_CONNECTION_TYPE]: {
-    brief: 'Specifies the type of the current connection (e.g. wifi, ethernet, cellular , etc).',
+    brief: "Specifies the type of the current connection (e.g. wifi, ethernet, cellular , etc).",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'wifi',
+    example: "wifi",
     aliases: [CONNECTIONTYPE],
-    sdks: ['javascript-browser'],
+    sdks: ["javascript-browser"],
     changelog: [
-      {
-        version: 'next',
-        prs: [279],
-        description: 'Added attribute network.connection.type to be used instead of connectionType',
-      },
+      { version: "next", prs: [279], description: "Added attribute network.connection.type to be used instead of connectionType" },
     ],
   },
   [NETWORK_LOCAL_ADDRESS]: {
-    brief: 'Local address of the network connection - IP address or Unix domain socket name.',
+    brief: "Local address of the network connection - IP address or Unix domain socket name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '10.1.2.80',
+    example: "10.1.2.80",
     aliases: [NET_HOST_IP, NET_SOCK_HOST_ADDR],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [NETWORK_LOCAL_PORT]: {
-    brief: 'Local port number of the network connection.',
+    brief: "Local port number of the network connection.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 65400,
     aliases: [NET_SOCK_HOST_PORT],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [NETWORK_PEER_ADDRESS]: {
-    brief: 'Peer address of the network connection - IP address or Unix domain socket name.',
+    brief: "Peer address of the network connection - IP address or Unix domain socket name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '10.1.2.80',
+    example: "10.1.2.80",
     aliases: [NET_PEER_IP, NET_SOCK_PEER_ADDR],
-    changelog: [{ version: '0.1.0', prs: [108, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [108, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [NETWORK_PEER_PORT]: {
-    brief: 'Peer port number of the network connection.',
+    brief: "Peer port number of the network connection.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 65400,
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [NETWORK_PROTOCOL_NAME]: {
-    brief: 'OSI application layer or non-OSI equivalent.',
+    brief: "OSI application layer or non-OSI equivalent.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'http',
+    example: "http",
     aliases: [NET_PROTOCOL_NAME],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [NETWORK_PROTOCOL_VERSION]: {
-    brief: 'The actual version of the protocol used for network communication.',
+    brief: "The actual version of the protocol used for network communication.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '1.1',
+    example: "1.1",
     aliases: [HTTP_FLAVOR, NET_PROTOCOL_VERSION],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [NETWORK_TRANSPORT]: {
-    brief: 'OSI transport layer or inter-process communication method.',
+    brief: "OSI transport layer or inter-process communication method.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'tcp',
+    example: "tcp",
     aliases: [NET_TRANSPORT],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [NETWORK_TYPE]: {
-    brief: 'OSI network layer or non-OSI equivalent.',
+    brief: "OSI network layer or non-OSI equivalent.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'ipv4',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "ipv4",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_HOST_IP]: {
-    brief: 'Local address of the network connection - IP address or Unix domain socket name.',
+    brief: "Local address of the network connection - IP address or Unix domain socket name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '192.168.0.1',
+    example: "192.168.0.1",
     deprecation: {
-      replacement: 'network.local.address',
+      replacement: "network.local.address"
     },
     aliases: [NETWORK_LOCAL_ADDRESS, NET_SOCK_HOST_ADDR],
-    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 108, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_HOST_NAME]: {
-    brief:
-      'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
+    brief: "Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'example.com',
+    example: "example.com",
     deprecation: {
-      replacement: 'server.address',
+      replacement: "server.address"
     },
     aliases: [SERVER_ADDRESS, HTTP_SERVER_NAME, HTTP_HOST],
-    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 108, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_HOST_PORT]: {
-    brief: 'Server port number.',
+    brief: "Server port number.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 1337,
     deprecation: {
-      replacement: 'server.port',
+      replacement: "server.port"
     },
     aliases: [SERVER_PORT],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [61] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_PEER_IP]: {
-    brief: 'Peer address of the network connection - IP address or Unix domain socket name.',
+    brief: "Peer address of the network connection - IP address or Unix domain socket name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '192.168.0.1',
+    example: "192.168.0.1",
     deprecation: {
-      replacement: 'network.peer.address',
+      replacement: "network.peer.address"
     },
     aliases: [NETWORK_PEER_ADDRESS, NET_SOCK_PEER_ADDR],
-    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 108, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_PEER_NAME]: {
-    brief:
-      'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
+    brief: "Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'example.com',
+    example: "example.com",
     deprecation: {
-      replacement: 'server.address',
-      reason: 'Deprecated, use server.address on client spans and client.address on server spans.',
+      replacement: "server.address",
+      reason: "Deprecated, use server.address on client spans and client.address on server spans."
     },
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_PEER_PORT]: {
-    brief: 'Peer port number.',
+    brief: "Peer port number.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 1337,
     deprecation: {
-      replacement: 'server.port',
-      reason: 'Deprecated, use server.port on client spans and client.port on server spans.',
+      replacement: "server.port",
+      reason: "Deprecated, use server.port on client spans and client.port on server spans."
     },
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [61] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_PROTOCOL_NAME]: {
-    brief: 'OSI application layer or non-OSI equivalent.',
+    brief: "OSI application layer or non-OSI equivalent.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'http',
+    example: "http",
     deprecation: {
-      replacement: 'network.protocol.name',
+      replacement: "network.protocol.name"
     },
     aliases: [NETWORK_PROTOCOL_NAME],
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_PROTOCOL_VERSION]: {
-    brief: 'The actual version of the protocol used for network communication.',
+    brief: "The actual version of the protocol used for network communication.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '1.1',
+    example: "1.1",
     deprecation: {
-      replacement: 'network.protocol.version',
+      replacement: "network.protocol.version"
     },
     aliases: [NETWORK_PROTOCOL_VERSION, HTTP_FLAVOR],
-    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 108, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_SOCK_FAMILY]: {
-    brief: 'OSI transport and network layer',
+    brief: "OSI transport and network layer",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'inet',
+    example: "inet",
     deprecation: {
-      replacement: 'network.transport',
-      reason: 'Deprecated, use network.transport and network.type.',
+      replacement: "network.transport",
+      reason: "Deprecated, use network.transport and network.type."
     },
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_SOCK_HOST_ADDR]: {
-    brief: 'Local address of the network connection mapping to Unix domain socket name.',
+    brief: "Local address of the network connection mapping to Unix domain socket name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '/var/my.sock',
+    example: "/var/my.sock",
     deprecation: {
-      replacement: 'network.local.address',
+      replacement: "network.local.address"
     },
     aliases: [NETWORK_LOCAL_ADDRESS, NET_HOST_IP],
-    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 108, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_SOCK_HOST_PORT]: {
-    brief: 'Local port number of the network connection.',
+    brief: "Local port number of the network connection.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 8080,
     deprecation: {
-      replacement: 'network.local.port',
+      replacement: "network.local.port"
     },
     aliases: [NETWORK_LOCAL_PORT],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [61] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_SOCK_PEER_ADDR]: {
-    brief: 'Peer address of the network connection - IP address',
+    brief: "Peer address of the network connection - IP address",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '192.168.0.1',
+    example: "192.168.0.1",
     deprecation: {
-      replacement: 'network.peer.address',
+      replacement: "network.peer.address"
     },
     aliases: [NETWORK_PEER_ADDRESS, NET_PEER_IP],
-    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 108, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_SOCK_PEER_NAME]: {
-    brief: 'Peer address of the network connection - Unix domain socket name',
+    brief: "Peer address of the network connection - Unix domain socket name",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '/var/my.sock',
+    example: "/var/my.sock",
     deprecation: {
-      reason: 'Deprecated from OTEL, no replacement at this time',
+      reason: "Deprecated from OTEL, no replacement at this time"
     },
-    changelog: [{ version: '0.1.0', prs: [61, 119, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 119, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_SOCK_PEER_PORT]: {
-    brief: 'Peer port number of the network connection.',
+    brief: "Peer port number of the network connection.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 8080,
     deprecation: {
-      replacement: 'network.peer.port',
+      replacement: "network.peer.port"
     },
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.1.0", prs: [61] },
+      { version: "0.0.0" },
+    ],
   },
   [NET_TRANSPORT]: {
-    brief: 'OSI transport layer or inter-process communication method.',
+    brief: "OSI transport layer or inter-process communication method.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'tcp',
+    example: "tcp",
     deprecation: {
-      replacement: 'network.transport',
+      replacement: "network.transport"
     },
     aliases: [NETWORK_TRANSPORT],
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [OS_BUILD_ID]: {
-    brief: 'The build ID of the operating system.',
+    brief: "The build ID of the operating system.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '1234567890',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "1234567890",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [OS_DESCRIPTION]: {
-    brief:
-      'Human readable (not intended to be parsed) OS version information, like e.g. reported by ver or lsb_release -a commands.',
+    brief: "Human readable (not intended to be parsed) OS version information, like e.g. reported by ver or lsb_release -a commands.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'Ubuntu 18.04.1 LTS',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "Ubuntu 18.04.1 LTS",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [OS_NAME]: {
-    brief: 'Human readable operating system name.',
+    brief: "Human readable operating system name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'Ubuntu',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "Ubuntu",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [OS_TYPE]: {
-    brief: 'The operating system type.',
+    brief: "The operating system type.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'linux',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "linux",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [OS_VERSION]: {
-    brief: 'The version of the operating system.',
+    brief: "The version of the operating system.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '18.04.2',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "18.04.2",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [OTEL_SCOPE_NAME]: {
-    brief: 'The name of the instrumentation scope - (InstrumentationScope.Name in OTLP).',
+    brief: "The name of the instrumentation scope - (InstrumentationScope.Name in OTLP).",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'io.opentelemetry.contrib.mongodb',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "io.opentelemetry.contrib.mongodb",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [OTEL_SCOPE_VERSION]: {
-    brief: 'The version of the instrumentation scope - (InstrumentationScope.Version in OTLP).',
+    brief: "The version of the instrumentation scope - (InstrumentationScope.Version in OTLP).",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '2.4.5',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "2.4.5",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [OTEL_STATUS_CODE]: {
-    brief: 'Name of the code, either “OK” or “ERROR”. MUST NOT be set if the status code is UNSET.',
+    brief: "Name of the code, either “OK” or “ERROR”. MUST NOT be set if the status code is UNSET.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'OK',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "OK",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [OTEL_STATUS_DESCRIPTION]: {
-    brief: 'Description of the Status if it has a value, otherwise not set.',
+    brief: "Description of the Status if it has a value, otherwise not set.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'resource not found',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "resource not found",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [PARAMS_KEY]: {
-    brief:
-      'Decoded parameters extracted from a URL path. Usually added by client-side routing frameworks like vue-router.',
+    brief: "Decoded parameters extracted from a URL path. Usually added by client-side routing frameworks like vue-router.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     hasDynamicSuffix: true,
     example: "params.id='123'",
     aliases: [URL_PATH_PARAMETER_KEY],
-    changelog: [{ version: '0.1.0', prs: [103] }],
+    changelog: [
+      { version: "0.1.0", prs: [103] },
+    ],
   },
   [PREVIOUS_ROUTE]: {
-    brief: 'Also used by mobile SDKs to indicate the previous route in the application.',
+    brief: "Also used by mobile SDKs to indicate the previous route in the application.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'HomeScreen',
-    sdks: ['javascript-reactnative'],
-    changelog: [{ version: '0.1.0', prs: [74] }, { version: '0.0.0' }],
+    example: "HomeScreen",
+    sdks: ["javascript-reactnative"],
+    changelog: [
+      { version: "0.1.0", prs: [74] },
+      { version: "0.0.0" },
+    ],
   },
   [PROCESS_EXECUTABLE_NAME]: {
-    brief: 'The name of the executable that started the process.',
+    brief: "The name of the executable that started the process.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'getsentry',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "getsentry",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [PROCESS_PID]: {
-    brief: 'The process ID of the running process.',
+    brief: "The process ID of the running process.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 12345,
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [PROCESS_RUNTIME_DESCRIPTION]: {
-    brief:
-      'An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment. Equivalent to `raw_description` in the Sentry runtime context.',
+    brief: "An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment. Equivalent to `raw_description` in the Sentry runtime context.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'Eclipse OpenJ9 VM openj9-0.21.0',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "Eclipse OpenJ9 VM openj9-0.21.0",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [PROCESS_RUNTIME_NAME]: {
-    brief: 'The name of the runtime. Equivalent to `name` in the Sentry runtime context.',
+    brief: "The name of the runtime. Equivalent to `name` in the Sentry runtime context.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'node',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "node",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [PROCESS_RUNTIME_VERSION]: {
-    brief:
-      'The version of the runtime of this process, as returned by the runtime without modification. Equivalent to `version` in the Sentry runtime context.',
+    brief: "The version of the runtime of this process, as returned by the runtime without modification. Equivalent to `version` in the Sentry runtime context.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '18.04.2',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "18.04.2",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [QUERY_KEY]: {
-    brief: 'An item in a query string. Usually added by client-side routing frameworks like vue-router.',
+    brief: "An item in a query string. Usually added by client-side routing frameworks like vue-router.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     hasDynamicSuffix: true,
     example: "query.id='123'",
     deprecation: {
-      replacement: 'url.query',
-      reason: 'Instead of sending items individually in query.<key>, they should be sent all together with url.query.',
+      replacement: "url.query",
+      reason: "Instead of sending items individually in query.<key>, they should be sent all together with url.query."
     },
-    changelog: [{ version: '0.1.0', prs: [103] }],
+    changelog: [
+      { version: "0.1.0", prs: [103] },
+    ],
   },
   [RELEASE]: {
-    brief: 'The sentry release.',
+    brief: "The sentry release.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'production',
+    example: "production",
     deprecation: {
-      replacement: 'sentry.release',
+      replacement: "sentry.release"
     },
     aliases: [SENTRY_RELEASE],
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [REMIX_ACTION_FORM_DATA_KEY]: {
-    brief: 'Remix form data, <key> being the form data key, the value being the form data value.',
+    brief: "Remix form data, <key> being the form data key, the value being the form data value.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     hasDynamicSuffix: true,
     example: "http.response.header.text='test'",
-    sdks: ['javascript-remix'],
-    changelog: [{ version: '0.1.0', prs: [103] }],
+    sdks: ["javascript-remix"],
+    changelog: [
+      { version: "0.1.0", prs: [103] },
+    ],
   },
   [REPLAY_ID]: {
-    brief: 'The id of the sentry replay.',
+    brief: "The id of the sentry replay.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '123e4567e89b12d3a456426614174000',
+    example: "123e4567e89b12d3a456426614174000",
     deprecation: {
-      replacement: 'sentry.replay_id',
+      replacement: "sentry.replay_id"
     },
     aliases: [SENTRY_REPLAY_ID],
-    changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61] },
+      { version: "0.0.0" },
+    ],
   },
   [RESOURCE_DEPLOYMENT_ENVIRONMENT]: {
-    brief: 'The software deployment environment name.',
+    brief: "The software deployment environment name.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: true,
-    example: 'production',
+    example: "production",
     deprecation: {
-      replacement: 'sentry.environment',
+      replacement: "sentry.environment"
     },
-    changelog: [{ version: 'next', prs: [266] }],
+    changelog: [
+      { version: "next", prs: [266] },
+    ],
   },
   [RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME]: {
-    brief: 'The software deployment environment name.',
+    brief: "The software deployment environment name.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: true,
-    example: 'production',
+    example: "production",
     deprecation: {
-      replacement: 'sentry.environment',
+      replacement: "sentry.environment"
     },
-    changelog: [{ version: '0.3.1', prs: [196] }],
+    changelog: [
+      { version: "0.3.1", prs: [196] },
+    ],
   },
   [RESOURCE_RENDER_BLOCKING_STATUS]: {
-    brief: 'The render blocking status of the resource.',
+    brief: "The render blocking status of the resource.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'non-blocking',
-    sdks: ['javascript-browser'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "non-blocking",
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [ROUTE]: {
-    brief:
-      'The matched route, that is, the path template in the format used by the respective server framework. Also used by mobile SDKs to indicate the current route in the application.',
+    brief: "The matched route, that is, the path template in the format used by the respective server framework. Also used by mobile SDKs to indicate the current route in the application.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'App\\Controller::indexAction',
+    example: "App\\Controller::indexAction",
     deprecation: {
-      replacement: 'http.route',
+      replacement: "http.route"
     },
     aliases: [HTTP_ROUTE],
-    sdks: ['php-laravel', 'javascript-reactnative'],
-    changelog: [{ version: '0.1.0', prs: [61, 74] }, { version: '0.0.0' }],
+    sdks: ["php-laravel","javascript-reactnative"],
+    changelog: [
+      { version: "0.1.0", prs: [61, 74] },
+      { version: "0.0.0" },
+    ],
   },
   [RPC_GRPC_STATUS_CODE]: {
-    brief: 'The numeric status code of the gRPC request.',
+    brief: "The numeric status code of the gRPC request.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 2,
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [RPC_SERVICE]: {
-    brief: 'The full (logical) name of the service being called, including its package name, if applicable.',
+    brief: "The full (logical) name of the service being called, including its package name, if applicable.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'myService.BestService',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "myService.BestService",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_ACTION]: {
-    brief:
-      'Used as a generic attribute representing the action depending on the type of span. For instance, this is the database query operation for DB spans, and the request method for HTTP spans.',
+    brief: "Used as a generic attribute representing the action depending on the type of span. For instance, this is the database query operation for DB spans, and the request method for HTTP spans.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'SELECT',
-    changelog: [{ version: '0.4.0', prs: [212] }],
+    example: "SELECT",
+    changelog: [
+      { version: "0.4.0", prs: [212] },
+    ],
   },
   [SENTRY_BROWSER_NAME]: {
-    brief: 'The name of the browser.',
+    brief: "The name of the browser.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'Chrome',
+    example: "Chrome",
     deprecation: {
-      replacement: 'browser.name',
+      replacement: "browser.name"
     },
     aliases: [BROWSER_NAME],
-    changelog: [{ version: '0.1.0', prs: [139] }],
+    changelog: [
+      { version: "0.1.0", prs: [139] },
+    ],
   },
   [SENTRY_BROWSER_VERSION]: {
-    brief: 'The version of the browser.',
+    brief: "The version of the browser.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '120.0.6099.130',
+    example: "120.0.6099.130",
     deprecation: {
-      replacement: 'browser.version',
+      replacement: "browser.version"
     },
     aliases: [BROWSER_VERSION],
-    changelog: [{ version: '0.1.0', prs: [139] }],
+    changelog: [
+      { version: "0.1.0", prs: [139] },
+    ],
   },
   [SENTRY_CANCELLATION_REASON]: {
-    brief: 'The reason why a span ended early.',
+    brief: "The reason why a span ended early.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'document.hidden',
-    changelog: [{ version: '0.0.0' }],
+    example: "document.hidden",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_CATEGORY]: {
-    brief:
-      "The high-level category of a span, derived from the span operation or span attributes. This categorizes spans by their general purpose (e.g., database, HTTP, UI). Known values include: 'ai', 'ai.pipeline', 'app', 'browser', 'cache', 'console', 'db', 'event', 'file', 'function.aws', 'function.azure', 'function.gcp', 'function.nextjs', 'function.remix', 'graphql', 'grpc', 'http', 'measure', 'middleware', 'navigation', 'pageload', 'queue', 'resource', 'rpc', 'serialize', 'subprocess', 'template', 'topic', 'ui', 'ui.angular', 'ui.ember', 'ui.react', 'ui.svelte', 'ui.vue', 'view', 'websocket'.",
+    brief: "The high-level category of a span, derived from the span operation or span attributes. This categorizes spans by their general purpose (e.g., database, HTTP, UI). Known values include: 'ai', 'ai.pipeline', 'app', 'browser', 'cache', 'console', 'db', 'event', 'file', 'function.aws', 'function.azure', 'function.gcp', 'function.nextjs', 'function.remix', 'graphql', 'grpc', 'http', 'measure', 'middleware', 'navigation', 'pageload', 'queue', 'resource', 'rpc', 'serialize', 'subprocess', 'template', 'topic', 'ui', 'ui.angular', 'ui.ember', 'ui.react', 'ui.svelte', 'ui.vue', 'view', 'websocket'.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'db',
-    changelog: [{ version: '0.4.0', prs: [218] }],
+    example: "db",
+    changelog: [
+      { version: "0.4.0", prs: [218] },
+    ],
   },
   [SENTRY_CLIENT_SAMPLE_RATE]: {
-    brief: 'Rate at which a span was sampled in the SDK.',
+    brief: "Rate at which a span was sampled in the SDK.",
     type: 'double',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: 0.5,
-    changelog: [{ version: '0.1.0', prs: [102] }],
+    changelog: [
+      { version: "0.1.0", prs: [102] },
+    ],
   },
   [SENTRY_DESCRIPTION]: {
-    brief: 'The human-readable description of a span.',
+    brief: "The human-readable description of a span.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'index view query',
-    changelog: [{ version: '0.1.0', prs: [135] }],
+    example: "index view query",
+    changelog: [
+      { version: "0.1.0", prs: [135] },
+    ],
   },
   [SENTRY_DIST]: {
-    brief: 'The sentry dist.',
+    brief: "The sentry dist.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '1.0',
-    changelog: [{ version: '0.0.0' }],
+    example: "1.0",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_DOMAIN]: {
-    brief:
-      'Used as a generic attribute representing the domain depending on the type of span. For instance, this is the collection/table name for database spans, and the server address for HTTP spans.',
+    brief: "Used as a generic attribute representing the domain depending on the type of span. For instance, this is the collection/table name for database spans, and the server address for HTTP spans.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'example.com',
-    changelog: [{ version: '0.4.0', prs: [212] }],
+    example: "example.com",
+    changelog: [
+      { version: "0.4.0", prs: [212] },
+    ],
   },
   [SENTRY_DSC_ENVIRONMENT]: {
-    brief: 'The environment from the dynamic sampling context.',
+    brief: "The environment from the dynamic sampling context.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'prod',
-    changelog: [{ version: '0.3.0', prs: [185] }],
+    example: "prod",
+    changelog: [
+      { version: "0.3.0", prs: [185] },
+    ],
   },
   [SENTRY_DSC_PUBLIC_KEY]: {
-    brief: 'The public key from the dynamic sampling context.',
+    brief: "The public key from the dynamic sampling context.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'c51734c603c4430eb57cb0a5728a479d',
-    changelog: [{ version: '0.3.0', prs: [185] }],
+    example: "c51734c603c4430eb57cb0a5728a479d",
+    changelog: [
+      { version: "0.3.0", prs: [185] },
+    ],
   },
   [SENTRY_DSC_RELEASE]: {
-    brief: 'The release identifier from the dynamic sampling context.',
+    brief: "The release identifier from the dynamic sampling context.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'frontend@e8211be71b214afab5b85de4b4c54be3714952bb',
-    changelog: [{ version: '0.3.0', prs: [185] }],
+    example: "frontend@e8211be71b214afab5b85de4b4c54be3714952bb",
+    changelog: [
+      { version: "0.3.0", prs: [185] },
+    ],
   },
   [SENTRY_DSC_SAMPLED]: {
-    brief: 'Whether the event was sampled according to the dynamic sampling context.',
+    brief: "Whether the event was sampled according to the dynamic sampling context.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: true,
-    changelog: [{ version: '0.3.0', prs: [185] }],
+    changelog: [
+      { version: "0.3.0", prs: [185] },
+    ],
   },
   [SENTRY_DSC_SAMPLE_RATE]: {
-    brief: 'The sample rate from the dynamic sampling context.',
+    brief: "The sample rate from the dynamic sampling context.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '1.0',
-    changelog: [{ version: '0.3.0', prs: [185] }],
+    example: "1.0",
+    changelog: [
+      { version: "0.3.0", prs: [185] },
+    ],
   },
   [SENTRY_DSC_TRACE_ID]: {
-    brief: 'The trace ID from the dynamic sampling context.',
+    brief: "The trace ID from the dynamic sampling context.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '047372980460430cbc78d9779df33a46',
-    changelog: [{ version: '0.3.0', prs: [185] }],
+    example: "047372980460430cbc78d9779df33a46",
+    changelog: [
+      { version: "0.3.0", prs: [185] },
+    ],
   },
   [SENTRY_DSC_TRANSACTION]: {
-    brief: 'The transaction name from the dynamic sampling context.',
+    brief: "The transaction name from the dynamic sampling context.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '/issues/errors-outages/',
-    changelog: [{ version: '0.3.0', prs: [185] }],
+    example: "/issues/errors-outages/",
+    changelog: [
+      { version: "0.3.0", prs: [185] },
+    ],
   },
   [SENTRY_ENVIRONMENT]: {
-    brief: 'The sentry environment.',
+    brief: "The sentry environment.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'production',
+    example: "production",
     aliases: [ENVIRONMENT],
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_EXCLUSIVE_TIME]: {
-    brief: 'The exclusive time duration of the span in milliseconds.',
+    brief: "The exclusive time duration of the span in milliseconds.",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1234,
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.3.0', prs: [160] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.3.0", prs: [160] },
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_GRAPHQL_OPERATION]: {
-    brief: 'Indicates the type of graphql operation, emitted by the Javascript SDK.',
+    brief: "Indicates the type of graphql operation, emitted by the Javascript SDK.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'getUserById',
-    changelog: [{ version: '0.3.1', prs: [190] }],
+    example: "getUserById",
+    changelog: [
+      { version: "0.3.1", prs: [190] },
+    ],
   },
   [SENTRY_GROUP]: {
-    brief:
-      'Stores the hash of `sentry.normalized_description`. This is primarily used for grouping spans in the product end.',
+    brief: "Stores the hash of `sentry.normalized_description`. This is primarily used for grouping spans in the product end.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    changelog: [{ version: '0.4.0', prs: [212] }],
+    changelog: [
+      { version: "0.4.0", prs: [212] },
+    ],
   },
   [SENTRY_HTTP_PREFETCH]: {
-    brief: 'If an http request was a prefetch request.',
+    brief: "If an http request was a prefetch request.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: true,
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_IDLE_SPAN_FINISH_REASON]: {
-    brief: 'The reason why an idle span ended early.',
+    brief: "The reason why an idle span ended early.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'idleTimeout',
-    changelog: [{ version: '0.0.0' }],
+    example: "idleTimeout",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_IS_REMOTE]: {
     brief: "Indicates whether a span's parent is remote.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: true,
-    changelog: [{ version: '0.3.1', prs: [190] }],
+    changelog: [
+      { version: "0.3.1", prs: [190] },
+    ],
   },
   [SENTRY_KIND]: {
-    brief:
-      'Used to clarify the relationship between parents and children, or to distinguish between spans, e.g. a `server` and `client` span with the same name.',
+    brief: "Used to clarify the relationship between parents and children, or to distinguish between spans, e.g. a `server` and `client` span with the same name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'server',
-    changelog: [{ version: '0.3.1', prs: [190] }],
+    example: "server",
+    changelog: [
+      { version: "0.3.1", prs: [190] },
+    ],
   },
   [SENTRY_MESSAGE_PARAMETER_KEY]: {
-    brief:
-      "A parameter used in the message template. <key> can either be the number that represent the parameter's position in the template string (sentry.message.parameter.0, sentry.message.parameter.1, etc) or the parameter's name (sentry.message.parameter.item_id, sentry.message.parameter.user_id, etc)",
+    brief: "A parameter used in the message template. <key> can either be the number that represent the parameter's position in the template string (sentry.message.parameter.0, sentry.message.parameter.1, etc) or the parameter's name (sentry.message.parameter.item_id, sentry.message.parameter.user_id, etc)",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: "sentry.message.parameter.0='123'",
-    changelog: [{ version: '0.1.0', prs: [116] }],
+    changelog: [
+      { version: "0.1.0", prs: [116] },
+    ],
   },
   [SENTRY_MESSAGE_TEMPLATE]: {
-    brief: 'The parameterized template string.',
+    brief: "The parameterized template string.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'Hello, {name}!',
-    changelog: [{ version: '0.1.0', prs: [116] }],
+    example: "Hello, {name}!",
+    changelog: [
+      { version: "0.1.0", prs: [116] },
+    ],
   },
   [SENTRY_MODULE_KEY]: {
-    brief: 'A module that was loaded in the process. The key is the name of the module.',
+    brief: "A module that was loaded in the process. The key is the name of the module.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     hasDynamicSuffix: true,
     example: "sentry.module.brianium/paratest='v7.7.0'",
-    changelog: [{ version: '0.1.0', prs: [103] }],
+    changelog: [
+      { version: "0.1.0", prs: [103] },
+    ],
   },
   [SENTRY_NEXTJS_SSR_FUNCTION_ROUTE]: {
-    brief:
-      'A parameterized route for a function in Next.js that contributes to Server-Side Rendering. Should be present on spans that track such functions when the file location of the function is known.',
+    brief: "A parameterized route for a function in Next.js that contributes to Server-Side Rendering. Should be present on spans that track such functions when the file location of the function is known.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '/posts/[id]/layout',
-    sdks: ['javascript'],
-    changelog: [{ version: '0.1.0', prs: [54, 106] }],
+    example: "/posts/[id]/layout",
+    sdks: ["javascript"],
+    changelog: [
+      { version: "0.1.0", prs: [54, 106] },
+    ],
   },
   [SENTRY_NEXTJS_SSR_FUNCTION_TYPE]: {
-    brief:
-      'A descriptor for a for a function in Next.js that contributes to Server-Side Rendering. Should be present on spans that track such functions.',
+    brief: "A descriptor for a for a function in Next.js that contributes to Server-Side Rendering. Should be present on spans that track such functions.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'generateMetadata',
-    sdks: ['javascript'],
-    changelog: [{ version: '0.1.0', prs: [54, 106] }],
+    example: "generateMetadata",
+    sdks: ["javascript"],
+    changelog: [
+      { version: "0.1.0", prs: [54, 106] },
+    ],
   },
   [SENTRY_NORMALIZED_DB_QUERY]: {
-    brief: 'The normalized version of `db.query.text`.',
+    brief: "The normalized version of `db.query.text`.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'SELECT .. FROM sentry_project WHERE (project_id = %s)',
-    changelog: [{ version: '0.3.1', prs: [194] }],
+    example: "SELECT .. FROM sentry_project WHERE (project_id = %s)",
+    changelog: [
+      { version: "0.3.1", prs: [194] },
+    ],
   },
   [SENTRY_NORMALIZED_DB_QUERY_HASH]: {
-    brief: 'The hash of `sentry.normalized_db_query`.',
+    brief: "The hash of `sentry.normalized_db_query`.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    changelog: [{ version: '0.4.0', prs: [200] }],
+    changelog: [
+      { version: "0.4.0", prs: [200] },
+    ],
   },
   [SENTRY_NORMALIZED_DESCRIPTION]: {
-    brief:
-      'Used as a generic attribute representing the normalized `sentry.description`. This refers to the legacy use case of `sentry.description` where it holds relevant data depending on the type of span (e.g. database query, resource url, http request description, etc).',
+    brief: "Used as a generic attribute representing the normalized `sentry.description`. This refers to the legacy use case of `sentry.description` where it holds relevant data depending on the type of span (e.g. database query, resource url, http request description, etc).",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'SELECT .. FROM sentry_project WHERE (project_id = %s)',
-    changelog: [{ version: '0.4.0', prs: [212] }],
+    example: "SELECT .. FROM sentry_project WHERE (project_id = %s)",
+    changelog: [
+      { version: "0.4.0", prs: [212] },
+    ],
   },
   [SENTRY_OBSERVED_TIMESTAMP_NANOS]: {
-    brief: 'The timestamp at which an envelope was received by Relay, in nanoseconds.',
+    brief: "The timestamp at which an envelope was received by Relay, in nanoseconds.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '1544712660300000000',
+    example: "1544712660300000000",
     changelog: [
-      { version: '0.3.0', prs: [174] },
-      { version: '0.2.0', prs: [137] },
+      { version: "0.3.0", prs: [174] },
+      { version: "0.2.0", prs: [137] },
     ],
   },
   [SENTRY_OP]: {
-    brief: 'The operation of a span.',
+    brief: "The operation of a span.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'http.client',
-    changelog: [{ version: '0.0.0' }],
+    example: "http.client",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_ORIGIN]: {
-    brief: 'The origin of the instrumentation (e.g. span, log, etc.)',
+    brief: "The origin of the instrumentation (e.g. span, log, etc.)",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'auto.http.otel.fastify',
-    changelog: [{ version: '0.1.0', prs: [68] }, { version: '0.0.0' }],
+    example: "auto.http.otel.fastify",
+    changelog: [
+      { version: "0.1.0", prs: [68] },
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_PLATFORM]: {
-    brief: 'The sdk platform that generated the event.',
+    brief: "The sdk platform that generated the event.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'php',
-    changelog: [{ version: '0.0.0' }],
+    example: "php",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_PROFILER_ID]: {
-    brief: 'The id of the currently running profiler (continuous profiling)',
+    brief: "The id of the currently running profiler (continuous profiling)",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '18779b64dd35d1a538e7ce2dd2d3fad3',
-    changelog: [{ version: '0.4.0', prs: [242] }],
+    example: "18779b64dd35d1a538e7ce2dd2d3fad3",
+    changelog: [
+      { version: "0.4.0", prs: [242] },
+    ],
   },
   [SENTRY_RELEASE]: {
-    brief: 'The sentry release.',
+    brief: "The sentry release.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '7.0.0',
+    example: "7.0.0",
     aliases: [SERVICE_VERSION, RELEASE],
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_REPLAY_ID]: {
-    brief: 'The id of the sentry replay.',
+    brief: "The id of the sentry replay.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '123e4567e89b12d3a456426614174000',
+    example: "123e4567e89b12d3a456426614174000",
     aliases: [REPLAY_ID],
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_REPLAY_IS_BUFFERING]: {
-    brief:
-      'A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate).',
+    brief: "A sentinel attribute on log events indicating whether the current Session Replay is being buffered (onErrorSampleRate).",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: true,
-    changelog: [{ version: '0.3.0', prs: [185] }],
+    changelog: [
+      { version: "0.3.0", prs: [185] },
+    ],
   },
   [SENTRY_SDK_INTEGRATIONS]: {
-    brief:
-      'A list of names identifying enabled integrations. The list shouldhave all enabled integrations, including default integrations. Defaultintegrations are included because different SDK releases may contain differentdefault integrations.',
+    brief: "A list of names identifying enabled integrations. The list shouldhave all enabled integrations, including default integrations. Defaultintegrations are included because different SDK releases may contain differentdefault integrations.",
     type: 'string[]',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: ['InboundFilters', 'FunctionToString', 'BrowserApiErrors', 'Breadcrumbs'],
-    changelog: [{ version: '0.0.0', prs: [42] }],
+    example: ["InboundFilters","FunctionToString","BrowserApiErrors","Breadcrumbs"],
+    changelog: [
+      { version: "0.0.0", prs: [42] },
+    ],
   },
   [SENTRY_SDK_NAME]: {
-    brief: 'The sentry sdk name.',
+    brief: "The sentry sdk name.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '@sentry/react',
-    changelog: [{ version: '0.0.0' }],
+    example: "@sentry/react",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_SDK_VERSION]: {
-    brief: 'The sentry sdk version.',
+    brief: "The sentry sdk version.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '7.0.0',
-    changelog: [{ version: '0.0.0' }],
+    example: "7.0.0",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_SEGMENT_ID]: {
-    brief: 'The segment ID of a span',
+    brief: "The segment ID of a span",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '051581bf3cb55c13',
+    example: "051581bf3cb55c13",
     aliases: [_SENTRY_SEGMENT_ID],
-    changelog: [{ version: '0.1.0', prs: [107, 124] }],
+    changelog: [
+      { version: "0.1.0", prs: [107, 124] },
+    ],
   },
   [_SENTRY_SEGMENT_ID]: {
-    brief: 'The segment ID of a span',
+    brief: "The segment ID of a span",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '051581bf3cb55c13',
+    example: "051581bf3cb55c13",
     deprecation: {
-      replacement: 'sentry.segment.id',
+      replacement: "sentry.segment.id"
     },
     aliases: [SENTRY_SEGMENT_ID],
-    changelog: [{ version: '0.1.0', prs: [124] }],
+    changelog: [
+      { version: "0.1.0", prs: [124] },
+    ],
   },
   [SENTRY_SEGMENT_NAME]: {
-    brief: 'The segment name of a span',
+    brief: "The segment name of a span",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'GET /user',
-    changelog: [{ version: '0.1.0', prs: [104] }],
+    example: "GET /user",
+    changelog: [
+      { version: "0.1.0", prs: [104] },
+    ],
   },
   [SENTRY_SERVER_SAMPLE_RATE]: {
-    brief: 'Rate at which a span was sampled in Relay.',
+    brief: "Rate at which a span was sampled in Relay.",
     type: 'double',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: 0.5,
-    changelog: [{ version: '0.1.0', prs: [102] }],
+    changelog: [
+      { version: "0.1.0", prs: [102] },
+    ],
   },
   [SENTRY_SOURCE]: {
-    brief:
-      "The source of a span, also referred to as transaction source. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`. '`source`' describes a parametrized route, while `'url'` describes the full URL, potentially containing identifiers.",
+    brief: "The source of a span, also referred to as transaction source. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`. '`source`' describes a parametrized route, while `'url'` describes the full URL, potentially containing identifiers.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'route',
+    example: "route",
     deprecation: {
-      replacement: 'sentry.span.source',
-      reason: 'This attribute is being deprecated in favor of sentry.span.source',
+      replacement: "sentry.span.source",
+      reason: "This attribute is being deprecated in favor of sentry.span.source"
     },
-    changelog: [{ version: 'next' }],
+    changelog: [
+      { version: "next" },
+    ],
   },
   [SENTRY_SPAN_SOURCE]: {
-    brief:
-      "The source of a span, also referred to as transaction source. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`. '`source`' describes a parametrized route, while `'url'` describes the full URL, potentially containing identifiers.",
+    brief: "The source of a span, also referred to as transaction source. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`. '`source`' describes a parametrized route, while `'url'` describes the full URL, potentially containing identifiers.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'route',
-    changelog: [{ version: '0.4.0', prs: [214] }, { version: '0.0.0' }],
+    example: "route",
+    changelog: [
+      { version: "0.4.0", prs: [214] },
+      { version: "0.0.0" },
+    ],
   },
   [SENTRY_STATUS_CODE]: {
-    brief:
-      'The HTTP status code used in Sentry Insights. Typically set by Sentry during ingestion, rather than by clients.',
+    brief: "The HTTP status code used in Sentry Insights. Typically set by Sentry during ingestion, rather than by clients.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 200,
-    changelog: [{ version: '0.4.0', prs: [223, 228] }],
+    changelog: [
+      { version: "0.4.0", prs: [223, 228] },
+    ],
   },
   [SENTRY_STATUS_MESSAGE]: {
-    brief: 'The from OTLP extracted status message.',
+    brief: "The from OTLP extracted status message.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'foobar',
-    changelog: [{ version: '0.3.1', prs: [190] }],
+    example: "foobar",
+    changelog: [
+      { version: "0.3.1", prs: [190] },
+    ],
   },
   [SENTRY_TIMESTAMP_SEQUENCE]: {
-    brief:
-      'A sequencing counter for deterministic ordering of logs or metrics when timestamps share the same integer millisecond. Starts at 0 on SDK initialization, increments by 1 for each captured item, and resets to 0 when the integer millisecond of the current item differs from the previous one.',
+    brief: "A sequencing counter for deterministic ordering of logs or metrics when timestamps share the same integer millisecond. Starts at 0 on SDK initialization, increments by 1 for each captured item, and resets to 0 when the integer millisecond of the current item differs from the previous one.",
     type: 'integer',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: 0,
-    changelog: [{ version: 'next', prs: [262] }],
+    changelog: [
+      { version: "next", prs: [262] },
+    ],
   },
   [SENTRY_TRACE_PARENT_SPAN_ID]: {
-    brief:
-      'The span id of the span that was active when the log was collected. This should not be set if there was no active span.',
+    brief: "The span id of the span that was active when the log was collected. This should not be set if there was no active span.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'b0e6f15b45c36b12',
+    example: "b0e6f15b45c36b12",
     deprecation: {},
     changelog: [
-      { version: 'next', prs: [287], description: 'Deprecate `sentry.trace.parent_span_id`' },
-      { version: '0.1.0', prs: [116] },
+      { version: "next", prs: [287], description: "Deprecate `sentry.trace.parent_span_id`" },
+      { version: "0.1.0", prs: [116] },
     ],
   },
   [SENTRY_TRANSACTION]: {
-    brief: 'The sentry transaction (segment name).',
+    brief: "The sentry transaction (segment name).",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'GET /',
+    example: "GET /",
     aliases: [TRANSACTION],
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [SERVER_ADDRESS]: {
-    brief:
-      'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
+    brief: "Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'example.com',
+    example: "example.com",
     aliases: [HTTP_SERVER_NAME, NET_HOST_NAME, HTTP_HOST],
-    changelog: [{ version: '0.1.0', prs: [108, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [108, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [SERVER_PORT]: {
-    brief: 'Server port number.',
+    brief: "Server port number.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 1337,
     aliases: [NET_HOST_PORT],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [SERVICE_NAME]: {
-    brief: 'Logical name of the service.',
+    brief: "Logical name of the service.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'omegastar',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "omegastar",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [SERVICE_VERSION]: {
-    brief: 'The version string of the service API or implementation. The format is not defined by these conventions.',
+    brief: "The version string of the service API or implementation. The format is not defined by these conventions.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '5.0.0',
+    example: "5.0.0",
     aliases: [SENTRY_RELEASE],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [THREAD_ID]: {
-    brief: 'Current “managed” thread ID.',
+    brief: "Current “managed” thread ID.",
     type: 'integer',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: true,
     example: 56,
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [THREAD_NAME]: {
-    brief: 'Current thread name.',
+    brief: "Current thread name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'main',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "main",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [TIMBER_TAG]: {
-    brief: 'The log tag provided by the timber logging framework.',
+    brief: "The log tag provided by the timber logging framework.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'MyTag',
-    sdks: ['sentry.java.android'],
-    changelog: [{ version: '0.3.0', prs: [183] }],
+    example: "MyTag",
+    sdks: ["sentry.java.android"],
+    changelog: [
+      { version: "0.3.0", prs: [183] },
+    ],
   },
   [TRANSACTION]: {
-    brief: 'The sentry transaction (segment name).',
+    brief: "The sentry transaction (segment name).",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'GET /',
+    example: "GET /",
     deprecation: {
-      replacement: 'sentry.transaction',
+      replacement: "sentry.transaction"
     },
     aliases: [SENTRY_TRANSACTION],
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [61, 127] },
+      { version: "0.0.0" },
+    ],
   },
   [TTFB]: {
-    brief: 'The value of the recorded Time To First Byte (TTFB) web vital in milliseconds',
+    brief: "The value of the recorded Time To First Byte (TTFB) web vital in milliseconds",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 194,
     deprecation: {
-      replacement: 'browser.web_vital.ttfb.value',
-      reason: 'This attribute is being deprecated in favor of browser.web_vital.ttfb.value',
+      replacement: "browser.web_vital.ttfb.value",
+      reason: "This attribute is being deprecated in favor of browser.web_vital.ttfb.value"
     },
     aliases: [BROWSER_WEB_VITAL_TTFB_VALUE],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [235] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [235] },
+    ],
   },
   [TTFB_REQUESTTIME]: {
-    brief:
-      "The time it takes for the server to process the initial request and send the first byte of a response to the user's browser",
+    brief: "The time it takes for the server to process the initial request and send the first byte of a response to the user's browser",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1554.5814,
     deprecation: {
-      replacement: 'browser.web_vital.ttfb.request_time',
-      reason: 'This attribute is being deprecated in favor of browser.web_vital.ttfb.request_time',
+      replacement: "browser.web_vital.ttfb.request_time",
+      reason: "This attribute is being deprecated in favor of browser.web_vital.ttfb.request_time"
     },
     aliases: [BROWSER_WEB_VITAL_TTFB_REQUEST_TIME],
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [235] }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [235] },
+    ],
   },
   [TYPE]: {
-    brief: 'More granular type of the operation happening.',
+    brief: "More granular type of the operation happening.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'fetch',
-    sdks: ['javascript-browser', 'javascript-node'],
-    changelog: [{ version: '0.0.0' }],
+    example: "fetch",
+    sdks: ["javascript-browser","javascript-node"],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [UI_COMPONENT_NAME]: {
-    brief: 'The name of the associated component.',
+    brief: "The name of the associated component.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'HomeButton',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "HomeButton",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [UI_CONTRIBUTES_TO_TTFD]: {
-    brief: 'Whether the span execution contributed to the TTFD (time to fully drawn) metric.',
+    brief: "Whether the span execution contributed to the TTFD (time to fully drawn) metric.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: true,
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [UI_CONTRIBUTES_TO_TTID]: {
-    brief: 'Whether the span execution contributed to the TTID (time to initial display) metric.',
+    brief: "Whether the span execution contributed to the TTID (time to initial display) metric.",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
     example: true,
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [UI_ELEMENT_HEIGHT]: {
-    brief: 'The height of the UI element (for Html in pixels)',
+    brief: "The height of the UI element (for Html in pixels)",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 256,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.height attribute' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [284], description: "Added ui.element.height attribute" },
+    ],
   },
   [UI_ELEMENT_ID]: {
-    brief: 'The id of the UI element',
+    brief: "The id of the UI element",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'btn-login',
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.id attribute' }],
+    example: "btn-login",
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [284], description: "Added ui.element.id attribute" },
+    ],
   },
   [UI_ELEMENT_IDENTIFIER]: {
-    brief: 'The identifier used to measure the UI element timing',
+    brief: "The identifier used to measure the UI element timing",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'heroImage',
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.identifier attribute' }],
+    example: "heroImage",
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [284], description: "Added ui.element.identifier attribute" },
+    ],
   },
   [UI_ELEMENT_LOAD_TIME]: {
-    brief: 'The loading time of a UI element (from time origin to finished loading)',
+    brief: "The loading time of a UI element (from time origin to finished loading)",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 998.2234,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.load_time attribute' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [284], description: "Added ui.element.load_time attribute" },
+    ],
   },
   [UI_ELEMENT_PAINT_TYPE]: {
     brief: "The type of element paint. Can either be 'image-paint' or 'text-paint'",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'image-paint',
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.paint_type attribute' }],
+    example: "image-paint",
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [284], description: "Added ui.element.paint_type attribute" },
+    ],
   },
   [UI_ELEMENT_RENDER_TIME]: {
-    brief: 'The rendering time of the UI element (from time origin to finished rendering)',
+    brief: "The rendering time of the UI element (from time origin to finished rendering)",
     type: 'double',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1023.1124,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.render_time attribute' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [284], description: "Added ui.element.render_time attribute" },
+    ],
   },
   [UI_ELEMENT_TYPE]: {
-    brief: 'type of the UI element',
+    brief: "type of the UI element",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'img',
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.type attribute' }],
+    example: "img",
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [284], description: "Added ui.element.type attribute" },
+    ],
   },
   [UI_ELEMENT_URL]: {
-    brief: 'The URL of the UI element (e.g. an img src)',
+    brief: "The URL of the UI element (e.g. an img src)",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'https://assets.myapp.com/hero.png',
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.url attribute' }],
+    example: "https://assets.myapp.com/hero.png",
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [284], description: "Added ui.element.url attribute" },
+    ],
   },
   [UI_ELEMENT_WIDTH]: {
-    brief: 'The width of the UI element (for HTML in pixels)',
+    brief: "The width of the UI element (for HTML in pixels)",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 512,
-    sdks: ['javascript-browser'],
-    changelog: [{ version: 'next', prs: [284], description: 'Added ui.element.width attribute' }],
+    sdks: ["javascript-browser"],
+    changelog: [
+      { version: "next", prs: [284], description: "Added ui.element.width attribute" },
+    ],
   },
   [URL]: {
-    brief: 'The URL of the resource that was fetched.',
+    brief: "The URL of the resource that was fetched.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'https://example.com/test?foo=bar#buzz',
+    example: "https://example.com/test?foo=bar#buzz",
     deprecation: {
-      replacement: 'url.full',
+      replacement: "url.full"
     },
     aliases: [URL_FULL, HTTP_URL],
-    sdks: ['javascript-browser', 'javascript-node'],
-    changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    sdks: ["javascript-browser","javascript-node"],
+    changelog: [
+      { version: "0.1.0", prs: [61] },
+      { version: "0.0.0" },
+    ],
   },
   [URL_DOMAIN]: {
-    brief:
-      'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
+    brief: "Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'example.com',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    example: "example.com",
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [URL_FRAGMENT]: {
-    brief:
-      'The fragments present in the URI. Note that this does not contain the leading # character, while the `http.fragment` attribute does.',
+    brief: "The fragments present in the URI. Note that this does not contain the leading # character, while the `http.fragment` attribute does.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'details',
-    changelog: [{ version: '0.0.0' }],
+    example: "details",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [URL_FULL]: {
-    brief: 'The URL of the resource that was fetched.',
+    brief: "The URL of the resource that was fetched.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'https://example.com/test?foo=bar#buzz',
+    example: "https://example.com/test?foo=bar#buzz",
     aliases: [HTTP_URL, URL],
-    changelog: [{ version: '0.1.0', prs: [108] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [108] },
+      { version: "0.0.0" },
+    ],
   },
   [URL_PATH]: {
-    brief: 'The URI path component.',
+    brief: "The URI path component.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '/foo',
-    changelog: [{ version: '0.0.0' }],
+    example: "/foo",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [URL_PATH_PARAMETER_KEY]: {
-    brief:
-      'Decoded parameters extracted from a URL path. Usually added by client-side routing frameworks like vue-router.',
+    brief: "Decoded parameters extracted from a URL path. Usually added by client-side routing frameworks like vue-router.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     hasDynamicSuffix: true,
     example: "url.path.parameter.id='123'",
     aliases: [PARAMS_KEY],
-    changelog: [{ version: '0.1.0', prs: [103] }],
+    changelog: [
+      { version: "0.1.0", prs: [103] },
+    ],
   },
   [URL_PORT]: {
-    brief: 'Server port number.',
+    brief: "Server port number.",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
     example: 1337,
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.4.0", prs: [228] },
+      { version: "0.0.0" },
+    ],
   },
   [URL_QUERY]: {
-    brief:
-      'The query string present in the URL. Note that this does not contain the leading ? character, while the `http.query` attribute does.',
+    brief: "The query string present in the URL. Note that this does not contain the leading ? character, while the `http.query` attribute does.",
     type: 'string',
     pii: {
       isPii: 'maybe',
-      reason:
-        'Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.',
+      reason: "Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information."
     },
     isInOtel: true,
-    example: 'foo=bar&bar=baz',
-    changelog: [{ version: '0.0.0' }],
+    example: "foo=bar&bar=baz",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [URL_SCHEME]: {
-    brief: 'The URI scheme component identifying the used protocol.',
+    brief: "The URI scheme component identifying the used protocol.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: 'https',
+    example: "https",
     aliases: [HTTP_SCHEME],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [URL_TEMPLATE]: {
-    brief: 'The low-cardinality template of an absolute path reference.',
+    brief: "The low-cardinality template of an absolute path reference.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example: '/users/:id',
+    example: "/users/:id",
     aliases: [HTTP_ROUTE],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [USER_AGENT_ORIGINAL]: {
-    brief: 'Value of the HTTP User-Agent header sent by the client.',
+    brief: "Value of the HTTP User-Agent header sent by the client.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: true,
-    example:
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1',
+    example: "Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1",
     aliases: [HTTP_USER_AGENT],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: "0.1.0", prs: [127] },
+      { version: "0.0.0" },
+    ],
   },
   [USER_EMAIL]: {
-    brief: 'User email address.',
+    brief: "User email address.",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: true,
-    example: 'test@example.com',
-    changelog: [{ version: '0.0.0' }],
+    example: "test@example.com",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [USER_FULL_NAME]: {
     brief: "User's full name.",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: true,
-    example: 'John Smith',
-    changelog: [{ version: '0.0.0' }],
+    example: "John Smith",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [USER_GEO_CITY]: {
-    brief: 'Human readable city name.',
+    brief: "Human readable city name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'Toronto',
-    changelog: [{ version: '0.0.0' }],
+    example: "Toronto",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [USER_GEO_COUNTRY_CODE]: {
-    brief: 'Two-letter country code (ISO 3166-1 alpha-2).',
+    brief: "Two-letter country code (ISO 3166-1 alpha-2).",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'CA',
-    changelog: [{ version: '0.0.0' }],
+    example: "CA",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [USER_GEO_REGION]: {
-    brief: 'Human readable region name or code.',
+    brief: "Human readable region name or code.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'Canada',
-    changelog: [{ version: '0.0.0' }],
+    example: "Canada",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [USER_GEO_SUBDIVISION]: {
-    brief: 'Human readable subdivision name.',
+    brief: "Human readable subdivision name.",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'Ontario',
-    changelog: [{ version: '0.0.0' }],
+    example: "Ontario",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [USER_HASH]: {
-    brief: 'Unique user hash to correlate information for a user in anonymized form.',
+    brief: "Unique user hash to correlate information for a user in anonymized form.",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: true,
-    example: '8ae4c2993e0f4f3b8b2d1b1f3b5e8f4d',
-    changelog: [{ version: '0.0.0' }],
+    example: "8ae4c2993e0f4f3b8b2d1b1f3b5e8f4d",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [USER_ID]: {
-    brief: 'Unique identifier of the user.',
+    brief: "Unique identifier of the user.",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: true,
-    example: 'S-1-5-21-202424912787-2692429404-2351956786-1000',
-    changelog: [{ version: '0.0.0' }],
+    example: "S-1-5-21-202424912787-2692429404-2351956786-1000",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [USER_IP_ADDRESS]: {
-    brief: 'The IP address of the user.',
+    brief: "The IP address of the user.",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: '192.168.1.1',
-    changelog: [{ version: '0.1.0', prs: [75] }],
+    example: "192.168.1.1",
+    changelog: [
+      { version: "0.1.0", prs: [75] },
+    ],
   },
   [USER_NAME]: {
-    brief: 'Short name or login/username of the user.',
+    brief: "Short name or login/username of the user.",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: true,
-    example: 'j.smith',
-    changelog: [{ version: '0.0.0' }],
+    example: "j.smith",
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [USER_ROLES]: {
-    brief: 'Array of user roles at the time of the event.',
+    brief: "Array of user roles at the time of the event.",
     type: 'string[]',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: true,
-    example: ['admin', 'editor'],
-    changelog: [{ version: '0.0.0' }],
+    example: ["admin","editor"],
+    changelog: [
+      { version: "0.0.0" },
+    ],
   },
   [VERCEL_BRANCH]: {
-    brief: 'Git branch name for Vercel project',
+    brief: "Git branch name for Vercel project",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'main',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "main",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_BUILD_ID]: {
-    brief: 'Identifier for the Vercel build (only present on build logs)',
+    brief: "Identifier for the Vercel build (only present on build logs)",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'bld_cotnkcr76',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "bld_cotnkcr76",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_DEPLOYMENT_ID]: {
-    brief: 'Identifier for the Vercel deployment',
+    brief: "Identifier for the Vercel deployment",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'dpl_233NRGRjVZX1caZrXWtz5g1TAksD',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "dpl_233NRGRjVZX1caZrXWtz5g1TAksD",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_DESTINATION]: {
-    brief: 'Origin of the external content in Vercel (only on external logs)',
+    brief: "Origin of the external content in Vercel (only on external logs)",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'https://vitals.vercel-insights.com/v1',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "https://vitals.vercel-insights.com/v1",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_EDGE_TYPE]: {
-    brief: 'Type of edge runtime in Vercel',
+    brief: "Type of edge runtime in Vercel",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'edge-function',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "edge-function",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_ENTRYPOINT]: {
-    brief: 'Entrypoint for the request in Vercel',
+    brief: "Entrypoint for the request in Vercel",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'api/index.js',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "api/index.js",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_EXECUTION_REGION]: {
-    brief: 'Region where the request is executed',
+    brief: "Region where the request is executed",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'sfo1',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "sfo1",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_ID]: {
-    brief: 'Unique identifier for the log entry in Vercel',
+    brief: "Unique identifier for the log entry in Vercel",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '1573817187330377061717300000',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "1573817187330377061717300000",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_JA3_DIGEST]: {
-    brief: 'JA3 fingerprint digest of Vercel request',
+    brief: "JA3 fingerprint digest of Vercel request",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_JA4_DIGEST]: {
-    brief: 'JA4 fingerprint digest',
+    brief: "JA4 fingerprint digest",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 't13d1516h2_8daaf6152771_02713d6af862',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "t13d1516h2_8daaf6152771_02713d6af862",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_LOG_TYPE]: {
-    brief: 'Vercel log output type',
+    brief: "Vercel log output type",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'stdout',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "stdout",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROJECT_ID]: {
-    brief: 'Identifier for the Vercel project',
+    brief: "Identifier for the Vercel project",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'gdufoJxB6b9b1fEqr1jUtFkyavUU',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "gdufoJxB6b9b1fEqr1jUtFkyavUU",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROJECT_NAME]: {
-    brief: 'Name of the Vercel project',
+    brief: "Name of the Vercel project",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'my-app',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "my-app",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_CACHE_ID]: {
-    brief: 'Original request ID when request is served from cache',
+    brief: "Original request ID when request is served from cache",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'pdx1::v8g4b-1744143786684-93dafbc0f70d',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "pdx1::v8g4b-1744143786684-93dafbc0f70d",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_CLIENT_IP]: {
-    brief: 'Client IP address',
+    brief: "Client IP address",
     type: 'string',
     pii: {
-      isPii: 'true',
+      isPii: 'true'
     },
     isInOtel: false,
-    example: '120.75.16.101',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "120.75.16.101",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_HOST]: {
-    brief: 'Hostname of the request',
+    brief: "Hostname of the request",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'test.vercel.app',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "test.vercel.app",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_LAMBDA_REGION]: {
-    brief: 'Region where lambda function executed',
+    brief: "Region where lambda function executed",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'sfo1',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "sfo1",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_METHOD]: {
-    brief: 'HTTP method of the request',
+    brief: "HTTP method of the request",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'GET',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "GET",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_PATH]: {
-    brief: 'Request path with query parameters',
+    brief: "Request path with query parameters",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '/dynamic/some-value.json?route=some-value',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "/dynamic/some-value.json?route=some-value",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_PATH_TYPE]: {
-    brief: 'How the request was served based on its path and project configuration',
+    brief: "How the request was served based on its path and project configuration",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'func',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "func",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_PATH_TYPE_VARIANT]: {
-    brief: 'Variant of the path type',
+    brief: "Variant of the path type",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: 'api',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "api",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_REFERER]: {
-    brief: 'Referer of the request',
+    brief: "Referer of the request",
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: '*.vercel.app',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "*.vercel.app",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_REGION]: {
-    brief: 'Region where the request is processed',
+    brief: "Region where the request is processed",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'sfo1',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "sfo1",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_RESPONSE_BYTE_SIZE]: {
-    brief: 'Size of the response in bytes',
+    brief: "Size of the response in bytes",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1024,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.2.0', prs: [163] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.2.0", prs: [163] },
     ],
   },
   [VERCEL_PROXY_SCHEME]: {
-    brief: 'Protocol of the request',
+    brief: "Protocol of the request",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'https',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "https",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_STATUS_CODE]: {
-    brief: 'HTTP status code of the proxy request',
+    brief: "HTTP status code of the proxy request",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 200,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.2.0', prs: [163] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.2.0", prs: [163] },
     ],
   },
   [VERCEL_PROXY_TIMESTAMP]: {
-    brief: 'Unix timestamp when the proxy request was made',
+    brief: "Unix timestamp when the proxy request was made",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 1573817250172,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.2.0', prs: [163] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.2.0", prs: [163] },
     ],
   },
   [VERCEL_PROXY_USER_AGENT]: {
-    brief: 'User agent strings of the request',
+    brief: "User agent strings of the request",
     type: 'string[]',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
-    example: ['Mozilla/5.0...'],
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: ["Mozilla/5.0..."],
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_VERCEL_CACHE]: {
-    brief: 'Cache status sent to the browser',
+    brief: "Cache status sent to the browser",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'REVALIDATED',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "REVALIDATED",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_VERCEL_ID]: {
-    brief: 'Vercel-specific identifier',
+    brief: "Vercel-specific identifier",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'sfo1::abc123',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "sfo1::abc123",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_WAF_ACTION]: {
-    brief: 'Action taken by firewall rules',
+    brief: "Action taken by firewall rules",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'deny',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "deny",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_PROXY_WAF_RULE_ID]: {
-    brief: 'ID of the firewall rule that matched',
+    brief: "ID of the firewall rule that matched",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'rule_gAHz8jtSB1Gy',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "rule_gAHz8jtSB1Gy",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_REQUEST_ID]: {
-    brief: 'Identifier of the Vercel request',
+    brief: "Identifier of the Vercel request",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: '643af4e3-975a-4cc7-9e7a-1eda11539d90',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "643af4e3-975a-4cc7-9e7a-1eda11539d90",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_SOURCE]: {
-    brief: 'Origin of the Vercel log (build, edge, lambda, static, external, or firewall)',
+    brief: "Origin of the Vercel log (build, edge, lambda, static, external, or firewall)",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'false'
     },
     isInOtel: false,
-    example: 'build',
-    changelog: [{ version: '0.2.0', prs: [163] }],
+    example: "build",
+    changelog: [
+      { version: "0.2.0", prs: [163] },
+    ],
   },
   [VERCEL_STATUS_CODE]: {
-    brief: 'HTTP status code of the request (-1 means no response returned and the lambda crashed)',
+    brief: "HTTP status code of the request (-1 means no response returned and the lambda crashed)",
     type: 'integer',
     pii: {
-      isPii: 'maybe',
+      isPii: 'maybe'
     },
     isInOtel: false,
     example: 200,
     changelog: [
-      { version: '0.4.0', prs: [228] },
-      { version: '0.2.0', prs: [163] },
+      { version: "0.4.0", prs: [228] },
+      { version: "0.2.0", prs: [163] },
     ],
   },
 };
@@ -17583,3 +17953,4 @@ export type Attributes = {
   [VERCEL_SOURCE]?: VERCEL_SOURCE_TYPE;
   [VERCEL_STATUS_CODE]?: VERCEL_STATUS_CODE_TYPE;
 } & Record<string, AttributeValue | undefined>;
+

--- a/model/attributes/gen_ai/gen_ai__tool__type.json
+++ b/model/attributes/gen_ai/gen_ai__tool__type.json
@@ -7,6 +7,10 @@
   },
   "is_in_otel": true,
   "example": "function",
+  "deprecation": {
+    "_status": null,
+    "reason": "The gen_ai.tool.type attribute is deprecated and should no longer be set."
+  },
   "changelog": [
     {
       "version": "0.1.0",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -165,6 +165,7 @@ class _AttributeNamesMeta(type):
         "GEN_AI_TOOL_INPUT",
         "GEN_AI_TOOL_MESSAGE",
         "GEN_AI_TOOL_OUTPUT",
+        "GEN_AI_TOOL_TYPE",
         "GEN_AI_USAGE_COMPLETION_TOKENS",
         "GEN_AI_USAGE_PROMPT_TOKENS",
         "HARDWARECONCURRENCY",
@@ -2260,6 +2261,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: str
     Contains PII: maybe
     Defined in OTEL: Yes
+    DEPRECATED: No replacement at this time - The gen_ai.tool.type attribute is deprecated and should no longer be set.
     Example: "function"
     """
 
@@ -7889,6 +7891,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         example="function",
+        deprecation=DeprecationInfo(
+            reason="The gen_ai.tool.type attribute is deprecated and should no longer be set."
+        ),
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[62, 127]),
         ],

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -10,23 +10,17 @@
       },
       "is_in_otel": false,
       "example": 0.2361,
-      "sdks": [
-        "javascript-browser"
-      ],
+      "sdks": ["javascript-browser"],
       "deprecation": {
         "replacement": "browser.web_vital.cls.value",
         "reason": "The CLS web vital is now recorded as a browser.web_vital.cls.value attribute.",
         "_status": "backfill"
       },
-      "alias": [
-        "browser.web_vital.cls.value"
-      ],
+      "alias": ["browser.web_vital.cls.value"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            229
-          ],
+          "prs": [229],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -40,12 +34,8 @@
       },
       "is_in_otel": false,
       "example": "wifi",
-      "sdks": [
-        "javascript-browser"
-      ],
-      "alias": [
-        "network.connection.type"
-      ],
+      "sdks": ["javascript-browser"],
+      "alias": ["network.connection.type"],
       "deprecation": {
         "replacement": "network.connection.type",
         "reason": "Old namespace-less attribute, to be replaced with network.connection.type for span-first future",
@@ -54,9 +44,7 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            279
-          ],
+          "prs": [279],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -70,12 +58,8 @@
       },
       "is_in_otel": false,
       "example": "8 GB",
-      "sdks": [
-        "javascript-browser"
-      ],
-      "alias": [
-        "device.memory.estimated_capacity"
-      ],
+      "sdks": ["javascript-browser"],
+      "alias": ["device.memory.estimated_capacity"],
       "deprecation": {
         "replacement": "device.memory.estimated_capacity",
         "reason": "Old namespace-less attribute, to be replaced with device.memory.estimated_capacity for span-first future",
@@ -84,9 +68,7 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            281
-          ],
+          "prs": [281],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -100,12 +82,8 @@
       },
       "is_in_otel": false,
       "example": "4g",
-      "sdks": [
-        "javascript-browser"
-      ],
-      "alias": [
-        "network.connection.effective_type"
-      ],
+      "sdks": ["javascript-browser"],
+      "alias": ["network.connection.effective_type"],
       "deprecation": {
         "replacement": "network.connection.effective_type",
         "reason": "Old namespace-less attribute, to be replaced with network.connection.effective_type for span-first future",
@@ -114,9 +92,7 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            279
-          ],
+          "prs": [279],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -134,16 +110,11 @@
         "_status": null,
         "replacement": "sentry.environment"
       },
-      "alias": [
-        "sentry.environment"
-      ],
+      "alias": ["sentry.environment"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -159,23 +130,17 @@
       },
       "is_in_otel": false,
       "example": 547.6951,
-      "sdks": [
-        "javascript-browser"
-      ],
+      "sdks": ["javascript-browser"],
       "deprecation": {
         "_status": "backfill",
         "replacement": "browser.web_vital.fcp.value",
         "reason": "This attribute is being deprecated in favor of browser.web_vital.fcp.value"
       },
-      "alias": [
-        "browser.web_vital.fcp.value"
-      ],
+      "alias": ["browser.web_vital.fcp.value"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            235
-          ]
+          "prs": [235]
         }
       ]
     },
@@ -188,23 +153,17 @@
       },
       "is_in_otel": false,
       "example": 477.1926,
-      "sdks": [
-        "javascript-browser"
-      ],
+      "sdks": ["javascript-browser"],
       "deprecation": {
         "_status": "backfill",
         "replacement": "browser.web_vital.fp.value",
         "reason": "This attribute is being deprecated in favor of browser.web_vital.fp.value"
       },
-      "alias": [
-        "browser.web_vital.fp.value"
-      ],
+      "alias": ["browser.web_vital.fp.value"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            235
-          ]
+          "prs": [235]
         }
       ]
     },
@@ -222,16 +181,11 @@
         "reason": "This attribute is not part of the OpenTelemetry specification and error.type fits much better."
       },
       "example": "ENOENT: no such file or directory",
-      "sdks": [
-        "javascript-node"
-      ],
+      "sdks": ["javascript-node"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -247,12 +201,8 @@
       },
       "is_in_otel": false,
       "example": "14",
-      "sdks": [
-        "javascript-browser"
-      ],
-      "alias": [
-        "device.processor_count"
-      ],
+      "sdks": ["javascript-browser"],
+      "alias": ["device.processor_count"],
       "deprecation": {
         "replacement": "device.processor_count",
         "reason": "Old namespace-less attribute, to be replaced with device.processor_count for span-first future",
@@ -261,16 +211,12 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            300
-          ],
+          "prs": [300],
           "description": "Updated deprecation replacement from device.cpu.logical_core_count to device.processor_count"
         },
         {
           "version": "next",
-          "prs": [
-            281
-          ],
+          "prs": [281],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -284,23 +230,17 @@
       },
       "is_in_otel": false,
       "example": 200,
-      "sdks": [
-        "javascript-browser"
-      ],
+      "sdks": ["javascript-browser"],
       "deprecation": {
         "replacement": "browser.web_vital.inp.value",
         "reason": "The INP web vital is now recorded as a browser.web_vital.inp.value attribute.",
         "_status": "backfill"
       },
-      "alias": [
-        "browser.web_vital.inp.value"
-      ],
+      "alias": ["browser.web_vital.inp.value"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            229
-          ],
+          "prs": [229],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -314,23 +254,17 @@
       },
       "is_in_otel": false,
       "example": 2500,
-      "sdks": [
-        "javascript-browser"
-      ],
+      "sdks": ["javascript-browser"],
       "deprecation": {
         "replacement": "browser.web_vital.lcp.value",
         "reason": "The LCP web vital is now recorded as a browser.web_vital.lcp.value attribute.",
         "_status": "backfill"
       },
-      "alias": [
-        "browser.web_vital.lcp.value"
-      ],
+      "alias": ["browser.web_vital.lcp.value"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            229
-          ],
+          "prs": [229],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -348,20 +282,12 @@
         "_status": null,
         "replacement": "http.request.method"
       },
-      "alias": [
-        "http.request.method"
-      ],
-      "sdks": [
-        "javascript-browser",
-        "javascript-node"
-      ],
+      "alias": ["http.request.method"],
+      "sdks": ["javascript-browser", "javascript-node"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -381,16 +307,11 @@
         "_status": null,
         "replacement": "sentry.release"
       },
-      "alias": [
-        "sentry.release"
-      ],
+      "alias": ["sentry.release"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -410,15 +331,11 @@
         "_status": null,
         "replacement": "sentry.replay_id"
       },
-      "alias": [
-        "sentry.replay_id"
-      ],
+      "alias": ["sentry.replay_id"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61
-          ]
+          "prs": [61]
         },
         {
           "version": "0.0.0"
@@ -438,20 +355,12 @@
         "_status": null,
         "replacement": "http.route"
       },
-      "alias": [
-        "http.route"
-      ],
-      "sdks": [
-        "php-laravel",
-        "javascript-reactnative"
-      ],
+      "alias": ["http.route"],
+      "sdks": ["php-laravel", "javascript-reactnative"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            74
-          ]
+          "prs": [61, 74]
         },
         {
           "version": "0.0.0"
@@ -471,16 +380,11 @@
         "_status": null,
         "replacement": "sentry.transaction"
       },
-      "alias": [
-        "sentry.transaction"
-      ],
+      "alias": ["sentry.transaction"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -496,12 +400,8 @@
       },
       "is_in_otel": false,
       "example": 194,
-      "alias": [
-        "browser.web_vital.ttfb.value"
-      ],
-      "sdks": [
-        "javascript-browser"
-      ],
+      "alias": ["browser.web_vital.ttfb.value"],
+      "sdks": ["javascript-browser"],
       "deprecation": {
         "_status": "backfill",
         "replacement": "browser.web_vital.ttfb.value",
@@ -510,9 +410,7 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            235
-          ]
+          "prs": [235]
         }
       ]
     },
@@ -529,20 +427,12 @@
         "_status": null,
         "replacement": "url.full"
       },
-      "alias": [
-        "url.full",
-        "http.url"
-      ],
-      "sdks": [
-        "javascript-browser",
-        "javascript-node"
-      ],
+      "alias": ["url.full", "http.url"],
+      "sdks": ["javascript-browser", "javascript-node"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61
-          ]
+          "prs": [61]
         },
         {
           "version": "0.0.0"
@@ -557,25 +447,18 @@
         "key": "true"
       },
       "is_in_otel": false,
-      "example": [
-        "Citation 1",
-        "Citation 2"
-      ],
+      "example": ["Citation 1", "Citation 2"],
       "deprecation": {
         "_status": null
       },
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            264
-          ]
+          "prs": [264]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55
-          ]
+          "prs": [55]
         }
       ]
     },
@@ -588,13 +471,8 @@
       },
       "is_in_otel": false,
       "example": 10,
-      "alias": [
-        "gen_ai.usage.output_tokens",
-        "gen_ai.usage.completion_tokens"
-      ],
-      "sdks": [
-        "python"
-      ],
+      "alias": ["gen_ai.usage.output_tokens", "gen_ai.usage.completion_tokens"],
+      "sdks": ["python"],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.usage.output_tokens"
@@ -602,16 +480,11 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            57,
-            61
-          ]
+          "prs": [57, 61]
         },
         {
           "version": "0.0.0"
@@ -626,25 +499,18 @@
         "key": "true"
       },
       "is_in_otel": false,
-      "example": [
-        "document1.txt",
-        "document2.pdf"
-      ],
+      "example": ["document1.txt", "document2.pdf"],
       "deprecation": {
         "_status": null
       },
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            264
-          ]
+          "prs": [264]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55
-          ]
+          "prs": [55]
         }
       ]
     },
@@ -661,19 +527,11 @@
         "_status": null,
         "replacement": "gen_ai.response.finish_reason"
       },
-      "alias": [
-        "gen_ai.response.finish_reasons"
-      ],
+      "alias": ["gen_ai.response.finish_reasons"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            55,
-            57,
-            61,
-            108,
-            127
-          ]
+          "prs": [55, 57, 61, 108, 127]
         }
       ]
     },
@@ -690,24 +548,15 @@
         "_status": null,
         "replacement": "gen_ai.request.frequency_penalty"
       },
-      "alias": [
-        "gen_ai.request.frequency_penalty"
-      ],
+      "alias": ["gen_ai.request.frequency_penalty"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55,
-            57,
-            61,
-            108
-          ]
+          "prs": [55, 57, 61, 108]
         }
       ]
     },
@@ -724,18 +573,11 @@
         "_status": null,
         "replacement": "gen_ai.tool.name"
       },
-      "alias": [
-        "gen_ai.tool.name"
-      ],
+      "alias": ["gen_ai.tool.name"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            55,
-            57,
-            61,
-            108
-          ]
+          "prs": [55, 57, 61, 108]
         }
       ]
     },
@@ -752,19 +594,11 @@
         "_status": null,
         "replacement": "gen_ai.response.id"
       },
-      "alias": [
-        "gen_ai.response.id"
-      ],
+      "alias": ["gen_ai.response.id"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            55,
-            57,
-            61,
-            108,
-            127
-          ]
+          "prs": [55, 57, 61, 108, 127]
         }
       ]
     },
@@ -777,12 +611,8 @@
       },
       "is_in_otel": false,
       "example": "[{\"role\": \"user\", \"message\": \"hello\"}]",
-      "alias": [
-        "gen_ai.request.messages"
-      ],
-      "sdks": [
-        "python"
-      ],
+      "alias": ["gen_ai.request.messages"],
+      "sdks": ["python"],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.request.messages"
@@ -790,10 +620,7 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            65,
-            119
-          ]
+          "prs": [65, 119]
         },
         {
           "version": "0.0.0"
@@ -815,15 +642,11 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            264
-          ]
+          "prs": [264]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55
-          ]
+          "prs": [55]
         }
       ]
     },
@@ -842,16 +665,11 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            264
-          ]
+          "prs": [264]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55,
-            127
-          ]
+          "prs": [55, 127]
         }
       ]
     },
@@ -868,25 +686,15 @@
         "_status": null,
         "replacement": "gen_ai.provider.name"
       },
-      "alias": [
-        "gen_ai.provider.name",
-        "gen_ai.system"
-      ],
+      "alias": ["gen_ai.provider.name", "gen_ai.system"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            253
-          ]
+          "prs": [253]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            57,
-            61,
-            108,
-            127
-          ]
+          "prs": [57, 61, 108, 127]
         }
       ]
     },
@@ -899,12 +707,8 @@
       },
       "is_in_otel": false,
       "example": "gpt-4",
-      "alias": [
-        "gen_ai.response.model"
-      ],
-      "sdks": [
-        "python"
-      ],
+      "alias": ["gen_ai.response.model"],
+      "sdks": ["python"],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.response.model"
@@ -912,11 +716,7 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            57,
-            61,
-            127
-          ]
+          "prs": [57, 61, 127]
         },
         {
           "version": "0.0.0"
@@ -936,18 +736,11 @@
         "_status": null,
         "replacement": "gen_ai.pipeline.name"
       },
-      "alias": [
-        "gen_ai.pipeline.name"
-      ],
+      "alias": ["gen_ai.pipeline.name"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            53,
-            76,
-            108,
-            127
-          ]
+          "prs": [53, 76, 108, 127]
         }
       ]
     },
@@ -964,21 +757,15 @@
         "_status": null,
         "replacement": "gen_ai.system_instructions"
       },
-      "alias": [
-        "gen_ai.system_instructions"
-      ],
+      "alias": ["gen_ai.system_instructions"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            264
-          ]
+          "prs": [264]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55
-          ]
+          "prs": [55]
         }
       ]
     },
@@ -995,24 +782,15 @@
         "_status": null,
         "replacement": "gen_ai.request.presence_penalty"
       },
-      "alias": [
-        "gen_ai.request.presence_penalty"
-      ],
+      "alias": ["gen_ai.request.presence_penalty"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55,
-            57,
-            61,
-            108
-          ]
+          "prs": [55, 57, 61, 108]
         }
       ]
     },
@@ -1025,13 +803,8 @@
       },
       "is_in_otel": false,
       "example": 20,
-      "alias": [
-        "gen_ai.usage.prompt_tokens",
-        "gen_ai.usage.input_tokens"
-      ],
-      "sdks": [
-        "python"
-      ],
+      "alias": ["gen_ai.usage.prompt_tokens", "gen_ai.usage.input_tokens"],
+      "sdks": ["python"],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.usage.input_tokens"
@@ -1039,16 +812,11 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            57,
-            61
-          ]
+          "prs": [57, 61]
         },
         {
           "version": "0.0.0"
@@ -1070,15 +838,11 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            264
-          ]
+          "prs": [264]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55
-          ]
+          "prs": [55]
         }
       ]
     },
@@ -1097,16 +861,11 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            264
-          ]
+          "prs": [264]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55,
-            127
-          ]
+          "prs": [55, 127]
         }
       ]
     },
@@ -1118,13 +877,8 @@
         "key": "maybe"
       },
       "is_in_otel": false,
-      "example": [
-        "hello",
-        "world"
-      ],
-      "sdks": [
-        "python"
-      ],
+      "example": ["hello", "world"],
+      "sdks": ["python"],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.response.text"
@@ -1132,10 +886,7 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            65,
-            127
-          ]
+          "prs": [65, 127]
         },
         {
           "version": "0.0.0"
@@ -1150,25 +901,18 @@
         "key": "true"
       },
       "is_in_otel": false,
-      "example": [
-        "climate change effects",
-        "renewable energy"
-      ],
+      "example": ["climate change effects", "renewable energy"],
       "deprecation": {
         "_status": null
       },
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            264
-          ]
+          "prs": [264]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55
-          ]
+          "prs": [55]
         }
       ]
     },
@@ -1180,24 +924,18 @@
         "key": "true"
       },
       "is_in_otel": false,
-      "example": [
-        "search_result_1, search_result_2"
-      ],
+      "example": ["search_result_1, search_result_2"],
       "deprecation": {
         "_status": null
       },
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            264
-          ]
+          "prs": [264]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55
-          ]
+          "prs": [55]
         }
       ]
     },
@@ -1214,19 +952,11 @@
         "_status": null,
         "replacement": "gen_ai.request.seed"
       },
-      "alias": [
-        "gen_ai.request.seed"
-      ],
+      "alias": ["gen_ai.request.seed"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            55,
-            57,
-            61,
-            108,
-            127
-          ]
+          "prs": [55, 57, 61, 108, 127]
         }
       ]
     },
@@ -1239,23 +969,16 @@
       },
       "is_in_otel": false,
       "example": true,
-      "sdks": [
-        "python"
-      ],
+      "sdks": ["python"],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.response.streaming"
       },
-      "alias": [
-        "gen_ai.response.streaming"
-      ],
+      "alias": ["gen_ai.response.streaming"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            76,
-            108
-          ]
+          "prs": [76, 108]
         },
         {
           "version": "0.0.0"
@@ -1277,16 +1000,11 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            264
-          ]
+          "prs": [264]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55,
-            127
-          ]
+          "prs": [55, 127]
         }
       ]
     },
@@ -1303,24 +1021,15 @@
         "_status": null,
         "replacement": "gen_ai.request.temperature"
       },
-      "alias": [
-        "gen_ai.request.temperature"
-      ],
+      "alias": ["gen_ai.request.temperature"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55,
-            57,
-            61,
-            108
-          ]
+          "prs": [55, 57, 61, 108]
         }
       ]
     },
@@ -1332,29 +1041,20 @@
         "key": "true"
       },
       "is_in_otel": false,
-      "example": [
-        "Hello, how are you?",
-        "What is the capital of France?"
-      ],
+      "example": ["Hello, how are you?", "What is the capital of France?"],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.input.messages"
       },
-      "alias": [
-        "gen_ai.input.messages"
-      ],
+      "alias": ["gen_ai.input.messages"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            264
-          ]
+          "prs": [264]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55
-          ]
+          "prs": [55]
         }
       ]
     },
@@ -1366,10 +1066,7 @@
         "key": "true"
       },
       "is_in_otel": false,
-      "example": [
-        "tool_call_1",
-        "tool_call_2"
-      ],
+      "example": ["tool_call_1", "tool_call_2"],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.response.tool_calls"
@@ -1377,10 +1074,7 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            55,
-            65
-          ]
+          "prs": [55, 65]
         }
       ]
     },
@@ -1392,10 +1086,7 @@
         "key": "maybe"
       },
       "is_in_otel": false,
-      "example": [
-        "function_1",
-        "function_2"
-      ],
+      "example": ["function_1", "function_2"],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.request.available_tools"
@@ -1403,11 +1094,7 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            55,
-            65,
-            127
-          ]
+          "prs": [55, 65, 127]
         }
       ]
     },
@@ -1424,24 +1111,15 @@
         "_status": null,
         "replacement": "gen_ai.request.top_k"
       },
-      "alias": [
-        "gen_ai.request.top_k"
-      ],
+      "alias": ["gen_ai.request.top_k"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55,
-            57,
-            61,
-            108
-          ]
+          "prs": [55, 57, 61, 108]
         }
       ]
     },
@@ -1458,24 +1136,15 @@
         "_status": null,
         "replacement": "gen_ai.request.top_p"
       },
-      "alias": [
-        "gen_ai.request.top_p"
-      ],
+      "alias": ["gen_ai.request.top_p"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55,
-            57,
-            61,
-            108
-          ]
+          "prs": [55, 57, 61, 108]
         }
       ]
     },
@@ -1492,27 +1161,19 @@
         "_status": null,
         "replacement": "gen_ai.cost.total_tokens"
       },
-      "alias": [
-        "gen_ai.cost.total_tokens"
-      ],
+      "alias": ["gen_ai.cost.total_tokens"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            264
-          ]
+          "prs": [264]
         },
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            53
-          ]
+          "prs": [53]
         }
       ]
     },
@@ -1525,30 +1186,20 @@
       },
       "is_in_otel": false,
       "example": 30,
-      "sdks": [
-        "python"
-      ],
+      "sdks": ["python"],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.usage.total_tokens"
       },
-      "alias": [
-        "gen_ai.usage.total_tokens"
-      ],
+      "alias": ["gen_ai.usage.total_tokens"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            57,
-            61,
-            108
-          ]
+          "prs": [57, 61, 108]
         },
         {
           "version": "0.0.0"
@@ -1563,24 +1214,18 @@
         "key": "true"
       },
       "is_in_otel": false,
-      "example": [
-        "Token limit exceeded"
-      ],
+      "example": ["Token limit exceeded"],
       "deprecation": {
         "_status": null
       },
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            264
-          ]
+          "prs": [264]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            55
-          ]
+          "prs": [55]
         }
       ]
     },
@@ -1593,24 +1238,18 @@
       },
       "is_in_otel": false,
       "example": "body > div#app",
-      "sdks": [
-        "javascript-browser"
-      ],
+      "sdks": ["javascript-browser"],
       "deprecation": {
         "replacement": "browser.web_vital.cls.source.<key>",
         "reason": "The CLS source is now recorded as a browser.web_vital.cls.source.<key> attribute.",
         "_status": "backfill"
       },
       "has_dynamic_suffix": true,
-      "alias": [
-        "browser.web_vital.cls.source.<key>"
-      ],
+      "alias": ["browser.web_vital.cls.source.<key>"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            234
-          ]
+          "prs": [234]
         }
       ]
     },
@@ -1627,15 +1266,11 @@
         "_status": null,
         "replacement": "code.file.path"
       },
-      "alias": [
-        "code.file.path"
-      ],
+      "alias": ["code.file.path"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61
-          ]
+          "prs": [61]
         },
         {
           "version": "0.0.0"
@@ -1655,16 +1290,11 @@
         "_status": null,
         "replacement": "code.function.name"
       },
-      "alias": [
-        "code.function.name"
-      ],
+      "alias": ["code.function.name"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            74
-          ]
+          "prs": [61, 74]
         },
         {
           "version": "0.0.0"
@@ -1684,22 +1314,15 @@
         "_status": null,
         "replacement": "code.line.number"
       },
-      "alias": [
-        "code.line.number"
-      ],
+      "alias": ["code.line.number"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            108
-          ]
+          "prs": [61, 108]
         },
         {
           "version": "0.0.0"
@@ -1723,10 +1346,7 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            74
-          ]
+          "prs": [61, 74]
         },
         {
           "version": "0.0.0"
@@ -1742,12 +1362,8 @@
       },
       "is_in_otel": false,
       "example": 100,
-      "sdks": [
-        "javascript-browser"
-      ],
-      "alias": [
-        "network.connection.rtt"
-      ],
+      "sdks": ["javascript-browser"],
+      "alias": ["network.connection.rtt"],
       "deprecation": {
         "replacement": "network.connection.rtt",
         "reason": "Old attribute name (no official namespace), to be replaced with network.connection.rtt for span-first future",
@@ -1756,9 +1372,7 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            279
-          ],
+          "prs": [279],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -1776,16 +1390,11 @@
         "_status": null,
         "replacement": "db.namespace"
       },
-      "alias": [
-        "db.namespace"
-      ],
+      "alias": ["db.namespace"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -1805,22 +1414,15 @@
         "_status": "normalize",
         "replacement": "db.operation.name"
       },
-      "alias": [
-        "db.operation.name"
-      ],
+      "alias": ["db.operation.name"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            199
-          ]
+          "prs": [199]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -1840,19 +1442,12 @@
         "replacement": "db.query.parameter.<key>",
         "reason": "Instead of adding every binding in the db.sql.bindings attribute, add them as individual entires with db.query.parameter.<key>."
       },
-      "example": [
-        "1",
-        "foo"
-      ],
-      "sdks": [
-        "php-laravel"
-      ],
+      "example": ["1", "foo"],
+      "sdks": ["php-laravel"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61
-          ]
+          "prs": [61]
         },
         {
           "version": "0.0.0"
@@ -1872,22 +1467,15 @@
         "_status": "normalize",
         "replacement": "db.query.text"
       },
-      "alias": [
-        "db.query.text"
-      ],
+      "alias": ["db.query.text"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            199
-          ]
+          "prs": [199]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -1907,23 +1495,15 @@
         "_status": "backfill",
         "replacement": "db.system.name"
       },
-      "alias": [
-        "db.system.name"
-      ],
+      "alias": ["db.system.name"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            199,
-            224
-          ]
+          "prs": [199, 224]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -1946,11 +1526,7 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            74,
-            108,
-            119
-          ]
+          "prs": [74, 108, 119]
         },
         {
           "version": "0.0.0"
@@ -1974,16 +1550,11 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            221
-          ]
+          "prs": [221]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            63,
-            127
-          ]
+          "prs": [63, 127]
         }
       ]
     },
@@ -1996,9 +1567,7 @@
       },
       "is_in_otel": false,
       "example": "[{\"role\": \"system\", \"content\": \"Generate a random number.\"}, {\"role\": \"user\", \"content\": [{\"text\": \"Generate a random number between 0 and 10.\", \"type\": \"text\"}]}, {\"role\": \"tool\", \"content\": {\"toolCallId\": \"1\", \"toolName\": \"Weather\", \"output\": \"rainy\"}}]",
-      "alias": [
-        "ai.input_messages"
-      ],
+      "alias": ["ai.input_messages"],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.input.messages"
@@ -2006,19 +1575,11 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            221
-          ]
+          "prs": [221]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            63,
-            74,
-            108,
-            119,
-            122
-          ]
+          "prs": [63, 74, 108, 119, 122]
         }
       ]
     },
@@ -2039,16 +1600,11 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            221
-          ]
+          "prs": [221]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            63,
-            74
-          ]
+          "prs": [63, 74]
         }
       ]
     },
@@ -2069,16 +1625,11 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            221
-          ]
+          "prs": [221]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            63,
-            74
-          ]
+          "prs": [63, 74]
         }
       ]
     },
@@ -2095,23 +1646,15 @@
         "_status": null,
         "replacement": "gen_ai.provider.name"
       },
-      "alias": [
-        "ai.model.provider",
-        "gen_ai.provider.name"
-      ],
+      "alias": ["ai.model.provider", "gen_ai.provider.name"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            253
-          ]
+          "prs": [253]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            57,
-            127
-          ]
+          "prs": [57, 127]
         }
       ]
     },
@@ -2131,15 +1674,11 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            221
-          ]
+          "prs": [221]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            62
-          ]
+          "prs": [62]
         }
       ]
     },
@@ -2152,9 +1691,7 @@
       },
       "is_in_otel": false,
       "example": "{\"location\": \"Paris\"}",
-      "alias": [
-        "gen_ai.tool.call.arguments"
-      ],
+      "alias": ["gen_ai.tool.call.arguments"],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.tool.call.arguments"
@@ -2162,16 +1699,11 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            265
-          ]
+          "prs": [265]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            63,
-            74
-          ]
+          "prs": [63, 74]
         }
       ]
     },
@@ -2184,10 +1716,7 @@
       },
       "is_in_otel": false,
       "example": "rainy, 57°F",
-      "alias": [
-        "gen_ai.tool.call.result",
-        "gen_ai.tool.output"
-      ],
+      "alias": ["gen_ai.tool.call.result", "gen_ai.tool.output"],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.tool.call.result"
@@ -2195,15 +1724,11 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            265
-          ]
+          "prs": [265]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            62
-          ]
+          "prs": [62]
         }
       ]
     },
@@ -2216,10 +1741,7 @@
       },
       "is_in_otel": false,
       "example": "rainy, 57°F",
-      "alias": [
-        "gen_ai.tool.call.result",
-        "gen_ai.tool.message"
-      ],
+      "alias": ["gen_ai.tool.call.result", "gen_ai.tool.message"],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.tool.call.result"
@@ -2227,16 +1749,11 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            265
-          ]
+          "prs": [265]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            63,
-            74
-          ]
+          "prs": [63, 74]
         }
       ]
     },
@@ -2256,10 +1773,7 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            62,
-            127
-          ]
+          "prs": [62, 127]
         }
       ]
     },
@@ -2276,22 +1790,15 @@
         "_status": null,
         "replacement": "gen_ai.usage.output_tokens"
       },
-      "alias": [
-        "ai.completion_tokens.used",
-        "gen_ai.usage.output_tokens"
-      ],
+      "alias": ["ai.completion_tokens.used", "gen_ai.usage.output_tokens"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            61
-          ]
+          "prs": [61]
         },
         {
           "version": "0.0.0"
@@ -2311,22 +1818,15 @@
         "_status": null,
         "replacement": "gen_ai.usage.input_tokens"
       },
-      "alias": [
-        "ai.prompt_tokens.used",
-        "gen_ai.usage.input_tokens"
-      ],
+      "alias": ["ai.prompt_tokens.used", "gen_ai.usage.input_tokens"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            61
-          ]
+          "prs": [61]
         },
         {
           "version": "0.0.0"
@@ -2346,17 +1846,11 @@
         "_status": null,
         "replacement": "client.address"
       },
-      "alias": [
-        "client.address"
-      ],
+      "alias": ["client.address"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            106,
-            127
-          ]
+          "prs": [61, 106, 127]
         },
         {
           "version": "0.0.0"
@@ -2376,18 +1870,11 @@
         "_status": null,
         "replacement": "network.protocol.version"
       },
-      "alias": [
-        "network.protocol.version",
-        "net.protocol.version"
-      ],
+      "alias": ["network.protocol.version", "net.protocol.version"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            108,
-            127
-          ]
+          "prs": [61, 108, 127]
         },
         {
           "version": "0.0.0"
@@ -2408,20 +1895,11 @@
         "replacement": "server.address",
         "reason": "Deprecated, use one of `server.address` or `client.address`, depending on the usage"
       },
-      "alias": [
-        "server.address",
-        "client.address",
-        "http.server_name",
-        "net.host.name"
-      ],
+      "alias": ["server.address", "client.address", "http.server_name", "net.host.name"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            108,
-            127
-          ]
+          "prs": [61, 108, 127]
         },
         {
           "version": "0.0.0"
@@ -2441,16 +1919,11 @@
         "_status": null,
         "replacement": "http.request.method"
       },
-      "alias": [
-        "http.request.method"
-      ],
+      "alias": ["http.request.method"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -2470,23 +1943,15 @@
         "_status": "backfill",
         "replacement": "http.response.body.size"
       },
-      "alias": [
-        "http.response.body.size",
-        "http.response.header.content-length"
-      ],
+      "alias": ["http.response.body.size", "http.response.header.content-length"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            106
-          ]
+          "prs": [61, 106]
         },
         {
           "version": "0.0.0"
@@ -2506,21 +1971,15 @@
         "_status": "backfill",
         "replacement": "http.response.size"
       },
-      "alias": [
-        "http.response.size"
-      ],
+      "alias": ["http.response.size"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            61
-          ]
+          "prs": [61]
         },
         {
           "version": "0.0.0"
@@ -2540,16 +1999,11 @@
         "_status": null,
         "replacement": "url.scheme"
       },
-      "alias": [
-        "url.scheme"
-      ],
+      "alias": ["url.scheme"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -2569,19 +2023,11 @@
         "_status": null,
         "replacement": "server.address"
       },
-      "alias": [
-        "server.address",
-        "net.host.name",
-        "http.host"
-      ],
+      "alias": ["server.address", "net.host.name", "http.host"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            108,
-            127
-          ]
+          "prs": [61, 108, 127]
         },
         {
           "version": "0.0.0"
@@ -2601,21 +2047,15 @@
         "_status": null,
         "replacement": "http.response.status_code"
       },
-      "alias": [
-        "http.response.status_code"
-      ],
+      "alias": ["http.response.status_code"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            61
-          ]
+          "prs": [61]
         },
         {
           "version": "0.0.0"
@@ -2639,9 +2079,7 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61
-          ]
+          "prs": [61]
         },
         {
           "version": "0.0.0"
@@ -2661,17 +2099,11 @@
         "_status": null,
         "replacement": "url.full"
       },
-      "alias": [
-        "url.full",
-        "url"
-      ],
+      "alias": ["url.full", "url"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            108
-          ]
+          "prs": [61, 108]
         },
         {
           "version": "0.0.0"
@@ -2691,16 +2123,11 @@
         "_status": null,
         "replacement": "user_agent.original"
       },
-      "alias": [
-        "user_agent.original"
-      ],
+      "alias": ["user_agent.original"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -2721,21 +2148,15 @@
         "reason": "The LCP element is now recorded as a browser.web_vital.lcp.element attribute.",
         "_status": "backfill"
       },
-      "alias": [
-        "browser.web_vital.lcp.element"
-      ],
+      "alias": ["browser.web_vital.lcp.element"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            233
-          ]
+          "prs": [233]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            127
-          ]
+          "prs": [127]
         },
         {
           "version": "0.0.0"
@@ -2756,21 +2177,15 @@
         "reason": "The LCP id is now recorded as a browser.web_vital.lcp.id attribute.",
         "_status": "backfill"
       },
-      "alias": [
-        "browser.web_vital.lcp.id"
-      ],
+      "alias": ["browser.web_vital.lcp.id"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            233
-          ]
+          "prs": [233]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            127
-          ]
+          "prs": [127]
         },
         {
           "version": "0.0.0"
@@ -2786,23 +2201,17 @@
       },
       "is_in_otel": false,
       "example": 1402,
-      "sdks": [
-        "javascript-browser"
-      ],
+      "sdks": ["javascript-browser"],
       "deprecation": {
         "replacement": "browser.web_vital.lcp.load_time",
         "reason": "The LCP load time is now recorded as a browser.web_vital.lcp.load_time attribute.",
         "_status": "backfill"
       },
-      "alias": [
-        "browser.web_vital.lcp.load_time"
-      ],
+      "alias": ["browser.web_vital.lcp.load_time"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            233
-          ]
+          "prs": [233]
         }
       ]
     },
@@ -2815,23 +2224,17 @@
       },
       "is_in_otel": false,
       "example": 1685,
-      "sdks": [
-        "javascript-browser"
-      ],
+      "sdks": ["javascript-browser"],
       "deprecation": {
         "replacement": "browser.web_vital.lcp.render_time",
         "reason": "The LCP render time is now recorded as a browser.web_vital.lcp.render_time attribute.",
         "_status": "backfill"
       },
-      "alias": [
-        "browser.web_vital.lcp.render_time"
-      ],
+      "alias": ["browser.web_vital.lcp.render_time"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            233
-          ]
+          "prs": [233]
         }
       ]
     },
@@ -2849,21 +2252,15 @@
         "reason": "The LCP size is now recorded as a browser.web_vital.lcp.size attribute.",
         "_status": "backfill"
       },
-      "alias": [
-        "browser.web_vital.lcp.size"
-      ],
+      "alias": ["browser.web_vital.lcp.size"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            233
-          ]
+          "prs": [233]
         },
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.0.0"
@@ -2884,21 +2281,15 @@
         "reason": "The LCP url is now recorded as a browser.web_vital.lcp.url attribute.",
         "_status": "backfill"
       },
-      "alias": [
-        "browser.web_vital.lcp.url"
-      ],
+      "alias": ["browser.web_vital.lcp.url"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            233
-          ]
+          "prs": [233]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            127
-          ]
+          "prs": [127]
         },
         {
           "version": "0.0.0"
@@ -2918,18 +2309,11 @@
         "_status": null,
         "replacement": "network.local.address"
       },
-      "alias": [
-        "network.local.address",
-        "net.sock.host.addr"
-      ],
+      "alias": ["network.local.address", "net.sock.host.addr"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            108,
-            127
-          ]
+          "prs": [61, 108, 127]
         },
         {
           "version": "0.0.0"
@@ -2949,19 +2333,11 @@
         "_status": null,
         "replacement": "server.address"
       },
-      "alias": [
-        "server.address",
-        "http.server_name",
-        "http.host"
-      ],
+      "alias": ["server.address", "http.server_name", "http.host"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            108,
-            127
-          ]
+          "prs": [61, 108, 127]
         },
         {
           "version": "0.0.0"
@@ -2981,21 +2357,15 @@
         "_status": null,
         "replacement": "server.port"
       },
-      "alias": [
-        "server.port"
-      ],
+      "alias": ["server.port"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            61
-          ]
+          "prs": [61]
         },
         {
           "version": "0.0.0"
@@ -3015,18 +2385,11 @@
         "_status": null,
         "replacement": "network.peer.address"
       },
-      "alias": [
-        "network.peer.address",
-        "net.sock.peer.addr"
-      ],
+      "alias": ["network.peer.address", "net.sock.peer.addr"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            108,
-            127
-          ]
+          "prs": [61, 108, 127]
         },
         {
           "version": "0.0.0"
@@ -3050,10 +2413,7 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -3077,15 +2437,11 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            61
-          ]
+          "prs": [61]
         },
         {
           "version": "0.0.0"
@@ -3105,16 +2461,11 @@
         "_status": null,
         "replacement": "network.protocol.name"
       },
-      "alias": [
-        "network.protocol.name"
-      ],
+      "alias": ["network.protocol.name"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -3134,18 +2485,11 @@
         "_status": null,
         "replacement": "network.protocol.version"
       },
-      "alias": [
-        "network.protocol.version",
-        "http.flavor"
-      ],
+      "alias": ["network.protocol.version", "http.flavor"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            108,
-            127
-          ]
+          "prs": [61, 108, 127]
         },
         {
           "version": "0.0.0"
@@ -3169,10 +2513,7 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -3192,18 +2533,11 @@
         "_status": null,
         "replacement": "network.local.address"
       },
-      "alias": [
-        "network.local.address",
-        "net.host.ip"
-      ],
+      "alias": ["network.local.address", "net.host.ip"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            108,
-            127
-          ]
+          "prs": [61, 108, 127]
         },
         {
           "version": "0.0.0"
@@ -3223,21 +2557,15 @@
         "_status": null,
         "replacement": "network.local.port"
       },
-      "alias": [
-        "network.local.port"
-      ],
+      "alias": ["network.local.port"],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            61
-          ]
+          "prs": [61]
         },
         {
           "version": "0.0.0"
@@ -3257,18 +2585,11 @@
         "_status": null,
         "replacement": "network.peer.address"
       },
-      "alias": [
-        "network.peer.address",
-        "net.peer.ip"
-      ],
+      "alias": ["network.peer.address", "net.peer.ip"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            108,
-            127
-          ]
+          "prs": [61, 108, 127]
         },
         {
           "version": "0.0.0"
@@ -3291,11 +2612,7 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            119,
-            127
-          ]
+          "prs": [61, 119, 127]
         },
         {
           "version": "0.0.0"
@@ -3318,15 +2635,11 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [
-            228
-          ]
+          "prs": [228]
         },
         {
           "version": "0.1.0",
-          "prs": [
-            61
-          ]
+          "prs": [61]
         },
         {
           "version": "0.0.0"
@@ -3346,16 +2659,11 @@
         "_status": null,
         "replacement": "network.transport"
       },
-      "alias": [
-        "network.transport"
-      ],
+      "alias": ["network.transport"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            61,
-            127
-          ]
+          "prs": [61, 127]
         },
         {
           "version": "0.0.0"
@@ -3380,9 +2688,7 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            103
-          ]
+          "prs": [103]
         }
       ]
     },
@@ -3402,9 +2708,7 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            266
-          ]
+          "prs": [266]
         }
       ]
     },
@@ -3424,9 +2728,7 @@
       "changelog": [
         {
           "version": "0.3.1",
-          "prs": [
-            196
-          ]
+          "prs": [196]
         }
       ]
     },
@@ -3443,15 +2745,11 @@
         "_status": null,
         "replacement": "browser.name"
       },
-      "alias": [
-        "browser.name"
-      ],
+      "alias": ["browser.name"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            139
-          ]
+          "prs": [139]
         }
       ]
     },
@@ -3468,15 +2766,11 @@
         "_status": null,
         "replacement": "browser.version"
       },
-      "alias": [
-        "browser.version"
-      ],
+      "alias": ["browser.version"],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            139
-          ]
+          "prs": [139]
         }
       ]
     },
@@ -3489,9 +2783,7 @@
       },
       "is_in_otel": false,
       "example": "051581bf3cb55c13",
-      "alias": [
-        "sentry.segment.id"
-      ],
+      "alias": ["sentry.segment.id"],
       "deprecation": {
         "_status": null,
         "replacement": "sentry.segment.id"
@@ -3499,9 +2791,7 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [
-            124
-          ]
+          "prs": [124]
         }
       ]
     },
@@ -3540,16 +2830,12 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            287
-          ],
+          "prs": [287],
           "description": "Deprecate `sentry.trace.parent_span_id`"
         },
         {
           "version": "0.1.0",
-          "prs": [
-            116
-          ]
+          "prs": [116]
         }
       ]
     },
@@ -3562,23 +2848,17 @@
       },
       "is_in_otel": false,
       "example": 1554.5814,
-      "sdks": [
-        "javascript-browser"
-      ],
+      "sdks": ["javascript-browser"],
       "deprecation": {
         "_status": "backfill",
         "replacement": "browser.web_vital.ttfb.request_time",
         "reason": "This attribute is being deprecated in favor of browser.web_vital.ttfb.request_time"
       },
-      "alias": [
-        "browser.web_vital.ttfb.request_time"
-      ],
+      "alias": ["browser.web_vital.ttfb.request_time"],
       "changelog": [
         {
           "version": "next",
-          "prs": [
-            235
-          ]
+          "prs": [235]
         }
       ]
     }

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -10,17 +10,23 @@
       },
       "is_in_otel": false,
       "example": 0.2361,
-      "sdks": ["javascript-browser"],
+      "sdks": [
+        "javascript-browser"
+      ],
       "deprecation": {
         "replacement": "browser.web_vital.cls.value",
         "reason": "The CLS web vital is now recorded as a browser.web_vital.cls.value attribute.",
         "_status": "backfill"
       },
-      "alias": ["browser.web_vital.cls.value"],
+      "alias": [
+        "browser.web_vital.cls.value"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [229],
+          "prs": [
+            229
+          ],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -34,8 +40,12 @@
       },
       "is_in_otel": false,
       "example": "wifi",
-      "sdks": ["javascript-browser"],
-      "alias": ["network.connection.type"],
+      "sdks": [
+        "javascript-browser"
+      ],
+      "alias": [
+        "network.connection.type"
+      ],
       "deprecation": {
         "replacement": "network.connection.type",
         "reason": "Old namespace-less attribute, to be replaced with network.connection.type for span-first future",
@@ -44,7 +54,9 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [279],
+          "prs": [
+            279
+          ],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -58,8 +70,12 @@
       },
       "is_in_otel": false,
       "example": "8 GB",
-      "sdks": ["javascript-browser"],
-      "alias": ["device.memory.estimated_capacity"],
+      "sdks": [
+        "javascript-browser"
+      ],
+      "alias": [
+        "device.memory.estimated_capacity"
+      ],
       "deprecation": {
         "replacement": "device.memory.estimated_capacity",
         "reason": "Old namespace-less attribute, to be replaced with device.memory.estimated_capacity for span-first future",
@@ -68,7 +84,9 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [281],
+          "prs": [
+            281
+          ],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -82,8 +100,12 @@
       },
       "is_in_otel": false,
       "example": "4g",
-      "sdks": ["javascript-browser"],
-      "alias": ["network.connection.effective_type"],
+      "sdks": [
+        "javascript-browser"
+      ],
+      "alias": [
+        "network.connection.effective_type"
+      ],
       "deprecation": {
         "replacement": "network.connection.effective_type",
         "reason": "Old namespace-less attribute, to be replaced with network.connection.effective_type for span-first future",
@@ -92,7 +114,9 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [279],
+          "prs": [
+            279
+          ],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -110,11 +134,16 @@
         "_status": null,
         "replacement": "sentry.environment"
       },
-      "alias": ["sentry.environment"],
+      "alias": [
+        "sentry.environment"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -130,17 +159,23 @@
       },
       "is_in_otel": false,
       "example": 547.6951,
-      "sdks": ["javascript-browser"],
+      "sdks": [
+        "javascript-browser"
+      ],
       "deprecation": {
         "_status": "backfill",
         "replacement": "browser.web_vital.fcp.value",
         "reason": "This attribute is being deprecated in favor of browser.web_vital.fcp.value"
       },
-      "alias": ["browser.web_vital.fcp.value"],
+      "alias": [
+        "browser.web_vital.fcp.value"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [235]
+          "prs": [
+            235
+          ]
         }
       ]
     },
@@ -153,17 +188,23 @@
       },
       "is_in_otel": false,
       "example": 477.1926,
-      "sdks": ["javascript-browser"],
+      "sdks": [
+        "javascript-browser"
+      ],
       "deprecation": {
         "_status": "backfill",
         "replacement": "browser.web_vital.fp.value",
         "reason": "This attribute is being deprecated in favor of browser.web_vital.fp.value"
       },
-      "alias": ["browser.web_vital.fp.value"],
+      "alias": [
+        "browser.web_vital.fp.value"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [235]
+          "prs": [
+            235
+          ]
         }
       ]
     },
@@ -181,11 +222,16 @@
         "reason": "This attribute is not part of the OpenTelemetry specification and error.type fits much better."
       },
       "example": "ENOENT: no such file or directory",
-      "sdks": ["javascript-node"],
+      "sdks": [
+        "javascript-node"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -201,8 +247,12 @@
       },
       "is_in_otel": false,
       "example": "14",
-      "sdks": ["javascript-browser"],
-      "alias": ["device.processor_count"],
+      "sdks": [
+        "javascript-browser"
+      ],
+      "alias": [
+        "device.processor_count"
+      ],
       "deprecation": {
         "replacement": "device.processor_count",
         "reason": "Old namespace-less attribute, to be replaced with device.processor_count for span-first future",
@@ -211,12 +261,16 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [300],
+          "prs": [
+            300
+          ],
           "description": "Updated deprecation replacement from device.cpu.logical_core_count to device.processor_count"
         },
         {
           "version": "next",
-          "prs": [281],
+          "prs": [
+            281
+          ],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -230,17 +284,23 @@
       },
       "is_in_otel": false,
       "example": 200,
-      "sdks": ["javascript-browser"],
+      "sdks": [
+        "javascript-browser"
+      ],
       "deprecation": {
         "replacement": "browser.web_vital.inp.value",
         "reason": "The INP web vital is now recorded as a browser.web_vital.inp.value attribute.",
         "_status": "backfill"
       },
-      "alias": ["browser.web_vital.inp.value"],
+      "alias": [
+        "browser.web_vital.inp.value"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [229],
+          "prs": [
+            229
+          ],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -254,17 +314,23 @@
       },
       "is_in_otel": false,
       "example": 2500,
-      "sdks": ["javascript-browser"],
+      "sdks": [
+        "javascript-browser"
+      ],
       "deprecation": {
         "replacement": "browser.web_vital.lcp.value",
         "reason": "The LCP web vital is now recorded as a browser.web_vital.lcp.value attribute.",
         "_status": "backfill"
       },
-      "alias": ["browser.web_vital.lcp.value"],
+      "alias": [
+        "browser.web_vital.lcp.value"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [229],
+          "prs": [
+            229
+          ],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -282,12 +348,20 @@
         "_status": null,
         "replacement": "http.request.method"
       },
-      "alias": ["http.request.method"],
-      "sdks": ["javascript-browser", "javascript-node"],
+      "alias": [
+        "http.request.method"
+      ],
+      "sdks": [
+        "javascript-browser",
+        "javascript-node"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -307,11 +381,16 @@
         "_status": null,
         "replacement": "sentry.release"
       },
-      "alias": ["sentry.release"],
+      "alias": [
+        "sentry.release"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -331,11 +410,15 @@
         "_status": null,
         "replacement": "sentry.replay_id"
       },
-      "alias": ["sentry.replay_id"],
+      "alias": [
+        "sentry.replay_id"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61]
+          "prs": [
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -355,12 +438,20 @@
         "_status": null,
         "replacement": "http.route"
       },
-      "alias": ["http.route"],
-      "sdks": ["php-laravel", "javascript-reactnative"],
+      "alias": [
+        "http.route"
+      ],
+      "sdks": [
+        "php-laravel",
+        "javascript-reactnative"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 74]
+          "prs": [
+            61,
+            74
+          ]
         },
         {
           "version": "0.0.0"
@@ -380,11 +471,16 @@
         "_status": null,
         "replacement": "sentry.transaction"
       },
-      "alias": ["sentry.transaction"],
+      "alias": [
+        "sentry.transaction"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -400,8 +496,12 @@
       },
       "is_in_otel": false,
       "example": 194,
-      "alias": ["browser.web_vital.ttfb.value"],
-      "sdks": ["javascript-browser"],
+      "alias": [
+        "browser.web_vital.ttfb.value"
+      ],
+      "sdks": [
+        "javascript-browser"
+      ],
       "deprecation": {
         "_status": "backfill",
         "replacement": "browser.web_vital.ttfb.value",
@@ -410,7 +510,9 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [235]
+          "prs": [
+            235
+          ]
         }
       ]
     },
@@ -427,12 +529,20 @@
         "_status": null,
         "replacement": "url.full"
       },
-      "alias": ["url.full", "http.url"],
-      "sdks": ["javascript-browser", "javascript-node"],
+      "alias": [
+        "url.full",
+        "http.url"
+      ],
+      "sdks": [
+        "javascript-browser",
+        "javascript-node"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61]
+          "prs": [
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -447,18 +557,25 @@
         "key": "true"
       },
       "is_in_otel": false,
-      "example": ["Citation 1", "Citation 2"],
+      "example": [
+        "Citation 1",
+        "Citation 2"
+      ],
       "deprecation": {
         "_status": null
       },
       "changelog": [
         {
           "version": "next",
-          "prs": [264]
+          "prs": [
+            264
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55]
+          "prs": [
+            55
+          ]
         }
       ]
     },
@@ -471,8 +588,13 @@
       },
       "is_in_otel": false,
       "example": 10,
-      "alias": ["gen_ai.usage.output_tokens", "gen_ai.usage.completion_tokens"],
-      "sdks": ["python"],
+      "alias": [
+        "gen_ai.usage.output_tokens",
+        "gen_ai.usage.completion_tokens"
+      ],
+      "sdks": [
+        "python"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.usage.output_tokens"
@@ -480,11 +602,16 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [57, 61]
+          "prs": [
+            57,
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -499,18 +626,25 @@
         "key": "true"
       },
       "is_in_otel": false,
-      "example": ["document1.txt", "document2.pdf"],
+      "example": [
+        "document1.txt",
+        "document2.pdf"
+      ],
       "deprecation": {
         "_status": null
       },
       "changelog": [
         {
           "version": "next",
-          "prs": [264]
+          "prs": [
+            264
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55]
+          "prs": [
+            55
+          ]
         }
       ]
     },
@@ -527,11 +661,19 @@
         "_status": null,
         "replacement": "gen_ai.response.finish_reason"
       },
-      "alias": ["gen_ai.response.finish_reasons"],
+      "alias": [
+        "gen_ai.response.finish_reasons"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [55, 57, 61, 108, 127]
+          "prs": [
+            55,
+            57,
+            61,
+            108,
+            127
+          ]
         }
       ]
     },
@@ -548,15 +690,24 @@
         "_status": null,
         "replacement": "gen_ai.request.frequency_penalty"
       },
-      "alias": ["gen_ai.request.frequency_penalty"],
+      "alias": [
+        "gen_ai.request.frequency_penalty"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55, 57, 61, 108]
+          "prs": [
+            55,
+            57,
+            61,
+            108
+          ]
         }
       ]
     },
@@ -573,11 +724,18 @@
         "_status": null,
         "replacement": "gen_ai.tool.name"
       },
-      "alias": ["gen_ai.tool.name"],
+      "alias": [
+        "gen_ai.tool.name"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [55, 57, 61, 108]
+          "prs": [
+            55,
+            57,
+            61,
+            108
+          ]
         }
       ]
     },
@@ -594,11 +752,19 @@
         "_status": null,
         "replacement": "gen_ai.response.id"
       },
-      "alias": ["gen_ai.response.id"],
+      "alias": [
+        "gen_ai.response.id"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [55, 57, 61, 108, 127]
+          "prs": [
+            55,
+            57,
+            61,
+            108,
+            127
+          ]
         }
       ]
     },
@@ -611,8 +777,12 @@
       },
       "is_in_otel": false,
       "example": "[{\"role\": \"user\", \"message\": \"hello\"}]",
-      "alias": ["gen_ai.request.messages"],
-      "sdks": ["python"],
+      "alias": [
+        "gen_ai.request.messages"
+      ],
+      "sdks": [
+        "python"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.request.messages"
@@ -620,7 +790,10 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [65, 119]
+          "prs": [
+            65,
+            119
+          ]
         },
         {
           "version": "0.0.0"
@@ -642,11 +815,15 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [264]
+          "prs": [
+            264
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55]
+          "prs": [
+            55
+          ]
         }
       ]
     },
@@ -665,11 +842,16 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [264]
+          "prs": [
+            264
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55, 127]
+          "prs": [
+            55,
+            127
+          ]
         }
       ]
     },
@@ -686,15 +868,25 @@
         "_status": null,
         "replacement": "gen_ai.provider.name"
       },
-      "alias": ["gen_ai.provider.name", "gen_ai.system"],
+      "alias": [
+        "gen_ai.provider.name",
+        "gen_ai.system"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [253]
+          "prs": [
+            253
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [57, 61, 108, 127]
+          "prs": [
+            57,
+            61,
+            108,
+            127
+          ]
         }
       ]
     },
@@ -707,8 +899,12 @@
       },
       "is_in_otel": false,
       "example": "gpt-4",
-      "alias": ["gen_ai.response.model"],
-      "sdks": ["python"],
+      "alias": [
+        "gen_ai.response.model"
+      ],
+      "sdks": [
+        "python"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.response.model"
@@ -716,7 +912,11 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [57, 61, 127]
+          "prs": [
+            57,
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -736,11 +936,18 @@
         "_status": null,
         "replacement": "gen_ai.pipeline.name"
       },
-      "alias": ["gen_ai.pipeline.name"],
+      "alias": [
+        "gen_ai.pipeline.name"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [53, 76, 108, 127]
+          "prs": [
+            53,
+            76,
+            108,
+            127
+          ]
         }
       ]
     },
@@ -757,15 +964,21 @@
         "_status": null,
         "replacement": "gen_ai.system_instructions"
       },
-      "alias": ["gen_ai.system_instructions"],
+      "alias": [
+        "gen_ai.system_instructions"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [264]
+          "prs": [
+            264
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55]
+          "prs": [
+            55
+          ]
         }
       ]
     },
@@ -782,15 +995,24 @@
         "_status": null,
         "replacement": "gen_ai.request.presence_penalty"
       },
-      "alias": ["gen_ai.request.presence_penalty"],
+      "alias": [
+        "gen_ai.request.presence_penalty"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55, 57, 61, 108]
+          "prs": [
+            55,
+            57,
+            61,
+            108
+          ]
         }
       ]
     },
@@ -803,8 +1025,13 @@
       },
       "is_in_otel": false,
       "example": 20,
-      "alias": ["gen_ai.usage.prompt_tokens", "gen_ai.usage.input_tokens"],
-      "sdks": ["python"],
+      "alias": [
+        "gen_ai.usage.prompt_tokens",
+        "gen_ai.usage.input_tokens"
+      ],
+      "sdks": [
+        "python"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.usage.input_tokens"
@@ -812,11 +1039,16 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [57, 61]
+          "prs": [
+            57,
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -838,11 +1070,15 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [264]
+          "prs": [
+            264
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55]
+          "prs": [
+            55
+          ]
         }
       ]
     },
@@ -861,11 +1097,16 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [264]
+          "prs": [
+            264
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55, 127]
+          "prs": [
+            55,
+            127
+          ]
         }
       ]
     },
@@ -877,8 +1118,13 @@
         "key": "maybe"
       },
       "is_in_otel": false,
-      "example": ["hello", "world"],
-      "sdks": ["python"],
+      "example": [
+        "hello",
+        "world"
+      ],
+      "sdks": [
+        "python"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.response.text"
@@ -886,7 +1132,10 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [65, 127]
+          "prs": [
+            65,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -901,18 +1150,25 @@
         "key": "true"
       },
       "is_in_otel": false,
-      "example": ["climate change effects", "renewable energy"],
+      "example": [
+        "climate change effects",
+        "renewable energy"
+      ],
       "deprecation": {
         "_status": null
       },
       "changelog": [
         {
           "version": "next",
-          "prs": [264]
+          "prs": [
+            264
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55]
+          "prs": [
+            55
+          ]
         }
       ]
     },
@@ -924,18 +1180,24 @@
         "key": "true"
       },
       "is_in_otel": false,
-      "example": ["search_result_1, search_result_2"],
+      "example": [
+        "search_result_1, search_result_2"
+      ],
       "deprecation": {
         "_status": null
       },
       "changelog": [
         {
           "version": "next",
-          "prs": [264]
+          "prs": [
+            264
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55]
+          "prs": [
+            55
+          ]
         }
       ]
     },
@@ -952,11 +1214,19 @@
         "_status": null,
         "replacement": "gen_ai.request.seed"
       },
-      "alias": ["gen_ai.request.seed"],
+      "alias": [
+        "gen_ai.request.seed"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [55, 57, 61, 108, 127]
+          "prs": [
+            55,
+            57,
+            61,
+            108,
+            127
+          ]
         }
       ]
     },
@@ -969,16 +1239,23 @@
       },
       "is_in_otel": false,
       "example": true,
-      "sdks": ["python"],
+      "sdks": [
+        "python"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.response.streaming"
       },
-      "alias": ["gen_ai.response.streaming"],
+      "alias": [
+        "gen_ai.response.streaming"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [76, 108]
+          "prs": [
+            76,
+            108
+          ]
         },
         {
           "version": "0.0.0"
@@ -1000,11 +1277,16 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [264]
+          "prs": [
+            264
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55, 127]
+          "prs": [
+            55,
+            127
+          ]
         }
       ]
     },
@@ -1021,15 +1303,24 @@
         "_status": null,
         "replacement": "gen_ai.request.temperature"
       },
-      "alias": ["gen_ai.request.temperature"],
+      "alias": [
+        "gen_ai.request.temperature"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55, 57, 61, 108]
+          "prs": [
+            55,
+            57,
+            61,
+            108
+          ]
         }
       ]
     },
@@ -1041,20 +1332,29 @@
         "key": "true"
       },
       "is_in_otel": false,
-      "example": ["Hello, how are you?", "What is the capital of France?"],
+      "example": [
+        "Hello, how are you?",
+        "What is the capital of France?"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.input.messages"
       },
-      "alias": ["gen_ai.input.messages"],
+      "alias": [
+        "gen_ai.input.messages"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [264]
+          "prs": [
+            264
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55]
+          "prs": [
+            55
+          ]
         }
       ]
     },
@@ -1066,7 +1366,10 @@
         "key": "true"
       },
       "is_in_otel": false,
-      "example": ["tool_call_1", "tool_call_2"],
+      "example": [
+        "tool_call_1",
+        "tool_call_2"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.response.tool_calls"
@@ -1074,7 +1377,10 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [55, 65]
+          "prs": [
+            55,
+            65
+          ]
         }
       ]
     },
@@ -1086,7 +1392,10 @@
         "key": "maybe"
       },
       "is_in_otel": false,
-      "example": ["function_1", "function_2"],
+      "example": [
+        "function_1",
+        "function_2"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.request.available_tools"
@@ -1094,7 +1403,11 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [55, 65, 127]
+          "prs": [
+            55,
+            65,
+            127
+          ]
         }
       ]
     },
@@ -1111,15 +1424,24 @@
         "_status": null,
         "replacement": "gen_ai.request.top_k"
       },
-      "alias": ["gen_ai.request.top_k"],
+      "alias": [
+        "gen_ai.request.top_k"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55, 57, 61, 108]
+          "prs": [
+            55,
+            57,
+            61,
+            108
+          ]
         }
       ]
     },
@@ -1136,15 +1458,24 @@
         "_status": null,
         "replacement": "gen_ai.request.top_p"
       },
-      "alias": ["gen_ai.request.top_p"],
+      "alias": [
+        "gen_ai.request.top_p"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55, 57, 61, 108]
+          "prs": [
+            55,
+            57,
+            61,
+            108
+          ]
         }
       ]
     },
@@ -1161,19 +1492,27 @@
         "_status": null,
         "replacement": "gen_ai.cost.total_tokens"
       },
-      "alias": ["gen_ai.cost.total_tokens"],
+      "alias": [
+        "gen_ai.cost.total_tokens"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [264]
+          "prs": [
+            264
+          ]
         },
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [53]
+          "prs": [
+            53
+          ]
         }
       ]
     },
@@ -1186,20 +1525,30 @@
       },
       "is_in_otel": false,
       "example": 30,
-      "sdks": ["python"],
+      "sdks": [
+        "python"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.usage.total_tokens"
       },
-      "alias": ["gen_ai.usage.total_tokens"],
+      "alias": [
+        "gen_ai.usage.total_tokens"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [57, 61, 108]
+          "prs": [
+            57,
+            61,
+            108
+          ]
         },
         {
           "version": "0.0.0"
@@ -1214,18 +1563,24 @@
         "key": "true"
       },
       "is_in_otel": false,
-      "example": ["Token limit exceeded"],
+      "example": [
+        "Token limit exceeded"
+      ],
       "deprecation": {
         "_status": null
       },
       "changelog": [
         {
           "version": "next",
-          "prs": [264]
+          "prs": [
+            264
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [55]
+          "prs": [
+            55
+          ]
         }
       ]
     },
@@ -1238,18 +1593,24 @@
       },
       "is_in_otel": false,
       "example": "body > div#app",
-      "sdks": ["javascript-browser"],
+      "sdks": [
+        "javascript-browser"
+      ],
       "deprecation": {
         "replacement": "browser.web_vital.cls.source.<key>",
         "reason": "The CLS source is now recorded as a browser.web_vital.cls.source.<key> attribute.",
         "_status": "backfill"
       },
       "has_dynamic_suffix": true,
-      "alias": ["browser.web_vital.cls.source.<key>"],
+      "alias": [
+        "browser.web_vital.cls.source.<key>"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [234]
+          "prs": [
+            234
+          ]
         }
       ]
     },
@@ -1266,11 +1627,15 @@
         "_status": null,
         "replacement": "code.file.path"
       },
-      "alias": ["code.file.path"],
+      "alias": [
+        "code.file.path"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61]
+          "prs": [
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -1290,11 +1655,16 @@
         "_status": null,
         "replacement": "code.function.name"
       },
-      "alias": ["code.function.name"],
+      "alias": [
+        "code.function.name"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 74]
+          "prs": [
+            61,
+            74
+          ]
         },
         {
           "version": "0.0.0"
@@ -1314,15 +1684,22 @@
         "_status": null,
         "replacement": "code.line.number"
       },
-      "alias": ["code.line.number"],
+      "alias": [
+        "code.line.number"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [61, 108]
+          "prs": [
+            61,
+            108
+          ]
         },
         {
           "version": "0.0.0"
@@ -1346,7 +1723,10 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 74]
+          "prs": [
+            61,
+            74
+          ]
         },
         {
           "version": "0.0.0"
@@ -1362,8 +1742,12 @@
       },
       "is_in_otel": false,
       "example": 100,
-      "sdks": ["javascript-browser"],
-      "alias": ["network.connection.rtt"],
+      "sdks": [
+        "javascript-browser"
+      ],
+      "alias": [
+        "network.connection.rtt"
+      ],
       "deprecation": {
         "replacement": "network.connection.rtt",
         "reason": "Old attribute name (no official namespace), to be replaced with network.connection.rtt for span-first future",
@@ -1372,7 +1756,9 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [279],
+          "prs": [
+            279
+          ],
           "description": "Added and deprecated attribute to document JS SDK's current behaviour"
         }
       ]
@@ -1390,11 +1776,16 @@
         "_status": null,
         "replacement": "db.namespace"
       },
-      "alias": ["db.namespace"],
+      "alias": [
+        "db.namespace"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -1414,15 +1805,22 @@
         "_status": "normalize",
         "replacement": "db.operation.name"
       },
-      "alias": ["db.operation.name"],
+      "alias": [
+        "db.operation.name"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [199]
+          "prs": [
+            199
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -1442,12 +1840,19 @@
         "replacement": "db.query.parameter.<key>",
         "reason": "Instead of adding every binding in the db.sql.bindings attribute, add them as individual entires with db.query.parameter.<key>."
       },
-      "example": ["1", "foo"],
-      "sdks": ["php-laravel"],
+      "example": [
+        "1",
+        "foo"
+      ],
+      "sdks": [
+        "php-laravel"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61]
+          "prs": [
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -1467,15 +1872,22 @@
         "_status": "normalize",
         "replacement": "db.query.text"
       },
-      "alias": ["db.query.text"],
+      "alias": [
+        "db.query.text"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [199]
+          "prs": [
+            199
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -1495,15 +1907,23 @@
         "_status": "backfill",
         "replacement": "db.system.name"
       },
-      "alias": ["db.system.name"],
+      "alias": [
+        "db.system.name"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [199, 224]
+          "prs": [
+            199,
+            224
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -1526,7 +1946,11 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [74, 108, 119]
+          "prs": [
+            74,
+            108,
+            119
+          ]
         },
         {
           "version": "0.0.0"
@@ -1550,11 +1974,16 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [221]
+          "prs": [
+            221
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [63, 127]
+          "prs": [
+            63,
+            127
+          ]
         }
       ]
     },
@@ -1567,7 +1996,9 @@
       },
       "is_in_otel": false,
       "example": "[{\"role\": \"system\", \"content\": \"Generate a random number.\"}, {\"role\": \"user\", \"content\": [{\"text\": \"Generate a random number between 0 and 10.\", \"type\": \"text\"}]}, {\"role\": \"tool\", \"content\": {\"toolCallId\": \"1\", \"toolName\": \"Weather\", \"output\": \"rainy\"}}]",
-      "alias": ["ai.input_messages"],
+      "alias": [
+        "ai.input_messages"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.input.messages"
@@ -1575,11 +2006,19 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [221]
+          "prs": [
+            221
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [63, 74, 108, 119, 122]
+          "prs": [
+            63,
+            74,
+            108,
+            119,
+            122
+          ]
         }
       ]
     },
@@ -1600,11 +2039,16 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [221]
+          "prs": [
+            221
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [63, 74]
+          "prs": [
+            63,
+            74
+          ]
         }
       ]
     },
@@ -1625,11 +2069,16 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [221]
+          "prs": [
+            221
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [63, 74]
+          "prs": [
+            63,
+            74
+          ]
         }
       ]
     },
@@ -1646,15 +2095,23 @@
         "_status": null,
         "replacement": "gen_ai.provider.name"
       },
-      "alias": ["ai.model.provider", "gen_ai.provider.name"],
+      "alias": [
+        "ai.model.provider",
+        "gen_ai.provider.name"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [253]
+          "prs": [
+            253
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [57, 127]
+          "prs": [
+            57,
+            127
+          ]
         }
       ]
     },
@@ -1674,11 +2131,15 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [221]
+          "prs": [
+            221
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [62]
+          "prs": [
+            62
+          ]
         }
       ]
     },
@@ -1691,7 +2152,9 @@
       },
       "is_in_otel": false,
       "example": "{\"location\": \"Paris\"}",
-      "alias": ["gen_ai.tool.call.arguments"],
+      "alias": [
+        "gen_ai.tool.call.arguments"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.tool.call.arguments"
@@ -1699,11 +2162,16 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [265]
+          "prs": [
+            265
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [63, 74]
+          "prs": [
+            63,
+            74
+          ]
         }
       ]
     },
@@ -1716,7 +2184,10 @@
       },
       "is_in_otel": false,
       "example": "rainy, 57°F",
-      "alias": ["gen_ai.tool.call.result", "gen_ai.tool.output"],
+      "alias": [
+        "gen_ai.tool.call.result",
+        "gen_ai.tool.output"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.tool.call.result"
@@ -1724,11 +2195,15 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [265]
+          "prs": [
+            265
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [62]
+          "prs": [
+            62
+          ]
         }
       ]
     },
@@ -1741,7 +2216,10 @@
       },
       "is_in_otel": false,
       "example": "rainy, 57°F",
-      "alias": ["gen_ai.tool.call.result", "gen_ai.tool.message"],
+      "alias": [
+        "gen_ai.tool.call.result",
+        "gen_ai.tool.message"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "gen_ai.tool.call.result"
@@ -1749,11 +2227,39 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [265]
+          "prs": [
+            265
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [63, 74]
+          "prs": [
+            63,
+            74
+          ]
+        }
+      ]
+    },
+    {
+      "key": "gen_ai.tool.type",
+      "brief": "The type of tool being used.",
+      "type": "string",
+      "pii": {
+        "key": "maybe"
+      },
+      "is_in_otel": true,
+      "example": "function",
+      "deprecation": {
+        "_status": null,
+        "reason": "The gen_ai.tool.type attribute is deprecated and should no longer be set."
+      },
+      "changelog": [
+        {
+          "version": "0.1.0",
+          "prs": [
+            62,
+            127
+          ]
         }
       ]
     },
@@ -1770,15 +2276,22 @@
         "_status": null,
         "replacement": "gen_ai.usage.output_tokens"
       },
-      "alias": ["ai.completion_tokens.used", "gen_ai.usage.output_tokens"],
+      "alias": [
+        "ai.completion_tokens.used",
+        "gen_ai.usage.output_tokens"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [61]
+          "prs": [
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -1798,15 +2311,22 @@
         "_status": null,
         "replacement": "gen_ai.usage.input_tokens"
       },
-      "alias": ["ai.prompt_tokens.used", "gen_ai.usage.input_tokens"],
+      "alias": [
+        "ai.prompt_tokens.used",
+        "gen_ai.usage.input_tokens"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [61]
+          "prs": [
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -1826,11 +2346,17 @@
         "_status": null,
         "replacement": "client.address"
       },
-      "alias": ["client.address"],
+      "alias": [
+        "client.address"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 106, 127]
+          "prs": [
+            61,
+            106,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -1850,11 +2376,18 @@
         "_status": null,
         "replacement": "network.protocol.version"
       },
-      "alias": ["network.protocol.version", "net.protocol.version"],
+      "alias": [
+        "network.protocol.version",
+        "net.protocol.version"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 108, 127]
+          "prs": [
+            61,
+            108,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -1875,11 +2408,20 @@
         "replacement": "server.address",
         "reason": "Deprecated, use one of `server.address` or `client.address`, depending on the usage"
       },
-      "alias": ["server.address", "client.address", "http.server_name", "net.host.name"],
+      "alias": [
+        "server.address",
+        "client.address",
+        "http.server_name",
+        "net.host.name"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 108, 127]
+          "prs": [
+            61,
+            108,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -1899,11 +2441,16 @@
         "_status": null,
         "replacement": "http.request.method"
       },
-      "alias": ["http.request.method"],
+      "alias": [
+        "http.request.method"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -1923,15 +2470,23 @@
         "_status": "backfill",
         "replacement": "http.response.body.size"
       },
-      "alias": ["http.response.body.size", "http.response.header.content-length"],
+      "alias": [
+        "http.response.body.size",
+        "http.response.header.content-length"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [61, 106]
+          "prs": [
+            61,
+            106
+          ]
         },
         {
           "version": "0.0.0"
@@ -1951,15 +2506,21 @@
         "_status": "backfill",
         "replacement": "http.response.size"
       },
-      "alias": ["http.response.size"],
+      "alias": [
+        "http.response.size"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [61]
+          "prs": [
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -1979,11 +2540,16 @@
         "_status": null,
         "replacement": "url.scheme"
       },
-      "alias": ["url.scheme"],
+      "alias": [
+        "url.scheme"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2003,11 +2569,19 @@
         "_status": null,
         "replacement": "server.address"
       },
-      "alias": ["server.address", "net.host.name", "http.host"],
+      "alias": [
+        "server.address",
+        "net.host.name",
+        "http.host"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 108, 127]
+          "prs": [
+            61,
+            108,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2027,15 +2601,21 @@
         "_status": null,
         "replacement": "http.response.status_code"
       },
-      "alias": ["http.response.status_code"],
+      "alias": [
+        "http.response.status_code"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [61]
+          "prs": [
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -2059,7 +2639,9 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61]
+          "prs": [
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -2079,11 +2661,17 @@
         "_status": null,
         "replacement": "url.full"
       },
-      "alias": ["url.full", "url"],
+      "alias": [
+        "url.full",
+        "url"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 108]
+          "prs": [
+            61,
+            108
+          ]
         },
         {
           "version": "0.0.0"
@@ -2103,11 +2691,16 @@
         "_status": null,
         "replacement": "user_agent.original"
       },
-      "alias": ["user_agent.original"],
+      "alias": [
+        "user_agent.original"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2128,15 +2721,21 @@
         "reason": "The LCP element is now recorded as a browser.web_vital.lcp.element attribute.",
         "_status": "backfill"
       },
-      "alias": ["browser.web_vital.lcp.element"],
+      "alias": [
+        "browser.web_vital.lcp.element"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [233]
+          "prs": [
+            233
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [127]
+          "prs": [
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2157,15 +2756,21 @@
         "reason": "The LCP id is now recorded as a browser.web_vital.lcp.id attribute.",
         "_status": "backfill"
       },
-      "alias": ["browser.web_vital.lcp.id"],
+      "alias": [
+        "browser.web_vital.lcp.id"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [233]
+          "prs": [
+            233
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [127]
+          "prs": [
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2181,17 +2786,23 @@
       },
       "is_in_otel": false,
       "example": 1402,
-      "sdks": ["javascript-browser"],
+      "sdks": [
+        "javascript-browser"
+      ],
       "deprecation": {
         "replacement": "browser.web_vital.lcp.load_time",
         "reason": "The LCP load time is now recorded as a browser.web_vital.lcp.load_time attribute.",
         "_status": "backfill"
       },
-      "alias": ["browser.web_vital.lcp.load_time"],
+      "alias": [
+        "browser.web_vital.lcp.load_time"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [233]
+          "prs": [
+            233
+          ]
         }
       ]
     },
@@ -2204,17 +2815,23 @@
       },
       "is_in_otel": false,
       "example": 1685,
-      "sdks": ["javascript-browser"],
+      "sdks": [
+        "javascript-browser"
+      ],
       "deprecation": {
         "replacement": "browser.web_vital.lcp.render_time",
         "reason": "The LCP render time is now recorded as a browser.web_vital.lcp.render_time attribute.",
         "_status": "backfill"
       },
-      "alias": ["browser.web_vital.lcp.render_time"],
+      "alias": [
+        "browser.web_vital.lcp.render_time"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [233]
+          "prs": [
+            233
+          ]
         }
       ]
     },
@@ -2232,15 +2849,21 @@
         "reason": "The LCP size is now recorded as a browser.web_vital.lcp.size attribute.",
         "_status": "backfill"
       },
-      "alias": ["browser.web_vital.lcp.size"],
+      "alias": [
+        "browser.web_vital.lcp.size"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [233]
+          "prs": [
+            233
+          ]
         },
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.0.0"
@@ -2261,15 +2884,21 @@
         "reason": "The LCP url is now recorded as a browser.web_vital.lcp.url attribute.",
         "_status": "backfill"
       },
-      "alias": ["browser.web_vital.lcp.url"],
+      "alias": [
+        "browser.web_vital.lcp.url"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [233]
+          "prs": [
+            233
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [127]
+          "prs": [
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2289,11 +2918,18 @@
         "_status": null,
         "replacement": "network.local.address"
       },
-      "alias": ["network.local.address", "net.sock.host.addr"],
+      "alias": [
+        "network.local.address",
+        "net.sock.host.addr"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 108, 127]
+          "prs": [
+            61,
+            108,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2313,11 +2949,19 @@
         "_status": null,
         "replacement": "server.address"
       },
-      "alias": ["server.address", "http.server_name", "http.host"],
+      "alias": [
+        "server.address",
+        "http.server_name",
+        "http.host"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 108, 127]
+          "prs": [
+            61,
+            108,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2337,15 +2981,21 @@
         "_status": null,
         "replacement": "server.port"
       },
-      "alias": ["server.port"],
+      "alias": [
+        "server.port"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [61]
+          "prs": [
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -2365,11 +3015,18 @@
         "_status": null,
         "replacement": "network.peer.address"
       },
-      "alias": ["network.peer.address", "net.sock.peer.addr"],
+      "alias": [
+        "network.peer.address",
+        "net.sock.peer.addr"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 108, 127]
+          "prs": [
+            61,
+            108,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2393,7 +3050,10 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2417,11 +3077,15 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [61]
+          "prs": [
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -2441,11 +3105,16 @@
         "_status": null,
         "replacement": "network.protocol.name"
       },
-      "alias": ["network.protocol.name"],
+      "alias": [
+        "network.protocol.name"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2465,11 +3134,18 @@
         "_status": null,
         "replacement": "network.protocol.version"
       },
-      "alias": ["network.protocol.version", "http.flavor"],
+      "alias": [
+        "network.protocol.version",
+        "http.flavor"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 108, 127]
+          "prs": [
+            61,
+            108,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2493,7 +3169,10 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2513,11 +3192,18 @@
         "_status": null,
         "replacement": "network.local.address"
       },
-      "alias": ["network.local.address", "net.host.ip"],
+      "alias": [
+        "network.local.address",
+        "net.host.ip"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 108, 127]
+          "prs": [
+            61,
+            108,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2537,15 +3223,21 @@
         "_status": null,
         "replacement": "network.local.port"
       },
-      "alias": ["network.local.port"],
+      "alias": [
+        "network.local.port"
+      ],
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [61]
+          "prs": [
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -2565,11 +3257,18 @@
         "_status": null,
         "replacement": "network.peer.address"
       },
-      "alias": ["network.peer.address", "net.peer.ip"],
+      "alias": [
+        "network.peer.address",
+        "net.peer.ip"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 108, 127]
+          "prs": [
+            61,
+            108,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2592,7 +3291,11 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 119, 127]
+          "prs": [
+            61,
+            119,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2615,11 +3318,15 @@
       "changelog": [
         {
           "version": "0.4.0",
-          "prs": [228]
+          "prs": [
+            228
+          ]
         },
         {
           "version": "0.1.0",
-          "prs": [61]
+          "prs": [
+            61
+          ]
         },
         {
           "version": "0.0.0"
@@ -2639,11 +3346,16 @@
         "_status": null,
         "replacement": "network.transport"
       },
-      "alias": ["network.transport"],
+      "alias": [
+        "network.transport"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [61, 127]
+          "prs": [
+            61,
+            127
+          ]
         },
         {
           "version": "0.0.0"
@@ -2668,7 +3380,9 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [103]
+          "prs": [
+            103
+          ]
         }
       ]
     },
@@ -2688,7 +3402,9 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [266]
+          "prs": [
+            266
+          ]
         }
       ]
     },
@@ -2708,7 +3424,9 @@
       "changelog": [
         {
           "version": "0.3.1",
-          "prs": [196]
+          "prs": [
+            196
+          ]
         }
       ]
     },
@@ -2725,11 +3443,15 @@
         "_status": null,
         "replacement": "browser.name"
       },
-      "alias": ["browser.name"],
+      "alias": [
+        "browser.name"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [139]
+          "prs": [
+            139
+          ]
         }
       ]
     },
@@ -2746,11 +3468,15 @@
         "_status": null,
         "replacement": "browser.version"
       },
-      "alias": ["browser.version"],
+      "alias": [
+        "browser.version"
+      ],
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [139]
+          "prs": [
+            139
+          ]
         }
       ]
     },
@@ -2763,7 +3489,9 @@
       },
       "is_in_otel": false,
       "example": "051581bf3cb55c13",
-      "alias": ["sentry.segment.id"],
+      "alias": [
+        "sentry.segment.id"
+      ],
       "deprecation": {
         "_status": null,
         "replacement": "sentry.segment.id"
@@ -2771,7 +3499,9 @@
       "changelog": [
         {
           "version": "0.1.0",
-          "prs": [124]
+          "prs": [
+            124
+          ]
         }
       ]
     },
@@ -2810,12 +3540,16 @@
       "changelog": [
         {
           "version": "next",
-          "prs": [287],
+          "prs": [
+            287
+          ],
           "description": "Deprecate `sentry.trace.parent_span_id`"
         },
         {
           "version": "0.1.0",
-          "prs": [116]
+          "prs": [
+            116
+          ]
         }
       ]
     },
@@ -2828,17 +3562,23 @@
       },
       "is_in_otel": false,
       "example": 1554.5814,
-      "sdks": ["javascript-browser"],
+      "sdks": [
+        "javascript-browser"
+      ],
       "deprecation": {
         "_status": "backfill",
         "replacement": "browser.web_vital.ttfb.request_time",
         "reason": "This attribute is being deprecated in favor of browser.web_vital.ttfb.request_time"
       },
-      "alias": ["browser.web_vital.ttfb.request_time"],
+      "alias": [
+        "browser.web_vital.ttfb.request_time"
+      ],
       "changelog": [
         {
           "version": "next",
-          "prs": [235]
+          "prs": [
+            235
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Marks `gen_ai.tool.type` as deprecated by adding a `deprecation` field to the model JSON
- Regenerates Python, JavaScript, and shared deprecated attributes files

Fixes PY-2285