### PR TITLE
feat(attributes): Add several measurement attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3949,7 +3949,7 @@ export type FRAMES_FROZEN_TYPE = number;
 // Path: model/attributes/frames_frozen_rate.json
 
 /**
- * The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`. `frames_frozen_rate`
+ * The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`. This is computed by Relay. `frames_frozen_rate`
  *
  * Attribute Value Type: `number` {@link FRAMES_FROZEN_RATE_TYPE}
  *
@@ -3990,7 +3990,7 @@ export type FRAMES_SLOW_TYPE = number;
 // Path: model/attributes/frames_slow_rate.json
 
 /**
- * The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`. `frames_slow_rate`
+ * The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`. This is computed by Relay. `frames_slow_rate`
  *
  * Attribute Value Type: `number` {@link FRAMES_SLOW_RATE_TYPE}
  *
@@ -10325,7 +10325,7 @@ export type SERVICE_VERSION_TYPE = string;
 // Path: model/attributes/stall_percentage.json
 
 /**
- * The fraction of time the app was stalled. Only applies to React Native. `stall_percentage`
+ * The fraction of time the app was stalled. Only applies to React Native. This is computed by Relay. `stall_percentage`
  *
  * Attribute Value Type: `number` {@link STALL_PERCENTAGE_TYPE}
  *
@@ -10343,7 +10343,7 @@ export type STALL_PERCENTAGE_TYPE = number;
 // Path: model/attributes/stall_total_time.json
 
 /**
- * The combined duration of all stalls in milliseconds. Only applies to React Native. `stall_total_time`
+ * The combined duration of all stalls in milliseconds. Only applies to React Native. This is computed by Relay. `stall_total_time`
  *
  * Attribute Value Type: `number` {@link STALL_TOTAL_TIME_TYPE}
  *
@@ -15578,7 +15578,8 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     ],
   },
   [FRAMES_FROZEN_RATE]: {
-    brief: 'The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`.',
+    brief:
+      'The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`. This is computed by Relay.',
     type: 'double',
     pii: {
       isPii: 'maybe',
@@ -15607,7 +15608,8 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     ],
   },
   [FRAMES_SLOW_RATE]: {
-    brief: 'The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`.',
+    brief:
+      'The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`. This is computed by Relay.',
     type: 'double',
     pii: {
       isPii: 'maybe',
@@ -19292,7 +19294,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [STALL_PERCENTAGE]: {
-    brief: 'The fraction of time the app was stalled. Only applies to React Native.',
+    brief: 'The fraction of time the app was stalled. Only applies to React Native. This is computed by Relay.',
     type: 'double',
     pii: {
       isPii: 'maybe',
@@ -19301,7 +19303,8 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     changelog: [{ version: 'next', prs: [362], description: 'Added stall_percentage attribute' }],
   },
   [STALL_TOTAL_TIME]: {
-    brief: 'The combined duration of all stalls in milliseconds. Only applies to React Native.',
+    brief:
+      'The combined duration of all stalls in milliseconds. Only applies to React Native. This is computed by Relay.',
     type: 'double',
     pii: {
       isPii: 'maybe',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3946,6 +3946,24 @@ export const FRAMES_FROZEN = 'frames.frozen';
  */
 export type FRAMES_FROZEN_TYPE = number;
 
+// Path: model/attributes/frames_frozen_rate.json
+
+/**
+ * The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`. `frames_frozen_rate`
+ *
+ * Attribute Value Type: `number` {@link FRAMES_FROZEN_RATE_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ */
+export const FRAMES_FROZEN_RATE = 'frames_frozen_rate';
+
+/**
+ * Type for {@link FRAMES_FROZEN_RATE} frames_frozen_rate
+ */
+export type FRAMES_FROZEN_RATE_TYPE = number;
+
 // Path: model/attributes/frames/frames__slow.json
 
 /**
@@ -3968,6 +3986,24 @@ export const FRAMES_SLOW = 'frames.slow';
  * Type for {@link FRAMES_SLOW} frames.slow
  */
 export type FRAMES_SLOW_TYPE = number;
+
+// Path: model/attributes/frames_slow_rate.json
+
+/**
+ * The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`. `frames_slow_rate`
+ *
+ * Attribute Value Type: `number` {@link FRAMES_SLOW_RATE_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ */
+export const FRAMES_SLOW_RATE = 'frames_slow_rate';
+
+/**
+ * Type for {@link FRAMES_SLOW_RATE} frames_slow_rate
+ */
+export type FRAMES_SLOW_RATE_TYPE = number;
 
 // Path: model/attributes/frames/frames__total.json
 
