### PR TITLE
ref(attributes): Mark deprecated gen_ai and ai attributes as backfill

### DIFF
--- a/model/attributes/ai/ai__completion_tokens__used.json
+++ b/model/attributes/ai/ai__completion_tokens__used.json
@@ -10,7 +10,7 @@
   "alias": ["gen_ai.usage.output_tokens", "gen_ai.usage.completion_tokens"],
   "sdks": ["python"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.usage.output_tokens"
   },
   "changelog": [

--- a/model/attributes/ai/ai__finish_reason.json
+++ b/model/attributes/ai/ai__finish_reason.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": "COMPLETE",
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.response.finish_reasons"
   },
   "alias": ["gen_ai.response.finish_reasons"],

--- a/model/attributes/ai/ai__frequency_penalty.json
+++ b/model/attributes/ai/ai__frequency_penalty.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": 0.5,
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.request.frequency_penalty"
   },
   "alias": ["gen_ai.request.frequency_penalty"],

--- a/model/attributes/ai/ai__function_call.json
+++ b/model/attributes/ai/ai__function_call.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": "function_name",
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.tool.name"
   },
   "alias": ["gen_ai.tool.name"],

--- a/model/attributes/ai/ai__generation_id.json
+++ b/model/attributes/ai/ai__generation_id.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": "gen_123abc",
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.response.id"
   },
   "alias": ["gen_ai.response.id"],

--- a/model/attributes/ai/ai__input_messages.json
+++ b/model/attributes/ai/ai__input_messages.json
@@ -10,7 +10,7 @@
   "alias": ["gen_ai.request.messages"],
   "sdks": ["python"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.request.messages"
   },
   "changelog": [

--- a/model/attributes/ai/ai__model__provider.json
+++ b/model/attributes/ai/ai__model__provider.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": "openai",
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.provider.name"
   },
   "alias": ["gen_ai.provider.name", "gen_ai.system"],

--- a/model/attributes/ai/ai__model_id.json
+++ b/model/attributes/ai/ai__model_id.json
@@ -10,7 +10,7 @@
   "alias": ["gen_ai.response.model"],
   "sdks": ["python"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.response.model"
   },
   "changelog": [

--- a/model/attributes/ai/ai__pipeline__name.json
+++ b/model/attributes/ai/ai__pipeline__name.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": "Autofix Pipeline",
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.pipeline.name"
   },
   "alias": ["gen_ai.pipeline.name"],

--- a/model/attributes/ai/ai__preamble.json
+++ b/model/attributes/ai/ai__preamble.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": "You are now a clown.",
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.system_instructions"
   },
   "alias": ["gen_ai.system_instructions"],

--- a/model/attributes/ai/ai__presence_penalty.json
+++ b/model/attributes/ai/ai__presence_penalty.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": 0.5,
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.request.presence_penalty"
   },
   "alias": ["gen_ai.request.presence_penalty"],

--- a/model/attributes/ai/ai__prompt_tokens__used.json
+++ b/model/attributes/ai/ai__prompt_tokens__used.json
@@ -10,7 +10,7 @@
   "alias": ["gen_ai.usage.prompt_tokens", "gen_ai.usage.input_tokens"],
   "sdks": ["python"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.usage.input_tokens"
   },
   "changelog": [

--- a/model/attributes/ai/ai__responses.json
+++ b/model/attributes/ai/ai__responses.json
@@ -9,7 +9,7 @@
   "example": ["hello", "world"],
   "sdks": ["python"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.response.text"
   },
   "changelog": [

--- a/model/attributes/ai/ai__seed.json
+++ b/model/attributes/ai/ai__seed.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": "1234567890",
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.request.seed"
   },
   "alias": ["gen_ai.request.seed"],

--- a/model/attributes/ai/ai__streaming.json
+++ b/model/attributes/ai/ai__streaming.json
@@ -9,7 +9,7 @@
   "example": true,
   "sdks": ["python"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.response.streaming"
   },
   "alias": ["gen_ai.response.streaming"],

--- a/model/attributes/ai/ai__temperature.json
+++ b/model/attributes/ai/ai__temperature.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": 0.1,
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.request.temperature"
   },
   "alias": ["gen_ai.request.temperature"],

--- a/model/attributes/ai/ai__texts.json
+++ b/model/attributes/ai/ai__texts.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": ["Hello, how are you?", "What is the capital of France?"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.input.messages"
   },
   "alias": ["gen_ai.input.messages"],

