### PR TITLE
feat(attribute): Add browser performance attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1237,6 +1237,50 @@ export const BROWSER_NAME = 'browser.name';
  */
 export type BROWSER_NAME_TYPE = string;
 
+// Path: model/attributes/browser/browser__performance__navigation__activation_start.json
+
+/**
+ * The time between initiating a navigation to a page and the browser activating the page `browser.performance.navigation.activation_start`
+ *
+ * Attribute Value Type: `number` {@link BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Aliases: {@link PERFORMANCE_ACTIVATIONSTART} `performance.activationStart`
+ *
+ * @example 1.983
+ */
+export const BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START = 'browser.performance.navigation.activation_start';
+
+/**
+ * Type for {@link BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START} browser.performance.navigation.activation_start
+ */
+export type BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START_TYPE = number;
+
+// Path: model/attributes/browser/browser__performance__time_origin.json
+
+/**
+ * The browser's performance.timeOrigin timestamp representing the time when the pageload was initiated `browser.performance.time_origin`
+ *
+ * Attribute Value Type: `number` {@link BROWSER_PERFORMANCE_TIME_ORIGIN_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Aliases: {@link PERFORMANCE_TIMEORIGIN} `performance.timeOrigin`
+ *
+ * @example 1776185678.886
+ */
+export const BROWSER_PERFORMANCE_TIME_ORIGIN = 'browser.performance.time_origin';
+
+/**
+ * Type for {@link BROWSER_PERFORMANCE_TIME_ORIGIN} browser.performance.time_origin
+ */
+export type BROWSER_PERFORMANCE_TIME_ORIGIN_TYPE = number;
+
 // Path: model/attributes/browser/browser__report__type.json
 
 /**
@@ -8167,6 +8211,9 @@ export type PARAMS_KEY_TYPE = string;
  *
  * Attribute defined in OTEL: No
  *
+ * Aliases: {@link BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START} `browser.performance.navigation.activation_start`
+ *
+ * @deprecated Use {@link BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START} (browser.performance.navigation.activation_start) instead - The activationStart is now recorded as the browser.performance.navigation.activation_start attribute.
  * @example 1.983
  */
 export const PERFORMANCE_ACTIVATIONSTART = 'performance.activationStart';
@@ -8179,7 +8226,7 @@ export type PERFORMANCE_ACTIVATIONSTART_TYPE = number;
 // Path: model/attributes/performance/performance__timeOrigin.json
 
 /**
- * the browser's performance.timeOrigin timestamp representing the time when the pageload was initiated `performance.timeOrigin`
+ * The browser's performance.timeOrigin timestamp representing the time when the pageload was initiated `performance.timeOrigin`
  *
  * Attribute Value Type: `number` {@link PERFORMANCE_TIMEORIGIN_TYPE}
  *
@@ -8187,7 +8234,10 @@ export type PERFORMANCE_ACTIVATIONSTART_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * @example "1776185678.886"
+ * Aliases: {@link BROWSER_PERFORMANCE_TIME_ORIGIN} `browser.performance.time_origin`
+ *
+ * @deprecated Use {@link BROWSER_PERFORMANCE_TIME_ORIGIN} (browser.performance.time_origin) instead - The timeOrigin is now recorded as the browser.performance.time_origin attribute.
+ * @example 1776185678.886
  */
 export const PERFORMANCE_TIMEORIGIN = 'performance.timeOrigin';
 
@@ -11463,6 +11513,8 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [APP_VITALS_TTID_VALUE]: 'double',
   [BLOCKED_MAIN_THREAD]: 'boolean',
   [BROWSER_NAME]: 'string',
+  [BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START]: 'double',
+  [BROWSER_PERFORMANCE_TIME_ORIGIN]: 'double',
   [BROWSER_REPORT_TYPE]: 'string',
   [BROWSER_SCRIPT_INVOKER]: 'string',
   [BROWSER_SCRIPT_INVOKER_TYPE]: 'string',
@@ -12007,6 +12059,8 @@ export type AttributeName =
   | typeof APP_VITALS_TTID_VALUE
   | typeof BLOCKED_MAIN_THREAD
   | typeof BROWSER_NAME
