### PR TITLE
feat(attributes): Deprecate app_start_cold and app_start_warm

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -934,6 +934,29 @@ export const APP_NAME = 'app.name';
  */
 export type APP_NAME_TYPE = string;
 
+// Path: model/attributes/app_start_cold.json
+
+/**
+ * The duration of a cold app start in milliseconds `app_start_cold`
+ *
+ * Attribute Value Type: `number` {@link APP_START_COLD_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Aliases: {@link APP_VITALS_START_COLD_VALUE} `app.vitals.start.cold.value`
+ *
+ * @deprecated Use {@link APP_VITALS_START_COLD_VALUE} (app.vitals.start.cold.value) instead - Replaced by app.vitals.start.cold.value to align with the app.vitals.* namespace for mobile performance attributes
+ * @example 1234.56
+ */
+export const APP_START_COLD = 'app_start_cold';
+
+/**
+ * Type for {@link APP_START_COLD} app_start_cold
+ */
+export type APP_START_COLD_TYPE = number;
+
 // Path: model/attributes/app/app__start_time.json
 
 /**
@@ -978,6 +1001,29 @@ export const APP_START_TYPE = 'app_start_type';
  * Type for {@link APP_START_TYPE} app_start_type
  */
 export type APP_START_TYPE_TYPE = string;
+
+// Path: model/attributes/app_start_warm.json
+
+/**
+ * The duration of a warm app start in milliseconds `app_start_warm`
+ *
+ * Attribute Value Type: `number` {@link APP_START_WARM_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Aliases: {@link APP_VITALS_START_WARM_VALUE} `app.vitals.start.warm.value`
+ *
+ * @deprecated Use {@link APP_VITALS_START_WARM_VALUE} (app.vitals.start.warm.value) instead - Replaced by app.vitals.start.warm.value to align with the app.vitals.* namespace for mobile performance attributes
+ * @example 1234.56
+ */
+export const APP_START_WARM = 'app_start_warm';
+
+/**
+ * Type for {@link APP_START_WARM} app_start_warm
+ */
+export type APP_START_WARM_TYPE = number;
 
 // Path: model/attributes/app/app__version.json
 
@@ -1100,6 +1146,8 @@ export type APP_VITALS_FRAMES_TOTAL_COUNT_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
+ * Aliases: {@link APP_START_COLD} `app_start_cold`
+ *
  * @example 1234.56
  */
 export const APP_VITALS_START_COLD_VALUE = 'app.vitals.start.cold.value';
@@ -1141,6 +1189,8 @@ export type APP_VITALS_START_TYPE_TYPE = string;
  * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
+ *
+ * Aliases: {@link APP_START_WARM} `app_start_warm`
  *
  * @example 1234.56
  */
@@ -11409,8 +11459,10 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [APP_IDENTIFIER]: 'string',
   [APP_IN_FOREGROUND]: 'boolean',
   [APP_NAME]: 'string',
+  [APP_START_COLD]: 'double',
   [APP_START_TIME]: 'string',
   [APP_START_TYPE]: 'string',
+  [APP_START_WARM]: 'double',
   [APP_VERSION]: 'string',
   [APP_VITALS_FRAMES_DELAY_VALUE]: 'integer',
   [APP_VITALS_FRAMES_FROZEN_COUNT]: 'integer',
@@ -11951,8 +12003,10 @@ export type AttributeName =
   | typeof APP_IDENTIFIER
   | typeof APP_IN_FOREGROUND
   | typeof APP_NAME
+  | typeof APP_START_COLD
   | typeof APP_START_TIME
   | typeof APP_START_TYPE
+  | typeof APP_START_WARM
   | typeof APP_VERSION
   | typeof APP_VITALS_FRAMES_DELAY_VALUE
   | typeof APP_VITALS_FRAMES_FROZEN_COUNT
@@ -13094,6 +13148,25 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: 'next', prs: [296], description: 'Added app.name attribute' }],
   },
