### PR TITLE
fix: Backfill several deprecated attributes

### DIFF
--- a/model/attributes/gen_ai/gen_ai__system.json
+++ b/model/attributes/gen_ai/gen_ai__system.json
@@ -8,7 +8,7 @@
   "is_in_otel": true,
   "example": "openai",
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.provider.name"
   },
   "alias": ["ai.model.provider", "gen_ai.provider.name"],

--- a/model/attributes/http/http__method.json
+++ b/model/attributes/http/http__method.json
@@ -8,7 +8,7 @@
   "is_in_otel": true,
   "example": "GET",
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "http.request.method"
   },
   "alias": ["http.request.method"],

--- a/model/attributes/sentry/sentry__browser__name.json
+++ b/model/attributes/sentry/sentry__browser__name.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": "Chrome",
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "browser.name"
   },
   "alias": ["browser.name"],

--- a/model/attributes/sentry/sentry__browser__version.json
+++ b/model/attributes/sentry/sentry__browser__version.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": "120.0.6099.130",
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "browser.version"
   },
   "alias": ["browser.version"],

--- a/model/attributes/sentry/sentry__segment_id.json
+++ b/model/attributes/sentry/sentry__segment_id.json
@@ -9,7 +9,7 @@
   "example": "051581bf3cb55c13",
   "alias": ["sentry.segment.id"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "sentry.segment.id"
   },
   "changelog": [

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -9444,7 +9444,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         example="openai",
-        deprecation=DeprecationInfo(replacement="gen_ai.provider.name"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.provider.name", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["ai.model.provider", "gen_ai.provider.name"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[253]),
@@ -9800,7 +9802,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         example="GET",
-        deprecation=DeprecationInfo(replacement="http.request.method"),
+        deprecation=DeprecationInfo(
+            replacement="http.request.method", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["http.request.method"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
@@ -11838,7 +11842,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="Chrome",
-        deprecation=DeprecationInfo(replacement="browser.name"),
+        deprecation=DeprecationInfo(
+            replacement="browser.name", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["browser.name"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[139]),
@@ -11850,7 +11856,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="120.0.6099.130",
-        deprecation=DeprecationInfo(replacement="browser.version"),
+        deprecation=DeprecationInfo(
+            replacement="browser.version", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["browser.version"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[139]),
@@ -12334,7 +12342,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=False,
         example="051581bf3cb55c13",
-        deprecation=DeprecationInfo(replacement="sentry.segment.id"),
+        deprecation=DeprecationInfo(
+            replacement="sentry.segment.id", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["sentry.segment.id"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[124]),

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -2027,7 +2027,7 @@
       "is_in_otel": true,
       "example": "openai",
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.provider.name"
       },
       "alias": ["ai.model.provider", "gen_ai.provider.name"],
@@ -2300,7 +2300,7 @@
       "is_in_otel": true,
       "example": "GET",
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "http.request.method"
       },
       "alias": ["http.request.method"],
@@ -3196,7 +3196,7 @@
       "is_in_otel": false,
       "example": "Chrome",
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "browser.name"
       },
       "alias": ["browser.name"],
@@ -3217,7 +3217,7 @@
       "is_in_otel": false,
       "example": "120.0.6099.130",
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "browser.version"
       },
       "alias": ["browser.version"],
@@ -3261,7 +3261,7 @@
       "example": "051581bf3cb55c13",
       "alias": ["sentry.segment.id"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "sentry.segment.id"
       },
       "changelog": [


### PR DESCRIPTION
## Description
This sets the `_status` to `"backfill"` for several deprecated attributes that are used by name in Relay. Doing this means we no longer need to explicitly check the deprecated variants and can rely on normalization to provide the correct names.

Fixes #331. Fixes CON-88.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.