### PR TITLE
feat(attributes): Add sentry.profile_id

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -9581,6 +9581,26 @@ export const SENTRY_PROFILER_ID = 'sentry.profiler_id';
  */
 export type SENTRY_PROFILER_ID_TYPE = string;
 
+// Path: model/attributes/sentry/sentry__profile_id.json
+
+/**
+ * The ID of the Sentry profile the span is associated with. This is only meaningful for transaction-based profiling. `sentry.profile_id`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_PROFILE_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "123e4567e89b12d3a456426614174000"
+ */
+export const SENTRY_PROFILE_ID = 'sentry.profile_id';
+
+/**
+ * Type for {@link SENTRY_PROFILE_ID} sentry.profile_id
+ */
+export type SENTRY_PROFILE_ID_TYPE = string;
+
 // Path: model/attributes/sentry/sentry__release.json
 
 /**
@@ -12145,6 +12165,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SENTRY_ORIGIN]: 'string',
   [SENTRY_PLATFORM]: 'string',
   [SENTRY_PROFILER_ID]: 'string',
+  [SENTRY_PROFILE_ID]: 'string',
   [SENTRY_RELEASE]: 'string',
   [SENTRY_REPLAY_ID]: 'string',
   [SENTRY_REPLAY_IS_BUFFERING]: 'boolean',
@@ -12702,6 +12723,7 @@ export type AttributeName =
   | typeof SENTRY_ORIGIN
   | typeof SENTRY_PLATFORM
   | typeof SENTRY_PROFILER_ID
+  | typeof SENTRY_PROFILE_ID
   | typeof SENTRY_RELEASE
   | typeof SENTRY_REPLAY_ID
   | typeof SENTRY_REPLAY_IS_BUFFERING
@@ -18505,6 +18527,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '18779b64dd35d1a538e7ce2dd2d3fad3',
     changelog: [{ version: '0.4.0', prs: [242] }],
   },
+  [SENTRY_PROFILE_ID]: {
+    brief:
+      'The ID of the Sentry profile the span is associated with. This is only meaningful for transaction-based profiling.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '123e4567e89b12d3a456426614174000',
+    changelog: [{ version: 'next', prs: [344], description: 'Added sentry.profile_id attribute' }],
+  },
   [SENTRY_RELEASE]: {
     brief: 'The sentry release.',
     type: 'string',
@@ -20072,6 +20105,7 @@ export type Attributes = {
   [SENTRY_ORIGIN]?: SENTRY_ORIGIN_TYPE;
   [SENTRY_PLATFORM]?: SENTRY_PLATFORM_TYPE;
   [SENTRY_PROFILER_ID]?: SENTRY_PROFILER_ID_TYPE;
+  [SENTRY_PROFILE_ID]?: SENTRY_PROFILE_ID_TYPE;
   [SENTRY_RELEASE]?: SENTRY_RELEASE_TYPE;
   [SENTRY_REPLAY_ID]?: SENTRY_REPLAY_ID_TYPE;
   [SENTRY_REPLAY_IS_BUFFERING]?: SENTRY_REPLAY_IS_BUFFERING_TYPE;

--- a/model/attributes/sentry/sentry__profile_id.json
+++ b/model/attributes/sentry/sentry__profile_id.json
@@ -1,0 +1,17 @@
+{
+  "key": "sentry.profile_id",
+  "brief": "The ID of the Sentry profile the span is associated with. This is only meaningful for transaction-based profiling.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "123e4567e89b12d3a456426614174000",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [344],
+      "description": "Added sentry.profile_id attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5371,6 +5371,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "php"
     """
 
+    # Path: model/attributes/sentry/sentry__profile_id.json
+    SENTRY_PROFILE_ID: Literal["sentry.profile_id"] = "sentry.profile_id"
+    """The ID of the Sentry profile the span is associated with. This is only meaningful for transaction-based profiling.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "123e4567e89b12d3a456426614174000"
+    """
+
     # Path: model/attributes/sentry/sentry__profiler_id.json
     SENTRY_PROFILER_ID: Literal["sentry.profiler_id"] = "sentry.profiler_id"
     """The id of the currently running profiler (continuous profiling)
@@ -12412,6 +12422,20 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "sentry.profile_id": AttributeMetadata(
+        brief="The ID of the Sentry profile the span is associated with. This is only meaningful for transaction-based profiling.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="123e4567e89b12d3a456426614174000",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[344],
+                description="Added sentry.profile_id attribute",
+            ),
+        ],
+    ),
     "sentry.profiler_id": AttributeMetadata(
         brief="The id of the currently running profiler (continuous profiling)",
         type=AttributeType.STRING,
@@ -14042,6 +14066,7 @@ Attributes = TypedDict(
         "sentry.op": str,
         "sentry.origin": str,
         "sentry.platform": str,
+        "sentry.profile_id": str,
         "sentry.profiler_id": str,
         "sentry.release": str,
         "sentry.replay_id": str,


### PR DESCRIPTION
## Description
This attribute was removed in https://github.com/getsentry/sentry-conventions/pull/256, but Relay writes it for V2 spans that are converted from V1 spans.
Fixes https://github.com/getsentry/relay/issues/5904. Fixes RELAY-233.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)