### PR TITLE
feat(attributes): Add http.request.body.data attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -5322,7 +5322,7 @@ export type HTTP_QUERY_TYPE = string;
 // Path: model/attributes/http/http__request__body__data.json
 
 /**
- * HTTP request body data. Could be the JSON body or the form data. If form data, and a file is attached, the file is redacted. `http.request.body.data`
+ * HTTP request body data. Can be given as string or structural data of any format. `http.request.body.data`
  *
  * Attribute Value Type: `string` {@link HTTP_REQUEST_BODY_DATA_TYPE}
  *
@@ -15988,8 +15988,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     changelog: [{ version: '0.0.0' }],
   },
   [HTTP_REQUEST_BODY_DATA]: {
-    brief:
-      'HTTP request body data. Could be the JSON body or the form data. If form data, and a file is attached, the file is redacted.',
+    brief: 'HTTP request body data. Can be given as string or structural data of any format.',
     type: 'string',
     pii: {
       isPii: 'maybe',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -5319,6 +5319,26 @@ export const HTTP_QUERY = 'http.query';
  */
 export type HTTP_QUERY_TYPE = string;
 
+// Path: model/attributes/http/http__request__body__data.json
+
+/**
+ * HTTP request body data. Could be the JSON body or the form data. If form data, and a file is attached, the file is redacted. `http.request.body.data`
+ *
+ * Attribute Value Type: `string` {@link HTTP_REQUEST_BODY_DATA_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "[{\"role\": \"user\", \"message\": \"hello\"}]"
+ */
+export const HTTP_REQUEST_BODY_DATA = 'http.request.body.data';
+
+/**
+ * Type for {@link HTTP_REQUEST_BODY_DATA} http.request.body.data
+ */
+export type HTTP_REQUEST_BODY_DATA_TYPE = string;
+
 // Path: model/attributes/http/http__request__connection_end.json
 
 /**
@@ -11837,6 +11857,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [HTTP_HOST]: 'string',
   [HTTP_METHOD]: 'string',
   [HTTP_QUERY]: 'string',
+  [HTTP_REQUEST_BODY_DATA]: 'string',
   [HTTP_REQUEST_CONNECTION_END]: 'double',
   [HTTP_REQUEST_CONNECT_START]: 'double',
   [HTTP_REQUEST_DOMAIN_LOOKUP_END]: 'double',
@@ -12389,6 +12410,7 @@ export type AttributeName =
   | typeof HTTP_HOST
   | typeof HTTP_METHOD
   | typeof HTTP_QUERY
+  | typeof HTTP_REQUEST_BODY_DATA
   | typeof HTTP_REQUEST_CONNECTION_END
   | typeof HTTP_REQUEST_CONNECT_START
   | typeof HTTP_REQUEST_DOMAIN_LOOKUP_END
@@ -15964,6 +15986,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: '?foo=bar&bar=baz',
     changelog: [{ version: '0.0.0' }],
+  },
+  [HTTP_REQUEST_BODY_DATA]: {
+    brief:
+      'HTTP request body data. Could be the JSON body or the form data. If form data, and a file is attached, the file is redacted.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: '[{"role": "user", "message": "hello"}]',
+    changelog: [{ version: 'next', prs: [336], description: 'Added http.request.body.data attribute' }],
   },
   [HTTP_REQUEST_CONNECTION_END]: {
     brief:
@@ -19697,6 +19730,7 @@ export type Attributes = {
   [HTTP_HOST]?: HTTP_HOST_TYPE;
   [HTTP_METHOD]?: HTTP_METHOD_TYPE;
   [HTTP_QUERY]?: HTTP_QUERY_TYPE;
+  [HTTP_REQUEST_BODY_DATA]?: HTTP_REQUEST_BODY_DATA_TYPE;
   [HTTP_REQUEST_CONNECTION_END]?: HTTP_REQUEST_CONNECTION_END_TYPE;
   [HTTP_REQUEST_CONNECT_START]?: HTTP_REQUEST_CONNECT_START_TYPE;
   [HTTP_REQUEST_DOMAIN_LOOKUP_END]?: HTTP_REQUEST_DOMAIN_LOOKUP_END_TYPE;

--- a/model/attributes/http/http__request__body__data.json
+++ b/model/attributes/http/http__request__body__data.json
@@ -1,6 +1,6 @@
 {
   "key": "http.request.body.data",
-  "brief": "HTTP request body data. Could be the JSON body or the form data. If form data, and a file is attached, the file is redacted.",
+  "brief": "HTTP request body data. Can be given as string or structural data of any format.",
   "type": "string",
   "pii": {
     "key": "maybe"

--- a/model/attributes/http/http__request__body__data.json
+++ b/model/attributes/http/http__request__body__data.json
@@ -1,0 +1,17 @@
+{
+  "key": "http.request.body.data",
+  "brief": "HTTP request body data. Could be the JSON body or the form data. If form data, and a file is attached, the file is redacted.",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "[{\"role\": \"user\", \"message\": \"hello\"}]",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [336],
+      "description": "Added http.request.body.data attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3097,6 +3097,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "?foo=bar&bar=baz"
     """
 
+    # Path: model/attributes/http/http__request__body__data.json
+    HTTP_REQUEST_BODY_DATA: Literal["http.request.body.data"] = "http.request.body.data"
+    """HTTP request body data. Could be the JSON body or the form data. If form data, and a file is attached, the file is redacted.
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "[{\"role\": \"user\", \"message\": \"hello\"}]"
+    """
+
     # Path: model/attributes/http/http__request__connect_start.json
     HTTP_REQUEST_CONNECT_START: Literal["http.request.connect_start"] = (
         "http.request.connect_start"
@@ -9894,6 +9904,20 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "http.request.body.data": AttributeMetadata(
+        brief="HTTP request body data. Could be the JSON body or the form data. If form data, and a file is attached, the file is redacted.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example='[{"role": "user", "message": "hello"}]',
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[336],
+                description="Added http.request.body.data attribute",
+            ),
+        ],
+    ),
     "http.request.connect_start": AttributeMetadata(
         brief="The UNIX timestamp representing the time immediately before the user agent starts establishing the connection to the server to retrieve the resource.",
         type=AttributeType.DOUBLE,
@@ -13716,6 +13740,7 @@ Attributes = TypedDict(
         "http.host": str,
         "http.method": str,
         "http.query": str,
+        "http.request.body.data": str,
         "http.request.connect_start": float,
         "http.request.connection_end": float,
         "http.request.domain_lookup_end": float,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3099,7 +3099,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/http/http__request__body__data.json
     HTTP_REQUEST_BODY_DATA: Literal["http.request.body.data"] = "http.request.body.data"
-    """HTTP request body data. Could be the JSON body or the form data. If form data, and a file is attached, the file is redacted.
+    """HTTP request body data. Can be given as string or structural data of any format.
 
     Type: str
     Contains PII: maybe
@@ -9905,7 +9905,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "http.request.body.data": AttributeMetadata(
-        brief="HTTP request body data. Could be the JSON body or the form data. If form data, and a file is attached, the file is redacted.",
+        brief="HTTP request body data. Can be given as string or structural data of any format.",
         type=AttributeType.STRING,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,


### PR DESCRIPTION
Add a new HTTP attribute `http.request.body.data` capturing the request body payload — JSON body or form data, with any attached files redacted.

Defined as a `string` with `pii: maybe` since request bodies can carry sensitive user data, and `is_in_otel: false` because the OpenTelemetry semantic conventions registry does not define an equivalent. Placing it under the existing `http.request.*` namespace keeps it discoverable alongside `http.request.header.<key>` and `http.response.body.size`.

Model JSON is the source of truth; the TypeScript and Python attribute files were regenerated via `yarn generate` and should not be hand-edited.

Refs PY-2362