### PR TITLE
feat: Add messaging.batch.message_count

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -7125,6 +7125,26 @@ export const MDC_KEY = 'mdc.<key>';
  */
 export type MDC_KEY_TYPE = string;
 
+// Path: model/attributes/messaging/messaging__batch__message_count.json
+
+/**
+ * The number of messages sent, received, or processed in the scope of the batching operation. `messaging.batch.message_count`
+ *
+ * Attribute Value Type: `number` {@link MESSAGING_BATCH_MESSAGE_COUNT_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * @example 10
+ */
+export const MESSAGING_BATCH_MESSAGE_COUNT = 'messaging.batch.message_count';
+
+/**
+ * Type for {@link MESSAGING_BATCH_MESSAGE_COUNT} messaging.batch.message_count
+ */
+export type MESSAGING_BATCH_MESSAGE_COUNT_TYPE = number;
+
 // Path: model/attributes/messaging/messaging__destination__connection.json
 
 /**
@@ -11964,6 +11984,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [MCP_TOOL_RESULT_IS_ERROR]: 'boolean',
   [MCP_TRANSPORT]: 'string',
   [MDC_KEY]: 'string',
+  [MESSAGING_BATCH_MESSAGE_COUNT]: 'integer',
   [MESSAGING_DESTINATION_CONNECTION]: 'string',
   [MESSAGING_DESTINATION_NAME]: 'string',
   [MESSAGING_MESSAGE_BODY_SIZE]: 'integer',
@@ -12518,6 +12539,7 @@ export type AttributeName =
   | typeof MCP_TOOL_RESULT_IS_ERROR
   | typeof MCP_TRANSPORT
   | typeof MDC_KEY
+  | typeof MESSAGING_BATCH_MESSAGE_COUNT
   | typeof MESSAGING_DESTINATION_CONNECTION
   | typeof MESSAGING_DESTINATION_NAME
   | typeof MESSAGING_MESSAGE_BODY_SIZE
@@ -17059,6 +17081,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     sdks: ['java', 'java.logback', 'java.jul', 'java.log4j2'],
     changelog: [{ version: '0.3.0', prs: [176] }],
   },
+  [MESSAGING_BATCH_MESSAGE_COUNT]: {
+    brief: 'The number of messages sent, received, or processed in the scope of the batching operation.',
+    type: 'integer',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: true,
+    example: 10,
+    sdks: ['javascript-cloudflare'],
+    changelog: [{ version: 'next', prs: [341], description: 'Added messaging.batch.message_count attribute' }],
+  },
   [MESSAGING_DESTINATION_CONNECTION]: {
     brief: 'The message destination connection.',
     type: 'string',
@@ -19850,6 +19883,7 @@ export type Attributes = {
   [MCP_TOOL_RESULT_IS_ERROR]?: MCP_TOOL_RESULT_IS_ERROR_TYPE;
   [MCP_TRANSPORT]?: MCP_TRANSPORT_TYPE;
   [MDC_KEY]?: MDC_KEY_TYPE;
+  [MESSAGING_BATCH_MESSAGE_COUNT]?: MESSAGING_BATCH_MESSAGE_COUNT_TYPE;
   [MESSAGING_DESTINATION_CONNECTION]?: MESSAGING_DESTINATION_CONNECTION_TYPE;
   [MESSAGING_DESTINATION_NAME]?: MESSAGING_DESTINATION_NAME_TYPE;
   [MESSAGING_MESSAGE_BODY_SIZE]?: MESSAGING_MESSAGE_BODY_SIZE_TYPE;

--- a/model/attributes/messaging/messaging__batch__message_count.json
+++ b/model/attributes/messaging/messaging__batch__message_count.json
@@ -1,0 +1,18 @@
+{
+  "key": "messaging.batch.message_count",
+  "brief": "The number of messages sent, received, or processed in the scope of the batching operation.",
+  "type": "integer",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": 10,
+  "sdks": ["javascript-cloudflare"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [341],
+      "description": "Added messaging.batch.message_count attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4076,6 +4076,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "mdc.some_key='some_value'"
     """
 
+    # Path: model/attributes/messaging/messaging__batch__message_count.json
+    MESSAGING_BATCH_MESSAGE_COUNT: Literal["messaging.batch.message_count"] = (
+        "messaging.batch.message_count"
+    )
+    """The number of messages sent, received, or processed in the scope of the batching operation.
+
+    Type: int
+    Contains PII: false
+    Defined in OTEL: Yes
+    Example: 10
+    """
+
     # Path: model/attributes/messaging/messaging__destination__connection.json
     MESSAGING_DESTINATION_CONNECTION: Literal["messaging.destination.connection"] = (
         "messaging.destination.connection"
@@ -10978,6 +10990,21 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.3.0", prs=[176]),
         ],
     ),
+    "messaging.batch.message_count": AttributeMetadata(
+        brief="The number of messages sent, received, or processed in the scope of the batching operation.",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=True,
+        example=10,
+        sdks=["javascript-cloudflare"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[341],
+                description="Added messaging.batch.message_count attribute",
+            ),
+        ],
+    ),
     "messaging.destination.connection": AttributeMetadata(
         brief="The message destination connection.",
         type=AttributeType.STRING,
@@ -13847,6 +13874,7 @@ Attributes = TypedDict(
         "mcp.tool.result.is_error": bool,
         "mcp.transport": str,
         "mdc.<key>": str,
+        "messaging.batch.message_count": int,
         "messaging.destination.connection": str,
         "messaging.destination.name": str,
         "messaging.message.body.size": int,


### PR DESCRIPTION
## Description

closes #338 

generated via `yarn run create:attribute`

Adds the OTel `messaging.batch.message_count` attribute, used by the Cloudflare JS SDK to record the size of a Queue batch.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