+  | typeof BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START
+  | typeof BROWSER_PERFORMANCE_TIME_ORIGIN
   | typeof BROWSER_REPORT_TYPE
   | typeof BROWSER_SCRIPT_INVOKER
   | typeof BROWSER_SCRIPT_INVOKER_TYPE
@@ -13317,6 +13371,34 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'Chrome',
     aliases: [SENTRY_BROWSER_NAME],
     changelog: [{ version: '0.1.0', prs: [127, 139] }, { version: '0.0.0' }],
+  },
+  [BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START]: {
+    brief: 'The time between initiating a navigation to a page and the browser activating the page',
+    type: 'double',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 1.983,
+    aliases: [PERFORMANCE_ACTIVATIONSTART],
+    sdks: ['javascript-browser'],
+    changelog: [
+      { version: 'next', prs: [321], description: 'Added browser.performance.navigation.activation_start attribute' },
+    ],
+  },
+  [BROWSER_PERFORMANCE_TIME_ORIGIN]: {
+    brief: "The browser's performance.timeOrigin timestamp representing the time when the pageload was initiated",
+    type: 'double',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 1776185678.886,
+    aliases: [PERFORMANCE_TIMEORIGIN],
+    sdks: ['javascript-browser'],
+    changelog: [
+      { version: 'next', prs: [321], description: 'Added browser.performance.time_origin attribute attribute' },
+    ],
   },
   [BROWSER_REPORT_TYPE]: {
     brief: 'A browser report sent via reporting API..',
@@ -17418,17 +17500,27 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 1.983,
+    deprecation: {
+      replacement: 'browser.performance.navigation.activation_start',
+      reason: 'The activationStart is now recorded as the browser.performance.navigation.activation_start attribute.',
+    },
+    aliases: [BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START],
     sdks: ['javascript-browser'],
     changelog: [{ version: 'next', prs: [321], description: 'Added performance.activationStart attribute' }],
   },
   [PERFORMANCE_TIMEORIGIN]: {
-    brief: "the browser's performance.timeOrigin timestamp representing the time when the pageload was initiated",
+    brief: "The browser's performance.timeOrigin timestamp representing the time when the pageload was initiated",
     type: 'double',
     pii: {
       isPii: 'maybe',
     },
     isInOtel: false,
-    example: '1776185678.886',
+    example: 1776185678.886,
+    deprecation: {
+      replacement: 'browser.performance.time_origin',
+      reason: 'The timeOrigin is now recorded as the browser.performance.time_origin attribute.',
+    },
+    aliases: [BROWSER_PERFORMANCE_TIME_ORIGIN],
     sdks: ['javascript-browser'],
     changelog: [{ version: 'next', prs: [321], description: 'Added performance.timeOrigin attribute' }],
   },
