### PR TITLE
feat(attributes): Add app vitals start attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1160,7 +1160,7 @@ export type APP_VITALS_START_COLD_VALUE_TYPE = number;
 // Path: model/attributes/app/app__vitals__start__reason.json
 
 /**
- * The reason that triggered the app start. Values may differ between iOS and Android. `app.vitals.start.reason`
+ * The reason that triggered the app start. `app.vitals.start.reason`
  *
  * Attribute Value Type: `string` {@link APP_VITALS_START_REASON_TYPE}
  *
@@ -13713,7 +13713,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     changelog: [{ version: '0.5.0', prs: [313], description: 'Added app.vitals.start.cold.value attribute' }],
   },
   [APP_VITALS_START_REASON]: {
-    brief: 'The reason that triggered the app start. Values may differ between iOS and Android.',
+    brief: 'The reason that triggered the app start.',
     type: 'string',
     pii: {
       isPii: 'maybe',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1157,6 +1157,26 @@ export const APP_VITALS_START_COLD_VALUE = 'app.vitals.start.cold.value';
  */
 export type APP_VITALS_START_COLD_VALUE_TYPE = number;
 
+// Path: model/attributes/app/app__vitals__start__reason.json
+
+/**
+ * The reason that triggered the app start. Values may differ between iOS and Android. `app.vitals.start.reason`
+ *
+ * Attribute Value Type: `string` {@link APP_VITALS_START_REASON_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "push"
+ */
+export const APP_VITALS_START_REASON = 'app.vitals.start.reason';
+
+/**
+ * Type for {@link APP_VITALS_START_REASON} app.vitals.start.reason
+ */
+export type APP_VITALS_START_REASON_TYPE = string;
+
 // Path: model/attributes/app/app__vitals__start__screen.json
 
 /**
@@ -11824,6 +11844,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [APP_VITALS_FRAMES_SLOW_COUNT]: 'integer',
   [APP_VITALS_FRAMES_TOTAL_COUNT]: 'integer',
   [APP_VITALS_START_COLD_VALUE]: 'double',
+  [APP_VITALS_START_REASON]: 'string',
   [APP_VITALS_START_SCREEN]: 'string',
   [APP_VITALS_START_TYPE]: 'string',
   [APP_VITALS_START_WARM_VALUE]: 'double',
@@ -12385,6 +12406,7 @@ export type AttributeName =
   | typeof APP_VITALS_FRAMES_SLOW_COUNT
   | typeof APP_VITALS_FRAMES_TOTAL_COUNT
   | typeof APP_VITALS_START_COLD_VALUE
+  | typeof APP_VITALS_START_REASON
   | typeof APP_VITALS_START_SCREEN
   | typeof APP_VITALS_START_TYPE
   | typeof APP_VITALS_START_WARM_VALUE
@@ -13689,6 +13711,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: [APP_START_COLD],
     sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: '0.5.0', prs: [313], description: 'Added app.vitals.start.cold.value attribute' }],
+  },
+  [APP_VITALS_START_REASON]: {
+    brief: 'The reason that triggered the app start. Values may differ between iOS and Android.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 'push',
+    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
+    changelog: [{ version: 'next', prs: [353], description: 'Added app.vitals.start.reason attribute' }],
   },
   [APP_VITALS_START_SCREEN]: {
     brief:
@@ -19815,6 +19848,7 @@ export type Attributes = {
   [APP_VITALS_FRAMES_SLOW_COUNT]?: APP_VITALS_FRAMES_SLOW_COUNT_TYPE;
   [APP_VITALS_FRAMES_TOTAL_COUNT]?: APP_VITALS_FRAMES_TOTAL_COUNT_TYPE;
   [APP_VITALS_START_COLD_VALUE]?: APP_VITALS_START_COLD_VALUE_TYPE;
+  [APP_VITALS_START_REASON]?: APP_VITALS_START_REASON_TYPE;
   [APP_VITALS_START_SCREEN]?: APP_VITALS_START_SCREEN_TYPE;
   [APP_VITALS_START_TYPE]?: APP_VITALS_START_TYPE_TYPE;
   [APP_VITALS_START_WARM_VALUE]?: APP_VITALS_START_WARM_VALUE_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1160,7 +1160,7 @@ export type APP_VITALS_START_COLD_VALUE_TYPE = number;
 // Path: model/attributes/app/app__vitals__start__screen.json
 
 /**
- * The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered `app.vitals.start.screen`
+ * The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered. `app.vitals.start.screen`
  *
  * Attribute Value Type: `string` {@link APP_VITALS_START_SCREEN_TYPE}
  *
@@ -13692,7 +13692,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   },
   [APP_VITALS_START_SCREEN]: {
     brief:
-      'The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered',
+      'The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered.',
     type: 'string',
     pii: {
       isPii: 'maybe',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1157,6 +1157,26 @@ export const APP_VITALS_START_COLD_VALUE = 'app.vitals.start.cold.value';
  */
 export type APP_VITALS_START_COLD_VALUE_TYPE = number;
 
