### PR TITLE
feat(attributes): Add `profile.start_timestamp` attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ dist
 .playwright-mcp/
 
 .DS_Store
+.claude/projects/

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8684,7 +8684,7 @@ export type PROCESS_RUNTIME_VERSION_TYPE = string;
  *
  * Attribute Value Type: `number` {@link PROFILE_START_TIMESTAMP_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -18341,7 +18341,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The timestamp when the profile started',
     type: 'double',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1700000000.123,

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8677,6 +8677,26 @@ export const PROCESS_RUNTIME_VERSION = 'process.runtime.version';
  */
 export type PROCESS_RUNTIME_VERSION_TYPE = string;
 
+// Path: model/attributes/profile/profile__start_timestamp.json
+
+/**
+ * The timestamp when the profile started `profile.start_timestamp`
+ *
+ * Attribute Value Type: `number` {@link PROFILE_START_TIMESTAMP_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 1700000000.123
+ */
+export const PROFILE_START_TIMESTAMP = 'profile.start_timestamp';
+
+/**
+ * Type for {@link PROFILE_START_TIMESTAMP} profile.start_timestamp
+ */
+export type PROFILE_START_TIMESTAMP_TYPE = number;
+
 // Path: model/attributes/query/query__[key].json
 
 /**
@@ -12366,6 +12386,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [PROCESS_RUNTIME_ENGINE_VERSION]: 'string',
   [PROCESS_RUNTIME_NAME]: 'string',
   [PROCESS_RUNTIME_VERSION]: 'string',
+  [PROFILE_START_TIMESTAMP]: 'double',
   [QUERY_KEY]: 'string',
   [RELEASE]: 'string',
   [REMIX_ACTION_FORM_DATA_KEY]: 'string',
@@ -12936,6 +12957,7 @@ export type AttributeName =
   | typeof PROCESS_RUNTIME_ENGINE_VERSION
   | typeof PROCESS_RUNTIME_NAME
   | typeof PROCESS_RUNTIME_VERSION
+  | typeof PROFILE_START_TIMESTAMP
   | typeof QUERY_KEY
   | typeof RELEASE
   | typeof REMIX_ACTION_FORM_DATA_KEY
@@ -18315,6 +18337,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '18.04.2',
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
+  [PROFILE_START_TIMESTAMP]: {
+    brief: 'The timestamp when the profile started',
+    type: 'double',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 1700000000.123,
+    changelog: [{ version: 'next', prs: [363], description: 'Added profile.start_timestamp attribute' }],
+  },
   [QUERY_KEY]: {
     brief: 'An item in a query string. Usually added by client-side routing frameworks like vue-router.',
     type: 'string',
@@ -20482,6 +20514,7 @@ export type Attributes = {
   [PROCESS_RUNTIME_ENGINE_VERSION]?: PROCESS_RUNTIME_ENGINE_VERSION_TYPE;
   [PROCESS_RUNTIME_NAME]?: PROCESS_RUNTIME_NAME_TYPE;
   [PROCESS_RUNTIME_VERSION]?: PROCESS_RUNTIME_VERSION_TYPE;
+  [PROFILE_START_TIMESTAMP]?: PROFILE_START_TIMESTAMP_TYPE;
   [QUERY_KEY]?: QUERY_KEY_TYPE;
   [RELEASE]?: RELEASE_TYPE;
   [REMIX_ACTION_FORM_DATA_KEY]?: REMIX_ACTION_FORM_DATA_KEY_TYPE;

--- a/model/attributes/profile/profile__start_timestamp.json
+++ b/model/attributes/profile/profile__start_timestamp.json
@@ -1,0 +1,17 @@
+{
+  "key": "profile.start_timestamp",
+  "brief": "The timestamp when the profile started",
+  "type": "double",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": 1700000000.123,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added profile.start_timestamp attribute"
+    }
+  ]
+}

--- a/model/attributes/profile/profile__start_timestamp.json
+++ b/model/attributes/profile/profile__start_timestamp.json
@@ -3,7 +3,7 @@
   "brief": "The timestamp when the profile started",
   "type": "double",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": 1700000000.123,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4908,7 +4908,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The timestamp when the profile started
 
     Type: float
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: 1700000000.123
     """
@@ -12127,7 +12127,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "profile.start_timestamp": AttributeMetadata(
         brief="The timestamp when the profile started",
         type=AttributeType.DOUBLE,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=1700000000.123,
         changelog=[

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4901,6 +4901,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "18.04.2"
     """
 
+    # Path: model/attributes/profile/profile__start_timestamp.json
+    PROFILE_START_TIMESTAMP: Literal["profile.start_timestamp"] = (
+        "profile.start_timestamp"
+    )
+    """The timestamp when the profile started
+
+    Type: float
+    Contains PII: false
+    Defined in OTEL: No
+    Example: 1700000000.123
+    """
+
     # Path: model/attributes/query/query__[key].json
     QUERY_KEY: Literal["query.<key>"] = "query.<key>"
     """An item in a query string. Usually added by client-side routing frameworks like vue-router.
@@ -12112,6 +12124,20 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "profile.start_timestamp": AttributeMetadata(
+        brief="The timestamp when the profile started",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example=1700000000.123,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added profile.start_timestamp attribute",
+            ),
+        ],
+    ),
     "query.<key>": AttributeMetadata(
         brief="An item in a query string. Usually added by client-side routing frameworks like vue-router.",
         type=AttributeType.STRING,
@@ -14345,6 +14371,7 @@ Attributes = TypedDict(
         "process.runtime.engine.version": str,
         "process.runtime.name": str,
         "process.runtime.version": str,
+        "profile.start_timestamp": float,
         "query.<key>": str,
         "release": str,
         "remix.action_form_data.<key>": str,


### PR DESCRIPTION
## Summary
- Add `profile.start_timestamp` (double) attribute for recording when a profile started
- Needed by the JS SDK (JS-2221) for span streaming, where scope contexts are converted to segment span attributes