### PR TITLE
feat: Add `db.redis.key`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2589,6 +2589,26 @@ export const DB_REDIS_CONNECTION = 'db.redis.connection';
  */
 export type DB_REDIS_CONNECTION_TYPE = string;
 
+// Path: model/attributes/db/db__redis__key.json
+
+/**
+ * The key the Redis command is operating on. `db.redis.key`
+ *
+ * Attribute Value Type: `string` {@link DB_REDIS_KEY_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "user:2047:city"
+ */
+export const DB_REDIS_KEY = 'db.redis.key';
+
+/**
+ * Type for {@link DB_REDIS_KEY} db.redis.key
+ */
+export type DB_REDIS_KEY_TYPE = string;
+
 // Path: model/attributes/db/db__redis__parameters.json
 
 /**
@@ -11687,6 +11707,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [DB_QUERY_SUMMARY]: 'string',
   [DB_QUERY_TEXT]: 'string',
   [DB_REDIS_CONNECTION]: 'string',
+  [DB_REDIS_KEY]: 'string',
   [DB_REDIS_PARAMETERS]: 'string[]',
   [DB_SQL_BINDINGS]: 'string[]',
   [DB_STATEMENT]: 'string',
@@ -12238,6 +12259,7 @@ export type AttributeName =
   | typeof DB_QUERY_SUMMARY
   | typeof DB_QUERY_TEXT
   | typeof DB_REDIS_CONNECTION
+  | typeof DB_REDIS_KEY
   | typeof DB_REDIS_PARAMETERS
   | typeof DB_SQL_BINDINGS
   | typeof DB_STATEMENT
@@ -14281,6 +14303,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'my-redis-instance',
     sdks: ['php-laravel'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+  },
+  [DB_REDIS_KEY]: {
+    brief: 'The key the Redis command is operating on.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 'user:2047:city',
+    sdks: ['python'],
+    changelog: [{ version: 'next', prs: [326], description: 'Added db.redis.key attribute' }],
   },
   [DB_REDIS_PARAMETERS]: {
     brief: 'The array of command parameters given to a redis command.',
@@ -19538,6 +19571,7 @@ export type Attributes = {
   [DB_QUERY_SUMMARY]?: DB_QUERY_SUMMARY_TYPE;
   [DB_QUERY_TEXT]?: DB_QUERY_TEXT_TYPE;
   [DB_REDIS_CONNECTION]?: DB_REDIS_CONNECTION_TYPE;
+  [DB_REDIS_KEY]?: DB_REDIS_KEY_TYPE;
   [DB_REDIS_PARAMETERS]?: DB_REDIS_PARAMETERS_TYPE;
   [DB_SQL_BINDINGS]?: DB_SQL_BINDINGS_TYPE;
   [DB_STATEMENT]?: DB_STATEMENT_TYPE;

--- a/model/attributes/db/db__redis__key.json
+++ b/model/attributes/db/db__redis__key.json
@@ -1,0 +1,18 @@
+{
+  "key": "db.redis.key",
+  "brief": "The key the Redis command is operating on.",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "user:2047:city",
+  "sdks": ["python"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [326],
+      "description": "Added db.redis.key attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1638,6 +1638,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "my-redis-instance"
     """
 
+    # Path: model/attributes/db/db__redis__key.json
+    DB_REDIS_KEY: Literal["db.redis.key"] = "db.redis.key"
+    """The key the Redis command is operating on.
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "user:2047:city"
+    """
+
     # Path: model/attributes/db/db__redis__parameters.json
     DB_REDIS_PARAMETERS: Literal["db.redis.parameters"] = "db.redis.parameters"
     """The array of command parameters given to a redis command.
@@ -8116,6 +8126,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "db.redis.key": AttributeMetadata(
+        brief="The key the Redis command is operating on.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="user:2047:city",
+        sdks=["python"],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[326], description="Added db.redis.key attribute"
+            ),
+        ],
+    ),
     "db.redis.parameters": AttributeMetadata(
         brief="The array of command parameters given to a redis command.",
         type=AttributeType.STRING_ARRAY,
@@ -13483,6 +13506,7 @@ Attributes = TypedDict(
         "db.query.summary": str,
         "db.query.text": str,
         "db.redis.connection": str,
+        "db.redis.key": str,
         "db.redis.parameters": List[str],
         "db.sql.bindings": List[str],
         "db.statement": str,


### PR DESCRIPTION
## Description
Adding `db.redis.key` containing the Redis key name that the current operation is working on.

The attribute does not exist in OpenTelemetry ([Redis conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/db/redis.md), [DB conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/db/database-spans.md)).

The Python SDK currently sets `redis.key` as a tag. In span streaming mode, we'll migrate this to `db.redis.key` if this PR is accepted.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
