### PR TITLE
fix: Align `code.function.name` description with OTel

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2121,7 +2121,7 @@ export type CODE_FILE_PATH_TYPE = string;
 // Path: model/attributes/code/code__function.json
 
 /**
- * The method or function name, or equivalent (usually rightmost part of the code unit's name). `code.function`
+ * The method or function fully-qualified name without arguments. `code.function`
  *
  * Attribute Value Type: `string` {@link CODE_FUNCTION_TYPE}
  *

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -14043,7 +14043,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     changelog: [{ version: '0.1.0', prs: [61, 74] }, { version: '0.0.0' }],
   },
   [CODE_FUNCTION_NAME]: {
-    brief: "The method or function fully-qualified name without arguments.",
+    brief: 'The method or function fully-qualified name without arguments.',
     type: 'string',
     pii: {
       isPii: 'maybe',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2121,7 +2121,7 @@ export type CODE_FILE_PATH_TYPE = string;
 // Path: model/attributes/code/code__function.json
 
 /**
- * The method or function fully-qualified name without arguments. `code.function`
+ * The method or function name, or equivalent (usually rightmost part of the code unit's name). `code.function`
  *
  * Attribute Value Type: `string` {@link CODE_FUNCTION_TYPE}
  *

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2144,7 +2144,7 @@ export type CODE_FUNCTION_TYPE = string;
 // Path: model/attributes/code/code__function__name.json
 
 /**
- * The method or function name, or equivalent (usually rightmost part of the code unit's name). `code.function.name`
+ * The method or function fully-qualified name without arguments. `code.function.name`
  *
  * Attribute Value Type: `string` {@link CODE_FUNCTION_NAME_TYPE}
  *
@@ -14043,7 +14043,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     changelog: [{ version: '0.1.0', prs: [61, 74] }, { version: '0.0.0' }],
   },
   [CODE_FUNCTION_NAME]: {
-    brief: "The method or function name, or equivalent (usually rightmost part of the code unit's name).",
+    brief: "The method or function fully-qualified name without arguments.",
     type: 'string',
     pii: {
       isPii: 'maybe',

--- a/model/attributes/code/code__function__name.json
+++ b/model/attributes/code/code__function__name.json
@@ -1,6 +1,6 @@
 {
   "key": "code.function.name",
-  "brief": "The method or function name, or equivalent (usually rightmost part of the code unit's name).",
+  "brief": "The method or function fully-qualified name without arguments.",
   "type": "string",
   "pii": {
     "key": "maybe"

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1409,7 +1409,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/code/code__function__name.json
     CODE_FUNCTION_NAME: Literal["code.function.name"] = "code.function.name"
-    """The method or function name, or equivalent (usually rightmost part of the code unit's name).
+    """The method or function fully-qualified name without arguments.
 
     Type: str
     Contains PII: maybe

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -7908,7 +7908,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "code.function.name": AttributeMetadata(
-        brief="The method or function name, or equivalent (usually rightmost part of the code unit's name).",
+        brief="The method or function fully-qualified name without arguments.",
         type=AttributeType.STRING,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,


### PR DESCRIPTION
## Description
<!-- Describe your changes -->

Align the description with OTel to make it explicit that the attribute holds the fully qualified name: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/

The deprecation reason of the [`code.function.namespace` attribute](https://getsentry.github.io/sentry-conventions/attributes/code/#code-namespace) is that the `code.function.name` attribute should include the namespace, implying that the value of `code.function.name` is a qualified function name.

Looks like a copypasta mistake as the `code.function.name` description was copied from the `code.function` description.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [ ] I have run `yarn test` and verified that the tests pass.
- [ ] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
