### PR TITLE
feat(attributes): Add `typescript.version` attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -10276,6 +10276,26 @@ export const TYPE = 'type';
  */
 export type TYPE_TYPE = string;
 
+// Path: model/attributes/typescript/typescript__version.json
+
+/**
+ * The version of the TypeScript compiler used by the runtime. `typescript.version`
+ *
+ * Attribute Value Type: `string` {@link TYPESCRIPT_VERSION_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "5.6.2"
+ */
+export const TYPESCRIPT_VERSION = 'typescript.version';
+
+/**
+ * Type for {@link TYPESCRIPT_VERSION} typescript.version
+ */
+export type TYPESCRIPT_VERSION_TYPE = string;
+
 // Path: model/attributes/ui/ui__component_name.json
 
 /**
@@ -12218,6 +12238,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [TTFB]: 'double',
   [TTFB_REQUESTTIME]: 'double',
   [TYPE]: 'string',
+  [TYPESCRIPT_VERSION]: 'string',
   [UI_COMPONENT_NAME]: 'string',
   [UI_CONTRIBUTES_TO_TTFD]: 'boolean',
   [UI_CONTRIBUTES_TO_TTID]: 'boolean',
@@ -12777,6 +12798,7 @@ export type AttributeName =
   | typeof TTFB
   | typeof TTFB_REQUESTTIME
   | typeof TYPE
+  | typeof TYPESCRIPT_VERSION
   | typeof UI_COMPONENT_NAME
   | typeof UI_CONTRIBUTES_TO_TTFD
   | typeof UI_CONTRIBUTES_TO_TTID
@@ -18950,6 +18972,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     sdks: ['javascript-browser', 'javascript-node'],
     changelog: [{ version: '0.0.0' }],
   },
+  [TYPESCRIPT_VERSION]: {
+    brief: 'The version of the TypeScript compiler used by the runtime.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '5.6.2',
+    changelog: [{ version: '0.0.0' }],
+  },
   [UI_COMPONENT_NAME]: {
     brief: 'The name of the associated component.',
     type: 'string',
@@ -20171,6 +20203,7 @@ export type Attributes = {
   [TTFB]?: TTFB_TYPE;
   [TTFB_REQUESTTIME]?: TTFB_REQUESTTIME_TYPE;
   [TYPE]?: TYPE_TYPE;
+  [TYPESCRIPT_VERSION]?: TYPESCRIPT_VERSION_TYPE;
   [UI_COMPONENT_NAME]?: UI_COMPONENT_NAME_TYPE;
   [UI_CONTRIBUTES_TO_TTFD]?: UI_CONTRIBUTES_TO_TTFD_TYPE;
   [UI_CONTRIBUTES_TO_TTID]?: UI_CONTRIBUTES_TO_TTID_TYPE;

--- a/model/attributes/typescript/typescript__version.json
+++ b/model/attributes/typescript/typescript__version.json
@@ -1,0 +1,15 @@
+{
+  "key": "typescript.version",
+  "brief": "The version of the TypeScript compiler used by the runtime.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "5.6.2",
+  "changelog": [
+    {
+      "version": "0.0.0"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5747,6 +5747,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "fetch"
     """
 
+    # Path: model/attributes/typescript/typescript__version.json
+    TYPESCRIPT_VERSION: Literal["typescript.version"] = "typescript.version"
+    """The version of the TypeScript compiler used by the runtime.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "5.6.2"
+    """
+
     # Path: model/attributes/ui/ui__component_name.json
     UI_COMPONENT_NAME: Literal["ui.component_name"] = "ui.component_name"
     """The name of the associated component.
@@ -12875,6 +12885,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "typescript.version": AttributeMetadata(
+        brief="The version of the TypeScript compiler used by the runtime.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="5.6.2",
+        changelog=[
+            ChangelogEntry(version="0.0.0"),
+        ],
+    ),
     "ui.component_name": AttributeMetadata(
         brief="The name of the associated component.",
         type=AttributeType.STRING,
@@ -14127,6 +14147,7 @@ Attributes = TypedDict(
         "ttfb.requestTime": float,
         "ttfb": float,
         "type": str,
+        "typescript.version": str,
         "ui.component_name": str,
         "ui.contributes_to_ttfd": bool,
         "ui.contributes_to_ttid": bool,


### PR DESCRIPTION
## Description
Adds a new attr for ts versioning. Though about moving this into some kind of `build.*` namespace but not sure if we need that.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
