### PR TITLE
feat(attributes): Add `process.runtime.engine.*` attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -10971,6 +10971,26 @@ export const USER_ROLES = 'user.roles';
  */
 export type USER_ROLES_TYPE = Array<string>;
 
+// Path: model/attributes/v8/v8__version.json
+
+/**
+ * The version of the V8 JavaScript engine. `v8.version`
+ *
+ * Attribute Value Type: `string` {@link V8_VERSION_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "12.9.202.13-rusty"
+ */
+export const V8_VERSION = 'v8.version';
+
+/**
+ * Type for {@link V8_VERSION} v8.version
+ */
+export type V8_VERSION_TYPE = string;
+
 // Path: model/attributes/vercel/vercel__branch.json
 
 /**
@@ -12252,6 +12272,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [USER_IP_ADDRESS]: 'string',
   [USER_NAME]: 'string',
   [USER_ROLES]: 'string[]',
+  [V8_VERSION]: 'string',
   [VERCEL_BRANCH]: 'string',
   [VERCEL_BUILD_ID]: 'string',
   [VERCEL_DEPLOYMENT_ID]: 'string',
@@ -12811,6 +12832,7 @@ export type AttributeName =
   | typeof USER_IP_ADDRESS
   | typeof USER_NAME
   | typeof USER_ROLES
+  | typeof V8_VERSION
   | typeof VERCEL_BRANCH
   | typeof VERCEL_BUILD_ID
   | typeof VERCEL_DEPLOYMENT_ID
@@ -19317,6 +19339,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: ['admin', 'editor'],
     changelog: [{ version: '0.0.0' }],
   },
+  [V8_VERSION]: {
+    brief: 'The version of the V8 JavaScript engine.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '12.9.202.13-rusty',
+    changelog: [{ version: '0.0.0' }],
+  },
   [VERCEL_BRANCH]: {
     brief: 'Git branch name for Vercel project',
     type: 'string',
@@ -20205,6 +20237,7 @@ export type Attributes = {
   [USER_IP_ADDRESS]?: USER_IP_ADDRESS_TYPE;
   [USER_NAME]?: USER_NAME_TYPE;
   [USER_ROLES]?: USER_ROLES_TYPE;
+  [V8_VERSION]?: V8_VERSION_TYPE;
   [VERCEL_BRANCH]?: VERCEL_BRANCH_TYPE;
   [VERCEL_BUILD_ID]?: VERCEL_BUILD_ID_TYPE;
   [VERCEL_DEPLOYMENT_ID]?: VERCEL_DEPLOYMENT_ID_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8559,6 +8559,46 @@ export const PROCESS_RUNTIME_DESCRIPTION = 'process.runtime.description';
  */
 export type PROCESS_RUNTIME_DESCRIPTION_TYPE = string;
 
+// Path: model/attributes/process/process__runtime__engine__name.json
+
+/**
+ * The name of the runtime engine. `process.runtime.engine.name`
+ *
+ * Attribute Value Type: `string` {@link PROCESS_RUNTIME_ENGINE_NAME_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "v8"
+ */
+export const PROCESS_RUNTIME_ENGINE_NAME = 'process.runtime.engine.name';
+
+/**
+ * Type for {@link PROCESS_RUNTIME_ENGINE_NAME} process.runtime.engine.name
+ */
+export type PROCESS_RUNTIME_ENGINE_NAME_TYPE = string;
+
+// Path: model/attributes/process/process__runtime__engine__version.json
+
+/**
+ * The version of the runtime engine. `process.runtime.engine.version`
+ *
+ * Attribute Value Type: `string` {@link PROCESS_RUNTIME_ENGINE_VERSION_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "12.9.202.13-rusty"
+ */
+export const PROCESS_RUNTIME_ENGINE_VERSION = 'process.runtime.engine.version';
+
+/**
+ * Type for {@link PROCESS_RUNTIME_ENGINE_VERSION} process.runtime.engine.version
+ */
+export type PROCESS_RUNTIME_ENGINE_VERSION_TYPE = string;
+
 // Path: model/attributes/process/process__runtime__name.json
 
 /**
@@ -10971,26 +11011,6 @@ export const USER_ROLES = 'user.roles';
  */
 export type USER_ROLES_TYPE = Array<string>;
 
