### PR TITLE
fix: Don't backfill `sentry.browser.*` attributes

### DIFF
--- a/model/attributes/sentry/sentry__browser__name.json
+++ b/model/attributes/sentry/sentry__browser__name.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": "Chrome",
   "deprecation": {
-    "_status": "backfill",
+    "_status": null,
     "replacement": "browser.name"
   },
   "alias": ["browser.name"],

--- a/model/attributes/sentry/sentry__browser__version.json
+++ b/model/attributes/sentry/sentry__browser__version.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": "120.0.6099.130",
   "deprecation": {
-    "_status": "backfill",
+    "_status": null,
     "replacement": "browser.version"
   },
   "alias": ["browser.version"],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -11960,9 +11960,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="Chrome",
-        deprecation=DeprecationInfo(
-            replacement="browser.name", status=DeprecationStatus.BACKFILL
-        ),
+        deprecation=DeprecationInfo(replacement="browser.name"),
         aliases=["browser.name"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[139]),
@@ -11974,9 +11972,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="120.0.6099.130",
-        deprecation=DeprecationInfo(
-            replacement="browser.version", status=DeprecationStatus.BACKFILL
-        ),
+        deprecation=DeprecationInfo(replacement="browser.version"),
         aliases=["browser.version"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[139]),

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -3196,7 +3196,7 @@
       "is_in_otel": false,
       "example": "Chrome",
       "deprecation": {
-        "_status": "backfill",
+        "_status": null,
         "replacement": "browser.name"
       },
       "alias": ["browser.name"],
@@ -3217,7 +3217,7 @@
       "is_in_otel": false,
       "example": "120.0.6099.130",
       "deprecation": {
-        "_status": "backfill",
+        "_status": null,
         "replacement": "browser.version"
       },
       "alias": ["browser.version"],


### PR DESCRIPTION
## Description
We'll need to figure out exactly what we need in the product before we do this.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.