--- a/model/attributes/ai/ai__tool_calls.json
+++ b/model/attributes/ai/ai__tool_calls.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": ["tool_call_1", "tool_call_2"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.response.tool_calls"
   },
   "changelog": [

--- a/model/attributes/ai/ai__tools.json
+++ b/model/attributes/ai/ai__tools.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": ["function_1", "function_2"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.request.available_tools"
   },
   "changelog": [

--- a/model/attributes/ai/ai__top_k.json
+++ b/model/attributes/ai/ai__top_k.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": 35,
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.request.top_k"
   },
   "alias": ["gen_ai.request.top_k"],

--- a/model/attributes/ai/ai__top_p.json
+++ b/model/attributes/ai/ai__top_p.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": 0.7,
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.request.top_p"
   },
   "alias": ["gen_ai.request.top_p"],

--- a/model/attributes/ai/ai__total_cost.json
+++ b/model/attributes/ai/ai__total_cost.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": 12.34,
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.cost.total_tokens"
   },
   "alias": ["gen_ai.cost.total_tokens"],

--- a/model/attributes/ai/ai__total_tokens__used.json
+++ b/model/attributes/ai/ai__total_tokens__used.json
@@ -9,7 +9,7 @@
   "example": 30,
   "sdks": ["python"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.usage.total_tokens"
   },
   "alias": ["gen_ai.usage.total_tokens"],