+  [APP_START_COLD]: {
+    brief: 'The duration of a cold app start in milliseconds',
+    type: 'double',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 1234.56,
+    deprecation: {
+      replacement: 'app.vitals.start.cold.value',
+      reason:
+        'Replaced by app.vitals.start.cold.value to align with the app.vitals.* namespace for mobile performance attributes',
+    },
+    aliases: [APP_VITALS_START_COLD_VALUE],
+    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
+    changelog: [
+      { version: 'next', prs: [323], description: 'Added and deprecated in favor of app.vitals.start.cold.value' },
+    ],
+  },
   [APP_START_TIME]: {
     brief: 'Formatted UTC timestamp when the user started the application.',
     type: 'string',
@@ -13124,6 +13197,25 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: 'next', prs: [313], description: 'Deprecated in favor of app.vitals.start.type' },
       { version: '0.1.0', prs: [127] },
       { version: '0.0.0' },
+    ],
+  },
+  [APP_START_WARM]: {
+    brief: 'The duration of a warm app start in milliseconds',
+    type: 'double',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 1234.56,
+    deprecation: {
+      replacement: 'app.vitals.start.warm.value',
+      reason:
+        'Replaced by app.vitals.start.warm.value to align with the app.vitals.* namespace for mobile performance attributes',
+    },
+    aliases: [APP_VITALS_START_WARM_VALUE],
+    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
+    changelog: [
+      { version: 'next', prs: [323], description: 'Added and deprecated in favor of app.vitals.start.warm.value' },
     ],
   },
   [APP_VERSION]: {
@@ -13203,6 +13295,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 1234.56,
+    aliases: [APP_START_COLD],
     sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: 'next', prs: [313], description: 'Added app.vitals.start.cold.value attribute' }],
   },
@@ -13226,6 +13319,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 1234.56,
+    aliases: [APP_START_WARM],
     sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: 'next', prs: [313], description: 'Added app.vitals.start.warm.value attribute' }],
   },
@@ -19105,8 +19199,10 @@ export type Attributes = {
   [APP_IDENTIFIER]?: APP_IDENTIFIER_TYPE;
   [APP_IN_FOREGROUND]?: APP_IN_FOREGROUND_TYPE;
   [APP_NAME]?: APP_NAME_TYPE;
+  [APP_START_COLD]?: APP_START_COLD_TYPE;
   [APP_START_TIME]?: APP_START_TIME_TYPE;
   [APP_START_TYPE]?: APP_START_TYPE_TYPE;
+  [APP_START_WARM]?: APP_START_WARM_TYPE;
   [APP_VERSION]?: APP_VERSION_TYPE;
   [APP_VITALS_FRAMES_DELAY_VALUE]?: APP_VITALS_FRAMES_DELAY_VALUE_TYPE;
   [APP_VITALS_FRAMES_FROZEN_COUNT]?: APP_VITALS_FRAMES_FROZEN_COUNT_TYPE;

--- a/model/attributes/app/app__vitals__start__cold__value.json
+++ b/model/attributes/app/app__vitals__start__cold__value.json
@@ -6,6 +6,7 @@
     "key": "maybe"
   },
   "is_in_otel": false,
+  "alias": ["app_start_cold"],
   "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "example": 1234.56,
   "changelog": [

--- a/model/attributes/app/app__vitals__start__warm__value.json
+++ b/model/attributes/app/app__vitals__start__warm__value.json
@@ -6,6 +6,7 @@
     "key": "maybe"
   },
   "is_in_otel": false,
+  "alias": ["app_start_warm"],
   "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "example": 1234.56,
   "changelog": [

--- a/model/attributes/app_start_cold.json
+++ b/model/attributes/app_start_cold.json
@@ -1,0 +1,24 @@
+{
+  "key": "app_start_cold",
+  "brief": "The duration of a cold app start in milliseconds",
+  "type": "double",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": 1234.56,
+  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
+  "alias": ["app.vitals.start.cold.value"],
+  "deprecation": {
+    "replacement": "app.vitals.start.cold.value",
+    "reason": "Replaced by app.vitals.start.cold.value to align with the app.vitals.* namespace for mobile performance attributes",
+    "_status": "backfill"
+  },
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [323],
+      "description": "Added and deprecated in favor of app.vitals.start.cold.value"
+    }
+  ]
+}

