### PR TITLE
fix(attributes): change several deprecation statuses to `normalize` to align with ingestion paths

### DIFF
--- a/model/attributes/gen_ai/gen_ai__request__available_tools.json
+++ b/model/attributes/gen_ai/gen_ai__request__available_tools.json
@@ -9,7 +9,7 @@
   "example": "[{\"name\": \"get_weather\", \"description\": \"Get the weather for a given location\"}, {\"name\": \"get_news\", \"description\": \"Get the news for a given topic\"}]",
   "alias": [],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "gen_ai.tool.definitions"
   },
   "changelog": [

--- a/model/attributes/gen_ai/gen_ai__request__messages.json
+++ b/model/attributes/gen_ai/gen_ai__request__messages.json
@@ -9,7 +9,7 @@
   "example": "[{\"role\": \"system\", \"content\": \"Generate a random number.\"}, {\"role\": \"user\", \"content\": [{\"text\": \"Generate a random number between 0 and 10.\", \"type\": \"text\"}]}, {\"role\": \"tool\", \"content\": {\"toolCallId\": \"1\", \"toolName\": \"Weather\", \"output\": \"rainy\"}}]",
   "alias": ["ai.input_messages"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "gen_ai.input.messages"
   },
   "changelog": [

--- a/model/attributes/gen_ai/gen_ai__response__text.json
+++ b/model/attributes/gen_ai/gen_ai__response__text.json
@@ -9,7 +9,7 @@
   "example": "[\"The weather in Paris is rainy and overcast, with temperatures around 57°F\", \"The weather in London is sunny and warm, with temperatures around 65°F\"]",
   "alias": [],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "gen_ai.output.messages"
   },
   "changelog": [

--- a/model/attributes/gen_ai/gen_ai__response__tool_calls.json
+++ b/model/attributes/gen_ai/gen_ai__response__tool_calls.json
@@ -9,7 +9,7 @@
   "example": "[{\"name\": \"get_weather\", \"arguments\": {\"location\": \"Paris\"}}]",
   "alias": [],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "gen_ai.output.messages"
   },
   "changelog": [

--- a/model/attributes/gen_ai/gen_ai__system.json
+++ b/model/attributes/gen_ai/gen_ai__system.json
@@ -8,7 +8,7 @@
   "is_in_otel": true,
   "example": "openai",
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "gen_ai.provider.name"
   },
   "alias": ["ai.model.provider", "gen_ai.provider.name"],

--- a/model/attributes/gen_ai/gen_ai__tool__input.json
+++ b/model/attributes/gen_ai/gen_ai__tool__input.json
@@ -9,7 +9,7 @@
   "example": "{\"location\": \"Paris\"}",
   "alias": ["gen_ai.tool.call.arguments"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "gen_ai.tool.call.arguments"
   },
   "changelog": [

--- a/model/attributes/gen_ai/gen_ai__tool__message.json
+++ b/model/attributes/gen_ai/gen_ai__tool__message.json
@@ -9,7 +9,7 @@
   "example": "rainy, 57°F",
   "alias": ["gen_ai.tool.call.result", "gen_ai.tool.output"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "gen_ai.tool.call.result"
   },
   "changelog": [

--- a/model/attributes/gen_ai/gen_ai__tool__output.json
+++ b/model/attributes/gen_ai/gen_ai__tool__output.json
@@ -9,7 +9,7 @@
   "example": "rainy, 57°F",
   "alias": ["gen_ai.tool.call.result", "gen_ai.tool.message"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "gen_ai.tool.call.result"
   },
   "changelog": [

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -9377,7 +9377,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example='[{"name": "get_weather", "description": "Get the weather for a given location"}, {"name": "get_news", "description": "Get the news for a given topic"}]',
         deprecation=DeprecationInfo(
-            replacement="gen_ai.tool.definitions", status=DeprecationStatus.BACKFILL
+            replacement="gen_ai.tool.definitions", status=DeprecationStatus.NORMALIZE
         ),
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[221]),
@@ -9414,7 +9414,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example='[{"role": "system", "content": "Generate a random number."}, {"role": "user", "content": [{"text": "Generate a random number between 0 and 10.", "type": "text"}]}, {"role": "tool", "content": {"toolCallId": "1", "toolName": "Weather", "output": "rainy"}}]',
         deprecation=DeprecationInfo(
-            replacement="gen_ai.input.messages", status=DeprecationStatus.BACKFILL
+            replacement="gen_ai.input.messages", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["ai.input_messages"],
         changelog=[
@@ -9543,7 +9543,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example='["The weather in Paris is rainy and overcast, with temperatures around 57°F", "The weather in London is sunny and warm, with temperatures around 65°F"]',
         deprecation=DeprecationInfo(
-            replacement="gen_ai.output.messages", status=DeprecationStatus.BACKFILL
+            replacement="gen_ai.output.messages", status=DeprecationStatus.NORMALIZE
         ),
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[221]),
@@ -9578,7 +9578,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example='[{"name": "get_weather", "arguments": {"location": "Paris"}}]',
         deprecation=DeprecationInfo(
-            replacement="gen_ai.output.messages", status=DeprecationStatus.BACKFILL
+            replacement="gen_ai.output.messages", status=DeprecationStatus.NORMALIZE
         ),
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[221]),
@@ -9592,7 +9592,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         example="openai",
         deprecation=DeprecationInfo(
-            replacement="gen_ai.provider.name", status=DeprecationStatus.BACKFILL
+            replacement="gen_ai.provider.name", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["ai.model.provider", "gen_ai.provider.name"],
         changelog=[
@@ -9677,7 +9677,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example='{"location": "Paris"}',
         deprecation=DeprecationInfo(
-            replacement="gen_ai.tool.call.arguments", status=DeprecationStatus.BACKFILL
+            replacement="gen_ai.tool.call.arguments", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["gen_ai.tool.call.arguments"],
         changelog=[
@@ -9692,7 +9692,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example="rainy, 57°F",
         deprecation=DeprecationInfo(
-            replacement="gen_ai.tool.call.result", status=DeprecationStatus.BACKFILL
+            replacement="gen_ai.tool.call.result", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["gen_ai.tool.call.result", "gen_ai.tool.output"],
         changelog=[
@@ -9718,7 +9718,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example="rainy, 57°F",
         deprecation=DeprecationInfo(
-            replacement="gen_ai.tool.call.result", status=DeprecationStatus.BACKFILL
+            replacement="gen_ai.tool.call.result", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["gen_ai.tool.call.result", "gen_ai.tool.message"],
         changelog=[

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -1880,7 +1880,7 @@
       "example": "[{\"name\": \"get_weather\", \"description\": \"Get the weather for a given location\"}, {\"name\": \"get_news\", \"description\": \"Get the news for a given topic\"}]",
       "alias": [],
       "deprecation": {
-        "_status": "backfill",
+        "_status": "normalize",
         "replacement": "gen_ai.tool.definitions"
       },
       "changelog": [
@@ -1905,7 +1905,7 @@
       "example": "[{\"role\": \"system\", \"content\": \"Generate a random number.\"}, {\"role\": \"user\", \"content\": [{\"text\": \"Generate a random number between 0 and 10.\", \"type\": \"text\"}]}, {\"role\": \"tool\", \"content\": {\"toolCallId\": \"1\", \"toolName\": \"Weather\", \"output\": \"rainy\"}}]",
       "alias": ["ai.input_messages"],
       "deprecation": {
-        "_status": "backfill",
+        "_status": "normalize",
         "replacement": "gen_ai.input.messages"
       },
       "changelog": [
@@ -1930,7 +1930,7 @@
       "example": "[\"The weather in Paris is rainy and overcast, with temperatures around 57°F\", \"The weather in London is sunny and warm, with temperatures around 65°F\"]",
       "alias": [],
       "deprecation": {
-        "_status": "backfill",
+        "_status": "normalize",
         "replacement": "gen_ai.output.messages"
       },
       "changelog": [
@@ -1955,7 +1955,7 @@
       "example": "[{\"name\": \"get_weather\", \"arguments\": {\"location\": \"Paris\"}}]",
       "alias": [],
       "deprecation": {
-        "_status": "backfill",
+        "_status": "normalize",
         "replacement": "gen_ai.output.messages"
       },
       "changelog": [
@@ -1979,7 +1979,7 @@
       "is_in_otel": true,
       "example": "openai",
       "deprecation": {
-        "_status": "backfill",
+        "_status": "normalize",
         "replacement": "gen_ai.provider.name"
       },
       "alias": ["ai.model.provider", "gen_ai.provider.name"],
@@ -2029,7 +2029,7 @@
       "example": "{\"location\": \"Paris\"}",
       "alias": ["gen_ai.tool.call.arguments"],
       "deprecation": {
-        "_status": "backfill",
+        "_status": "normalize",
         "replacement": "gen_ai.tool.call.arguments"
       },
       "changelog": [
@@ -2054,7 +2054,7 @@
       "example": "rainy, 57°F",
       "alias": ["gen_ai.tool.call.result", "gen_ai.tool.output"],
       "deprecation": {
-        "_status": "backfill",
+        "_status": "normalize",
         "replacement": "gen_ai.tool.call.result"
       },
       "changelog": [
@@ -2079,7 +2079,7 @@
       "example": "rainy, 57°F",
       "alias": ["gen_ai.tool.call.result", "gen_ai.tool.message"],
       "deprecation": {
-        "_status": "backfill",
+        "_status": "normalize",
         "replacement": "gen_ai.tool.call.result"
       },
       "changelog": [


### PR DESCRIPTION
## Description

Mirrors the changes in this PR: https://github.com/getsentry/relay/pull/5798

Closes https://linear.app/getsentry/issue/TET-2280/otlp-gen-airesponsetext-is-copied-and-not-moved-to-gen

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
