### PR TITLE
feat(attributes): Deprecate sentry.transaction

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -9822,6 +9822,8 @@ export type _SENTRY_SEGMENT_ID_TYPE = string;
  *
  * Attribute defined in OTEL: No
  *
+ * Aliases: {@link SENTRY_TRANSACTION} `sentry.transaction`, {@link TRANSACTION} `transaction`
+ *
  * @example "GET /user"
  */
 export const SENTRY_SEGMENT_NAME = 'sentry.segment.name';
@@ -9984,8 +9986,9 @@ export type SENTRY_TRACE_PARENT_SPAN_ID_TYPE = string;
  *
  * Attribute defined in OTEL: No
  *
- * Aliases: {@link TRANSACTION} `transaction`
+ * Aliases: {@link SENTRY_SEGMENT_NAME} `sentry.segment.name`, {@link TRANSACTION} `transaction`
  *
+ * @deprecated Use {@link SENTRY_SEGMENT_NAME} (sentry.segment.name) instead - This attribute is being deprecated in favor of sentry.segment.name
  * @example "GET /"
  */
 export const SENTRY_TRANSACTION = 'sentry.transaction';
@@ -10198,9 +10201,9 @@ export type TIME_TO_INITIAL_DISPLAY_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * Aliases: {@link SENTRY_TRANSACTION} `sentry.transaction`
+ * Aliases: {@link SENTRY_SEGMENT_NAME} `sentry.segment.name`, {@link SENTRY_TRANSACTION} `sentry.transaction`
  *
- * @deprecated Use {@link SENTRY_TRANSACTION} (sentry.transaction) instead
+ * @deprecated Use {@link SENTRY_SEGMENT_NAME} (sentry.segment.name) instead
  * @example "GET /"
  */
 export const TRANSACTION = 'transaction';
