### PR TITLE
fix(create): Replace angle brackets in file names

### DIFF
--- a/scripts/create_attribute.ts
+++ b/scripts/create_attribute.ts
@@ -158,7 +158,7 @@ const createAttribute = async () => {
     validateSchema(attribute);
 
     // Replace angle brackets for Windows path safety
-    let fileKey = key.replaceAll('<', '[').replaceAll('>', ']');
+    const fileKey = key.replaceAll('<', '[').replaceAll('>', ']');
     // Create the directory structure based on the key
     const parts = fileKey.split('.');
     let filePath: string;

--- a/scripts/create_attribute.ts
+++ b/scripts/create_attribute.ts
@@ -175,6 +175,8 @@ const createAttribute = async () => {
       filePath = path.join(dirPath, `${fileName}.json`);
     }
 
+    // Replace angle brackets for Windows path safety
+    filePath = filePath.replaceAll('<', '[').replaceAll('>', ']');
     fs.writeFileSync(filePath, `${JSON.stringify(attribute, null, 2)}\n`);
     log.success(`Successfully created attribute file at: ${filePath}`);
 

--- a/scripts/create_attribute.ts
+++ b/scripts/create_attribute.ts
@@ -157,13 +157,15 @@ const createAttribute = async () => {
 
     validateSchema(attribute);
 
+    // Replace angle brackets for Windows path safety
+    let fileKey = key.replaceAll('<', '[').replaceAll('>', ']');
     // Create the directory structure based on the key
-    const parts = key.split('.');
+    const parts = fileKey.split('.');
     let filePath: string;
 
     if (parts.length === 1) {
       // Handle simple keys like 'replay_id'
-      filePath = path.join('model', 'attributes', `${key}.json`);
+      filePath = path.join('model', 'attributes', `${fileKey}.json`);
     } else {
       // Handle dotted keys like 'http.route'
       const dirPath = path.join('model', 'attributes', parts[0] ?? '');
@@ -175,8 +177,6 @@ const createAttribute = async () => {
       filePath = path.join(dirPath, `${fileName}.json`);
     }
 
-    // Replace angle brackets for Windows path safety
-    filePath = filePath.replaceAll('<', '[').replaceAll('>', ']');
     fs.writeFileSync(filePath, `${JSON.stringify(attribute, null, 2)}\n`);
     log.success(`Successfully created attribute file at: ${filePath}`);
 


### PR DESCRIPTION
## Description
File names shouldn't contain angle brackets since those are invalid on Windows.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.