### PR TITLE
feat(attributes): Add `sentry.mobile` and `sentry.main_thread` attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -7983,7 +7983,7 @@ export type SENTRY_KIND_TYPE = string;
  *
  * Attribute Value Type: `boolean` {@link SENTRY_MAIN_THREAD_TYPE}
  *
- * Contains PII: maybe
+ * Contains PII: false
  *
  * Attribute defined in OTEL: No
  *
@@ -8043,7 +8043,7 @@ export type SENTRY_MESSAGE_TEMPLATE_TYPE = string;
  *
  * Attribute Value Type: `boolean` {@link SENTRY_MOBILE_TYPE}
  *
- * Contains PII: maybe
+ * Contains PII: false
  *
  * Attribute defined in OTEL: No
  *
@@ -16046,7 +16046,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'Whether the span or event occurred on the main thread. Computed by Relay and should not be set by SDKs.',
     type: 'boolean',
     pii: {
-      isPii: 'maybe',
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,
@@ -16077,7 +16077,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'Whether the application is using a mobile SDK. Computed by Relay and should not be set by SDKs.',
     type: 'boolean',
     pii: {
-      isPii: 'maybe',
+      isPii: 'false',
     },
     isInOtel: false,
     example: true,

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -7976,6 +7976,26 @@ export const SENTRY_KIND = 'sentry.kind';
  */
 export type SENTRY_KIND_TYPE = string;
 
+// Path: model/attributes/sentry/sentry__main_thread.json
+
+/**
+ * Whether the span or event occurred on the main thread. Computed by Relay and should not be set by SDKs. `sentry.main_thread`
+ *
+ * Attribute Value Type: `boolean` {@link SENTRY_MAIN_THREAD_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example true
+ */
+export const SENTRY_MAIN_THREAD = 'sentry.main_thread';
+
+/**
+ * Type for {@link SENTRY_MAIN_THREAD} sentry.main_thread
+ */
+export type SENTRY_MAIN_THREAD_TYPE = boolean;
+
 // Path: model/attributes/sentry/sentry__message__parameter__[key].json
 
 /**
@@ -8015,6 +8035,26 @@ export const SENTRY_MESSAGE_TEMPLATE = 'sentry.message.template';
  * Type for {@link SENTRY_MESSAGE_TEMPLATE} sentry.message.template
  */
 export type SENTRY_MESSAGE_TEMPLATE_TYPE = string;
+
+// Path: model/attributes/sentry/sentry__mobile.json
+
+/**
+ * Whether the application is using a mobile SDK. Computed by Relay and should not be set by SDKs. `sentry.mobile`
+ *
+ * Attribute Value Type: `boolean` {@link SENTRY_MOBILE_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example true
+ */
+export const SENTRY_MOBILE = 'sentry.mobile';
+
+/**
+ * Type for {@link SENTRY_MOBILE} sentry.mobile
+ */
+export type SENTRY_MOBILE_TYPE = boolean;
 
 // Path: model/attributes/sentry/sentry__module__[key].json
 
@@ -10657,8 +10697,10 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SENTRY_IDLE_SPAN_FINISH_REASON]: 'string',
   [SENTRY_IS_REMOTE]: 'boolean',
   [SENTRY_KIND]: 'string',
+  [SENTRY_MAIN_THREAD]: 'boolean',
   [SENTRY_MESSAGE_PARAMETER_KEY]: 'string',
   [SENTRY_MESSAGE_TEMPLATE]: 'string',
+  [SENTRY_MOBILE]: 'boolean',
   [SENTRY_MODULE_KEY]: 'string',
   [SENTRY_NEXTJS_SSR_FUNCTION_ROUTE]: 'string',
   [SENTRY_NEXTJS_SSR_FUNCTION_TYPE]: 'string',
@@ -11148,8 +11190,10 @@ export type AttributeName =
   | typeof SENTRY_IDLE_SPAN_FINISH_REASON
   | typeof SENTRY_IS_REMOTE
   | typeof SENTRY_KIND
+  | typeof SENTRY_MAIN_THREAD
   | typeof SENTRY_MESSAGE_PARAMETER_KEY
   | typeof SENTRY_MESSAGE_TEMPLATE
