### PR TITLE
fix: Correct replacement for `"ai.finish_reason"`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -78,7 +78,7 @@ export type AI_DOCUMENTS_TYPE = Array<string>;
  *
  * Aliases: {@link GEN_AI_RESPONSE_FINISH_REASONS} `gen_ai.response.finish_reasons`
  *
- * @deprecated Use {@link GEN_AI_RESPONSE_FINISH_REASON} (gen_ai.response.finish_reason) instead
+ * @deprecated Use {@link GEN_AI_RESPONSE_FINISH_REASONS} (gen_ai.response.finish_reasons) instead
  * @example "COMPLETE"
  */
 export const AI_FINISH_REASON = 'ai.finish_reason';
@@ -12556,7 +12556,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: 'COMPLETE',
     deprecation: {
-      replacement: 'gen_ai.response.finish_reason',
+      replacement: 'gen_ai.response.finish_reasons',
     },
     aliases: [GEN_AI_RESPONSE_FINISH_REASONS],
     changelog: [{ version: '0.1.0', prs: [55, 57, 61, 108, 127] }],

--- a/model/attributes/ai/ai__finish_reason.json
+++ b/model/attributes/ai/ai__finish_reason.json
@@ -9,7 +9,7 @@
   "example": "COMPLETE",
   "deprecation": {
     "_status": null,
-    "replacement": "gen_ai.response.finish_reason"
+    "replacement": "gen_ai.response.finish_reasons"
   },
   "alias": ["gen_ai.response.finish_reasons"],
   "changelog": [

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -297,7 +297,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Aliases: gen_ai.response.finish_reasons
-    DEPRECATED: Use gen_ai.response.finish_reason instead
+    DEPRECATED: Use gen_ai.response.finish_reasons instead
     Example: "COMPLETE"
     """
 
@@ -6337,7 +6337,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="COMPLETE",
-        deprecation=DeprecationInfo(replacement="gen_ai.response.finish_reason"),
+        deprecation=DeprecationInfo(replacement="gen_ai.response.finish_reasons"),
         aliases=["gen_ai.response.finish_reasons"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[55, 57, 61, 108, 127]),

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -651,7 +651,7 @@
       "example": "COMPLETE",
       "deprecation": {
         "_status": null,
-        "replacement": "gen_ai.response.finish_reason"
+        "replacement": "gen_ai.response.finish_reasons"
       },
       "alias": ["gen_ai.response.finish_reasons"],
       "changelog": [


### PR DESCRIPTION

## Description
The attribute is correctly called `"gen_ai.response.finish_reasons"` in the alias list.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