+// Path: model/attributes/app/app__vitals__start__screen.json
+
+/**
+ * The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered `app.vitals.start.screen`
+ *
+ * Attribute Value Type: `string` {@link APP_VITALS_START_SCREEN_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "MainActivity"
+ */
+export const APP_VITALS_START_SCREEN = 'app.vitals.start.screen';
+
+/**
+ * Type for {@link APP_VITALS_START_SCREEN} app.vitals.start.screen
+ */
+export type APP_VITALS_START_SCREEN_TYPE = string;
+
 // Path: model/attributes/app/app__vitals__start__type.json
 
 /**
@@ -11804,6 +11824,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [APP_VITALS_FRAMES_SLOW_COUNT]: 'integer',
   [APP_VITALS_FRAMES_TOTAL_COUNT]: 'integer',
   [APP_VITALS_START_COLD_VALUE]: 'double',
+  [APP_VITALS_START_SCREEN]: 'string',
   [APP_VITALS_START_TYPE]: 'string',
   [APP_VITALS_START_WARM_VALUE]: 'double',
   [APP_VITALS_TTFD_VALUE]: 'double',
@@ -12364,6 +12385,7 @@ export type AttributeName =
   | typeof APP_VITALS_FRAMES_SLOW_COUNT
   | typeof APP_VITALS_FRAMES_TOTAL_COUNT
   | typeof APP_VITALS_START_COLD_VALUE
+  | typeof APP_VITALS_START_SCREEN
   | typeof APP_VITALS_START_TYPE
   | typeof APP_VITALS_START_WARM_VALUE
   | typeof APP_VITALS_TTFD_VALUE
@@ -13667,6 +13689,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: [APP_START_COLD],
     sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: '0.5.0', prs: [313], description: 'Added app.vitals.start.cold.value attribute' }],
+  },
+  [APP_VITALS_START_SCREEN]: {
+    brief:
+      'The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 'MainActivity',
+    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
+    changelog: [{ version: 'next', prs: [353], description: 'Added app.vitals.start.screen attribute' }],
   },
   [APP_VITALS_START_TYPE]: {
     brief: 'The type of app start, for example `cold` or `warm`',
@@ -19781,6 +19815,7 @@ export type Attributes = {
   [APP_VITALS_FRAMES_SLOW_COUNT]?: APP_VITALS_FRAMES_SLOW_COUNT_TYPE;
   [APP_VITALS_FRAMES_TOTAL_COUNT]?: APP_VITALS_FRAMES_TOTAL_COUNT_TYPE;
   [APP_VITALS_START_COLD_VALUE]?: APP_VITALS_START_COLD_VALUE_TYPE;
+  [APP_VITALS_START_SCREEN]?: APP_VITALS_START_SCREEN_TYPE;
   [APP_VITALS_START_TYPE]?: APP_VITALS_START_TYPE_TYPE;
   [APP_VITALS_START_WARM_VALUE]?: APP_VITALS_START_WARM_VALUE_TYPE;
   [APP_VITALS_TTFD_VALUE]?: APP_VITALS_TTFD_VALUE_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -13720,7 +13720,13 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 'push',
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
+    sdks: [
+      'sentry.cocoa',
+      'sentry.java.android',
+      'sentry.javascript.react-native',
+      'sentry.dart.flutter',
+      'sentry.dotnet.maui',
+    ],
     changelog: [{ version: 'next', prs: [353], description: 'Added app.vitals.start.reason attribute' }],
   },
   [APP_VITALS_START_SCREEN]: {
@@ -13732,7 +13738,13 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 'MainActivity',
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
+    sdks: [
+      'sentry.cocoa',
+      'sentry.java.android',
+      'sentry.javascript.react-native',
+      'sentry.dart.flutter',
+      'sentry.dotnet.maui',
+    ],
     changelog: [{ version: 'next', prs: [353], description: 'Added app.vitals.start.screen attribute' }],
   },
   [APP_VITALS_START_TYPE]: {

--- a/model/attributes/app/app__vitals__start__reason.json
+++ b/model/attributes/app/app__vitals__start__reason.json
@@ -1,0 +1,18 @@
+{
+  "key": "app.vitals.start.reason",
+  "brief": "The reason that triggered the app start. Values may differ between iOS and Android.",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "push",
+  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [353],
+      "description": "Added app.vitals.start.reason attribute"
+    }
+  ]
+}

--- a/model/attributes/app/app__vitals__start__reason.json
+++ b/model/attributes/app/app__vitals__start__reason.json
@@ -1,6 +1,6 @@
 {
   "key": "app.vitals.start.reason",
-  "brief": "The reason that triggered the app start. Values may differ between iOS and Android.",
+  "brief": "The reason that triggered the app start.",
   "type": "string",
   "pii": {
     "key": "maybe"

--- a/model/attributes/app/app__vitals__start__reason.json
+++ b/model/attributes/app/app__vitals__start__reason.json
@@ -7,7 +7,13 @@
   },
   "is_in_otel": false,
   "example": "push",
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
+  "sdks": [
+    "sentry.cocoa",
+    "sentry.java.android",
+    "sentry.javascript.react-native",
+    "sentry.dart.flutter",
+    "sentry.dotnet.maui"
+  ],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/app/app__vitals__start__screen.json
+++ b/model/attributes/app/app__vitals__start__screen.json
@@ -7,7 +7,13 @@
   },
   "is_in_otel": false,
   "example": "MainActivity",
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
+  "sdks": [
+    "sentry.cocoa",
+    "sentry.java.android",
+    "sentry.javascript.react-native",
+    "sentry.dart.flutter",
+    "sentry.dotnet.maui"
+  ],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/app/app__vitals__start__screen.json
+++ b/model/attributes/app/app__vitals__start__screen.json
@@ -1,6 +1,6 @@
 {
   "key": "app.vitals.start.screen",
-  "brief": "The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered",
+  "brief": "The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered.",
   "type": "string",
   "pii": {
     "key": "maybe"

--- a/model/attributes/app/app__vitals__start__screen.json
+++ b/model/attributes/app/app__vitals__start__screen.json
@@ -1,0 +1,18 @@
+{
+  "key": "app.vitals.start.screen",
+  "brief": "The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "MainActivity",
+  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [353],
+      "description": "Added app.vitals.start.screen attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -831,6 +831,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 1234.56
     """
 
+    # Path: model/attributes/app/app__vitals__start__screen.json
+    APP_VITALS_START_SCREEN: Literal["app.vitals.start.screen"] = (
+        "app.vitals.start.screen"
+    )
+    """The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "MainActivity"
+    """
+
     # Path: model/attributes/app/app__vitals__start__type.json
     APP_VITALS_START_TYPE: Literal["app.vitals.start.type"] = "app.vitals.start.type"
     """The type of app start, for example `cold` or `warm`
@@ -7296,6 +7308,26 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "app.vitals.start.screen": AttributeMetadata(
+        brief="The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="MainActivity",
+        sdks=[
+            "sentry.cocoa",
+            "sentry.java.android",
+            "sentry.javascript.react-native",
+            "sentry.dart.flutter",
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[353],
+                description="Added app.vitals.start.screen attribute",
+            ),
+        ],
+    ),
     "app.vitals.start.type": AttributeMetadata(
         brief="The type of app start, for example `cold` or `warm`",
         type=AttributeType.STRING,
@@ -13730,6 +13762,7 @@ Attributes = TypedDict(
         "app.vitals.frames.slow.count": int,
         "app.vitals.frames.total.count": int,
         "app.vitals.start.cold.value": float,
+        "app.vitals.start.screen": str,
         "app.vitals.start.type": str,
         "app.vitals.start.warm.value": float,
         "app.vitals.ttfd.value": float,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -7331,6 +7331,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "sentry.java.android",
             "sentry.javascript.react-native",
             "sentry.dart.flutter",
+            "sentry.dotnet.maui",
         ],
         changelog=[
             ChangelogEntry(
@@ -7351,6 +7352,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "sentry.java.android",
             "sentry.javascript.react-native",
             "sentry.dart.flutter",
+            "sentry.dotnet.maui",
         ],
         changelog=[
             ChangelogEntry(

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -835,7 +835,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     APP_VITALS_START_REASON: Literal["app.vitals.start.reason"] = (
         "app.vitals.start.reason"
     )
-    """The reason that triggered the app start. Values may differ between iOS and Android.
+    """The reason that triggered the app start.
 
     Type: str
     Contains PII: maybe
@@ -7321,7 +7321,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "app.vitals.start.reason": AttributeMetadata(
-        brief="The reason that triggered the app start. Values may differ between iOS and Android.",
+        brief="The reason that triggered the app start.",
         type=AttributeType.STRING,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -831,6 +831,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 1234.56
     """
 
+    # Path: model/attributes/app/app__vitals__start__reason.json
+    APP_VITALS_START_REASON: Literal["app.vitals.start.reason"] = (
+        "app.vitals.start.reason"
+    )
+    """The reason that triggered the app start. Values may differ between iOS and Android.
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Example: "push"
+    """
+
     # Path: model/attributes/app/app__vitals__start__screen.json
     APP_VITALS_START_SCREEN: Literal["app.vitals.start.screen"] = (
         "app.vitals.start.screen"
@@ -7308,6 +7320,26 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "app.vitals.start.reason": AttributeMetadata(
+        brief="The reason that triggered the app start. Values may differ between iOS and Android.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example="push",
+        sdks=[
+            "sentry.cocoa",
+            "sentry.java.android",
+            "sentry.javascript.react-native",
+            "sentry.dart.flutter",
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[353],
+                description="Added app.vitals.start.reason attribute",
+            ),
+        ],
+    ),
     "app.vitals.start.screen": AttributeMetadata(
         brief="The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered.",
         type=AttributeType.STRING,
@@ -13762,6 +13794,7 @@ Attributes = TypedDict(
         "app.vitals.frames.slow.count": int,
         "app.vitals.frames.total.count": int,
         "app.vitals.start.cold.value": float,
+        "app.vitals.start.reason": str,
         "app.vitals.start.screen": str,
         "app.vitals.start.type": str,
         "app.vitals.start.warm.value": float,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -835,7 +835,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     APP_VITALS_START_SCREEN: Literal["app.vitals.start.screen"] = (
         "app.vitals.start.screen"
     )
-    """The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered
+    """The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered.
 
     Type: str
     Contains PII: maybe
@@ -7309,7 +7309,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "app.vitals.start.screen": AttributeMetadata(
-        brief="The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered",
+        brief="The screen that is rendered when the app start is complete. This is the screen the user first sees and can interact with after launch. The absence of this attribute on the app start span indicates a background app start where no UI was rendered.",
         type=AttributeType.STRING,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,


### PR DESCRIPTION
Add `app.vitals.start.screen` and `app.vitals.start.reason` for app start spans.

The screen attribute records the first interactive screen after launch, while the reason attribute records the normalized launch trigger such as `push`. Omitting the screen attribute indicates a background app start where no UI was rendered.

Generated the TypeScript and Python convention outputs from the new attribute models.