### PR TITLE
feat(attributes): Add http.request_method

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -5307,7 +5307,7 @@ export type HTTP_HOST_TYPE = string;
  *
  * Attribute defined in OTEL: Yes
  *
- * Aliases: {@link HTTP_REQUEST_METHOD} `http.request.method`
+ * Aliases: {@link HTTP_REQUEST_METHOD} `http.request.method`, {@link _HTTP_REQUEST_METHOD} `http.request_method`, {@link METHOD} `method`
  *
  * @deprecated Use {@link HTTP_REQUEST_METHOD} (http.request.method) instead
  * @example "GET"
@@ -5492,7 +5492,7 @@ export type HTTP_REQUEST_HEADER_KEY_TYPE = Array<string>;
  *
  * Attribute defined in OTEL: Yes
  *
- * Aliases: {@link METHOD} `method`, {@link HTTP_METHOD} `http.method`
+ * Aliases: {@link METHOD} `method`, {@link HTTP_METHOD} `http.method`, {@link _HTTP_REQUEST_METHOD} `http.request_method`
  *
  * @example "GET"
  */
@@ -5502,6 +5502,29 @@ export const HTTP_REQUEST_METHOD = 'http.request.method';
  * Type for {@link HTTP_REQUEST_METHOD} http.request.method
  */
 export type HTTP_REQUEST_METHOD_TYPE = string;
+
+// Path: model/attributes/http/http__request_method.json
+
+/**
+ * The HTTP method used. `http.request_method`
+ *
+ * Attribute Value Type: `string` {@link _HTTP_REQUEST_METHOD_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Aliases: {@link METHOD} `method`, {@link HTTP_METHOD} `http.method`, {@link HTTP_REQUEST_METHOD} `http.request.method`
+ *
+ * @deprecated Use {@link HTTP_REQUEST_METHOD} (http.request.method) instead
+ * @example "GET"
+ */
+export const _HTTP_REQUEST_METHOD = 'http.request_method';
+
+/**
+ * Type for {@link _HTTP_REQUEST_METHOD} http.request_method
+ */
+export type _HTTP_REQUEST_METHOD_TYPE = string;
 
 // Path: model/attributes/http/http__request__redirect_end.json
 
@@ -7336,7 +7359,7 @@ export type MESSAGING_SYSTEM_TYPE = string;
  *
  * Attribute defined in OTEL: No
  *
- * Aliases: {@link HTTP_REQUEST_METHOD} `http.request.method`
+ * Aliases: {@link HTTP_REQUEST_METHOD} `http.request.method`, {@link _HTTP_REQUEST_METHOD} `http.request_method`, {@link HTTP_METHOD} `http.method`
  *
  * @deprecated Use {@link HTTP_REQUEST_METHOD} (http.request.method) instead
  * @example "GET"
@@ -11926,6 +11949,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [HTTP_REQUEST_FETCH_START]: 'double',
   [HTTP_REQUEST_HEADER_KEY]: 'string[]',
   [HTTP_REQUEST_METHOD]: 'string',
+  [_HTTP_REQUEST_METHOD]: 'string',
   [HTTP_REQUEST_REDIRECT_END]: 'double',
   [HTTP_REQUEST_REDIRECT_START]: 'double',
   [HTTP_REQUEST_REQUEST_START]: 'double',
@@ -12482,6 +12506,7 @@ export type AttributeName =
   | typeof HTTP_REQUEST_FETCH_START
   | typeof HTTP_REQUEST_HEADER_KEY
   | typeof HTTP_REQUEST_METHOD
+  | typeof _HTTP_REQUEST_METHOD
   | typeof HTTP_REQUEST_REDIRECT_END
   | typeof HTTP_REQUEST_REDIRECT_START
   | typeof HTTP_REQUEST_REQUEST_START
@@ -16048,7 +16073,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'http.request.method',
     },