--- a/model/attributes/gen_ai/gen_ai__request__available_tools.json
+++ b/model/attributes/gen_ai/gen_ai__request__available_tools.json
@@ -9,7 +9,7 @@
   "example": "[{\"name\": \"get_weather\", \"description\": \"Get the weather for a given location\"}, {\"name\": \"get_news\", \"description\": \"Get the news for a given topic\"}]",
   "alias": [],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.tool.definitions"
   },
   "changelog": [

--- a/model/attributes/gen_ai/gen_ai__request__messages.json
+++ b/model/attributes/gen_ai/gen_ai__request__messages.json
@@ -9,7 +9,7 @@
   "example": "[{\"role\": \"system\", \"content\": \"Generate a random number.\"}, {\"role\": \"user\", \"content\": [{\"text\": \"Generate a random number between 0 and 10.\", \"type\": \"text\"}]}, {\"role\": \"tool\", \"content\": {\"toolCallId\": \"1\", \"toolName\": \"Weather\", \"output\": \"rainy\"}}]",
   "alias": ["ai.input_messages"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.input.messages"
   },
   "changelog": [

--- a/model/attributes/gen_ai/gen_ai__response__text.json
+++ b/model/attributes/gen_ai/gen_ai__response__text.json
@@ -9,7 +9,7 @@
   "example": "[\"The weather in Paris is rainy and overcast, with temperatures around 57°F\", \"The weather in London is sunny and warm, with temperatures around 65°F\"]",
   "alias": [],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.output.messages"
   },
   "changelog": [

--- a/model/attributes/gen_ai/gen_ai__response__tool_calls.json
+++ b/model/attributes/gen_ai/gen_ai__response__tool_calls.json
@@ -9,7 +9,7 @@
   "example": "[{\"name\": \"get_weather\", \"arguments\": {\"location\": \"Paris\"}}]",
   "alias": [],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.output.messages"
   },
   "changelog": [

--- a/model/attributes/gen_ai/gen_ai__system__message.json
+++ b/model/attributes/gen_ai/gen_ai__system__message.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": "You are a helpful assistant",
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.system_instructions"
   },
   "changelog": [

--- a/model/attributes/gen_ai/gen_ai__tool__input.json
+++ b/model/attributes/gen_ai/gen_ai__tool__input.json
@@ -9,7 +9,7 @@
   "example": "{\"location\": \"Paris\"}",
   "alias": ["gen_ai.tool.call.arguments"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.tool.call.arguments"
   },
   "changelog": [

--- a/model/attributes/gen_ai/gen_ai__tool__message.json
+++ b/model/attributes/gen_ai/gen_ai__tool__message.json
@@ -9,7 +9,7 @@
   "example": "rainy, 57°F",
   "alias": ["gen_ai.tool.call.result", "gen_ai.tool.output"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.tool.call.result"
   },
   "changelog": [

--- a/model/attributes/gen_ai/gen_ai__tool__output.json
+++ b/model/attributes/gen_ai/gen_ai__tool__output.json
@@ -9,7 +9,7 @@
   "example": "rainy, 57°F",
   "alias": ["gen_ai.tool.call.result", "gen_ai.tool.message"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.tool.call.result"
   },
   "changelog": [

--- a/model/attributes/gen_ai/gen_ai__usage__completion_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__usage__completion_tokens.json
@@ -8,7 +8,7 @@
   "is_in_otel": true,
   "example": 10,
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.usage.output_tokens"
   },
   "alias": ["ai.completion_tokens.used", "gen_ai.usage.output_tokens"],

--- a/model/attributes/gen_ai/gen_ai__usage__prompt_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__usage__prompt_tokens.json
@@ -8,7 +8,7 @@
   "is_in_otel": true,
   "example": 20,
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "gen_ai.usage.input_tokens"
   },
   "alias": ["ai.prompt_tokens.used", "gen_ai.usage.input_tokens"],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -6410,7 +6410,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=10,
-        deprecation=DeprecationInfo(replacement="gen_ai.usage.output_tokens"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.usage.output_tokens", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.usage.output_tokens", "gen_ai.usage.completion_tokens"],
         sdks=["python"],
         changelog=[
@@ -6437,7 +6439,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="COMPLETE",
-        deprecation=DeprecationInfo(replacement="gen_ai.response.finish_reasons"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.response.finish_reasons",
+            status=DeprecationStatus.BACKFILL,
+        ),
         aliases=["gen_ai.response.finish_reasons"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[55, 57, 61, 108, 127]),
@@ -6449,7 +6454,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=0.5,
-        deprecation=DeprecationInfo(replacement="gen_ai.request.frequency_penalty"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.request.frequency_penalty",
+            status=DeprecationStatus.BACKFILL,
+        ),
         aliases=["gen_ai.request.frequency_penalty"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
@@ -6462,7 +6470,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.TRUE),
         is_in_otel=False,
         example="function_name",
-        deprecation=DeprecationInfo(replacement="gen_ai.tool.name"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.tool.name", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.tool.name"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[55, 57, 61, 108]),
@@ -6474,7 +6484,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="gen_123abc",
-        deprecation=DeprecationInfo(replacement="gen_ai.response.id"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.response.id", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.response.id"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[55, 57, 61, 108, 127]),
@@ -6486,7 +6498,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example='[{"role": "user", "message": "hello"}]',
-        deprecation=DeprecationInfo(replacement="gen_ai.request.messages"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.request.messages", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.request.messages"],
         sdks=["python"],
         changelog=[
@@ -6524,7 +6538,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="openai",
-        deprecation=DeprecationInfo(replacement="gen_ai.provider.name"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.provider.name", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.provider.name", "gen_ai.system"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[253]),
@@ -6537,7 +6553,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="gpt-4",
-        deprecation=DeprecationInfo(replacement="gen_ai.response.model"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.response.model", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.response.model"],
         sdks=["python"],
         changelog=[
@@ -6551,7 +6569,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="Autofix Pipeline",
-        deprecation=DeprecationInfo(replacement="gen_ai.pipeline.name"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.pipeline.name", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.pipeline.name"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[53, 76, 108, 127]),
@@ -6563,7 +6583,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.TRUE),
         is_in_otel=False,
         example="You are now a clown.",
-        deprecation=DeprecationInfo(replacement="gen_ai.system_instructions"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.system_instructions", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.system_instructions"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[264]),
@@ -6576,7 +6598,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=0.5,
-        deprecation=DeprecationInfo(replacement="gen_ai.request.presence_penalty"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.request.presence_penalty",
+            status=DeprecationStatus.BACKFILL,
+        ),
         aliases=["gen_ai.request.presence_penalty"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
@@ -6589,7 +6614,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=20,
-        deprecation=DeprecationInfo(replacement="gen_ai.usage.input_tokens"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.usage.input_tokens", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.usage.prompt_tokens", "gen_ai.usage.input_tokens"],
         sdks=["python"],
         changelog=[
@@ -6628,7 +6655,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=["hello", "world"],
-        deprecation=DeprecationInfo(replacement="gen_ai.response.text"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.response.text", status=DeprecationStatus.BACKFILL
+        ),
         sdks=["python"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[65, 127]),
@@ -6665,7 +6694,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="1234567890",
-        deprecation=DeprecationInfo(replacement="gen_ai.request.seed"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.request.seed", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.request.seed"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[55, 57, 61, 108, 127]),
@@ -6677,7 +6708,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=False,
         example=True,
-        deprecation=DeprecationInfo(replacement="gen_ai.response.streaming"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.response.streaming", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.response.streaming"],
         sdks=["python"],
         changelog=[
@@ -6703,7 +6736,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=0.1,
-        deprecation=DeprecationInfo(replacement="gen_ai.request.temperature"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.request.temperature", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.request.temperature"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
@@ -6716,7 +6751,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.TRUE),
         is_in_otel=False,
         example=["Hello, how are you?", "What is the capital of France?"],
-        deprecation=DeprecationInfo(replacement="gen_ai.input.messages"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.input.messages", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.input.messages"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[264]),
@@ -6729,7 +6766,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.TRUE),
         is_in_otel=False,
         example=["tool_call_1", "tool_call_2"],
-        deprecation=DeprecationInfo(replacement="gen_ai.response.tool_calls"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.response.tool_calls", status=DeprecationStatus.BACKFILL
+        ),
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[55, 65]),
         ],
@@ -6740,7 +6779,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=["function_1", "function_2"],
-        deprecation=DeprecationInfo(replacement="gen_ai.request.available_tools"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.request.available_tools",
+            status=DeprecationStatus.BACKFILL,
+        ),
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[55, 65, 127]),
         ],
@@ -6751,7 +6793,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=35,
-        deprecation=DeprecationInfo(replacement="gen_ai.request.top_k"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.request.top_k", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.request.top_k"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
@@ -6764,7 +6808,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=0.7,
-        deprecation=DeprecationInfo(replacement="gen_ai.request.top_p"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.request.top_p", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.request.top_p"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
@@ -6777,7 +6823,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=12.34,
-        deprecation=DeprecationInfo(replacement="gen_ai.cost.total_tokens"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.cost.total_tokens", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.cost.total_tokens"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[264]),
@@ -6791,7 +6839,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=30,
-        deprecation=DeprecationInfo(replacement="gen_ai.usage.total_tokens"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.usage.total_tokens", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.usage.total_tokens"],
         sdks=["python"],
         changelog=[
@@ -9237,7 +9287,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example='[{"name": "get_weather", "description": "Get the weather for a given location"}, {"name": "get_news", "description": "Get the news for a given topic"}]',
-        deprecation=DeprecationInfo(replacement="gen_ai.tool.definitions"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.tool.definitions", status=DeprecationStatus.BACKFILL
+        ),
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[221]),
             ChangelogEntry(version="0.1.0", prs=[63, 127]),
@@ -9272,7 +9324,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example='[{"role": "system", "content": "Generate a random number."}, {"role": "user", "content": [{"text": "Generate a random number between 0 and 10.", "type": "text"}]}, {"role": "tool", "content": {"toolCallId": "1", "toolName": "Weather", "output": "rainy"}}]',
-        deprecation=DeprecationInfo(replacement="gen_ai.input.messages"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.input.messages", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["ai.input_messages"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[221]),
@@ -9399,7 +9453,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example='["The weather in Paris is rainy and overcast, with temperatures around 57°F", "The weather in London is sunny and warm, with temperatures around 65°F"]',
-        deprecation=DeprecationInfo(replacement="gen_ai.output.messages"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.output.messages", status=DeprecationStatus.BACKFILL
+        ),
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[221]),
             ChangelogEntry(version="0.1.0", prs=[63, 74]),
@@ -9432,7 +9488,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example='[{"name": "get_weather", "arguments": {"location": "Paris"}}]',
-        deprecation=DeprecationInfo(replacement="gen_ai.output.messages"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.output.messages", status=DeprecationStatus.BACKFILL
+        ),
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[221]),
             ChangelogEntry(version="0.1.0", prs=[63, 74]),
@@ -9459,7 +9517,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.TRUE),
         is_in_otel=False,
         example="You are a helpful assistant",
-        deprecation=DeprecationInfo(replacement="gen_ai.system_instructions"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.system_instructions", status=DeprecationStatus.BACKFILL
+        ),
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[221]),
             ChangelogEntry(version="0.1.0", prs=[62]),
@@ -9527,7 +9587,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example='{"location": "Paris"}',
-        deprecation=DeprecationInfo(replacement="gen_ai.tool.call.arguments"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.tool.call.arguments", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.tool.call.arguments"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[265]),
@@ -9540,7 +9602,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.TRUE),
         is_in_otel=False,
         example="rainy, 57°F",
-        deprecation=DeprecationInfo(replacement="gen_ai.tool.call.result"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.tool.call.result", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.tool.call.result", "gen_ai.tool.output"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[265]),
@@ -9564,7 +9628,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="rainy, 57°F",
-        deprecation=DeprecationInfo(replacement="gen_ai.tool.call.result"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.tool.call.result", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["gen_ai.tool.call.result", "gen_ai.tool.message"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[265]),
@@ -9590,7 +9656,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         example=10,
-        deprecation=DeprecationInfo(replacement="gen_ai.usage.output_tokens"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.usage.output_tokens", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["ai.completion_tokens.used", "gen_ai.usage.output_tokens"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
@@ -9664,7 +9732,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         example=20,
-        deprecation=DeprecationInfo(replacement="gen_ai.usage.input_tokens"),
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.usage.input_tokens", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["ai.prompt_tokens.used", "gen_ai.usage.input_tokens"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -595,7 +595,7 @@
       "alias": ["gen_ai.usage.output_tokens", "gen_ai.usage.completion_tokens"],
       "sdks": ["python"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.usage.output_tokens"
       },
       "changelog": [
@@ -645,7 +645,7 @@
       "is_in_otel": false,
       "example": "COMPLETE",
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.response.finish_reasons"
       },
       "alias": ["gen_ai.response.finish_reasons"],
@@ -666,7 +666,7 @@
       "is_in_otel": false,
       "example": 0.5,
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.request.frequency_penalty"
       },
       "alias": ["gen_ai.request.frequency_penalty"],
@@ -691,7 +691,7 @@
       "is_in_otel": false,
       "example": "function_name",
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.tool.name"
       },
       "alias": ["gen_ai.tool.name"],
@@ -712,7 +712,7 @@
       "is_in_otel": false,
       "example": "gen_123abc",
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.response.id"
       },
       "alias": ["gen_ai.response.id"],