@@ -10286,6 +10322,42 @@ export const SERVICE_VERSION = 'service.version';
  */
 export type SERVICE_VERSION_TYPE = string;
 
+// Path: model/attributes/stall_percentage.json
+
+/**
+ * The fraction of time the app was stalled. Only applies to React Native. `stall_percentage`
+ *
+ * Attribute Value Type: `number` {@link STALL_PERCENTAGE_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ */
+export const STALL_PERCENTAGE = 'stall_percentage';
+
+/**
+ * Type for {@link STALL_PERCENTAGE} stall_percentage
+ */
+export type STALL_PERCENTAGE_TYPE = number;
+
+// Path: model/attributes/stall_total_time.json
+
+/**
+ * The combined duration of all stalls in milliseconds. Only applies to React Native. `stall_total_time`
+ *
+ * Attribute Value Type: `number` {@link STALL_TOTAL_TIME_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ */
+export const STALL_TOTAL_TIME = 'stall_total_time';
+
+/**
+ * Type for {@link STALL_TOTAL_TIME} stall_total_time
+ */
+export type STALL_TOTAL_TIME_TYPE = number;
+
 // Path: model/attributes/thread/thread__id.json
 
 /**
@@ -12141,7 +12213,9 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [FP]: 'double',
   [FRAMES_DELAY]: 'integer',
   [FRAMES_FROZEN]: 'integer',
+  [FRAMES_FROZEN_RATE]: 'double',
   [FRAMES_SLOW]: 'integer',
+  [FRAMES_SLOW_RATE]: 'double',
   [FRAMES_TOTAL]: 'integer',
   [FS_ERROR]: 'string',
   [GEN_AI_AGENT_NAME]: 'string',
@@ -12444,6 +12518,8 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SERVER_PORT]: 'integer',
   [SERVICE_NAME]: 'string',
   [SERVICE_VERSION]: 'string',
+  [STALL_PERCENTAGE]: 'double',
+  [STALL_TOTAL_TIME]: 'integer',
   [THREAD_ID]: 'integer',
   [THREAD_NAME]: 'string',
   [TIMBER_TAG]: 'string',
@@ -12711,7 +12787,9 @@ export type AttributeName =
   | typeof FP
   | typeof FRAMES_DELAY
   | typeof FRAMES_FROZEN
+  | typeof FRAMES_FROZEN_RATE
   | typeof FRAMES_SLOW
+  | typeof FRAMES_SLOW_RATE
   | typeof FRAMES_TOTAL
   | typeof FS_ERROR
   | typeof GEN_AI_AGENT_NAME
@@ -13014,6 +13092,8 @@ export type AttributeName =
   | typeof SERVER_PORT
   | typeof SERVICE_NAME
   | typeof SERVICE_VERSION
+  | typeof STALL_PERCENTAGE
+  | typeof STALL_TOTAL_TIME
   | typeof THREAD_ID
   | typeof THREAD_NAME
   | typeof TIMBER_TAG
@@ -15497,6 +15577,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: '0.0.0' },
     ],
   },
+  [FRAMES_FROZEN_RATE]: {
+    brief: 'The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`.',
+    type: 'double',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    changelog: [{ version: 'next', prs: [362], description: 'Added frames_frozen_rate attribute' }],
+  },
   [FRAMES_SLOW]: {
     brief: 'The number of slow frames rendered during the lifetime of the span.',
     type: 'integer',
@@ -15516,6 +15605,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: '0.4.0', prs: [228] },
       { version: '0.0.0' },
     ],
+  },
+  [FRAMES_SLOW_RATE]: {
+    brief: 'The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`.',
+    type: 'double',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    changelog: [{ version: 'next', prs: [362], description: 'Added frames_slow_rate attribute' }],
   },
   [FRAMES_TOTAL]: {
     brief: 'The number of total frames rendered during the lifetime of the span.',
@@ -19193,6 +19291,24 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: [SENTRY_RELEASE],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
+  [STALL_PERCENTAGE]: {
+    brief: 'The fraction of time the app was stalled. Only applies to React Native.',
+    type: 'double',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    changelog: [{ version: 'next', prs: [362], description: 'Added stall_percentage attribute' }],
+  },
+  [STALL_TOTAL_TIME]: {
+    brief: 'The combined duration of all stalls in milliseconds. Only applies to React Native.',
+    type: 'integer',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    changelog: [{ version: 'next', prs: [362], description: 'Added stall_total_time attribute' }],
+  },
   [THREAD_ID]: {
     brief: 'Current “managed” thread ID.',
     type: 'integer',
@@ -20257,7 +20373,9 @@ export type Attributes = {
   [FP]?: FP_TYPE;
   [FRAMES_DELAY]?: FRAMES_DELAY_TYPE;
   [FRAMES_FROZEN]?: FRAMES_FROZEN_TYPE;
+  [FRAMES_FROZEN_RATE]?: FRAMES_FROZEN_RATE_TYPE;
   [FRAMES_SLOW]?: FRAMES_SLOW_TYPE;
+  [FRAMES_SLOW_RATE]?: FRAMES_SLOW_RATE_TYPE;
   [FRAMES_TOTAL]?: FRAMES_TOTAL_TYPE;
   [FS_ERROR]?: FS_ERROR_TYPE;
   [GEN_AI_AGENT_NAME]?: GEN_AI_AGENT_NAME_TYPE;
@@ -20560,6 +20678,8 @@ export type Attributes = {
   [SERVER_PORT]?: SERVER_PORT_TYPE;
   [SERVICE_NAME]?: SERVICE_NAME_TYPE;
   [SERVICE_VERSION]?: SERVICE_VERSION_TYPE;
+  [STALL_PERCENTAGE]?: STALL_PERCENTAGE_TYPE;
+  [STALL_TOTAL_TIME]?: STALL_TOTAL_TIME_TYPE;
   [THREAD_ID]?: THREAD_ID_TYPE;
   [THREAD_NAME]?: THREAD_NAME_TYPE;
   [TIMBER_TAG]?: TIMBER_TAG_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -12519,7 +12519,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SERVICE_NAME]: 'string',
   [SERVICE_VERSION]: 'string',
   [STALL_PERCENTAGE]: 'double',
-  [STALL_TOTAL_TIME]: 'integer',
+  [STALL_TOTAL_TIME]: 'double',
   [THREAD_ID]: 'integer',
   [THREAD_NAME]: 'string',
   [TIMBER_TAG]: 'string',
@@ -19302,7 +19302,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   },
   [STALL_TOTAL_TIME]: {
     brief: 'The combined duration of all stalls in milliseconds. Only applies to React Native.',
-    type: 'integer',
+    type: 'double',
     pii: {
       isPii: 'maybe',
     },

--- a/model/attributes/frames_frozen_rate.json
+++ b/model/attributes/frames_frozen_rate.json
@@ -1,6 +1,6 @@
 {
   "key": "frames_frozen_rate",
-  "brief": "The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`.",
+  "brief": "The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`. This is computed by Relay.",
   "type": "double",
   "pii": {
     "key": "maybe"

--- a/model/attributes/frames_frozen_rate.json
+++ b/model/attributes/frames_frozen_rate.json
@@ -1,0 +1,16 @@
+{
+  "key": "frames_frozen_rate",
+  "brief": "The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`.",
+  "type": "double",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [362],
+      "description": "Added frames_frozen_rate attribute"
+    }
+  ]
+}

--- a/model/attributes/frames_slow_rate.json
+++ b/model/attributes/frames_slow_rate.json
@@ -1,0 +1,16 @@
+{
+  "key": "frames_slow_rate",
+  "brief": "The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`.",
+  "type": "double",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [362],
+      "description": "Added frames_slow_rate attribute"
+    }
+  ]
+}

--- a/model/attributes/frames_slow_rate.json
+++ b/model/attributes/frames_slow_rate.json
@@ -1,6 +1,6 @@
 {
   "key": "frames_slow_rate",
-  "brief": "The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`.",
+  "brief": "The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`. This is computed by Relay.",
   "type": "double",
   "pii": {
     "key": "maybe"

--- a/model/attributes/stall_percentage.json
+++ b/model/attributes/stall_percentage.json
@@ -1,0 +1,16 @@
+{
+  "key": "stall_percentage",
+  "brief": "The fraction of time the app was stalled. Only applies to React Native.",
+  "type": "double",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [362],
+      "description": "Added stall_percentage attribute"
+    }
+  ]
+}

--- a/model/attributes/stall_percentage.json
+++ b/model/attributes/stall_percentage.json
@@ -1,6 +1,6 @@
 {
   "key": "stall_percentage",
-  "brief": "The fraction of time the app was stalled. Only applies to React Native.",
+  "brief": "The fraction of time the app was stalled. Only applies to React Native. This is computed by Relay.",
   "type": "double",
   "pii": {
     "key": "maybe"

--- a/model/attributes/stall_total_time.json
+++ b/model/attributes/stall_total_time.json
@@ -1,6 +1,6 @@
 {
   "key": "stall_total_time",
-  "brief": "The combined duration of all stalls in milliseconds. Only applies to React Native.",
+  "brief": "The combined duration of all stalls in milliseconds. Only applies to React Native. This is computed by Relay.",
   "type": "double",
   "pii": {
     "key": "maybe"

--- a/model/attributes/stall_total_time.json
+++ b/model/attributes/stall_total_time.json
@@ -1,7 +1,7 @@
 {
   "key": "stall_total_time",
   "brief": "The combined duration of all stalls in milliseconds. Only applies to React Native.",
-  "type": "integer",
+  "type": "double",
   "pii": {
     "key": "maybe"
   },

--- a/model/attributes/stall_total_time.json
+++ b/model/attributes/stall_total_time.json
@@ -1,0 +1,16 @@
+{
+  "key": "stall_total_time",
+  "brief": "The combined duration of all stalls in milliseconds. Only applies to React Native.",
+  "type": "integer",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [362],
+      "description": "Added stall_total_time attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5787,7 +5787,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     STALL_TOTAL_TIME: Literal["stall_total_time"] = "stall_total_time"
     """The combined duration of all stalls in milliseconds. Only applies to React Native.
 
-    Type: int
+    Type: float
     Contains PII: maybe
     Defined in OTEL: No
     """
@@ -13086,7 +13086,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     ),
     "stall_total_time": AttributeMetadata(
         brief="The combined duration of all stalls in milliseconds. Only applies to React Native.",
-        type=AttributeType.INTEGER,
+        type=AttributeType.DOUBLE,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         changelog=[
@@ -14514,7 +14514,7 @@ Attributes = TypedDict(
         "service.name": str,
         "service.version": str,
         "stall_percentage": float,
-        "stall_total_time": int,
+        "stall_total_time": float,
         "thread.id": int,
         "thread.name": str,
         "timber.tag": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2367,7 +2367,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/frames_frozen_rate.json
     FRAMES_FROZEN_RATE: Literal["frames_frozen_rate"] = "frames_frozen_rate"
-    """The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`.
+    """The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`. This is computed by Relay.
 
     Type: float
     Contains PII: maybe
@@ -2376,7 +2376,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/frames_slow_rate.json
     FRAMES_SLOW_RATE: Literal["frames_slow_rate"] = "frames_slow_rate"
-    """The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`.
+    """The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`. This is computed by Relay.
 
     Type: float
     Contains PII: maybe
@@ -5776,7 +5776,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/stall_percentage.json
     STALL_PERCENTAGE: Literal["stall_percentage"] = "stall_percentage"
-    """The fraction of time the app was stalled. Only applies to React Native.
+    """The fraction of time the app was stalled. Only applies to React Native. This is computed by Relay.
 
     Type: float
     Contains PII: maybe
@@ -5785,7 +5785,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/stall_total_time.json
     STALL_TOTAL_TIME: Literal["stall_total_time"] = "stall_total_time"
-    """The combined duration of all stalls in milliseconds. Only applies to React Native.
+    """The combined duration of all stalls in milliseconds. Only applies to React Native. This is computed by Relay.
 
     Type: float
     Contains PII: maybe
@@ -9361,7 +9361,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "frames_frozen_rate": AttributeMetadata(
-        brief="The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`.",
+        brief="The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`. This is computed by Relay.",
         type=AttributeType.DOUBLE,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
@@ -9374,7 +9374,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "frames_slow_rate": AttributeMetadata(
-        brief="The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`.",
+        brief="The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`. This is computed by Relay.",
         type=AttributeType.DOUBLE,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
@@ -13072,7 +13072,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "stall_percentage": AttributeMetadata(
-        brief="The fraction of time the app was stalled. Only applies to React Native.",
+        brief="The fraction of time the app was stalled. Only applies to React Native. This is computed by Relay.",
         type=AttributeType.DOUBLE,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
@@ -13085,7 +13085,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "stall_total_time": AttributeMetadata(
-        brief="The combined duration of all stalls in milliseconds. Only applies to React Native.",
+        brief="The combined duration of all stalls in milliseconds. Only applies to React Native. This is computed by Relay.",
         type=AttributeType.DOUBLE,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2365,6 +2365,24 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 60
     """
 
+    # Path: model/attributes/frames_frozen_rate.json
+    FRAMES_FROZEN_RATE: Literal["frames_frozen_rate"] = "frames_frozen_rate"
+    """The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`.
+
+    Type: float
+    Contains PII: maybe
+    Defined in OTEL: No
+    """
+
+    # Path: model/attributes/frames_slow_rate.json
+    FRAMES_SLOW_RATE: Literal["frames_slow_rate"] = "frames_slow_rate"
+    """The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`.
+
+    Type: float
+    Contains PII: maybe
+    Defined in OTEL: No
+    """
+
     # Path: model/attributes/fs_error.json
     FS_ERROR: Literal["fs_error"] = "fs_error"
     """The error message of a file system error.
@@ -5754,6 +5772,24 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Aliases: sentry.release
     Example: "5.0.0"
+    """
+
+    # Path: model/attributes/stall_percentage.json
+    STALL_PERCENTAGE: Literal["stall_percentage"] = "stall_percentage"
+    """The fraction of time the app was stalled. Only applies to React Native.
+
+    Type: float
+    Contains PII: maybe
+    Defined in OTEL: No
+    """
+
+    # Path: model/attributes/stall_total_time.json
+    STALL_TOTAL_TIME: Literal["stall_total_time"] = "stall_total_time"
+    """The combined duration of all stalls in milliseconds. Only applies to React Native.
+
+    Type: int
+    Contains PII: maybe
+    Defined in OTEL: No
     """
 
     # Path: model/attributes/thread/thread__id.json
@@ -9322,6 +9358,32 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "frames_frozen_rate": AttributeMetadata(
+        brief="The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`.",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[362],
+                description="Added frames_frozen_rate attribute",
+            ),
+        ],
+    ),
+    "frames_slow_rate": AttributeMetadata(
+        brief="The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`.",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[362],
+                description="Added frames_slow_rate attribute",
+            ),
         ],
     ),
     "fs_error": AttributeMetadata(
@@ -13009,6 +13071,32 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "stall_percentage": AttributeMetadata(
+        brief="The fraction of time the app was stalled. Only applies to React Native.",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[362],
+                description="Added stall_percentage attribute",
+            ),
+        ],
+    ),
+    "stall_total_time": AttributeMetadata(
+        brief="The combined duration of all stalls in milliseconds. Only applies to React Native.",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[362],
+                description="Added stall_total_time attribute",
+            ),
+        ],
+    ),
     "thread.id": AttributeMetadata(
         brief="Current “managed” thread ID.",
         type=AttributeType.INTEGER,
@@ -14122,6 +14210,8 @@ Attributes = TypedDict(
         "frames.frozen": int,
         "frames.slow": int,
         "frames.total": int,
+        "frames_frozen_rate": float,
+        "frames_slow_rate": float,
         "fs_error": str,
         "gen_ai.agent.name": str,
         "gen_ai.context.utilization": float,
@@ -14423,6 +14513,8 @@ Attributes = TypedDict(
         "server.port": int,
         "service.name": str,
         "service.version": str,
+        "stall_percentage": float,
+        "stall_total_time": int,
         "thread.id": int,
         "thread.name": str,
         "timber.tag": str,


### PR DESCRIPTION
## Description
This adds the attributes
- `frames_frozen_rate`
- `frames_slow_rate`
- `stall_total_time`
- `stall_percentage`

These attributes are the equivalents of measurements accessed/computed by Relay in https://github.com/getsentry/relay/blob/2061055ea0e7a82266ba4c90205c416daa04875d/relay-event-normalization/src/event.rs#L1094-L1145. Defining them as attributes is a prerequisite to running the same computation for V2 spans.

This PR intentionally doesn't put the attributes under their "proper" names (I don't know in all cases what those would be, but I know that they wouldn't be _this_). This is because Relay converts measurements to attributes 1-to-1, so to preserve parity between V1 and V2 spans, we want to reuse the names. Renaming the attributes can later be accomplished through the normal deprecation process.

ref: INGEST-909

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)
