### PR TITLE
feat(attributes): Add LCP and CLS web vital report event attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8373,6 +8373,7 @@ export type SENTRY_REPLAY_IS_BUFFERING_TYPE = boolean;
  *
  * Aliases: {@link BROWSER_WEB_VITAL_LCP_REPORT_EVENT} `browser.web_vital.lcp.report_event`, {@link BROWSER_WEB_VITAL_CLS_REPORT_EVENT} `browser.web_vital.cls.report_event`
  *
+ * @deprecated  - The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required.
  * @example "pagehide"
  */
 export const SENTRY_REPORT_EVENT = 'sentry.report_event';
@@ -16301,6 +16302,10 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 'pagehide',
+    deprecation: {
+      reason:
+        'The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required.',
+    },
     aliases: [BROWSER_WEB_VITAL_LCP_REPORT_EVENT, BROWSER_WEB_VITAL_CLS_REPORT_EVENT],
     sdks: ['javascript-browser'],
     changelog: [{ version: 'next', prs: [320], description: 'Added sentry.report_event attribute' }],

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8360,6 +8360,28 @@ export const SENTRY_REPLAY_IS_BUFFERING = 'sentry.replay_is_buffering';
  */
 export type SENTRY_REPLAY_IS_BUFFERING_TYPE = boolean;
 
+// Path: model/attributes/sentry/sentry__report_event.json
+
+/**
+ * (Deprecated) The event that caused the SDK to report CLS or LCP (pagehide or navigation) `sentry.report_event`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_REPORT_EVENT_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Aliases: {@link BROWSER_WEB_VITAL_LCP_REPORT_EVENT} `browser.web_vital.lcp.report_event`, {@link BROWSER_WEB_VITAL_CLS_REPORT_EVENT} `browser.web_vital.cls.report_event`
+ *
+ * @example "pagehide"
+ */
+export const SENTRY_REPORT_EVENT = 'sentry.report_event';
+
+/**
+ * Type for {@link SENTRY_REPORT_EVENT} sentry.report_event
+ */
+export type SENTRY_REPORT_EVENT_TYPE = string;
+
 // Path: model/attributes/sentry/sentry__sdk__integrations.json
 
 /**
@@ -10736,6 +10758,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SENTRY_RELEASE]: 'string',
   [SENTRY_REPLAY_ID]: 'string',
   [SENTRY_REPLAY_IS_BUFFERING]: 'boolean',
+  [SENTRY_REPORT_EVENT]: 'string',
   [SENTRY_SDK_INTEGRATIONS]: 'string[]',
   [SENTRY_SDK_NAME]: 'string',
   [SENTRY_SDK_VERSION]: 'string',
@@ -11230,6 +11253,7 @@ export type AttributeName =
   | typeof SENTRY_RELEASE
   | typeof SENTRY_REPLAY_ID
   | typeof SENTRY_REPLAY_IS_BUFFERING
+  | typeof SENTRY_REPORT_EVENT
   | typeof SENTRY_SDK_INTEGRATIONS
   | typeof SENTRY_SDK_NAME
   | typeof SENTRY_SDK_VERSION
@@ -16269,6 +16293,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: true,
     changelog: [{ version: '0.3.0', prs: [185] }],
   },
+  [SENTRY_REPORT_EVENT]: {
+    brief: '(Deprecated) The event that caused the SDK to report CLS or LCP (pagehide or navigation)',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 'pagehide',
+    aliases: [BROWSER_WEB_VITAL_LCP_REPORT_EVENT, BROWSER_WEB_VITAL_CLS_REPORT_EVENT],
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [320], description: 'Added sentry.report_event attribute' }],
+  },
   [SENTRY_SDK_INTEGRATIONS]: {
     brief:
       'A list of names identifying enabled integrations. The list shouldhave all enabled integrations, including default integrations. Defaultintegrations are included because different SDK releases may contain differentdefault integrations.',
@@ -17693,6 +17729,7 @@ export type Attributes = {
   [SENTRY_RELEASE]?: SENTRY_RELEASE_TYPE;
   [SENTRY_REPLAY_ID]?: SENTRY_REPLAY_ID_TYPE;
   [SENTRY_REPLAY_IS_BUFFERING]?: SENTRY_REPLAY_IS_BUFFERING_TYPE;
+  [SENTRY_REPORT_EVENT]?: SENTRY_REPORT_EVENT_TYPE;
   [SENTRY_SDK_INTEGRATIONS]?: SENTRY_SDK_INTEGRATIONS_TYPE;
   [SENTRY_SDK_NAME]?: SENTRY_SDK_NAME_TYPE;
   [SENTRY_SDK_VERSION]?: SENTRY_SDK_VERSION_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8371,8 +8371,6 @@ export type SENTRY_REPLAY_IS_BUFFERING_TYPE = boolean;
  *
  * Attribute defined in OTEL: No
  *
- * Aliases: {@link BROWSER_WEB_VITAL_LCP_REPORT_EVENT} `browser.web_vital.lcp.report_event`, {@link BROWSER_WEB_VITAL_CLS_REPORT_EVENT} `browser.web_vital.cls.report_event`
- *
  * @deprecated  - The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required.
  * @example "pagehide"
  */