+  | typeof SENTRY_MOBILE
   | typeof SENTRY_MODULE_KEY
   | typeof SENTRY_NEXTJS_SSR_FUNCTION_ROUTE
   | typeof SENTRY_NEXTJS_SSR_FUNCTION_TYPE
@@ -15998,6 +16042,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'server',
     changelog: [{ version: '0.3.1', prs: [190] }],
   },
+  [SENTRY_MAIN_THREAD]: {
+    brief: 'Whether the span or event occurred on the main thread. Computed by Relay and should not be set by SDKs.',
+    type: 'boolean',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: true,
+    changelog: [{ version: 'next' }],
+  },
   [SENTRY_MESSAGE_PARAMETER_KEY]: {
     brief:
       "A parameter used in the message template. <key> can either be the number that represent the parameter's position in the template string (sentry.message.parameter.0, sentry.message.parameter.1, etc) or the parameter's name (sentry.message.parameter.item_id, sentry.message.parameter.user_id, etc)",
@@ -16018,6 +16072,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: 'Hello, {name}!',
     changelog: [{ version: '0.1.0', prs: [116] }],
+  },
+  [SENTRY_MOBILE]: {
+    brief: 'Whether the application is using a mobile SDK. Computed by Relay and should not be set by SDKs.',
+    type: 'boolean',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: true,
+    changelog: [{ version: 'next' }],
   },
   [SENTRY_MODULE_KEY]: {
     brief: 'A module that was loaded in the process. The key is the name of the module.',
@@ -17575,8 +17639,10 @@ export type Attributes = {
   [SENTRY_IDLE_SPAN_FINISH_REASON]?: SENTRY_IDLE_SPAN_FINISH_REASON_TYPE;
   [SENTRY_IS_REMOTE]?: SENTRY_IS_REMOTE_TYPE;
   [SENTRY_KIND]?: SENTRY_KIND_TYPE;
+  [SENTRY_MAIN_THREAD]?: SENTRY_MAIN_THREAD_TYPE;
   [SENTRY_MESSAGE_PARAMETER_KEY]?: SENTRY_MESSAGE_PARAMETER_KEY_TYPE;
   [SENTRY_MESSAGE_TEMPLATE]?: SENTRY_MESSAGE_TEMPLATE_TYPE;
+  [SENTRY_MOBILE]?: SENTRY_MOBILE_TYPE;
   [SENTRY_MODULE_KEY]?: SENTRY_MODULE_KEY_TYPE;
   [SENTRY_NEXTJS_SSR_FUNCTION_ROUTE]?: SENTRY_NEXTJS_SSR_FUNCTION_ROUTE_TYPE;
   [SENTRY_NEXTJS_SSR_FUNCTION_TYPE]?: SENTRY_NEXTJS_SSR_FUNCTION_TYPE_TYPE;

--- a/model/attributes/sentry/sentry__main_thread.json
+++ b/model/attributes/sentry/sentry__main_thread.json
@@ -1,0 +1,15 @@
+{
+  "key": "sentry.main_thread",
+  "brief": "Whether the span or event occurred on the main thread. Computed by Relay and should not be set by SDKs.",
+  "type": "boolean",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": true,
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/sentry/sentry__main_thread.json
+++ b/model/attributes/sentry/sentry__main_thread.json
@@ -3,7 +3,7 @@
   "brief": "Whether the span or event occurred on the main thread. Computed by Relay and should not be set by SDKs.",
   "type": "boolean",
   "pii": {
-    "key": "maybe"
+    "key": "false"
   },
   "is_in_otel": false,
   "example": true,

--- a/model/attributes/sentry/sentry__mobile.json
+++ b/model/attributes/sentry/sentry__mobile.json
@@ -1,0 +1,15 @@
+{
+  "key": "sentry.mobile",
+  "brief": "Whether the application is using a mobile SDK. Computed by Relay and should not be set by SDKs.",
+  "type": "boolean",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": true,
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/sentry/sentry__mobile.json
+++ b/model/attributes/sentry/sentry__mobile.json
@@ -3,7 +3,7 @@
   "brief": "Whether the application is using a mobile SDK. Computed by Relay and should not be set by SDKs.",
   "type": "boolean",
   "pii": {
-    "key": "maybe"
+    "key": "false"
   },
   "is_in_otel": false,
   "example": true,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4500,6 +4500,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "server"
     """
 
+    # Path: model/attributes/sentry/sentry__main_thread.json
+    SENTRY_MAIN_THREAD: Literal["sentry.main_thread"] = "sentry.main_thread"
+    """Whether the span or event occurred on the main thread. Computed by Relay and should not be set by SDKs.
+
+    Type: bool
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: true
+    """
+
     # Path: model/attributes/sentry/sentry__message__parameter__[key].json
     SENTRY_MESSAGE_PARAMETER_KEY: Literal["sentry.message.parameter.<key>"] = (
         "sentry.message.parameter.<key>"
@@ -4522,6 +4532,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Example: "Hello, {name}!"
+    """
+
+    # Path: model/attributes/sentry/sentry__mobile.json
+    SENTRY_MOBILE: Literal["sentry.mobile"] = "sentry.mobile"
+    """Whether the application is using a mobile SDK. Computed by Relay and should not be set by SDKs.
+
+    Type: bool
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: true
     """
 
     # Path: model/attributes/sentry/sentry__module__[key].json
@@ -10347,6 +10367,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.3.1", prs=[190]),
         ],
     ),
+    "sentry.main_thread": AttributeMetadata(
+        brief="Whether the span or event occurred on the main thread. Computed by Relay and should not be set by SDKs.",
+        type=AttributeType.BOOLEAN,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=True,
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
     "sentry.message.parameter.<key>": AttributeMetadata(
         brief="A parameter used in the message template. <key> can either be the number that represent the parameter's position in the template string (sentry.message.parameter.0, sentry.message.parameter.1, etc) or the parameter's name (sentry.message.parameter.item_id, sentry.message.parameter.user_id, etc)",
         type=AttributeType.STRING,
@@ -10365,6 +10395,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="Hello, {name}!",
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[116]),
+        ],
+    ),
+    "sentry.mobile": AttributeMetadata(
+        brief="Whether the application is using a mobile SDK. Computed by Relay and should not be set by SDKs.",
+        type=AttributeType.BOOLEAN,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=True,
+        changelog=[
+            ChangelogEntry(version="next"),
         ],
     ),
     "sentry.module.<key>": AttributeMetadata(
@@ -11952,8 +11992,10 @@ Attributes = TypedDict(
         "sentry.idle_span_finish_reason": str,
         "sentry.is_remote": bool,
         "sentry.kind": str,
+        "sentry.main_thread": bool,
         "sentry.message.parameter.<key>": str,
         "sentry.message.template": str,
+        "sentry.mobile": bool,
         "sentry.module.<key>": str,
         "sentry.nextjs.ssr.function.route": str,
         "sentry.nextjs.ssr.function.type": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4505,7 +4505,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """Whether the span or event occurred on the main thread. Computed by Relay and should not be set by SDKs.
 
     Type: bool
-    Contains PII: maybe
+    Contains PII: false
     Defined in OTEL: No
     Example: true
     """
@@ -4539,7 +4539,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """Whether the application is using a mobile SDK. Computed by Relay and should not be set by SDKs.
 
     Type: bool
-    Contains PII: maybe
+    Contains PII: false
     Defined in OTEL: No
     Example: true
     """
@@ -10370,7 +10370,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "sentry.main_thread": AttributeMetadata(
         brief="Whether the span or event occurred on the main thread. Computed by Relay and should not be set by SDKs.",
         type=AttributeType.BOOLEAN,
-        pii=PiiInfo(isPii=IsPii.MAYBE),
+        pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=False,
         example=True,
         changelog=[
@@ -10400,7 +10400,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "sentry.mobile": AttributeMetadata(
         brief="Whether the application is using a mobile SDK. Computed by Relay and should not be set by SDKs.",
         type=AttributeType.BOOLEAN,
-        pii=PiiInfo(isPii=IsPii.MAYBE),
+        pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=False,
         example=True,
         changelog=[


### PR DESCRIPTION
## Description

Add two Sentry attributes (note these are also pre-computed by relay in v1 transactions and used today in transactions):

- **`sentry.mobile`** — Whether a mobile SDK is being used.
- **`sentry.main_thread`** — Whether the event occurred on the main thread.

Both attributes are computed by Relay and should not be set by SDKs.

## PR Checklist
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)