-// Path: model/attributes/v8/v8__version.json
-
-/**
- * The version of the V8 JavaScript engine. `v8.version`
- *
- * Attribute Value Type: `string` {@link V8_VERSION_TYPE}
- *
- * Contains PII: false
- *
- * Attribute defined in OTEL: No
- *
- * @example "12.9.202.13-rusty"
- */
-export const V8_VERSION = 'v8.version';
-
-/**
- * Type for {@link V8_VERSION} v8.version
- */
-export type V8_VERSION_TYPE = string;
-
 // Path: model/attributes/vercel/vercel__branch.json
 
 /**
@@ -12155,6 +12175,8 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [PROCESS_EXECUTABLE_NAME]: 'string',
   [PROCESS_PID]: 'integer',
   [PROCESS_RUNTIME_DESCRIPTION]: 'string',
+  [PROCESS_RUNTIME_ENGINE_NAME]: 'string',
+  [PROCESS_RUNTIME_ENGINE_VERSION]: 'string',
   [PROCESS_RUNTIME_NAME]: 'string',
   [PROCESS_RUNTIME_VERSION]: 'string',
   [QUERY_KEY]: 'string',
@@ -12272,7 +12294,6 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [USER_IP_ADDRESS]: 'string',
   [USER_NAME]: 'string',
   [USER_ROLES]: 'string[]',
-  [V8_VERSION]: 'string',
   [VERCEL_BRANCH]: 'string',
   [VERCEL_BUILD_ID]: 'string',
   [VERCEL_DEPLOYMENT_ID]: 'string',
@@ -12715,6 +12736,8 @@ export type AttributeName =
   | typeof PROCESS_EXECUTABLE_NAME
   | typeof PROCESS_PID
   | typeof PROCESS_RUNTIME_DESCRIPTION
+  | typeof PROCESS_RUNTIME_ENGINE_NAME
+  | typeof PROCESS_RUNTIME_ENGINE_VERSION
   | typeof PROCESS_RUNTIME_NAME
   | typeof PROCESS_RUNTIME_VERSION
   | typeof QUERY_KEY
@@ -12832,7 +12855,6 @@ export type AttributeName =
   | typeof USER_IP_ADDRESS
   | typeof USER_NAME
   | typeof USER_ROLES
-  | typeof V8_VERSION
   | typeof VERCEL_BRANCH
   | typeof VERCEL_BUILD_ID
   | typeof VERCEL_DEPLOYMENT_ID
@@ -18021,6 +18043,26 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'Eclipse OpenJ9 VM openj9-0.21.0',
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
+  [PROCESS_RUNTIME_ENGINE_NAME]: {
+    brief: 'The name of the runtime engine.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 'v8',
+    changelog: [{ version: '0.0.0' }],
+  },
+  [PROCESS_RUNTIME_ENGINE_VERSION]: {
+    brief: 'The version of the runtime engine.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: '12.9.202.13-rusty',
+    changelog: [{ version: '0.0.0' }],
+  },
   [PROCESS_RUNTIME_NAME]: {
     brief: 'The name of the runtime. Equivalent to `name` in the Sentry runtime context.',
     type: 'string',
@@ -19339,16 +19381,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: ['admin', 'editor'],
     changelog: [{ version: '0.0.0' }],
   },
-  [V8_VERSION]: {
-    brief: 'The version of the V8 JavaScript engine.',
-    type: 'string',
-    pii: {
-      isPii: 'false',
-    },
-    isInOtel: false,
-    example: '12.9.202.13-rusty',
-    changelog: [{ version: '0.0.0' }],
-  },
   [VERCEL_BRANCH]: {
     brief: 'Git branch name for Vercel project',
     type: 'string',
@@ -20120,6 +20152,8 @@ export type Attributes = {
   [PROCESS_EXECUTABLE_NAME]?: PROCESS_EXECUTABLE_NAME_TYPE;
   [PROCESS_PID]?: PROCESS_PID_TYPE;
   [PROCESS_RUNTIME_DESCRIPTION]?: PROCESS_RUNTIME_DESCRIPTION_TYPE;
+  [PROCESS_RUNTIME_ENGINE_NAME]?: PROCESS_RUNTIME_ENGINE_NAME_TYPE;
+  [PROCESS_RUNTIME_ENGINE_VERSION]?: PROCESS_RUNTIME_ENGINE_VERSION_TYPE;
   [PROCESS_RUNTIME_NAME]?: PROCESS_RUNTIME_NAME_TYPE;
   [PROCESS_RUNTIME_VERSION]?: PROCESS_RUNTIME_VERSION_TYPE;
   [QUERY_KEY]?: QUERY_KEY_TYPE;
@@ -20237,7 +20271,6 @@ export type Attributes = {
   [USER_IP_ADDRESS]?: USER_IP_ADDRESS_TYPE;
   [USER_NAME]?: USER_NAME_TYPE;
   [USER_ROLES]?: USER_ROLES_TYPE;
-  [V8_VERSION]?: V8_VERSION_TYPE;
   [VERCEL_BRANCH]?: VERCEL_BRANCH_TYPE;
   [VERCEL_BUILD_ID]?: VERCEL_BUILD_ID_TYPE;
   [VERCEL_DEPLOYMENT_ID]?: VERCEL_DEPLOYMENT_ID_TYPE;

--- a/model/attributes/process/process__runtime__engine__name.json
+++ b/model/attributes/process/process__runtime__engine__name.json
@@ -1,0 +1,15 @@
+{
+  "key": "process.runtime.engine.name",
+  "brief": "The name of the runtime engine.",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "v8",
+  "changelog": [
+    {
+      "version": "0.0.0"
+    }
+  ]
+}

--- a/model/attributes/process/process__runtime__engine__version.json
+++ b/model/attributes/process/process__runtime__engine__version.json
@@ -1,9 +1,9 @@
 {
-  "key": "v8.version",
-  "brief": "The version of the V8 JavaScript engine.",
+  "key": "process.runtime.engine.version",
+  "brief": "The version of the runtime engine.",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": "12.9.202.13-rusty",

--- a/model/attributes/v8/v8__version.json
+++ b/model/attributes/v8/v8__version.json
@@ -1,0 +1,15 @@
+{
+  "key": "v8.version",
+  "brief": "The version of the V8 JavaScript engine.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "12.9.202.13-rusty",
+  "changelog": [
+    {
+      "version": "0.0.0"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4834,6 +4834,30 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "Eclipse OpenJ9 VM openj9-0.21.0"
     """
 
+    # Path: model/attributes/process/process__runtime__engine__name.json
+    PROCESS_RUNTIME_ENGINE_NAME: Literal["process.runtime.engine.name"] = (
+        "process.runtime.engine.name"
+    )
+    """The name of the runtime engine.
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "v8"
+    """
+
+    # Path: model/attributes/process/process__runtime__engine__version.json
+    PROCESS_RUNTIME_ENGINE_VERSION: Literal["process.runtime.engine.version"] = (
+        "process.runtime.engine.version"
+    )
+    """The version of the runtime engine.
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "12.9.202.13-rusty"
+    """
+
     # Path: model/attributes/process/process__runtime__name.json
     PROCESS_RUNTIME_NAME: Literal["process.runtime.name"] = "process.runtime.name"
     """The name of the runtime. Equivalent to `name` in the Sentry runtime context.
@@ -6095,16 +6119,6 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Aliases: http.user_agent
     Example: "Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1"
-    """
-
-    # Path: model/attributes/v8/v8__version.json
-    V8_VERSION: Literal["v8.version"] = "v8.version"
-    """The version of the V8 JavaScript engine.
-
-    Type: str
-    Contains PII: false
-    Defined in OTEL: No
-    Example: "12.9.202.13-rusty"
     """
 
     # Path: model/attributes/vercel/vercel__branch.json
@@ -11920,6 +11934,26 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "process.runtime.engine.name": AttributeMetadata(
+        brief="The name of the runtime engine.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="v8",
+        changelog=[
+            ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "process.runtime.engine.version": AttributeMetadata(
+        brief="The version of the runtime engine.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="12.9.202.13-rusty",
+        changelog=[
+            ChangelogEntry(version="0.0.0"),
+        ],
+    ),
     "process.runtime.name": AttributeMetadata(
         brief="The name of the runtime. Equivalent to `name` in the Sentry runtime context.",
         type=AttributeType.STRING,
@@ -13286,16 +13320,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
-    "v8.version": AttributeMetadata(
-        brief="The version of the V8 JavaScript engine.",
-        type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
-        is_in_otel=False,
-        example="12.9.202.13-rusty",
-        changelog=[
-            ChangelogEntry(version="0.0.0"),
-        ],
-    ),
     "vercel.branch": AttributeMetadata(
         brief="Git branch name for Vercel project",
         type=AttributeType.STRING,
@@ -14064,6 +14088,8 @@ Attributes = TypedDict(
         "process.executable.name": str,
         "process.pid": int,
         "process.runtime.description": str,
+        "process.runtime.engine.name": str,
+        "process.runtime.engine.version": str,
         "process.runtime.name": str,
         "process.runtime.version": str,
         "query.<key>": str,
@@ -14181,7 +14207,6 @@ Attributes = TypedDict(
         "user.name": str,
         "user.roles": List[str],
         "user_agent.original": str,
-        "v8.version": str,
         "vercel.branch": str,
         "vercel.build_id": str,
         "vercel.deployment_id": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -6097,6 +6097,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1"
     """
 
+    # Path: model/attributes/v8/v8__version.json
+    V8_VERSION: Literal["v8.version"] = "v8.version"
+    """The version of the V8 JavaScript engine.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "12.9.202.13-rusty"
+    """
+
     # Path: model/attributes/vercel/vercel__branch.json
     VERCEL_BRANCH: Literal["vercel.branch"] = "vercel.branch"
     """Git branch name for Vercel project
@@ -13276,6 +13286,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "v8.version": AttributeMetadata(
+        brief="The version of the V8 JavaScript engine.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="12.9.202.13-rusty",
+        changelog=[
+            ChangelogEntry(version="0.0.0"),
+        ],
+    ),
     "vercel.branch": AttributeMetadata(
         brief="Git branch name for Vercel project",
         type=AttributeType.STRING,
@@ -14161,6 +14181,7 @@ Attributes = TypedDict(
         "user.name": str,
         "user.roles": List[str],
         "user_agent.original": str,
+        "v8.version": str,
         "vercel.branch": str,
         "vercel.build_id": str,
         "vercel.deployment_id": str,


### PR DESCRIPTION
## Description
Adds two new attributes for defining the js engine name + version.

ref https://github.com/getsentry/sentry-javascript/issues/20381

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