@@ -16306,7 +16304,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason:
         'The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required.',
     },
-    aliases: [BROWSER_WEB_VITAL_LCP_REPORT_EVENT, BROWSER_WEB_VITAL_CLS_REPORT_EVENT],
     sdks: ['javascript-browser'],
     changelog: [{ version: 'next', prs: [320], description: 'Added sentry.report_event attribute' }],
   },

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1017,6 +1017,26 @@ export const BROWSER_VERSION = 'browser.version';
  */
 export type BROWSER_VERSION_TYPE = string;
 
+// Path: model/attributes/browser/browser__web_vital__cls__report_event.json
+
+/**
+ * The event that caused the SDK to report CLS (pagehide or navigation) `browser.web_vital.cls.report_event`
+ *
+ * Attribute Value Type: `string` {@link BROWSER_WEB_VITAL_CLS_REPORT_EVENT_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "navigation"
+ */
+export const BROWSER_WEB_VITAL_CLS_REPORT_EVENT = 'browser.web_vital.cls.report_event';
+
+/**
+ * Type for {@link BROWSER_WEB_VITAL_CLS_REPORT_EVENT} browser.web_vital.cls.report_event
+ */
+export type BROWSER_WEB_VITAL_CLS_REPORT_EVENT_TYPE = string;
+
 // Path: model/attributes/browser/browser__web_vital__cls__source__[key].json
 
 /**
@@ -1216,6 +1236,26 @@ export const BROWSER_WEB_VITAL_LCP_RENDER_TIME = 'browser.web_vital.lcp.render_t
  * Type for {@link BROWSER_WEB_VITAL_LCP_RENDER_TIME} browser.web_vital.lcp.render_time
  */
 export type BROWSER_WEB_VITAL_LCP_RENDER_TIME_TYPE = number;
+
+// Path: model/attributes/browser/browser__web_vital__lcp__report_event.json
+
+/**
+ * The event that caused the SDK to report LCP (pagehide or navigation) `browser.web_vital.lcp.report_event`
+ *
+ * Attribute Value Type: `string` {@link BROWSER_WEB_VITAL_LCP_REPORT_EVENT_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "pagehide"
+ */
+export const BROWSER_WEB_VITAL_LCP_REPORT_EVENT = 'browser.web_vital.lcp.report_event';
+
+/**
+ * Type for {@link BROWSER_WEB_VITAL_LCP_REPORT_EVENT} browser.web_vital.lcp.report_event
+ */
+export type BROWSER_WEB_VITAL_LCP_REPORT_EVENT_TYPE = string;
 
 // Path: model/attributes/browser/browser__web_vital__lcp__size.json
 
@@ -10346,6 +10386,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [BROWSER_SCRIPT_INVOKER_TYPE]: 'string',
   [BROWSER_SCRIPT_SOURCE_CHAR_POSITION]: 'integer',
   [BROWSER_VERSION]: 'string',
