### PR TITLE
fix(release): Run yarn install before yarn generate in pre-release script

### DIFF
--- a/scripts/craft-pre-release.sh
+++ b/scripts/craft-pre-release.sh
@@ -15,6 +15,7 @@ cd $ROOT_DIR
 
 npx tsx scripts/bump_attribute_changelog.ts "${NEW_VERSION}"
 
+yarn install
 yarn generate
 
 # ==================== JS ====================


### PR DESCRIPTION
The release workflow was failing with exit code 127 (`tsx: not found`) during the `Prepare release` step.

The pre-release script added in #290 calls `yarn generate`, which internally runs `tsx scripts/generate.ts`. However, `node_modules` are not installed in the CI environment before the script runs, so `tsx` is not available in `node_modules/.bin`.

Adding `yarn install` before `yarn generate` ensures the dev dependencies are present when the generate script executes. This was the first release attempt since #290 was merged, which is why it wasn't caught earlier.