@@ -735,7 +735,7 @@
       "alias": ["gen_ai.request.messages"],
       "sdks": ["python"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.request.messages"
       },
       "changelog": [
@@ -804,7 +804,7 @@
       "is_in_otel": false,
       "example": "openai",
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.provider.name"
       },
       "alias": ["gen_ai.provider.name", "gen_ai.system"],
@@ -831,7 +831,7 @@
       "alias": ["gen_ai.response.model"],
       "sdks": ["python"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.response.model"
       },
       "changelog": [
@@ -854,7 +854,7 @@
       "is_in_otel": false,
       "example": "Autofix Pipeline",
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.pipeline.name"
       },
       "alias": ["gen_ai.pipeline.name"],
@@ -875,7 +875,7 @@
       "is_in_otel": false,
       "example": "You are now a clown.",
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.system_instructions"
       },
       "alias": ["gen_ai.system_instructions"],
@@ -900,7 +900,7 @@
       "is_in_otel": false,
       "example": 0.5,
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.request.presence_penalty"
       },
       "alias": ["gen_ai.request.presence_penalty"],
@@ -927,7 +927,7 @@
       "alias": ["gen_ai.usage.prompt_tokens", "gen_ai.usage.input_tokens"],
       "sdks": ["python"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.usage.input_tokens"
       },
       "changelog": [
@@ -1001,7 +1001,7 @@
       "example": ["hello", "world"],
       "sdks": ["python"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.response.text"
       },
       "changelog": [
@@ -1070,7 +1070,7 @@
       "is_in_otel": false,
       "example": "1234567890",
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.request.seed"
       },
       "alias": ["gen_ai.request.seed"],
@@ -1092,7 +1092,7 @@
       "example": true,
       "sdks": ["python"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.response.streaming"
       },
       "alias": ["gen_ai.response.streaming"],
@@ -1139,7 +1139,7 @@
       "is_in_otel": false,
       "example": 0.1,
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.request.temperature"
       },
       "alias": ["gen_ai.request.temperature"],