+  [BROWSER_WEB_VITAL_CLS_REPORT_EVENT]: 'string',
   [BROWSER_WEB_VITAL_CLS_SOURCE_KEY]: 'string',
   [BROWSER_WEB_VITAL_CLS_VALUE]: 'double',
   [BROWSER_WEB_VITAL_FCP_VALUE]: 'double',
@@ -10355,6 +10396,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [BROWSER_WEB_VITAL_LCP_ID]: 'string',
   [BROWSER_WEB_VITAL_LCP_LOAD_TIME]: 'integer',
   [BROWSER_WEB_VITAL_LCP_RENDER_TIME]: 'integer',
+  [BROWSER_WEB_VITAL_LCP_REPORT_EVENT]: 'string',
   [BROWSER_WEB_VITAL_LCP_SIZE]: 'integer',
   [BROWSER_WEB_VITAL_LCP_URL]: 'string',
   [BROWSER_WEB_VITAL_LCP_VALUE]: 'double',
@@ -10838,6 +10880,7 @@ export type AttributeName =
   | typeof BROWSER_SCRIPT_INVOKER_TYPE
   | typeof BROWSER_SCRIPT_SOURCE_CHAR_POSITION
   | typeof BROWSER_VERSION
+  | typeof BROWSER_WEB_VITAL_CLS_REPORT_EVENT
   | typeof BROWSER_WEB_VITAL_CLS_SOURCE_KEY
   | typeof BROWSER_WEB_VITAL_CLS_VALUE
   | typeof BROWSER_WEB_VITAL_FCP_VALUE
@@ -10847,6 +10890,7 @@ export type AttributeName =
   | typeof BROWSER_WEB_VITAL_LCP_ID
   | typeof BROWSER_WEB_VITAL_LCP_LOAD_TIME
   | typeof BROWSER_WEB_VITAL_LCP_RENDER_TIME
+  | typeof BROWSER_WEB_VITAL_LCP_REPORT_EVENT
   | typeof BROWSER_WEB_VITAL_LCP_SIZE
   | typeof BROWSER_WEB_VITAL_LCP_URL
   | typeof BROWSER_WEB_VITAL_LCP_VALUE
@@ -11934,6 +11978,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: [SENTRY_BROWSER_VERSION],
     changelog: [{ version: '0.1.0', prs: [59, 127, 139] }],
   },