--- a/model/attributes/app_start_warm.json
+++ b/model/attributes/app_start_warm.json
@@ -1,0 +1,24 @@
+{
+  "key": "app_start_warm",
+  "brief": "The duration of a warm app start in milliseconds",
+  "type": "double",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": 1234.56,
+  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
+  "alias": ["app.vitals.start.warm.value"],
+  "deprecation": {
+    "replacement": "app.vitals.start.warm.value",
+    "reason": "Replaced by app.vitals.start.warm.value to align with the app.vitals.* namespace for mobile performance attributes",
+    "_status": "backfill"
+  },
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [323],
+      "description": "Added and deprecated in favor of app.vitals.start.warm.value"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -141,7 +141,9 @@ class _AttributeNamesMeta(type):
         "APP_APP_NAME",
         "APP_APP_START_TIME",
         "APP_APP_VERSION",
+        "APP_START_COLD",
         "APP_START_TYPE",
+        "APP_START_WARM",
         "CLS_SOURCE_KEY",
         "CLS",
         "CODE_FILEPATH",
@@ -822,6 +824,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: float
     Contains PII: maybe
     Defined in OTEL: No
+    Aliases: app_start_cold
     Example: 1234.56
     """
 
@@ -845,6 +848,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: float
     Contains PII: maybe
     Defined in OTEL: No
+    Aliases: app_start_warm
     Example: 1234.56
     """
 
@@ -870,6 +874,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 1234.56
     """
 
+    # Path: model/attributes/app_start_cold.json
+    APP_START_COLD: Literal["app_start_cold"] = "app_start_cold"
+    """The duration of a cold app start in milliseconds
+
+    Type: float
+    Contains PII: maybe
+    Defined in OTEL: No
+    Aliases: app.vitals.start.cold.value
+    DEPRECATED: Use app.vitals.start.cold.value instead - Replaced by app.vitals.start.cold.value to align with the app.vitals.* namespace for mobile performance attributes
+    Example: 1234.56
+    """
+
     # Path: model/attributes/app_start_type.json
     APP_START_TYPE: Literal["app_start_type"] = "app_start_type"
     """Mobile app start variant. Either cold or warm.
@@ -880,6 +896,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Aliases: app.vitals.start.type
     DEPRECATED: Use app.vitals.start.type instead - Replaced by app.vitals.start.type to align with the app.vitals.* namespace for mobile performance attributes
     Example: "cold"
+    """
+
+    # Path: model/attributes/app_start_warm.json
+    APP_START_WARM: Literal["app_start_warm"] = "app_start_warm"
+    """The duration of a warm app start in milliseconds
+
+    Type: float
+    Contains PII: maybe
+    Defined in OTEL: No
+    Aliases: app.vitals.start.warm.value
+    DEPRECATED: Use app.vitals.start.warm.value instead - Replaced by app.vitals.start.warm.value to align with the app.vitals.* namespace for mobile performance attributes
+    Example: 1234.56
     """
 
     # Path: model/attributes/blocked_main_thread.json
@@ -7019,6 +7047,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=1234.56,
+        aliases=["app_start_cold"],
         sdks=[
             "sentry.cocoa",
             "sentry.java.android",
@@ -7060,6 +7089,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=1234.56,
+        aliases=["app_start_warm"],
         sdks=[
             "sentry.cocoa",
             "sentry.java.android",
@@ -7116,6 +7146,32 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "app_start_cold": AttributeMetadata(
+        brief="The duration of a cold app start in milliseconds",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=1234.56,
+        deprecation=DeprecationInfo(
+            replacement="app.vitals.start.cold.value",
+            reason="Replaced by app.vitals.start.cold.value to align with the app.vitals.* namespace for mobile performance attributes",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["app.vitals.start.cold.value"],
+        sdks=[
+            "sentry.cocoa",
+            "sentry.java.android",
+            "sentry.javascript.react-native",
+            "sentry.dart.flutter",
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[323],
+                description="Added and deprecated in favor of app.vitals.start.cold.value",
+            ),
+        ],
+    ),
     "app_start_type": AttributeMetadata(
         brief="Mobile app start variant. Either cold or warm.",
         type=AttributeType.STRING,
@@ -7136,6 +7192,32 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "app_start_warm": AttributeMetadata(
+        brief="The duration of a warm app start in milliseconds",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=1234.56,
+        deprecation=DeprecationInfo(
+            replacement="app.vitals.start.warm.value",
+            reason="Replaced by app.vitals.start.warm.value to align with the app.vitals.* namespace for mobile performance attributes",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["app.vitals.start.warm.value"],
+        sdks=[
+            "sentry.cocoa",
+            "sentry.java.android",
+            "sentry.javascript.react-native",
+            "sentry.dart.flutter",
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[323],
+                description="Added and deprecated in favor of app.vitals.start.warm.value",
+            ),
         ],
     ),
     "blocked_main_thread": AttributeMetadata(
@@ -13123,7 +13205,9 @@ Attributes = TypedDict(
         "app.vitals.start.warm.value": float,
         "app.vitals.ttfd.value": float,
         "app.vitals.ttid.value": float,
+        "app_start_cold": float,
         "app_start_type": str,
+        "app_start_warm": float,
         "blocked_main_thread": bool,
         "browser.name": str,
         "browser.report.type": str,

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -2,6 +2,30 @@
   "_generated": "This file is generated. Do not modify it directly. See scripts/generate_deprecated_attributes_json.ts",
   "attributes": [
     {
+      "key": "app_start_cold",
+      "brief": "The duration of a cold app start in milliseconds",
+      "type": "double",
+      "pii": {
+        "key": "maybe"
+      },
+      "is_in_otel": false,
+      "example": 1234.56,
+      "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
+      "alias": ["app.vitals.start.cold.value"],
+      "deprecation": {
+        "replacement": "app.vitals.start.cold.value",
+        "reason": "Replaced by app.vitals.start.cold.value to align with the app.vitals.* namespace for mobile performance attributes",
+        "_status": "backfill"
+      },
+      "changelog": [
+        {
+          "version": "next",
+          "prs": [323],
+          "description": "Added and deprecated in favor of app.vitals.start.cold.value"
+        }
+      ]
+    },
+    {
       "key": "app_start_type",
       "brief": "Mobile app start variant. Either cold or warm.",
       "type": "string",
@@ -28,6 +52,30 @@
         },
         {
           "version": "0.0.0"
+        }
+      ]
+    },
+    {
+      "key": "app_start_warm",
+      "brief": "The duration of a warm app start in milliseconds",
+      "type": "double",
+      "pii": {
+        "key": "maybe"
+      },
+      "is_in_otel": false,
+      "example": 1234.56,
+      "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
+      "alias": ["app.vitals.start.warm.value"],
+      "deprecation": {
+        "replacement": "app.vitals.start.warm.value",
+        "reason": "Replaced by app.vitals.start.warm.value to align with the app.vitals.* namespace for mobile performance attributes",
+        "_status": "backfill"
+      },
+      "changelog": [
+        {
+          "version": "next",
+          "prs": [323],
+          "description": "Added and deprecated in favor of app.vitals.start.warm.value"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Adds `app_start_cold` and `app_start_warm` as deprecated attributes pointing to `app.vitals.start.cold.value` and `app.vitals.start.warm.value`
- Adds alias cross-references on the `app.vitals.start.cold.value` and `app.vitals.start.warm.value` attributes

This was missed in #313 which added the other deprecated legacy attributes (`app_start_type`, `time_to_full_display`, `time_to_initial_display`, `frames.*`).

## Test plan
- [x] `yarn test` passes (4921 tests)
- [x] `yarn lint` passes
- [x] `yarn run generate` produces consistent output

🤖 Generated with [Claude Code](https://claude.com/claude-code)