@@ -19185,6 +19277,8 @@ export type Attributes = {
   [APP_VITALS_TTID_VALUE]?: APP_VITALS_TTID_VALUE_TYPE;
   [BLOCKED_MAIN_THREAD]?: BLOCKED_MAIN_THREAD_TYPE;
   [BROWSER_NAME]?: BROWSER_NAME_TYPE;
+  [BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START]?: BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START_TYPE;
+  [BROWSER_PERFORMANCE_TIME_ORIGIN]?: BROWSER_PERFORMANCE_TIME_ORIGIN_TYPE;
   [BROWSER_REPORT_TYPE]?: BROWSER_REPORT_TYPE_TYPE;
   [BROWSER_SCRIPT_INVOKER]?: BROWSER_SCRIPT_INVOKER_TYPE;
   [BROWSER_SCRIPT_INVOKER_TYPE]?: BROWSER_SCRIPT_INVOKER_TYPE_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8156,6 +8156,46 @@ export const PARAMS_KEY = 'params.<key>';
  */
 export type PARAMS_KEY_TYPE = string;
 
+// Path: model/attributes/performance/performance__activationStart.json
+
+/**
+ * The time between initiating a navigation to a page and the browser activating the page `performance.activationStart`
+ *
+ * Attribute Value Type: `number` {@link PERFORMANCE_ACTIVATIONSTART_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 1.983
+ */
+export const PERFORMANCE_ACTIVATIONSTART = 'performance.activationStart';
+
+/**
+ * Type for {@link PERFORMANCE_ACTIVATIONSTART} performance.activationStart
+ */
+export type PERFORMANCE_ACTIVATIONSTART_TYPE = number;
+
+// Path: model/attributes/performance/performance__timeOrigin.json
+
+/**
+ * the browser's performance.timeOrigin timestamp representing the time when the pageload was initiated `performance.timeOrigin`
+ *
+ * Attribute Value Type: `number` {@link PERFORMANCE_TIMEORIGIN_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "1776185678.886"
+ */
+export const PERFORMANCE_TIMEORIGIN = 'performance.timeOrigin';
+
+/**
+ * Type for {@link PERFORMANCE_TIMEORIGIN} performance.timeOrigin
+ */
+export type PERFORMANCE_TIMEORIGIN_TYPE = number;
+
 // Path: model/attributes/previous_route.json
 
 /**
@@ -11752,6 +11792,8 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [OTEL_STATUS_CODE]: 'string',
   [OTEL_STATUS_DESCRIPTION]: 'string',
   [PARAMS_KEY]: 'string',
+  [PERFORMANCE_ACTIVATIONSTART]: 'double',
+  [PERFORMANCE_TIMEORIGIN]: 'double',
   [PREVIOUS_ROUTE]: 'string',
   [PROCESS_EXECUTABLE_NAME]: 'string',
   [PROCESS_PID]: 'integer',
@@ -12294,6 +12336,8 @@ export type AttributeName =
   | typeof OTEL_STATUS_CODE
   | typeof OTEL_STATUS_DESCRIPTION
   | typeof PARAMS_KEY
+  | typeof PERFORMANCE_ACTIVATIONSTART
+  | typeof PERFORMANCE_TIMEORIGIN
   | typeof PREVIOUS_ROUTE
   | typeof PROCESS_EXECUTABLE_NAME
   | typeof PROCESS_PID
@@ -17366,6 +17410,28 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: [URL_PATH_PARAMETER_KEY],
     changelog: [{ version: '0.1.0', prs: [103] }],
   },
+  [PERFORMANCE_ACTIVATIONSTART]: {
+    brief: 'The time between initiating a navigation to a page and the browser activating the page',
+    type: 'double',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 1.983,
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [321], description: 'Added performance.activationStart attribute' }],
+  },
+  [PERFORMANCE_TIMEORIGIN]: {
+    brief: "the browser's performance.timeOrigin timestamp representing the time when the pageload was initiated",
+    type: 'double',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: '1776185678.886',
+    sdks: ['javascript-browser'],
+    changelog: [{ version: 'next', prs: [321], description: 'Added performance.timeOrigin attribute' }],
+  },
   [PREVIOUS_ROUTE]: {
     brief: 'Also used by mobile SDKs to indicate the previous route in the application.',
     type: 'string',
@@ -19448,6 +19514,8 @@ export type Attributes = {
   [OTEL_STATUS_CODE]?: OTEL_STATUS_CODE_TYPE;
   [OTEL_STATUS_DESCRIPTION]?: OTEL_STATUS_DESCRIPTION_TYPE;
   [PARAMS_KEY]?: PARAMS_KEY_TYPE;
+  [PERFORMANCE_ACTIVATIONSTART]?: PERFORMANCE_ACTIVATIONSTART_TYPE;
+  [PERFORMANCE_TIMEORIGIN]?: PERFORMANCE_TIMEORIGIN_TYPE;
   [PREVIOUS_ROUTE]?: PREVIOUS_ROUTE_TYPE;
   [PROCESS_EXECUTABLE_NAME]?: PROCESS_EXECUTABLE_NAME_TYPE;
   [PROCESS_PID]?: PROCESS_PID_TYPE;

--- a/model/attributes/browser/browser__performance__navigation__activation_start.json
+++ b/model/attributes/browser/browser__performance__navigation__activation_start.json
@@ -1,0 +1,19 @@
+{
+  "key": "browser.performance.navigation.activation_start",
+  "brief": "The time between initiating a navigation to a page and the browser activating the page",
+  "type": "double",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": 1.983,
+  "alias": ["performance.activationStart"],
+  "sdks": ["javascript-browser"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [321],
+      "description": "Added browser.performance.navigation.activation_start attribute"
+    }
+  ]
+}

--- a/model/attributes/browser/browser__performance__time_origin.json
+++ b/model/attributes/browser/browser__performance__time_origin.json
@@ -1,0 +1,19 @@
+{
+  "key": "browser.performance.time_origin",
+  "brief": "The browser's performance.timeOrigin timestamp representing the time when the pageload was initiated",
+  "type": "double",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": 1776185678.886,
+  "alias": ["performance.timeOrigin"],
+  "sdks": ["javascript-browser"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [321],
+      "description": "Added browser.performance.time_origin attribute attribute"
+    }
+  ]
+}

--- a/model/attributes/performance/performance__activationStart.json
+++ b/model/attributes/performance/performance__activationStart.json
@@ -8,6 +8,12 @@
   "is_in_otel": false,
   "example": 1.983,
   "sdks": ["javascript-browser"],
+  "alias": ["browser.performance.navigation.activation_start"],
+  "deprecation": {
+    "reason": "The activationStart is now recorded as the browser.performance.navigation.activation_start attribute.",
+    "replacement": "browser.performance.navigation.activation_start",
+    "_status": "backfill"
+  },
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/performance/performance__activationStart.json
+++ b/model/attributes/performance/performance__activationStart.json
@@ -1,0 +1,18 @@
+{
+  "key": "performance.activationStart",
+  "brief": "The time between initiating a navigation to a page and the browser activating the page",
+  "type": "double",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": 1.983,
+  "sdks": ["javascript-browser"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [321],
+      "description": "Added performance.activationStart attribute"
+    }
+  ]
+}

--- a/model/attributes/performance/performance__timeOrigin.json
+++ b/model/attributes/performance/performance__timeOrigin.json
@@ -1,13 +1,19 @@
 {
   "key": "performance.timeOrigin",
-  "brief": "the browser's performance.timeOrigin timestamp representing the time when the pageload was initiated",
+  "brief": "The browser's performance.timeOrigin timestamp representing the time when the pageload was initiated",
   "type": "double",
   "pii": {
     "key": "maybe"
   },
+  "alias": ["browser.performance.time_origin"],
   "is_in_otel": false,
-  "example": "1776185678.886",
+  "example": 1776185678.886,
   "sdks": ["javascript-browser"],
+  "deprecation": {
+    "reason": "The timeOrigin is now recorded as the browser.performance.time_origin attribute.",
+    "replacement": "browser.performance.time_origin",
+    "_status": "backfill"
+  },
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/performance/performance__timeOrigin.json
+++ b/model/attributes/performance/performance__timeOrigin.json
@@ -1,0 +1,18 @@
+{
+  "key": "performance.timeOrigin",
+  "brief": "the browser's performance.timeOrigin timestamp representing the time when the pageload was initiated",
+  "type": "double",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "1776185678.886",
+  "sdks": ["javascript-browser"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [321],
+      "description": "Added performance.timeOrigin attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4608,6 +4608,28 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "params.id='123'"
     """
 
+    # Path: model/attributes/performance/performance__activationStart.json
+    PERFORMANCE_ACTIVATIONSTART: Literal["performance.activationStart"] = (
+        "performance.activationStart"
+    )
+    """The time between initiating a navigation to a page and the browser activating the page
+
+    Type: float
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: 1.983
+    """
+
+    # Path: model/attributes/performance/performance__timeOrigin.json
+    PERFORMANCE_TIMEORIGIN: Literal["performance.timeOrigin"] = "performance.timeOrigin"
+    """the browser's performance.timeOrigin timestamp representing the time when the pageload was initiated
+
+    Type: float
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "1776185678.886"
+    """
+
     # Path: model/attributes/previous_route.json
     PREVIOUS_ROUTE: Literal["previous_route"] = "previous_route"
     """Also used by mobile SDKs to indicate the previous route in the application.
@@ -11331,6 +11353,36 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[103]),
         ],
     ),
+    "performance.activationStart": AttributeMetadata(
+        brief="The time between initiating a navigation to a page and the browser activating the page",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=1.983,
+        sdks=["javascript-browser"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[321],
+                description="Added performance.activationStart attribute",
+            ),
+        ],
+    ),
+    "performance.timeOrigin": AttributeMetadata(
+        brief="the browser's performance.timeOrigin timestamp representing the time when the pageload was initiated",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="1776185678.886",
+        sdks=["javascript-browser"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[321],
+                description="Added performance.timeOrigin attribute",
+            ),
+        ],
+    ),
     "previous_route": AttributeMetadata(
         brief="Also used by mobile SDKs to indicate the previous route in the application.",
         type=AttributeType.STRING,
@@ -13455,6 +13507,8 @@ Attributes = TypedDict(
         "otel.status_code": str,
         "otel.status_description": str,
         "params.<key>": str,
+        "performance.activationStart": float,
+        "performance.timeOrigin": float,
         "previous_route": str,
         "process.executable.name": str,
         "process.pid": int,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -217,6 +217,8 @@ class _AttributeNamesMeta(type):
         "NET_SOCK_PEER_PORT",
         "NET_TRANSPORT",
         "OS_BUILD",
+        "PERFORMANCE_ACTIVATIONSTART",
+        "PERFORMANCE_TIMEORIGIN",
         "QUERY_KEY",
         "RELEASE",
         "REPLAY_ID",
@@ -901,6 +903,32 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Aliases: sentry.browser.name
     Example: "Chrome"
+    """
+
+    # Path: model/attributes/browser/browser__performance__navigation__activation_start.json
+    BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START: Literal[
+        "browser.performance.navigation.activation_start"
+    ] = "browser.performance.navigation.activation_start"
+    """The time between initiating a navigation to a page and the browser activating the page
+
+    Type: float
+    Contains PII: maybe
+    Defined in OTEL: No
+    Aliases: performance.activationStart
+    Example: 1.983
+    """
+
+    # Path: model/attributes/browser/browser__performance__time_origin.json
+    BROWSER_PERFORMANCE_TIME_ORIGIN: Literal["browser.performance.time_origin"] = (
+        "browser.performance.time_origin"
+    )
+    """The browser's performance.timeOrigin timestamp representing the time when the pageload was initiated
+
+    Type: float
+    Contains PII: maybe
+    Defined in OTEL: No
+    Aliases: performance.timeOrigin
+    Example: 1776185678.886
     """
 
     # Path: model/attributes/browser/browser__report__type.json
@@ -4617,17 +4645,21 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: float
     Contains PII: maybe
     Defined in OTEL: No
+    Aliases: browser.performance.navigation.activation_start
+    DEPRECATED: Use browser.performance.navigation.activation_start instead - The activationStart is now recorded as the browser.performance.navigation.activation_start attribute.
     Example: 1.983
     """
 
     # Path: model/attributes/performance/performance__timeOrigin.json
     PERFORMANCE_TIMEORIGIN: Literal["performance.timeOrigin"] = "performance.timeOrigin"
-    """the browser's performance.timeOrigin timestamp representing the time when the pageload was initiated
+    """The browser's performance.timeOrigin timestamp representing the time when the pageload was initiated
 
     Type: float
     Contains PII: maybe
     Defined in OTEL: No
-    Example: "1776185678.886"
+    Aliases: browser.performance.time_origin
+    DEPRECATED: Use browser.performance.time_origin instead - The timeOrigin is now recorded as the browser.performance.time_origin attribute.
+    Example: 1776185678.886
     """
 
     # Path: model/attributes/previous_route.json
@@ -7180,6 +7212,38 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127, 139]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "browser.performance.navigation.activation_start": AttributeMetadata(
+        brief="The time between initiating a navigation to a page and the browser activating the page",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=1.983,
+        aliases=["performance.activationStart"],
+        sdks=["javascript-browser"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[321],
+                description="Added browser.performance.navigation.activation_start attribute",
+            ),
+        ],
+    ),
+    "browser.performance.time_origin": AttributeMetadata(
+        brief="The browser's performance.timeOrigin timestamp representing the time when the pageload was initiated",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=1776185678.886,
+        aliases=["performance.timeOrigin"],
+        sdks=["javascript-browser"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[321],
+                description="Added browser.performance.time_origin attribute attribute",
+            ),
         ],
     ),
     "browser.report.type": AttributeMetadata(
@@ -11359,6 +11423,12 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=1.983,
+        deprecation=DeprecationInfo(
+            replacement="browser.performance.navigation.activation_start",
+            reason="The activationStart is now recorded as the browser.performance.navigation.activation_start attribute.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["browser.performance.navigation.activation_start"],
         sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
@@ -11369,11 +11439,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "performance.timeOrigin": AttributeMetadata(
-        brief="the browser's performance.timeOrigin timestamp representing the time when the pageload was initiated",
+        brief="The browser's performance.timeOrigin timestamp representing the time when the pageload was initiated",
         type=AttributeType.DOUBLE,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
-        example="1776185678.886",
+        example=1776185678.886,
+        deprecation=DeprecationInfo(
+            replacement="browser.performance.time_origin",
+            reason="The timeOrigin is now recorded as the browser.performance.time_origin attribute.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["browser.performance.time_origin"],
         sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
@@ -13178,6 +13254,8 @@ Attributes = TypedDict(
         "app_start_type": str,
         "blocked_main_thread": bool,
         "browser.name": str,
+        "browser.performance.navigation.activation_start": float,
+        "browser.performance.time_origin": float,
         "browser.report.type": str,
         "browser.script.invoker": str,
         "browser.script.invoker_type": str,

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -3034,6 +3034,54 @@
       ]
     },
     {
+      "key": "performance.activationStart",
+      "brief": "The time between initiating a navigation to a page and the browser activating the page",
+      "type": "double",
+      "pii": {
+        "key": "maybe"
+      },
+      "is_in_otel": false,
+      "example": 1.983,
+      "sdks": ["javascript-browser"],
+      "alias": ["browser.performance.navigation.activation_start"],
+      "deprecation": {
+        "reason": "The activationStart is now recorded as the browser.performance.navigation.activation_start attribute.",
+        "replacement": "browser.performance.navigation.activation_start",
+        "_status": "backfill"
+      },
+      "changelog": [
+        {
+          "version": "next",
+          "prs": [321],
+          "description": "Added performance.activationStart attribute"
+        }
+      ]
+    },
+    {
+      "key": "performance.timeOrigin",
+      "brief": "The browser's performance.timeOrigin timestamp representing the time when the pageload was initiated",
+      "type": "double",
+      "pii": {
+        "key": "maybe"
+      },
+      "alias": ["browser.performance.time_origin"],
+      "is_in_otel": false,
+      "example": 1776185678.886,
+      "sdks": ["javascript-browser"],
+      "deprecation": {
+        "reason": "The timeOrigin is now recorded as the browser.performance.time_origin attribute.",
+        "replacement": "browser.performance.time_origin",
+        "_status": "backfill"
+      },
+      "changelog": [
+        {
+          "version": "next",
+          "prs": [321],
+          "description": "Added performance.timeOrigin attribute"
+        }
+      ]
+    },
+    {
       "key": "query.<key>",
       "brief": "An item in a query string. Usually added by client-side routing frameworks like vue-router.",
       "has_dynamic_suffix": true,


### PR DESCRIPTION
## Description

Adds browser performance attributes which previously were sent as `performance.*`. While this is namespaced, the namespace is (besides browser) unprecedented, and I'd rather have it scoped under `browser.performance`, given the attributes are taken from the browser's `performance` API.

Deprecated -> New:
- `performance.timeOrigin` -> `browser.performance.time_origin`
- `performance.activationStart` -> `browser.performance.navigation.activation_start`

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