+  [BROWSER_WEB_VITAL_CLS_REPORT_EVENT]: {
+    brief: 'The event that caused the SDK to report CLS (pagehide or navigation)',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 'navigation',
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [319], description: 'Added browser.web_vital.cls.report_event attribute' }],
+  },
   [BROWSER_WEB_VITAL_CLS_SOURCE_KEY]: {
     brief: 'The HTML elements or components responsible for the layout shift. <key> is a numeric index from 1 to N',
     type: 'string',
@@ -12042,6 +12097,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: [LCP_RENDERTIME],
     sdks: ['javascript-browser'],
     changelog: [{ version: 'next', prs: [233] }],
+  },
+  [BROWSER_WEB_VITAL_LCP_REPORT_EVENT]: {
+    brief: 'The event that caused the SDK to report LCP (pagehide or navigation)',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 'pagehide',
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [319], description: 'Added browser.web_vital.lcp.report_event attribute' }],
   },
   [BROWSER_WEB_VITAL_LCP_SIZE]: {
     brief: 'The size of the largest contentful paint element',
@@ -17277,6 +17343,7 @@ export type Attributes = {
   [BROWSER_SCRIPT_INVOKER_TYPE]?: BROWSER_SCRIPT_INVOKER_TYPE_TYPE;
   [BROWSER_SCRIPT_SOURCE_CHAR_POSITION]?: BROWSER_SCRIPT_SOURCE_CHAR_POSITION_TYPE;
   [BROWSER_VERSION]?: BROWSER_VERSION_TYPE;
+  [BROWSER_WEB_VITAL_CLS_REPORT_EVENT]?: BROWSER_WEB_VITAL_CLS_REPORT_EVENT_TYPE;
   [BROWSER_WEB_VITAL_CLS_SOURCE_KEY]?: BROWSER_WEB_VITAL_CLS_SOURCE_KEY_TYPE;
   [BROWSER_WEB_VITAL_CLS_VALUE]?: BROWSER_WEB_VITAL_CLS_VALUE_TYPE;
   [BROWSER_WEB_VITAL_FCP_VALUE]?: BROWSER_WEB_VITAL_FCP_VALUE_TYPE;
@@ -17286,6 +17353,7 @@ export type Attributes = {
   [BROWSER_WEB_VITAL_LCP_ID]?: BROWSER_WEB_VITAL_LCP_ID_TYPE;
   [BROWSER_WEB_VITAL_LCP_LOAD_TIME]?: BROWSER_WEB_VITAL_LCP_LOAD_TIME_TYPE;
   [BROWSER_WEB_VITAL_LCP_RENDER_TIME]?: BROWSER_WEB_VITAL_LCP_RENDER_TIME_TYPE;
+  [BROWSER_WEB_VITAL_LCP_REPORT_EVENT]?: BROWSER_WEB_VITAL_LCP_REPORT_EVENT_TYPE;
   [BROWSER_WEB_VITAL_LCP_SIZE]?: BROWSER_WEB_VITAL_LCP_SIZE_TYPE;
   [BROWSER_WEB_VITAL_LCP_URL]?: BROWSER_WEB_VITAL_LCP_URL_TYPE;
   [BROWSER_WEB_VITAL_LCP_VALUE]?: BROWSER_WEB_VITAL_LCP_VALUE_TYPE;

--- a/model/attributes/browser/browser__web_vital__cls__report_event.json
+++ b/model/attributes/browser/browser__web_vital__cls__report_event.json
@@ -1,0 +1,18 @@
+{
+  "key": "browser.web_vital.cls.report_event",
+  "brief": "The event that caused the SDK to report CLS (pagehide or navigation)",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "navigation",
+  "sdks": ["javascript-browser"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [319],
+      "description": "Added browser.web_vital.cls.report_event attribute"
+    }
+  ]
+}

--- a/model/attributes/browser/browser__web_vital__lcp__report_event.json
+++ b/model/attributes/browser/browser__web_vital__lcp__report_event.json
@@ -1,0 +1,18 @@
+{
+  "key": "browser.web_vital.lcp.report_event",
+  "brief": "The event that caused the SDK to report LCP (pagehide or navigation)",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "pagehide",
+  "sdks": ["javascript-browser"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [319],
+      "description": "Added browser.web_vital.lcp.report_event attribute"
+    }
+  ]
+}

--- a/model/attributes/sentry/sentry__report_event.json
+++ b/model/attributes/sentry/sentry__report_event.json
@@ -1,0 +1,24 @@
+{
+  "key": "sentry.report_event",
+  "brief": "(Deprecated) The event that caused the SDK to report CLS or LCP (pagehide or navigation)",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "pagehide",
+  "alias": ["browser.web_vital.lcp.report_event", "browser.web_vital.cls.report_event"],
+  "sdks": ["javascript-browser"],
+  "deprecation": {
+    "replacement": null,
+    "reason": "The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required.",
+    "_status": null
+  },
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [320],
+      "description": "Added sentry.report_event attribute"
+    }
+  ]
+}

