### PR TITLE
feat(attributes): Add `rpc.method` attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8793,6 +8793,26 @@ export const RPC_GRPC_STATUS_CODE = 'rpc.grpc.status_code';
  */
 export type RPC_GRPC_STATUS_CODE_TYPE = number;
 
+// Path: model/attributes/rpc/rpc__method.json
+
+/**
+ * The fully-qualified logical name of the method from the RPC interface perspective. `rpc.method`
+ *
+ * Attribute Value Type: `string` {@link RPC_METHOD_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * @example "com.example.ExampleService/exampleMethod"
+ */
+export const RPC_METHOD = 'rpc.method';
+
+/**
+ * Type for {@link RPC_METHOD} rpc.method
+ */
+export type RPC_METHOD_TYPE = string;
+
 // Path: model/attributes/rpc/rpc__service.json
 
 /**
@@ -12164,6 +12184,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [RESOURCE_RENDER_BLOCKING_STATUS]: 'string',
   [ROUTE]: 'string',
   [RPC_GRPC_STATUS_CODE]: 'integer',
+  [RPC_METHOD]: 'string',
   [RPC_SERVICE]: 'string',
   [SENTRY_ACTION]: 'string',
   [SENTRY_BROWSER_NAME]: 'string',
@@ -12724,6 +12745,7 @@ export type AttributeName =
   | typeof RESOURCE_RENDER_BLOCKING_STATUS
   | typeof ROUTE
   | typeof RPC_GRPC_STATUS_CODE
+  | typeof RPC_METHOD
   | typeof RPC_SERVICE
   | typeof SENTRY_ACTION
   | typeof SENTRY_BROWSER_NAME
@@ -18151,6 +18173,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 2,
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
+  [RPC_METHOD]: {
+    brief: 'The fully-qualified logical name of the method from the RPC interface perspective.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: true,
+    example: 'com.example.ExampleService/exampleMethod',
+    changelog: [{ version: 'next', prs: [351], description: 'Added rpc.method attribute' }],
+  },
   [RPC_SERVICE]: {
     brief: 'The full (logical) name of the service being called, including its package name, if applicable.',
     type: 'string',
@@ -20122,6 +20154,7 @@ export type Attributes = {
   [RESOURCE_RENDER_BLOCKING_STATUS]?: RESOURCE_RENDER_BLOCKING_STATUS_TYPE;
   [ROUTE]?: ROUTE_TYPE;
   [RPC_GRPC_STATUS_CODE]?: RPC_GRPC_STATUS_CODE_TYPE;
+  [RPC_METHOD]?: RPC_METHOD_TYPE;
   [RPC_SERVICE]?: RPC_SERVICE_TYPE;
   [SENTRY_ACTION]?: SENTRY_ACTION_TYPE;
   [SENTRY_BROWSER_NAME]?: SENTRY_BROWSER_NAME_TYPE;

--- a/model/attributes/rpc/rpc__method.json
+++ b/model/attributes/rpc/rpc__method.json
@@ -1,0 +1,17 @@
+{
+  "key": "rpc.method",
+  "brief": "The fully-qualified logical name of the method from the RPC interface perspective.",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": true,
+  "example": "com.example.ExampleService/exampleMethod",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [351],
+      "description": "Added rpc.method attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4961,6 +4961,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 2
     """
 
+    # Path: model/attributes/rpc/rpc__method.json
+    RPC_METHOD: Literal["rpc.method"] = "rpc.method"
+    """The fully-qualified logical name of the method from the RPC interface perspective.
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: Yes
+    Example: "com.example.ExampleService/exampleMethod"
+    """
+
     # Path: model/attributes/rpc/rpc__service.json
     RPC_SERVICE: Literal["rpc.service"] = "rpc.service"
     """The full (logical) name of the service being called, including its package name, if applicable.
@@ -12049,6 +12059,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "rpc.method": AttributeMetadata(
+        brief="The fully-qualified logical name of the method from the RPC interface perspective.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=True,
+        example="com.example.ExampleService/exampleMethod",
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[351], description="Added rpc.method attribute"
+            ),
+        ],
+    ),
     "rpc.service": AttributeMetadata(
         brief="The full (logical) name of the service being called, including its package name, if applicable.",
         type=AttributeType.STRING,
@@ -14068,6 +14090,7 @@ Attributes = TypedDict(
         "resource.render_blocking_status": str,
         "route": str,
         "rpc.grpc.status_code": int,
+        "rpc.method": str,
         "rpc.service": str,
         "sentry.action": str,
         "sentry.browser.name": str,


### PR DESCRIPTION
## Description
<!-- Describe your changes -->

The Python SDK currently emits the `method` attribute in the gRPC integration, which can be changed to `rpc.method` to align with OTel: https://opentelemetry.io/docs/specs/semconv/registry/attributes/rpc/

In the Python SDK's Boto3 integration `aws.service_id` and `aws.operation_name` can be replaced by `rpc.method` as well to align with OTel: https://opentelemetry.io/docs/specs/semconv/object-stores/s3/

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [ ] I have run `yarn test` and verified that the tests pass.
- [ ] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