@@ -18683,6 +18686,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 'GET /user',
+    aliases: [SENTRY_TRANSACTION, TRANSACTION],
     changelog: [{ version: '0.1.0', prs: [104] }],
   },
   [SENTRY_SERVER_SAMPLE_RATE]: {
@@ -18776,7 +18780,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 'GET /',
-    aliases: [TRANSACTION],
+    deprecation: {
+      replacement: 'sentry.segment.name',
+      reason: 'This attribute is being deprecated in favor of sentry.segment.name',
+    },
+    aliases: [SENTRY_SEGMENT_NAME, TRANSACTION],
     changelog: [{ version: '0.0.0' }],
   },
   [SERVER_ADDRESS]: {
@@ -18901,9 +18909,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: 'GET /',
     deprecation: {
-      replacement: 'sentry.transaction',
+      replacement: 'sentry.segment.name',
     },
-    aliases: [SENTRY_TRANSACTION],
+    aliases: [SENTRY_SEGMENT_NAME, SENTRY_TRANSACTION],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [TTFB]: {

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -18687,7 +18687,10 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: 'GET /user',
     aliases: [SENTRY_TRANSACTION, TRANSACTION],
-    changelog: [{ version: '0.1.0', prs: [104] }],
+    changelog: [
+      { version: 'next', prs: [345], description: 'Added sentry.transaction and transaction aliases' },
+      { version: '0.1.0', prs: [104] },
+    ],
   },
   [SENTRY_SERVER_SAMPLE_RATE]: {
     brief: 'Rate at which a span was sampled in Relay.',
@@ -18785,7 +18788,10 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'This attribute is being deprecated in favor of sentry.segment.name',
     },
     aliases: [SENTRY_SEGMENT_NAME, TRANSACTION],
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      { version: 'next', prs: [345], description: 'Deprecated sentry.transaction in favor of sentry.segment.name' },
+      { version: '0.0.0' },
+    ],
   },
   [SERVER_ADDRESS]: {
     brief:
@@ -18912,7 +18918,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'sentry.segment.name',
     },
     aliases: [SENTRY_SEGMENT_NAME, SENTRY_TRANSACTION],
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      {
+        version: 'next',
+        prs: [345],
+        description: 'Updated transaction deprecation replacement to sentry.segment.name',
+      },
+      { version: '0.1.0', prs: [61, 127] },
+      { version: '0.0.0' },
+    ],
   },
   [TTFB]: {
     brief: 'The value of the recorded Time To First Byte (TTFB) web vital in milliseconds',

--- a/model/attributes/sentry/sentry__segment__name.json
+++ b/model/attributes/sentry/sentry__segment__name.json
@@ -10,6 +10,11 @@
   "alias": ["sentry.transaction", "transaction"],
   "changelog": [
     {
+      "version": "next",
+      "prs": [345],
+      "description": "Added sentry.transaction and transaction aliases"
+    },
+    {
       "version": "0.1.0",
       "prs": [104]
     }

--- a/model/attributes/sentry/sentry__segment__name.json
+++ b/model/attributes/sentry/sentry__segment__name.json
@@ -7,6 +7,7 @@
   },
   "is_in_otel": false,
   "example": "GET /user",
+  "alias": ["sentry.transaction", "transaction"],
   "changelog": [
     {
       "version": "0.1.0",

--- a/model/attributes/sentry/sentry__transaction.json
+++ b/model/attributes/sentry/sentry__transaction.json
@@ -7,7 +7,12 @@
   },
   "is_in_otel": false,
   "example": "GET /",
-  "alias": ["transaction"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "sentry.segment.name",
+    "reason": "This attribute is being deprecated in favor of sentry.segment.name"
+  },
+  "alias": ["sentry.segment.name", "transaction"],
   "changelog": [
     {
       "version": "0.0.0"

--- a/model/attributes/sentry/sentry__transaction.json
+++ b/model/attributes/sentry/sentry__transaction.json
@@ -15,6 +15,11 @@
   "alias": ["sentry.segment.name", "transaction"],
   "changelog": [
     {
+      "version": "next",
+      "prs": [345],
+      "description": "Deprecated sentry.transaction in favor of sentry.segment.name"
+    },
+    {
       "version": "0.0.0"
     }
   ]

--- a/model/attributes/transaction.json
+++ b/model/attributes/transaction.json
@@ -14,6 +14,11 @@
   "alias": ["sentry.segment.name", "sentry.transaction"],
   "changelog": [
     {
+      "version": "next",
+      "prs": [345],
+      "description": "Updated transaction deprecation replacement to sentry.segment.name"
+    },
+    {
       "version": "0.1.0",
       "prs": [61, 127]
     },

--- a/model/attributes/transaction.json
+++ b/model/attributes/transaction.json
@@ -8,10 +8,10 @@
   "is_in_otel": false,
   "example": "GET /",
   "deprecation": {
-    "_status": null,
-    "replacement": "sentry.transaction"
+    "_status": "backfill",
+    "replacement": "sentry.segment.name"
   },
-  "alias": ["sentry.transaction"],
+  "alias": ["sentry.segment.name", "sentry.transaction"],
   "changelog": [
     {
       "version": "0.1.0",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -12580,6 +12580,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="GET /user",
         aliases=["sentry.transaction", "transaction"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[345],
+                description="Added sentry.transaction and transaction aliases",
+            ),
             ChangelogEntry(version="0.1.0", prs=[104]),
         ],
     ),
@@ -12692,6 +12697,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ),
         aliases=["sentry.segment.name", "transaction"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[345],
+                description="Deprecated sentry.transaction in favor of sentry.segment.name",
+            ),
             ChangelogEntry(version="0.0.0"),
         ],
     ),
@@ -12837,6 +12847,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ),
         aliases=["sentry.segment.name", "sentry.transaction"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[345],
+                description="Updated transaction deprecation replacement to sentry.segment.name",
+            ),
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
             ChangelogEntry(version="0.0.0"),
         ],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -234,6 +234,7 @@ class _AttributeNamesMeta(type):
         "_SENTRY_SEGMENT_ID",
         "SENTRY_SOURCE",
         "SENTRY_TRACE_PARENT_SPAN_ID",