--- a/model/attributes/sentry/sentry__report_event.json
+++ b/model/attributes/sentry/sentry__report_event.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "pagehide",
-  "alias": ["browser.web_vital.lcp.report_event", "browser.web_vital.cls.report_event"],
   "sdks": ["javascript-browser"],
   "deprecation": {
     "replacement": null,

--- a/model/attributes/sentry/sentry__report_event.json
+++ b/model/attributes/sentry/sentry__report_event.json
@@ -9,7 +9,6 @@
   "example": "pagehide",
   "sdks": ["javascript-browser"],
   "deprecation": {
-    "replacement": null,
     "reason": "The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required.",
     "_status": null
   },

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -768,6 +768,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "120.0.6099.130"
     """
 
+    # Path: model/attributes/browser/browser__web_vital__cls__report_event.json
+    BROWSER_WEB_VITAL_CLS_REPORT_EVENT: Literal[
+        "browser.web_vital.cls.report_event"
+    ] = "browser.web_vital.cls.report_event"
+    """The event that caused the SDK to report CLS (pagehide or navigation)
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "navigation"
+    """
+
     # Path: model/attributes/browser/browser__web_vital__cls__source__[key].json
     BROWSER_WEB_VITAL_CLS_SOURCE_KEY: Literal["browser.web_vital.cls.source.<key>"] = (
         "browser.web_vital.cls.source.<key>"
@@ -884,6 +896,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Aliases: lcp.renderTime
     Example: 1685
+    """
+
+    # Path: model/attributes/browser/browser__web_vital__lcp__report_event.json
+    BROWSER_WEB_VITAL_LCP_REPORT_EVENT: Literal[
+        "browser.web_vital.lcp.report_event"
+    ] = "browser.web_vital.lcp.report_event"
+    """The event that caused the SDK to report LCP (pagehide or navigation)
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "pagehide"
     """
 
     # Path: model/attributes/browser/browser__web_vital__lcp__size.json
@@ -6303,6 +6327,21 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[59, 127, 139]),
         ],
     ),