@@ -1164,7 +1164,7 @@
       "is_in_otel": false,
       "example": ["Hello, how are you?", "What is the capital of France?"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.input.messages"
       },
       "alias": ["gen_ai.input.messages"],
@@ -1189,7 +1189,7 @@
       "is_in_otel": false,
       "example": ["tool_call_1", "tool_call_2"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.response.tool_calls"
       },
       "changelog": [
@@ -1209,7 +1209,7 @@
       "is_in_otel": false,
       "example": ["function_1", "function_2"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.request.available_tools"
       },
       "changelog": [
@@ -1229,7 +1229,7 @@
       "is_in_otel": false,
       "example": 35,
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.request.top_k"
       },
       "alias": ["gen_ai.request.top_k"],
@@ -1254,7 +1254,7 @@
       "is_in_otel": false,
       "example": 0.7,
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.request.top_p"
       },
       "alias": ["gen_ai.request.top_p"],
@@ -1279,7 +1279,7 @@
       "is_in_otel": false,
       "example": 12.34,
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.cost.total_tokens"
       },
       "alias": ["gen_ai.cost.total_tokens"],
@@ -1309,7 +1309,7 @@
       "example": 30,
       "sdks": ["python"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.usage.total_tokens"
       },
       "alias": ["gen_ai.usage.total_tokens"],
