### PR TITLE
feat: Add `process.command_args`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8376,6 +8376,26 @@ export const PREVIOUS_ROUTE = 'previous_route';
  */
 export type PREVIOUS_ROUTE_TYPE = string;
 
+// Path: model/attributes/process/process__command_args.json
+
+/**
+ * All the command arguments (including the command/executable itself) as received by the process.  `process.command_args`
+ *
+ * Attribute Value Type: `Array<string>` {@link PROCESS_COMMAND_ARGS_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * @example ["cmd/otecol","--config=config.yaml"]
+ */
+export const PROCESS_COMMAND_ARGS = 'process.command_args';
+
+/**
+ * Type for {@link PROCESS_COMMAND_ARGS} process.command_args
+ */
+export type PROCESS_COMMAND_ARGS_TYPE = Array<string>;
+
 // Path: model/attributes/process/process__executable__name.json
 
 /**
@@ -11983,6 +12003,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [PERFORMANCE_ACTIVATIONSTART]: 'double',
   [PERFORMANCE_TIMEORIGIN]: 'double',
   [PREVIOUS_ROUTE]: 'string',
+  [PROCESS_COMMAND_ARGS]: 'string[]',
   [PROCESS_EXECUTABLE_NAME]: 'string',
   [PROCESS_PID]: 'integer',
   [PROCESS_RUNTIME_DESCRIPTION]: 'string',
@@ -12535,6 +12556,7 @@ export type AttributeName =
   | typeof PERFORMANCE_ACTIVATIONSTART
   | typeof PERFORMANCE_TIMEORIGIN
   | typeof PREVIOUS_ROUTE
+  | typeof PROCESS_COMMAND_ARGS
   | typeof PROCESS_EXECUTABLE_NAME
   | typeof PROCESS_PID
   | typeof PROCESS_RUNTIME_DESCRIPTION
@@ -17743,6 +17765,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     sdks: ['javascript-reactnative'],
     changelog: [{ version: '0.1.0', prs: [74] }, { version: '0.0.0' }],
   },
+  [PROCESS_COMMAND_ARGS]: {
+    brief: 'All the command arguments (including the command/executable itself) as received by the process. ',
+    type: 'string[]',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: true,
+    example: ['cmd/otecol', '--config=config.yaml'],
+    sdks: ['python'],
+    changelog: [{ version: 'next', prs: [327], description: 'Added process.command_args attribute' }],
+  },
   [PROCESS_EXECUTABLE_NAME]: {
     brief: 'The name of the executable that started the process.',
     type: 'string',
@@ -19843,6 +19876,7 @@ export type Attributes = {
   [PERFORMANCE_ACTIVATIONSTART]?: PERFORMANCE_ACTIVATIONSTART_TYPE;
   [PERFORMANCE_TIMEORIGIN]?: PERFORMANCE_TIMEORIGIN_TYPE;
   [PREVIOUS_ROUTE]?: PREVIOUS_ROUTE_TYPE;
+  [PROCESS_COMMAND_ARGS]?: PROCESS_COMMAND_ARGS_TYPE;
   [PROCESS_EXECUTABLE_NAME]?: PROCESS_EXECUTABLE_NAME_TYPE;
   [PROCESS_PID]?: PROCESS_PID_TYPE;
   [PROCESS_RUNTIME_DESCRIPTION]?: PROCESS_RUNTIME_DESCRIPTION_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8379,7 +8379,7 @@ export type PREVIOUS_ROUTE_TYPE = string;
 // Path: model/attributes/process/process__command_args.json
 
 /**
- * All the command arguments (including the command/executable itself) as received by the process.  `process.command_args`
+ * All the command arguments (including the command/executable itself) as received by the process. `process.command_args`
  *
  * Attribute Value Type: `Array<string>` {@link PROCESS_COMMAND_ARGS_TYPE}
  *
@@ -17766,7 +17766,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     changelog: [{ version: '0.1.0', prs: [74] }, { version: '0.0.0' }],
   },
   [PROCESS_COMMAND_ARGS]: {
-    brief: 'All the command arguments (including the command/executable itself) as received by the process. ',
+    brief: 'All the command arguments (including the command/executable itself) as received by the process.',
     type: 'string[]',
     pii: {
       isPii: 'maybe',

--- a/model/attributes/process/process__command_args.json
+++ b/model/attributes/process/process__command_args.json
@@ -1,0 +1,18 @@
+{
+  "key": "process.command_args",
+  "brief": "All the command arguments (including the command/executable itself) as received by the process. ",
+  "type": "string[]",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": true,
+  "example": ["cmd/otecol", "--config=config.yaml"],
+  "sdks": ["python"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [327],
+      "description": "Added process.command_args attribute"
+    }
+  ]
+}

--- a/model/attributes/process/process__command_args.json
+++ b/model/attributes/process/process__command_args.json
@@ -1,6 +1,6 @@
 {
   "key": "process.command_args",
-  "brief": "All the command arguments (including the command/executable itself) as received by the process. ",
+  "brief": "All the command arguments (including the command/executable itself) as received by the process.",
   "type": "string[]",
   "pii": {
     "key": "maybe"

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4735,6 +4735,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "HomeScreen"
     """
 
+    # Path: model/attributes/process/process__command_args.json
+    PROCESS_COMMAND_ARGS: Literal["process.command_args"] = "process.command_args"
+    """All the command arguments (including the command/executable itself) as received by the process.
+
+    Type: List[str]
+    Contains PII: maybe
+    Defined in OTEL: Yes
+    Example: ["cmd/otecol","--config=config.yaml"]
+    """
+
     # Path: model/attributes/process/process__executable__name.json
     PROCESS_EXECUTABLE_NAME: Literal["process.executable.name"] = (
         "process.executable.name"
@@ -11640,6 +11650,21 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "process.command_args": AttributeMetadata(
+        brief="All the command arguments (including the command/executable itself) as received by the process.",
+        type=AttributeType.STRING_ARRAY,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=True,
+        example=["cmd/otecol", "--config=config.yaml"],
+        sdks=["python"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[327],
+                description="Added process.command_args attribute",
+            ),
+        ],
+    ),
     "process.executable.name": AttributeMetadata(
         brief="The name of the executable that started the process.",
         type=AttributeType.STRING,
@@ -13782,6 +13807,7 @@ Attributes = TypedDict(
         "performance.activationStart": float,
         "performance.timeOrigin": float,
         "previous_route": str,
+        "process.command_args": List[str],
         "process.executable.name": str,
         "process.pid": int,
         "process.runtime.description": str,


### PR DESCRIPTION
## Description

Adding `process.command_args`. OTel: https://opentelemetry.io/docs/specs/semconv/registry/attributes/process/#process-attributes

We currently set [`sys.argv`](https://docs.python.org/3/library/sys.html#sys.argv) in `extra` [in the Python SDK](https://github.com/getsentry/sentry-python/blob/a594f8bd2cccec31d4b570f73ec692af18089645/sentry_sdk/integrations/argv.py#L27), so this would be the segment attribute to migrate it to in span first, if we want it.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