+    "browser.web_vital.cls.report_event": AttributeMetadata(
+        brief="The event that caused the SDK to report CLS (pagehide or navigation)",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="navigation",
+        sdks=["javascript-browser"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[319],
+                description="Added browser.web_vital.cls.report_event attribute",
+            ),
+        ],
+    ),
     "browser.web_vital.cls.source.<key>": AttributeMetadata(
         brief="The HTML elements or components responsible for the layout shift. <key> is a numeric index from 1 to N",
         type=AttributeType.STRING,
@@ -6418,6 +6457,21 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="next", prs=[233]),
+        ],
+    ),
+    "browser.web_vital.lcp.report_event": AttributeMetadata(
+        brief="The event that caused the SDK to report LCP (pagehide or navigation)",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="pagehide",
+        sdks=["javascript-browser"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[319],
+                description="Added browser.web_vital.lcp.report_event attribute",
+            ),
         ],
     ),
     "browser.web_vital.lcp.size": AttributeMetadata(
@@ -11645,6 +11699,7 @@ Attributes = TypedDict(
         "browser.script.invoker_type": str,
         "browser.script.source_char_position": int,
         "browser.version": str,
+        "browser.web_vital.cls.report_event": str,
         "browser.web_vital.cls.source.<key>": str,
         "browser.web_vital.cls.value": float,
         "browser.web_vital.fcp.value": float,
@@ -11654,6 +11709,7 @@ Attributes = TypedDict(
         "browser.web_vital.lcp.id": str,
         "browser.web_vital.lcp.load_time": int,
         "browser.web_vital.lcp.render_time": int,
+        "browser.web_vital.lcp.report_event": str,
         "browser.web_vital.lcp.size": int,
         "browser.web_vital.lcp.url": str,
         "browser.web_vital.lcp.value": float,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -213,6 +213,7 @@ class _AttributeNamesMeta(type):
         "ROUTE",
         "SENTRY_BROWSER_NAME",
         "SENTRY_BROWSER_VERSION",
+        "SENTRY_REPORT_EVENT",
         "_SENTRY_SEGMENT_ID",
         "SENTRY_SOURCE",
         "SENTRY_TRACE_PARENT_SPAN_ID",
@@ -4722,6 +4723,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Aliases: browser.web_vital.lcp.report_event, browser.web_vital.cls.report_event
+    DEPRECATED: No replacement at this time - The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required.
     Example: "pagehide"
     """
 
@@ -10608,6 +10610,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="pagehide",
+        deprecation=DeprecationInfo(
+            reason="The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required."
+        ),
         aliases=[
             "browser.web_vital.lcp.report_event",
             "browser.web_vital.cls.report_event",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4714,6 +4714,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: true
     """
 
+    # Path: model/attributes/sentry/sentry__report_event.json
+    SENTRY_REPORT_EVENT: Literal["sentry.report_event"] = "sentry.report_event"
+    """(Deprecated) The event that caused the SDK to report CLS or LCP (pagehide or navigation)
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Aliases: browser.web_vital.lcp.report_event, browser.web_vital.cls.report_event
+    Example: "pagehide"
+    """
+
     # Path: model/attributes/sentry/sentry__sdk__integrations.json
     SENTRY_SDK_INTEGRATIONS: Literal["sentry.sdk.integrations"] = (
         "sentry.sdk.integrations"
@@ -10591,6 +10602,25 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.3.0", prs=[185]),
         ],
     ),
+    "sentry.report_event": AttributeMetadata(
+        brief="(Deprecated) The event that caused the SDK to report CLS or LCP (pagehide or navigation)",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="pagehide",
+        aliases=[
+            "browser.web_vital.lcp.report_event",
+            "browser.web_vital.cls.report_event",
+        ],
+        sdks=["javascript-browser"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[320],
+                description="Added sentry.report_event attribute",
+            ),
+        ],
+    ),
     "sentry.sdk.integrations": AttributeMetadata(
         brief="A list of names identifying enabled integrations. The list shouldhave all enabled integrations, including default integrations. Defaultintegrations are included because different SDK releases may contain differentdefault integrations.",
         type=AttributeType.STRING_ARRAY,
@@ -12049,6 +12079,7 @@ Attributes = TypedDict(
         "sentry.release": str,
         "sentry.replay_id": str,
         "sentry.replay_is_buffering": bool,
+        "sentry.report_event": str,
         "sentry.sdk.integrations": List[str],
         "sentry.sdk.name": str,
         "sentry.sdk.version": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4722,7 +4722,6 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: str
     Contains PII: maybe
     Defined in OTEL: No
-    Aliases: browser.web_vital.lcp.report_event, browser.web_vital.cls.report_event
     DEPRECATED: No replacement at this time - The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required.
     Example: "pagehide"
     """
@@ -10613,10 +10612,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             reason="The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required."
         ),
-        aliases=[
-            "browser.web_vital.lcp.report_event",
-            "browser.web_vital.cls.report_event",
-        ],
         sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -2775,6 +2775,30 @@
       ]
     },
     {
+      "key": "sentry.report_event",
+      "brief": "(Deprecated) The event that caused the SDK to report CLS or LCP (pagehide or navigation)",
+      "type": "string",
+      "pii": {
+        "key": "maybe"
+      },
+      "is_in_otel": false,
+      "example": "pagehide",
+      "alias": ["browser.web_vital.lcp.report_event", "browser.web_vital.cls.report_event"],
+      "sdks": ["javascript-browser"],
+      "deprecation": {
+        "replacement": null,
+        "reason": "The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required.",
+        "_status": null
+      },
+      "changelog": [
+        {
+          "version": "next",
+          "prs": [320],
+          "description": "Added sentry.report_event attribute"
+        }
+      ]
+    },
+    {
       "key": "sentry.segment_id",
       "brief": "The segment ID of a span",
       "type": "string",

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -2783,10 +2783,8 @@
       },
       "is_in_otel": false,
       "example": "pagehide",
-      "alias": ["browser.web_vital.lcp.report_event", "browser.web_vital.cls.report_event"],
       "sdks": ["javascript-browser"],
       "deprecation": {
-        "replacement": null,
         "reason": "The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required.",
         "_status": null
       },


### PR DESCRIPTION
Two web vital attributes were missing which we should still include for web vital meta information:

- `browser.web_vital.lcp.report_event`
- `browser.web_vital.cls.report_event`

These attributes carry information on what event caused the SDK to report a web vital span for CLS and LCP: Either a `pagehide` or `navigation` event. More events could follow in the future.

For both of these web vitals, we previously sent `sentry.report_event` but in retrospect I believe this was a bad naming choice (my fault lol). Given we have a common pattern now for web vitals, let's align these. No product logic depends on these attributes. They're merely meta information.

ref: 
- https://github.com/getsentry/sentry-javascript/pull/19827
- https://github.com/getsentry/sentry-javascript/issues/17931