@@ -1928,7 +1928,7 @@
       "example": "[{\"name\": \"get_weather\", \"description\": \"Get the weather for a given location\"}, {\"name\": \"get_news\", \"description\": \"Get the news for a given topic\"}]",
       "alias": [],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.tool.definitions"
       },
       "changelog": [
@@ -1953,7 +1953,7 @@
       "example": "[{\"role\": \"system\", \"content\": \"Generate a random number.\"}, {\"role\": \"user\", \"content\": [{\"text\": \"Generate a random number between 0 and 10.\", \"type\": \"text\"}]}, {\"role\": \"tool\", \"content\": {\"toolCallId\": \"1\", \"toolName\": \"Weather\", \"output\": \"rainy\"}}]",
       "alias": ["ai.input_messages"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.input.messages"
       },
       "changelog": [
@@ -1978,7 +1978,7 @@
       "example": "[\"The weather in Paris is rainy and overcast, with temperatures around 57°F\", \"The weather in London is sunny and warm, with temperatures around 65°F\"]",
       "alias": [],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.output.messages"
       },
       "changelog": [
@@ -2003,7 +2003,7 @@
       "example": "[{\"name\": \"get_weather\", \"arguments\": {\"location\": \"Paris\"}}]",
       "alias": [],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.output.messages"
       },
       "changelog": [
@@ -2052,7 +2052,7 @@
       "is_in_otel": false,
       "example": "You are a helpful assistant",
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.system_instructions"
       },
       "changelog": [
@@ -2077,7 +2077,7 @@
       "example": "{\"location\": \"Paris\"}",
       "alias": ["gen_ai.tool.call.arguments"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.tool.call.arguments"
       },
       "changelog": [
@@ -2102,7 +2102,7 @@
       "example": "rainy, 57°F",
       "alias": ["gen_ai.tool.call.result", "gen_ai.tool.output"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.tool.call.result"
       },
       "changelog": [
@@ -2127,7 +2127,7 @@
       "example": "rainy, 57°F",
       "alias": ["gen_ai.tool.call.result", "gen_ai.tool.message"],
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.tool.call.result"
       },
       "changelog": [
@@ -2171,7 +2171,7 @@
       "is_in_otel": true,
       "example": 10,
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.usage.output_tokens"
       },
       "alias": ["ai.completion_tokens.used", "gen_ai.usage.output_tokens"],
@@ -2199,7 +2199,7 @@
       "is_in_otel": true,
       "example": 20,
       "deprecation": {
-        "_status": null,
+        "_status": "backfill",
         "replacement": "gen_ai.usage.input_tokens"
       },
       "alias": ["ai.prompt_tokens.used", "gen_ai.usage.input_tokens"],


### PR DESCRIPTION
Sets `deprecation._status` to `backfill` on every deprecated `gen_ai.*` and `ai.*` attribute that has a `replacement` defined.

## Why

Relay has two span ingestion paths. The V1 path (`SpanData` in relay-event-schema) rewrites legacy `ai.*` and old `gen_ai.*` keys to their modern counterparts via inline `legacy_alias` metadata on the struct. The V2 path drives the same rewriting from this registry.

With every gen_ai / ai entry previously at `_status: null`, the V2 pipeline passed legacy keys through untouched, producing a silent divergence from V1 for identical input. Flipping to `backfill` closes that gap conservatively: V2 writes the modern name alongside the legacy one rather than renaming outright, so consumers still reading the legacy key aren't broken.