+        "SENTRY_TRANSACTION",
         "TIME_TO_FULL_DISPLAY",
         "TIME_TO_INITIAL_DISPLAY",
         "TRANSACTION",
@@ -5498,6 +5499,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: str
     Contains PII: maybe
     Defined in OTEL: No
+    Aliases: sentry.transaction, transaction
     Example: "GET /user"
     """
 
@@ -5598,7 +5600,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: str
     Contains PII: false
     Defined in OTEL: No
-    Aliases: transaction
+    Aliases: sentry.segment.name, transaction
+    DEPRECATED: Use sentry.segment.name instead - This attribute is being deprecated in favor of sentry.segment.name
     Example: "GET /"
     """
 
@@ -5708,8 +5711,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: str
     Contains PII: maybe
     Defined in OTEL: No
-    Aliases: sentry.transaction
-    DEPRECATED: Use sentry.transaction instead
+    Aliases: sentry.segment.name, sentry.transaction
+    DEPRECATED: Use sentry.segment.name instead
     Example: "GET /"
     """
 
@@ -12575,6 +12578,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="GET /user",
+        aliases=["sentry.transaction", "transaction"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[104]),
         ],
@@ -12681,7 +12685,12 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=False,
         example="GET /",
-        aliases=["transaction"],
+        deprecation=DeprecationInfo(
+            replacement="sentry.segment.name",
+            reason="This attribute is being deprecated in favor of sentry.segment.name",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["sentry.segment.name", "transaction"],
         changelog=[
             ChangelogEntry(version="0.0.0"),
         ],
@@ -12823,8 +12832,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="GET /",
-        deprecation=DeprecationInfo(replacement="sentry.transaction"),
-        aliases=["sentry.transaction"],
+        deprecation=DeprecationInfo(
+            replacement="sentry.segment.name", status=DeprecationStatus.BACKFILL
+        ),
+        aliases=["sentry.segment.name", "sentry.transaction"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
             ChangelogEntry(version="0.0.0"),

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -498,10 +498,10 @@
       "is_in_otel": false,
       "example": "GET /",
       "deprecation": {
-        "_status": null,
-        "replacement": "sentry.transaction"
+        "_status": "backfill",
+        "replacement": "sentry.segment.name"
       },
-      "alias": ["sentry.transaction"],
+      "alias": ["sentry.segment.name", "sentry.transaction"],
       "changelog": [
         {
           "version": "0.1.0",
@@ -3334,6 +3334,27 @@
         {
           "version": "0.1.0",
           "prs": [116]
+        }
+      ]
+    },
+    {
+      "key": "sentry.transaction",
+      "brief": "The sentry transaction (segment name).",
+      "type": "string",
+      "pii": {
+        "key": "false"
+      },
+      "is_in_otel": false,
+      "example": "GET /",
+      "deprecation": {
+        "_status": "backfill",
+        "replacement": "sentry.segment.name",
+        "reason": "This attribute is being deprecated in favor of sentry.segment.name"
+      },
+      "alias": ["sentry.segment.name", "transaction"],
+      "changelog": [
+        {
+          "version": "0.0.0"
         }
       ]
     },

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -504,6 +504,11 @@
       "alias": ["sentry.segment.name", "sentry.transaction"],
       "changelog": [
         {
+          "version": "next",
+          "prs": [345],
+          "description": "Updated transaction deprecation replacement to sentry.segment.name"
+        },
+        {
           "version": "0.1.0",
           "prs": [61, 127]
         },
@@ -3353,6 +3358,11 @@
       },
       "alias": ["sentry.segment.name", "transaction"],
       "changelog": [
+        {
+          "version": "next",
+          "prs": [345],
+          "description": "Deprecated sentry.transaction in favor of sentry.segment.name"
+        },
         {
           "version": "0.0.0"
         }


### PR DESCRIPTION
Deprecate `sentry.transaction` in favor of `sentry.segment.name`.

The segment name is the preferred attribute going forward, so this marks `sentry.transaction` for backfill-based deprecation and updates the existing `transaction` alias to point at the same replacement.