### PR TITLE
feat(attributes): Add calculated performance scores

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -18330,7 +18330,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     hasDynamicSuffix: true,
     example: 'score.cls=0.1723',
-    changelog: [{ version: 'next', prs: [354], description: 'Added score.<key> attribute' }],
+    changelog: [{ version: 'next', prs: [355], description: 'Added score.<key> attribute' }],
   },
   [SCORE_RATIO_KEY]: {
     brief: 'For a measured web vital value, this is the ratio of values that fall below that value.',
@@ -18341,7 +18341,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     hasDynamicSuffix: true,
     example: 'score.ratio.inp=0.7748',
-    changelog: [{ version: 'next', prs: [354], description: 'Added score.ratio.<key> attribute' }],
+    changelog: [{ version: 'next', prs: [355], description: 'Added score.ratio.<key> attribute' }],
   },
   [SCORE_TOTAL]: {
     brief:
@@ -18351,7 +18351,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       isPii: 'maybe',
     },
     isInOtel: false,
-    changelog: [{ version: 'next', prs: [354], description: 'Added score.total attribute' }],
+    changelog: [{ version: 'next', prs: [355], description: 'Added score.total attribute' }],
   },
   [SCORE_WEIGHT_KEY]: {
     brief: "The relative weight of a web vital in a span's performance score.",
@@ -18362,7 +18362,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     hasDynamicSuffix: true,
     example: 'score.weight.fcp=0.25',
-    changelog: [{ version: 'next', prs: [354], description: 'Added score.weight.<key> attribute' }],
+    changelog: [{ version: 'next', prs: [355], description: 'Added score.weight.<key> attribute' }],
   },
   [SENTRY_ACTION]: {
     brief:

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8878,7 +8878,7 @@ export type SCORE_KEY_TYPE = number;
 // Path: model/attributes/score/score__ratio__[key].json
 
 /**
- * For a measured web vital value, this is the ratio of values that fall below that value. `score.ratio.<key>`
+ * The score for a web vital, normalized to a number between 0 and 1. `score.ratio.<key>`
  *
  * Attribute Value Type: `number` {@link SCORE_RATIO_KEY_TYPE}
  *
@@ -18333,7 +18333,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     changelog: [{ version: 'next', prs: [355], description: 'Added score.<key> attribute' }],
   },
   [SCORE_RATIO_KEY]: {
-    brief: 'For a measured web vital value, this is the ratio of values that fall below that value.',
+    brief: 'The score for a web vital, normalized to a number between 0 and 1.',
     type: 'double',
     pii: {
       isPii: 'maybe',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8856,7 +8856,7 @@ export type RPC_SERVICE_TYPE = string;
 // Path: model/attributes/score/score__[key].json
 
 /**
- * The weighted performance score for a web vital. This is defined as `score.weight.<key> * score.ratio.<key>`. `score.<key>`
+ * The weighted performance score for a web vital. This is defined as `score.weight.<key>` * `score.ratio.<key>`. `score.<key>`
  *
  * Attribute Value Type: `number` {@link SCORE_KEY_TYPE}
  *
@@ -18322,7 +18322,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   },
   [SCORE_KEY]: {
     brief:
-      'The weighted performance score for a web vital. This is defined as `score.weight.<key> * score.ratio.<key>`.',
+      'The weighted performance score for a web vital. This is defined as `score.weight.<key>` * `score.ratio.<key>`.',
     type: 'double',
     pii: {
       isPii: 'maybe',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8853,6 +8853,90 @@ export const RPC_SERVICE = 'rpc.service';
  */
 export type RPC_SERVICE_TYPE = string;
 
+// Path: model/attributes/score/score__[key].json
+
+/**
+ * The weighted performance score for a web vital. This is defined as `score.weight.<key> * score.ratio.<key>`. `score.<key>`
+ *
+ * Attribute Value Type: `number` {@link SCORE_KEY_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Has Dynamic Suffix: true
+ *
+ * @example "score.cls=0.1723"
+ */
+export const SCORE_KEY = 'score.<key>';
+
+/**
+ * Type for {@link SCORE_KEY} score.<key>
+ */
+export type SCORE_KEY_TYPE = number;
+
+// Path: model/attributes/score/score__ratio__[key].json
+
+/**
+ * For a measured web vital value, this is the ratio of values that fall below that value. `score.ratio.<key>`
+ *
+ * Attribute Value Type: `number` {@link SCORE_RATIO_KEY_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Has Dynamic Suffix: true
+ *
+ * @example "score.ratio.inp=0.7748"
+ */
+export const SCORE_RATIO_KEY = 'score.ratio.<key>';
+
+/**
+ * Type for {@link SCORE_RATIO_KEY} score.ratio.<key>
+ */
+export type SCORE_RATIO_KEY_TYPE = number;
+
+// Path: model/attributes/score/score__total.json
+
+/**
+ * The total performance score of a span. This is the sum of individual weighted web vital scores (see `score.<key>`). `score.total`
+ *
+ * Attribute Value Type: `number` {@link SCORE_TOTAL_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ */
+export const SCORE_TOTAL = 'score.total';
+
+/**
+ * Type for {@link SCORE_TOTAL} score.total
+ */
+export type SCORE_TOTAL_TYPE = number;
+
+// Path: model/attributes/score/score__weight__[key].json
+
+/**
+ * The relative weight of a web vital in a span's performance score. `score.weight.<key>`
+ *
+ * Attribute Value Type: `number` {@link SCORE_WEIGHT_KEY_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Has Dynamic Suffix: true
+ *
+ * @example "score.weight.fcp=0.25"
+ */
+export const SCORE_WEIGHT_KEY = 'score.weight.<key>';
+
+/**
+ * Type for {@link SCORE_WEIGHT_KEY} score.weight.<key>
+ */
+export type SCORE_WEIGHT_KEY_TYPE = number;
+
 // Path: model/attributes/sentry/sentry__action.json
 
 /**
@@ -12210,6 +12294,10 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [ROUTE]: 'string',
   [RPC_GRPC_STATUS_CODE]: 'integer',
   [RPC_SERVICE]: 'string',
+  [SCORE_KEY]: 'double',
+  [SCORE_RATIO_KEY]: 'double',
+  [SCORE_TOTAL]: 'double',
+  [SCORE_WEIGHT_KEY]: 'double',
   [SENTRY_ACTION]: 'string',
   [SENTRY_BROWSER_NAME]: 'string',
   [SENTRY_BROWSER_VERSION]: 'string',
@@ -12772,6 +12860,10 @@ export type AttributeName =
   | typeof ROUTE
   | typeof RPC_GRPC_STATUS_CODE
   | typeof RPC_SERVICE
+  | typeof SCORE_KEY
+  | typeof SCORE_RATIO_KEY
+  | typeof SCORE_TOTAL
+  | typeof SCORE_WEIGHT_KEY
   | typeof SENTRY_ACTION
   | typeof SENTRY_BROWSER_NAME
   | typeof SENTRY_BROWSER_VERSION
@@ -18228,6 +18320,50 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'myService.BestService',
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
+  [SCORE_KEY]: {
+    brief:
+      'The weighted performance score for a web vital. This is defined as `score.weight.<key> * score.ratio.<key>`.',
+    type: 'double',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    hasDynamicSuffix: true,
+    example: 'score.cls=0.1723',
+    changelog: [{ version: 'next', prs: [354], description: 'Added score.<key> attribute' }],
+  },
+  [SCORE_RATIO_KEY]: {
+    brief: 'For a measured web vital value, this is the ratio of values that fall below that value.',
+    type: 'double',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    hasDynamicSuffix: true,
+    example: 'score.ratio.inp=0.7748',
+    changelog: [{ version: 'next', prs: [354], description: 'Added score.ratio.<key> attribute' }],
+  },
+  [SCORE_TOTAL]: {
+    brief:
+      'The total performance score of a span. This is the sum of individual weighted web vital scores (see `score.<key>`).',
+    type: 'double',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    changelog: [{ version: 'next', prs: [354], description: 'Added score.total attribute' }],
+  },
+  [SCORE_WEIGHT_KEY]: {
+    brief: "The relative weight of a web vital in a span's performance score.",
+    type: 'double',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    hasDynamicSuffix: true,
+    example: 'score.weight.fcp=0.25',
+    changelog: [{ version: 'next', prs: [354], description: 'Added score.weight.<key> attribute' }],
+  },
   [SENTRY_ACTION]: {
     brief:
       'Used as a generic attribute representing the action depending on the type of span. For instance, this is the database query operation for DB spans, and the request method for HTTP spans.',
@@ -20211,6 +20347,10 @@ export type Attributes = {
   [ROUTE]?: ROUTE_TYPE;
   [RPC_GRPC_STATUS_CODE]?: RPC_GRPC_STATUS_CODE_TYPE;
   [RPC_SERVICE]?: RPC_SERVICE_TYPE;
+  [SCORE_KEY]?: SCORE_KEY_TYPE;
+  [SCORE_RATIO_KEY]?: SCORE_RATIO_KEY_TYPE;
+  [SCORE_TOTAL]?: SCORE_TOTAL_TYPE;
+  [SCORE_WEIGHT_KEY]?: SCORE_WEIGHT_KEY_TYPE;
   [SENTRY_ACTION]?: SENTRY_ACTION_TYPE;
   [SENTRY_BROWSER_NAME]?: SENTRY_BROWSER_NAME_TYPE;
   [SENTRY_BROWSER_VERSION]?: SENTRY_BROWSER_VERSION_TYPE;

--- a/model/attributes/score/score__[key].json
+++ b/model/attributes/score/score__[key].json
@@ -1,6 +1,6 @@
 {
   "key": "score.<key>",
-  "brief": "The weighted performance score for a web vital. This is defined as `score.weight.<key> * score.ratio.<key>`.",
+  "brief": "The weighted performance score for a web vital. This is defined as `score.weight.<key>` * `score.ratio.<key>`.",
   "has_dynamic_suffix": true,
   "type": "double",
   "pii": {

--- a/model/attributes/score/score__[key].json
+++ b/model/attributes/score/score__[key].json
@@ -1,0 +1,18 @@
+{
+  "key": "score.<key>",
+  "brief": "The weighted performance score for a web vital. This is defined as `score.weight.<key> * score.ratio.<key>`.",
+  "has_dynamic_suffix": true,
+  "type": "double",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "score.cls=0.1723",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [354],
+      "description": "Added score.<key> attribute"
+    }
+  ]
+}

--- a/model/attributes/score/score__[key].json
+++ b/model/attributes/score/score__[key].json
@@ -11,7 +11,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [354],
+      "prs": [355],
       "description": "Added score.<key> attribute"
     }
   ]

--- a/model/attributes/score/score__ratio__[key].json
+++ b/model/attributes/score/score__ratio__[key].json
@@ -11,7 +11,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [354],
+      "prs": [355],
       "description": "Added score.ratio.<key> attribute"
     }
   ]

--- a/model/attributes/score/score__ratio__[key].json
+++ b/model/attributes/score/score__ratio__[key].json
@@ -1,6 +1,6 @@
 {
   "key": "score.ratio.<key>",
-  "brief": "For a measured web vital value, this is the ratio of values that fall below that value.",
+  "brief": "The score for a web vital, normalized to a number between 0 and 1.",
   "has_dynamic_suffix": true,
   "type": "double",
   "pii": {

--- a/model/attributes/score/score__ratio__[key].json
+++ b/model/attributes/score/score__ratio__[key].json
@@ -1,0 +1,18 @@
+{
+  "key": "score.ratio.<key>",
+  "brief": "For a measured web vital value, this is the ratio of values that fall below that value.",
+  "has_dynamic_suffix": true,
+  "type": "double",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "score.ratio.inp=0.7748",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [354],
+      "description": "Added score.ratio.<key> attribute"
+    }
+  ]
+}

--- a/model/attributes/score/score__total.json
+++ b/model/attributes/score/score__total.json
@@ -1,0 +1,16 @@
+{
+  "key": "score.total",
+  "brief": "The total performance score of a span. This is the sum of individual weighted web vital scores (see `score.<key>`).",
+  "type": "double",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [354],
+      "description": "Added score.total attribute"
+    }
+  ]
+}

--- a/model/attributes/score/score__total.json
+++ b/model/attributes/score/score__total.json
@@ -9,7 +9,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [354],
+      "prs": [355],
       "description": "Added score.total attribute"
     }
   ]

--- a/model/attributes/score/score__weight__[key].json
+++ b/model/attributes/score/score__weight__[key].json
@@ -1,0 +1,18 @@
+{
+  "key": "score.weight.<key>",
+  "brief": "The relative weight of a web vital in a span's performance score.",
+  "has_dynamic_suffix": true,
+  "type": "double",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "score.weight.fcp=0.25",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [354],
+      "description": "Added score.weight.<key> attribute"
+    }
+  ]
+}

--- a/model/attributes/score/score__weight__[key].json
+++ b/model/attributes/score/score__weight__[key].json
@@ -11,7 +11,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [354],
+      "prs": [355],
       "description": "Added score.weight.<key> attribute"
     }
   ]

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5009,7 +5009,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/score/score__ratio__[key].json
     SCORE_RATIO_KEY: Literal["score.ratio.<key>"] = "score.ratio.<key>"
-    """For a measured web vital value, this is the ratio of values that fall below that value.
+    """The score for a web vital, normalized to a number between 0 and 1.
 
     Type: float
     Contains PII: maybe
@@ -12165,7 +12165,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "score.ratio.<key>": AttributeMetadata(
-        brief="For a measured web vital value, this is the ratio of values that fall below that value.",
+        brief="The score for a web vital, normalized to a number between 0 and 1.",
         type=AttributeType.DOUBLE,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -12160,7 +12160,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="score.cls=0.1723",
         changelog=[
             ChangelogEntry(
-                version="next", prs=[354], description="Added score.<key> attribute"
+                version="next", prs=[355], description="Added score.<key> attribute"
             ),
         ],
     ),
@@ -12174,7 +12174,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[354],
+                prs=[355],
                 description="Added score.ratio.<key> attribute",
             ),
         ],
@@ -12186,7 +12186,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         changelog=[
             ChangelogEntry(
-                version="next", prs=[354], description="Added score.total attribute"
+                version="next", prs=[355], description="Added score.total attribute"
             ),
         ],
     ),
@@ -12200,7 +12200,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[354],
+                prs=[355],
                 description="Added score.weight.<key> attribute",
             ),
         ],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4996,6 +4996,48 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "myService.BestService"
     """
 
+    # Path: model/attributes/score/score__[key].json
+    SCORE_KEY: Literal["score.<key>"] = "score.<key>"
+    """The weighted performance score for a web vital. This is defined as `score.weight.<key> * score.ratio.<key>`.
+
+    Type: float
+    Contains PII: maybe
+    Defined in OTEL: No
+    Has Dynamic Suffix: true
+    Example: "score.cls=0.1723"
+    """
+
+    # Path: model/attributes/score/score__ratio__[key].json
+    SCORE_RATIO_KEY: Literal["score.ratio.<key>"] = "score.ratio.<key>"
+    """For a measured web vital value, this is the ratio of values that fall below that value.
+
+    Type: float
+    Contains PII: maybe
+    Defined in OTEL: No
+    Has Dynamic Suffix: true
+    Example: "score.ratio.inp=0.7748"
+    """
+
+    # Path: model/attributes/score/score__total.json
+    SCORE_TOTAL: Literal["score.total"] = "score.total"
+    """The total performance score of a span. This is the sum of individual weighted web vital scores (see `score.<key>`).
+
+    Type: float
+    Contains PII: maybe
+    Defined in OTEL: No
+    """
+
+    # Path: model/attributes/score/score__weight__[key].json
+    SCORE_WEIGHT_KEY: Literal["score.weight.<key>"] = "score.weight.<key>"
+    """The relative weight of a web vital in a span's performance score.
+
+    Type: float
+    Contains PII: maybe
+    Defined in OTEL: No
+    Has Dynamic Suffix: true
+    Example: "score.weight.fcp=0.25"
+    """
+
     # Path: model/attributes/sentry/sentry__action.json
     SENTRY_ACTION: Literal["sentry.action"] = "sentry.action"
     """Used as a generic attribute representing the action depending on the type of span. For instance, this is the database query operation for DB spans, and the request method for HTTP spans.
@@ -12109,6 +12151,60 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "score.<key>": AttributeMetadata(
+        brief="The weighted performance score for a web vital. This is defined as `score.weight.<key> * score.ratio.<key>`.",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        has_dynamic_suffix=True,
+        example="score.cls=0.1723",
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[354], description="Added score.<key> attribute"
+            ),
+        ],
+    ),
+    "score.ratio.<key>": AttributeMetadata(
+        brief="For a measured web vital value, this is the ratio of values that fall below that value.",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        has_dynamic_suffix=True,
+        example="score.ratio.inp=0.7748",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[354],
+                description="Added score.ratio.<key> attribute",
+            ),
+        ],
+    ),
+    "score.total": AttributeMetadata(
+        brief="The total performance score of a span. This is the sum of individual weighted web vital scores (see `score.<key>`).",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[354], description="Added score.total attribute"
+            ),
+        ],
+    ),
+    "score.weight.<key>": AttributeMetadata(
+        brief="The relative weight of a web vital in a span's performance score.",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        has_dynamic_suffix=True,
+        example="score.weight.fcp=0.25",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[354],
+                description="Added score.weight.<key> attribute",
+            ),
+        ],
+    ),
     "sentry.action": AttributeMetadata(
         brief="Used as a generic attribute representing the action depending on the type of span. For instance, this is the database query operation for DB spans, and the request method for HTTP spans.",
         type=AttributeType.STRING,
@@ -14143,6 +14239,10 @@ Attributes = TypedDict(
         "route": str,
         "rpc.grpc.status_code": int,
         "rpc.service": str,
+        "score.<key>": float,
+        "score.ratio.<key>": float,
+        "score.total": float,
+        "score.weight.<key>": float,
         "sentry.action": str,
         "sentry.browser.name": str,
         "sentry.browser.version": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4998,7 +4998,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/score/score__[key].json
     SCORE_KEY: Literal["score.<key>"] = "score.<key>"
-    """The weighted performance score for a web vital. This is defined as `score.weight.<key> * score.ratio.<key>`.
+    """The weighted performance score for a web vital. This is defined as `score.weight.<key>` * `score.ratio.<key>`.
 
     Type: float
     Contains PII: maybe
@@ -12152,7 +12152,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "score.<key>": AttributeMetadata(
-        brief="The weighted performance score for a web vital. This is defined as `score.weight.<key> * score.ratio.<key>`.",
+        brief="The weighted performance score for a web vital. This is defined as `score.weight.<key>` * `score.ratio.<key>`.",
         type=AttributeType.DOUBLE,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,


### PR DESCRIPTION
## Description
This adds attributes for the results of performance score calculation in Relay, cf. https://github.com/getsentry/relay/blob/4b2a15909edaec2b95bd623d15923abbadb18b19/relay-event-normalization/src/event.rs#L869. The added attributes are exactly the measurements that Relay inserts in that function.

The reason to do this is that for V2 spans we use attributes to store the measurements, and we want every attribute that Relay writes to be defined here.

I hope my descriptions of these attributes make some sense. Please feel free to suggest improvements.

Closes INGEST-896.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)
