### PR TITLE
feat(attributes): add `gen_ai.context.window_size` and `gen_ai.context.utilization` for generation spans

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2944,6 +2944,46 @@ export const GEN_AI_AGENT_NAME = 'gen_ai.agent.name';
  */
 export type GEN_AI_AGENT_NAME_TYPE = string;
 
+// Path: model/attributes/gen_ai/gen_ai__context__utilization.json
+
+/**
+ * The fraction of the model context window utilized by this generation. `gen_ai.context.utilization`
+ *
+ * Attribute Value Type: `number` {@link GEN_AI_CONTEXT_UTILIZATION_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 0.75
+ */
+export const GEN_AI_CONTEXT_UTILIZATION = 'gen_ai.context.utilization';
+
+/**
+ * Type for {@link GEN_AI_CONTEXT_UTILIZATION} gen_ai.context.utilization
+ */
+export type GEN_AI_CONTEXT_UTILIZATION_TYPE = number;
+
+// Path: model/attributes/gen_ai/gen_ai__context__window_size.json
+
+/**
+ * The maximum context window size supported by the model for this generation. `gen_ai.context.window_size`
+ *
+ * Attribute Value Type: `number` {@link GEN_AI_CONTEXT_WINDOW_SIZE_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 128000
+ */
+export const GEN_AI_CONTEXT_WINDOW_SIZE = 'gen_ai.context.window_size';
+
+/**
+ * Type for {@link GEN_AI_CONTEXT_WINDOW_SIZE} gen_ai.context.window_size
+ */
+export type GEN_AI_CONTEXT_WINDOW_SIZE_TYPE = number;
+
 // Path: model/attributes/gen_ai/gen_ai__conversation__id.json
 
 /**
@@ -10376,6 +10416,8 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [FRAMES_TOTAL]: 'integer',
   [FS_ERROR]: 'string',
   [GEN_AI_AGENT_NAME]: 'string',
+  [GEN_AI_CONTEXT_UTILIZATION]: 'double',
+  [GEN_AI_CONTEXT_WINDOW_SIZE]: 'integer',
   [GEN_AI_CONVERSATION_ID]: 'string',
   [GEN_AI_COST_INPUT_TOKENS]: 'double',
   [GEN_AI_COST_OUTPUT_TOKENS]: 'double',
@@ -10865,6 +10907,8 @@ export type AttributeName =
   | typeof FRAMES_TOTAL
   | typeof FS_ERROR
   | typeof GEN_AI_AGENT_NAME
+  | typeof GEN_AI_CONTEXT_UTILIZATION
+  | typeof GEN_AI_CONTEXT_WINDOW_SIZE
   | typeof GEN_AI_CONVERSATION_ID
   | typeof GEN_AI_COST_INPUT_TOKENS
   | typeof GEN_AI_COST_OUTPUT_TOKENS
@@ -12995,6 +13039,26 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     example: 'ResearchAssistant',
     changelog: [{ version: '0.1.0', prs: [62, 127] }],
+  },
+  [GEN_AI_CONTEXT_UTILIZATION]: {
+    brief: 'The fraction of the model context window utilized by this generation.',
+    type: 'double',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 0.75,
+    changelog: [{ version: 'next', prs: [315], description: 'Added gen_ai.context.utilization attribute' }],
+  },
+  [GEN_AI_CONTEXT_WINDOW_SIZE]: {
+    brief: 'The maximum context window size supported by the model for this generation.',
+    type: 'integer',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 128000,
+    changelog: [{ version: 'next', prs: [315], description: 'Added gen_ai.context.window_size attribute' }],
   },
   [GEN_AI_CONVERSATION_ID]: {
     brief:
@@ -17267,6 +17331,8 @@ export type Attributes = {
   [FRAMES_TOTAL]?: FRAMES_TOTAL_TYPE;
   [FS_ERROR]?: FS_ERROR_TYPE;
   [GEN_AI_AGENT_NAME]?: GEN_AI_AGENT_NAME_TYPE;
+  [GEN_AI_CONTEXT_UTILIZATION]?: GEN_AI_CONTEXT_UTILIZATION_TYPE;
+  [GEN_AI_CONTEXT_WINDOW_SIZE]?: GEN_AI_CONTEXT_WINDOW_SIZE_TYPE;
   [GEN_AI_CONVERSATION_ID]?: GEN_AI_CONVERSATION_ID_TYPE;
   [GEN_AI_COST_INPUT_TOKENS]?: GEN_AI_COST_INPUT_TOKENS_TYPE;
   [GEN_AI_COST_OUTPUT_TOKENS]?: GEN_AI_COST_OUTPUT_TOKENS_TYPE;

--- a/model/attributes/gen_ai/gen_ai__context__utilization.json
+++ b/model/attributes/gen_ai/gen_ai__context__utilization.json
@@ -1,0 +1,17 @@
+{
+  "key": "gen_ai.context.utilization",
+  "brief": "The fraction of the model context window utilized by this generation.",
+  "type": "double",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": 0.75,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [315],
+      "description": "Added gen_ai.context.utilization attribute"
+    }
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__context__window_size.json
+++ b/model/attributes/gen_ai/gen_ai__context__window_size.json
@@ -1,0 +1,17 @@
+{
+  "key": "gen_ai.context.window_size",
+  "brief": "The maximum context window size supported by the model for this generation.",
+  "type": "integer",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": 128000,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [315],
+      "description": "Added gen_ai.context.window_size attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1780,6 +1780,30 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "ResearchAssistant"
     """
 
+    # Path: model/attributes/gen_ai/gen_ai__context__utilization.json
+    GEN_AI_CONTEXT_UTILIZATION: Literal["gen_ai.context.utilization"] = (
+        "gen_ai.context.utilization"
+    )
+    """The fraction of the model context window utilized by this generation.
+
+    Type: float
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: 0.75
+    """
+
+    # Path: model/attributes/gen_ai/gen_ai__context__window_size.json
+    GEN_AI_CONTEXT_WINDOW_SIZE: Literal["gen_ai.context.window_size"] = (
+        "gen_ai.context.window_size"
+    )
+    """The maximum context window size supported by the model for this generation.
+
+    Type: int
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: 128000
+    """
+
     # Path: model/attributes/gen_ai/gen_ai__conversation__id.json
     GEN_AI_CONVERSATION_ID: Literal["gen_ai.conversation.id"] = "gen_ai.conversation.id"
     """The unique identifier for a conversation (session, thread), used to store and correlate messages within this conversation.
@@ -7432,6 +7456,34 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[62, 127]),
         ],
     ),
+    "gen_ai.context.utilization": AttributeMetadata(
+        brief="The fraction of the model context window utilized by this generation.",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=0.75,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[315],
+                description="Added gen_ai.context.utilization attribute",
+            ),
+        ],
+    ),
+    "gen_ai.context.window_size": AttributeMetadata(
+        brief="The maximum context window size supported by the model for this generation.",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=128000,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[315],
+                description="Added gen_ai.context.window_size attribute",
+            ),
+        ],
+    ),
     "gen_ai.conversation.id": AttributeMetadata(
         brief="The unique identifier for a conversation (session, thread), used to store and correlate messages within this conversation.",
         type=AttributeType.STRING,
@@ -11655,6 +11707,8 @@ Attributes = TypedDict(
         "frames.total": int,
         "fs_error": str,
         "gen_ai.agent.name": str,
+        "gen_ai.context.utilization": float,
+        "gen_ai.context.window_size": int,
         "gen_ai.conversation.id": str,
         "gen_ai.cost.input_tokens": float,
         "gen_ai.cost.output_tokens": float,


### PR DESCRIPTION
Add two attributes we need to track context window utilization, the fraction of the possible context window of the LLM used up by the request.

Closes [TET-2218](https://linear.app/getsentry/issue/TET-2218/add-new-fields-to-sentry-conventions)