-    aliases: [HTTP_REQUEST_METHOD],
+    aliases: [HTTP_REQUEST_METHOD, _HTTP_REQUEST_METHOD, METHOD],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [HTTP_QUERY]: {
@@ -16156,8 +16181,22 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: true,
     example: 'GET',
-    aliases: [METHOD, HTTP_METHOD],
+    aliases: [METHOD, HTTP_METHOD, _HTTP_REQUEST_METHOD],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+  },
+  [_HTTP_REQUEST_METHOD]: {
+    brief: 'The HTTP method used.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 'GET',
+    deprecation: {
+      replacement: 'http.request.method',
+    },
+    aliases: [METHOD, HTTP_METHOD, HTTP_REQUEST_METHOD],
+    changelog: [{ version: 'next', prs: [343], description: 'Added http.request_method attribute' }],
   },
   [HTTP_REQUEST_REDIRECT_END]: {
     brief:
@@ -17222,7 +17261,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'http.request.method',
     },
-    aliases: [HTTP_REQUEST_METHOD],
+    aliases: [HTTP_REQUEST_METHOD, _HTTP_REQUEST_METHOD, HTTP_METHOD],
     sdks: ['javascript-browser', 'javascript-node'],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
@@ -19837,6 +19876,7 @@ export type Attributes = {
   [HTTP_REQUEST_FETCH_START]?: HTTP_REQUEST_FETCH_START_TYPE;
   [HTTP_REQUEST_HEADER_KEY]?: HTTP_REQUEST_HEADER_KEY_TYPE;
   [HTTP_REQUEST_METHOD]?: HTTP_REQUEST_METHOD_TYPE;
+  [_HTTP_REQUEST_METHOD]?: _HTTP_REQUEST_METHOD_TYPE;
   [HTTP_REQUEST_REDIRECT_END]?: HTTP_REQUEST_REDIRECT_END_TYPE;
   [HTTP_REQUEST_REDIRECT_START]?: HTTP_REQUEST_REDIRECT_START_TYPE;
   [HTTP_REQUEST_REQUEST_START]?: HTTP_REQUEST_REQUEST_START_TYPE;

--- a/model/attributes/http/http__request__method.json
+++ b/model/attributes/http/http__request__method.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "GET",
-  "alias": ["method", "http.method"],
+  "alias": ["method", "http.method", "http.request_method"],
   "changelog": [
     {
       "version": "0.1.0",

--- a/model/attributes/http/http__request_method.json
+++ b/model/attributes/http/http__request_method.json
@@ -1,24 +1,22 @@
 {
-  "key": "http.method",
+  "key": "http.request_method",
   "brief": "The HTTP method used.",
   "type": "string",
   "pii": {
     "key": "maybe"
   },
-  "is_in_otel": true,
+  "is_in_otel": false,
   "example": "GET",
   "deprecation": {
     "_status": "backfill",
     "replacement": "http.request.method"
   },
-  "alias": ["http.request.method", "http.request_method", "method"],
+  "alias": ["method", "http.method", "http.request.method"],
   "changelog": [
     {
-      "version": "0.1.0",
-      "prs": [61, 127]
-    },
-    {
-      "version": "0.0.0"
+      "version": "next",
+      "prs": [343],
+      "description": "Added http.request_method attribute"
     }
   ]
 }

--- a/model/attributes/method.json
+++ b/model/attributes/method.json
@@ -11,7 +11,7 @@
     "_status": null,
     "replacement": "http.request.method"
   },
-  "alias": ["http.request.method"],
+  "alias": ["http.request.method", "http.request_method", "http.method"],
   "sdks": ["javascript-browser", "javascript-node"],
   "changelog": [
     {

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -186,6 +186,7 @@ class _AttributeNamesMeta(type):
         "HTTP_FLAVOR",
         "HTTP_HOST",
         "HTTP_METHOD",
+        "_HTTP_REQUEST_METHOD",
         "HTTP_RESPONSE_CONTENT_LENGTH",
         "HTTP_RESPONSE_TRANSFER_SIZE",
         "HTTP_SCHEME",
@@ -3092,7 +3093,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: str
     Contains PII: maybe
     Defined in OTEL: Yes
-    Aliases: http.request.method
+    Aliases: http.request.method, http.request_method, method
     DEPRECATED: Use http.request.method instead
     Example: "GET"
     """
@@ -3197,7 +3198,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: str
     Contains PII: maybe
     Defined in OTEL: Yes
-    Aliases: method, http.method
+    Aliases: method, http.method, http.request_method
     Example: "GET"
     """
 
@@ -3307,6 +3308,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Example: 1732829553.68
+    """
+
+    # Path: model/attributes/http/http__request_method.json
+    _HTTP_REQUEST_METHOD: Literal["http.request_method"] = "http.request_method"
+    """The HTTP method used.
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Aliases: method, http.method, http.request.method
+    DEPRECATED: Use http.request.method instead
+    Example: "GET"
     """
 
     # Path: model/attributes/http/http__response__body__size.json
@@ -4197,7 +4210,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: str
     Contains PII: maybe
     Defined in OTEL: No
-    Aliases: http.request.method
+    Aliases: http.request.method, http.request_method, http.method
     DEPRECATED: Use http.request.method instead
     Example: "GET"
     """
@@ -9928,7 +9941,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="http.request.method", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["http.request.method"],
+        aliases=["http.request.method", "http.request_method", "method"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
             ChangelogEntry(version="0.0.0"),
@@ -10044,7 +10057,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         example="GET",
-        aliases=["method", "http.method"],
+        aliases=["method", "http.method", "http.request_method"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -10160,6 +10173,24 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[130, 134]),
+        ],
+    ),
+    "http.request_method": AttributeMetadata(
+        brief="The HTTP method used.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="GET",
+        deprecation=DeprecationInfo(
+            replacement="http.request.method", status=DeprecationStatus.BACKFILL
+        ),
+        aliases=["method", "http.method", "http.request.method"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[343],
+                description="Added http.request_method attribute",
+            ),
         ],
     ),
     "http.response.body.size": AttributeMetadata(
@@ -11125,7 +11156,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example="GET",
         deprecation=DeprecationInfo(replacement="http.request.method"),
-        aliases=["http.request.method"],
+        aliases=["http.request.method", "http.request_method", "http.method"],
         sdks=["javascript-browser", "javascript-node"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
@@ -13825,6 +13856,7 @@ Attributes = TypedDict(
         "http.request.secure_connection_start": float,
         "http.request.time_to_first_byte": float,
         "http.request.worker_start": float,
+        "http.request_method": str,
         "http.response.body.size": int,
         "http.response.header.<key>": List[str],
         "http.response.header.content-length": str,

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -355,7 +355,7 @@
         "_status": null,
         "replacement": "http.request.method"
       },
-      "alias": ["http.request.method"],
+      "alias": ["http.request.method", "http.request_method", "http.method"],
       "sdks": ["javascript-browser", "javascript-node"],
       "changelog": [
         {
@@ -2303,7 +2303,7 @@
         "_status": "backfill",
         "replacement": "http.request.method"
       },
-      "alias": ["http.request.method"],
+      "alias": ["http.request.method", "http.request_method", "method"],
       "changelog": [
         {
           "version": "0.1.0",
@@ -2311,6 +2311,28 @@
         },
         {
           "version": "0.0.0"
+        }
+      ]
+    },
+    {
+      "key": "http.request_method",
+      "brief": "The HTTP method used.",
+      "type": "string",
+      "pii": {
+        "key": "maybe"
+      },
+      "is_in_otel": false,
+      "example": "GET",
+      "deprecation": {
+        "_status": "backfill",
+        "replacement": "http.request.method"
+      },
+      "alias": ["method", "http.method", "http.request.method"],
+      "changelog": [
+        {
+          "version": "next",
+          "prs": [343],
+          "description": "Added http.request_method attribute"
         }
       ]
     },


### PR DESCRIPTION
## Description
Fixes #50. Fixes CON-37. The attribute's deprecation resolves the naming collision mentioned in the linked issue.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
