### PR TITLE
feat(attributes): Add `cloud.*` span attributes

### DIFF
--- a/.claude/projects/-Users-chargome-Desktop-code-sentry-conventions/memory/feedback_no_resolutions.md
+++ b/.claude/projects/-Users-chargome-Desktop-code-sentry-conventions/memory/feedback_no_resolutions.md
@@ -1,0 +1,11 @@
+---
+name: no-yarn-resolutions
+description: User prefers not to use yarn resolutions to fix transitive dependency vulnerabilities in sentry-conventions
+type: feedback
+---
+
+Do not use `resolutions` in package.json to fix transitive dependency vulnerabilities.
+
+**Why:** User preference — they want to solve dependency issues by upgrading direct dependencies instead.
+
+**How to apply:** When fixing Dependabot alerts for transitive deps, upgrade the direct dependency that pulls them in rather than adding resolutions overrides.

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2072,7 +2072,7 @@ export type CLOUDFLARE_D1_ROWS_WRITTEN_TYPE = number;
  *
  * Attribute Value Type: `string` {@link CLOUD_ACCOUNT_ID_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: Yes
  *
@@ -2092,7 +2092,7 @@ export type CLOUD_ACCOUNT_ID_TYPE = string;
  *
  * Attribute Value Type: `string` {@link CLOUD_AVAILABILITY_ZONE_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: Yes
  *
@@ -2112,7 +2112,7 @@ export type CLOUD_AVAILABILITY_ZONE_TYPE = string;
  *
  * Attribute Value Type: `string` {@link CLOUD_PLATFORM_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: Yes
  *
@@ -2132,7 +2132,7 @@ export type CLOUD_PLATFORM_TYPE = string;
  *
  * Attribute Value Type: `string` {@link CLOUD_PROVIDER_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: Yes
  *
@@ -2152,7 +2152,7 @@ export type CLOUD_PROVIDER_TYPE = string;
  *
  * Attribute Value Type: `string` {@link CLOUD_REGION_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: Yes
  *
@@ -14515,7 +14515,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The cloud account ID the resource is assigned to',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: '123456789012',
@@ -14525,7 +14525,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'Cloud regions often have multiple, isolated locations known as zones to increase availability',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 'us-east-1c',
@@ -14535,7 +14535,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The cloud platform in use',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 'aws_lambda',
@@ -14545,7 +14545,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'Name of the cloud provider',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 'aws',
@@ -14555,7 +14555,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The geographical region the resource is running',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 'us-east-1',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2065,6 +2065,106 @@ export const CLOUDFLARE_D1_ROWS_WRITTEN = 'cloudflare.d1.rows_written';
  */
 export type CLOUDFLARE_D1_ROWS_WRITTEN_TYPE = number;
 
+// Path: model/attributes/cloud/cloud__account__id.json
+
+/**
+ * The cloud account ID the resource is assigned to `cloud.account.id`
+ *
+ * Attribute Value Type: `string` {@link CLOUD_ACCOUNT_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * @example "123456789012"
+ */
+export const CLOUD_ACCOUNT_ID = 'cloud.account.id';
+
+/**
+ * Type for {@link CLOUD_ACCOUNT_ID} cloud.account.id
+ */
+export type CLOUD_ACCOUNT_ID_TYPE = string;
+
+// Path: model/attributes/cloud/cloud__availability_zone.json
+
+/**
+ * Cloud regions often have multiple, isolated locations known as zones to increase availability `cloud.availability_zone`
+ *
+ * Attribute Value Type: `string` {@link CLOUD_AVAILABILITY_ZONE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * @example "us-east-1c"
+ */
+export const CLOUD_AVAILABILITY_ZONE = 'cloud.availability_zone';
+
+/**
+ * Type for {@link CLOUD_AVAILABILITY_ZONE} cloud.availability_zone
+ */
+export type CLOUD_AVAILABILITY_ZONE_TYPE = string;
+
+// Path: model/attributes/cloud/cloud__platform.json
+
+/**
+ * The cloud platform in use `cloud.platform`
+ *
+ * Attribute Value Type: `string` {@link CLOUD_PLATFORM_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * @example "aws_lambda"
+ */
+export const CLOUD_PLATFORM = 'cloud.platform';
+
+/**
+ * Type for {@link CLOUD_PLATFORM} cloud.platform
+ */
+export type CLOUD_PLATFORM_TYPE = string;
+
+// Path: model/attributes/cloud/cloud__provider.json
+
+/**
+ * Name of the cloud provider `cloud.provider`
+ *
+ * Attribute Value Type: `string` {@link CLOUD_PROVIDER_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * @example "aws"
+ */
+export const CLOUD_PROVIDER = 'cloud.provider';
+
+/**
+ * Type for {@link CLOUD_PROVIDER} cloud.provider
+ */
+export type CLOUD_PROVIDER_TYPE = string;
+
+// Path: model/attributes/cloud/cloud__region.json
+
+/**
+ * The geographical region the resource is running `cloud.region`
+ *
+ * Attribute Value Type: `string` {@link CLOUD_REGION_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * @example "us-east-1"
+ */
+export const CLOUD_REGION = 'cloud.region';
+
+/**
+ * Type for {@link CLOUD_REGION} cloud.region
+ */
+export type CLOUD_REGION_TYPE = string;
+
 // Path: model/attributes/cls.json
 
 /**
@@ -12051,6 +12151,11 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [CLOUDFLARE_D1_DURATION]: 'integer',
   [CLOUDFLARE_D1_ROWS_READ]: 'integer',
   [CLOUDFLARE_D1_ROWS_WRITTEN]: 'integer',
+  [CLOUD_ACCOUNT_ID]: 'string',
+  [CLOUD_AVAILABILITY_ZONE]: 'string',
+  [CLOUD_PLATFORM]: 'string',
+  [CLOUD_PROVIDER]: 'string',
+  [CLOUD_REGION]: 'string',
   [CLS]: 'double',
   [CLS_SOURCE_KEY]: 'string',
   [CODE_FILEPATH]: 'string',
@@ -12621,6 +12726,11 @@ export type AttributeName =
   | typeof CLOUDFLARE_D1_DURATION
   | typeof CLOUDFLARE_D1_ROWS_READ
   | typeof CLOUDFLARE_D1_ROWS_WRITTEN
+  | typeof CLOUD_ACCOUNT_ID
+  | typeof CLOUD_AVAILABILITY_ZONE
+  | typeof CLOUD_PLATFORM
+  | typeof CLOUD_PROVIDER
+  | typeof CLOUD_REGION
   | typeof CLS
   | typeof CLS_SOURCE_KEY
   | typeof CODE_FILEPATH
@@ -14400,6 +14510,56 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 12,
     sdks: ['javascript-cloudflare'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+  },
+  [CLOUD_ACCOUNT_ID]: {
+    brief: 'The cloud account ID the resource is assigned to',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: true,
+    example: '123456789012',
+    changelog: [{ version: 'next', prs: [363], description: 'Added cloud.account.id attribute' }],
+  },
+  [CLOUD_AVAILABILITY_ZONE]: {
+    brief: 'Cloud regions often have multiple, isolated locations known as zones to increase availability',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: true,
+    example: 'us-east-1c',
+    changelog: [{ version: 'next', prs: [363], description: 'Added cloud.availability_zone attribute' }],
+  },
+  [CLOUD_PLATFORM]: {
+    brief: 'The cloud platform in use',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: true,
+    example: 'aws_lambda',
+    changelog: [{ version: 'next', prs: [363], description: 'Added cloud.platform attribute' }],
+  },
+  [CLOUD_PROVIDER]: {
+    brief: 'Name of the cloud provider',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: true,
+    example: 'aws',
+    changelog: [{ version: 'next', prs: [363], description: 'Added cloud.provider attribute' }],
+  },
+  [CLOUD_REGION]: {
+    brief: 'The geographical region the resource is running',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: true,
+    example: 'us-east-1',
+    changelog: [{ version: 'next', prs: [363], description: 'Added cloud.region attribute' }],
   },
   [CLS]: {
     brief: 'The value of the recorded Cumulative Layout Shift (CLS) web vital',
@@ -20167,6 +20327,11 @@ export type Attributes = {
   [CLOUDFLARE_D1_DURATION]?: CLOUDFLARE_D1_DURATION_TYPE;
   [CLOUDFLARE_D1_ROWS_READ]?: CLOUDFLARE_D1_ROWS_READ_TYPE;
   [CLOUDFLARE_D1_ROWS_WRITTEN]?: CLOUDFLARE_D1_ROWS_WRITTEN_TYPE;
+  [CLOUD_ACCOUNT_ID]?: CLOUD_ACCOUNT_ID_TYPE;
+  [CLOUD_AVAILABILITY_ZONE]?: CLOUD_AVAILABILITY_ZONE_TYPE;
+  [CLOUD_PLATFORM]?: CLOUD_PLATFORM_TYPE;
+  [CLOUD_PROVIDER]?: CLOUD_PROVIDER_TYPE;
+  [CLOUD_REGION]?: CLOUD_REGION_TYPE;
   [CLS]?: CLS_TYPE;
   [CLS_SOURCE_KEY]?: CLS_SOURCE_KEY_TYPE;
   [CODE_FILEPATH]?: CODE_FILEPATH_TYPE;

--- a/model/attributes/cloud/cloud__account__id.json
+++ b/model/attributes/cloud/cloud__account__id.json
@@ -1,0 +1,17 @@
+{
+  "key": "cloud.account.id",
+  "brief": "The cloud account ID the resource is assigned to",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": "123456789012",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added cloud.account.id attribute"
+    }
+  ]
+}

--- a/model/attributes/cloud/cloud__account__id.json
+++ b/model/attributes/cloud/cloud__account__id.json
@@ -3,7 +3,7 @@
   "brief": "The cloud account ID the resource is assigned to",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": true,
   "example": "123456789012",

--- a/model/attributes/cloud/cloud__availability_zone.json
+++ b/model/attributes/cloud/cloud__availability_zone.json
@@ -3,7 +3,7 @@
   "brief": "Cloud regions often have multiple, isolated locations known as zones to increase availability",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": true,
   "example": "us-east-1c",

--- a/model/attributes/cloud/cloud__availability_zone.json
+++ b/model/attributes/cloud/cloud__availability_zone.json
@@ -1,0 +1,17 @@
+{
+  "key": "cloud.availability_zone",
+  "brief": "Cloud regions often have multiple, isolated locations known as zones to increase availability",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": "us-east-1c",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added cloud.availability_zone attribute"
+    }
+  ]
+}

--- a/model/attributes/cloud/cloud__platform.json
+++ b/model/attributes/cloud/cloud__platform.json
@@ -1,0 +1,17 @@
+{
+  "key": "cloud.platform",
+  "brief": "The cloud platform in use",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": "aws_lambda",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added cloud.platform attribute"
+    }
+  ]
+}

--- a/model/attributes/cloud/cloud__platform.json
+++ b/model/attributes/cloud/cloud__platform.json
@@ -3,7 +3,7 @@
   "brief": "The cloud platform in use",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": true,
   "example": "aws_lambda",

--- a/model/attributes/cloud/cloud__provider.json
+++ b/model/attributes/cloud/cloud__provider.json
@@ -3,7 +3,7 @@
   "brief": "Name of the cloud provider",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": true,
   "example": "aws",

--- a/model/attributes/cloud/cloud__provider.json
+++ b/model/attributes/cloud/cloud__provider.json
@@ -1,0 +1,17 @@
+{
+  "key": "cloud.provider",
+  "brief": "Name of the cloud provider",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": "aws",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added cloud.provider attribute"
+    }
+  ]
+}

--- a/model/attributes/cloud/cloud__region.json
+++ b/model/attributes/cloud/cloud__region.json
@@ -1,0 +1,17 @@
+{
+  "key": "cloud.region",
+  "brief": "The geographical region the resource is running",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": "us-east-1",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added cloud.region attribute"
+    }
+  ]
+}

--- a/model/attributes/cloud/cloud__region.json
+++ b/model/attributes/cloud/cloud__region.json
@@ -3,7 +3,7 @@
   "brief": "The geographical region the resource is running",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": true,
   "example": "us-east-1",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1337,6 +1337,58 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 5432
     """
 
+    # Path: model/attributes/cloud/cloud__account__id.json
+    CLOUD_ACCOUNT_ID: Literal["cloud.account.id"] = "cloud.account.id"
+    """The cloud account ID the resource is assigned to
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: Yes
+    Example: "123456789012"
+    """
+
+    # Path: model/attributes/cloud/cloud__availability_zone.json
+    CLOUD_AVAILABILITY_ZONE: Literal["cloud.availability_zone"] = (
+        "cloud.availability_zone"
+    )
+    """Cloud regions often have multiple, isolated locations known as zones to increase availability
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: Yes
+    Example: "us-east-1c"
+    """
+
+    # Path: model/attributes/cloud/cloud__platform.json
+    CLOUD_PLATFORM: Literal["cloud.platform"] = "cloud.platform"
+    """The cloud platform in use
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: Yes
+    Example: "aws_lambda"
+    """
+
+    # Path: model/attributes/cloud/cloud__provider.json
+    CLOUD_PROVIDER: Literal["cloud.provider"] = "cloud.provider"
+    """Name of the cloud provider
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: Yes
+    Example: "aws"
+    """
+
+    # Path: model/attributes/cloud/cloud__region.json
+    CLOUD_REGION: Literal["cloud.region"] = "cloud.region"
+    """The geographical region the resource is running
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: Yes
+    Example: "us-east-1"
+    """
+
     # Path: model/attributes/cloudflare/cloudflare__d1__duration.json
     CLOUDFLARE_D1_DURATION: Literal["cloudflare.d1.duration"] = "cloudflare.d1.duration"
     """The duration of a Cloudflare D1 operation.
@@ -8033,6 +8085,70 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "cloud.account.id": AttributeMetadata(
+        brief="The cloud account ID the resource is assigned to",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=True,
+        example="123456789012",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added cloud.account.id attribute",
+            ),
+        ],
+    ),
+    "cloud.availability_zone": AttributeMetadata(
+        brief="Cloud regions often have multiple, isolated locations known as zones to increase availability",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=True,
+        example="us-east-1c",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added cloud.availability_zone attribute",
+            ),
+        ],
+    ),
+    "cloud.platform": AttributeMetadata(
+        brief="The cloud platform in use",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=True,
+        example="aws_lambda",
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[363], description="Added cloud.platform attribute"
+            ),
+        ],
+    ),
+    "cloud.provider": AttributeMetadata(
+        brief="Name of the cloud provider",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=True,
+        example="aws",
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[363], description="Added cloud.provider attribute"
+            ),
+        ],
+    ),
+    "cloud.region": AttributeMetadata(
+        brief="The geographical region the resource is running",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=True,
+        example="us-east-1",
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[363], description="Added cloud.region attribute"
+            ),
+        ],
+    ),
     "cloudflare.d1.duration": AttributeMetadata(
         brief="The duration of a Cloudflare D1 operation.",
         type=AttributeType.INTEGER,
@@ -14027,6 +14143,11 @@ Attributes = TypedDict(
         "channel": str,
         "client.address": str,
         "client.port": int,
+        "cloud.account.id": str,
+        "cloud.availability_zone": str,
+        "cloud.platform": str,
+        "cloud.provider": str,
+        "cloud.region": str,
         "cloudflare.d1.duration": int,
         "cloudflare.d1.rows_read": int,
         "cloudflare.d1.rows_written": int,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1342,7 +1342,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The cloud account ID the resource is assigned to
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: Yes
     Example: "123456789012"
     """
@@ -1354,7 +1354,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """Cloud regions often have multiple, isolated locations known as zones to increase availability
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: Yes
     Example: "us-east-1c"
     """
@@ -1364,7 +1364,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The cloud platform in use
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: Yes
     Example: "aws_lambda"
     """
@@ -1374,7 +1374,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """Name of the cloud provider
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: Yes
     Example: "aws"
     """
@@ -1384,7 +1384,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The geographical region the resource is running
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: Yes
     Example: "us-east-1"
     """
@@ -8088,7 +8088,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "cloud.account.id": AttributeMetadata(
         brief="The cloud account ID the resource is assigned to",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         example="123456789012",
         changelog=[
@@ -8102,7 +8102,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "cloud.availability_zone": AttributeMetadata(
         brief="Cloud regions often have multiple, isolated locations known as zones to increase availability",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         example="us-east-1c",
         changelog=[
@@ -8116,7 +8116,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "cloud.platform": AttributeMetadata(
         brief="The cloud platform in use",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         example="aws_lambda",
         changelog=[
@@ -8128,7 +8128,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "cloud.provider": AttributeMetadata(
         brief="Name of the cloud provider",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         example="aws",
         changelog=[
@@ -8140,7 +8140,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "cloud.region": AttributeMetadata(
         brief="The geographical region the resource is running",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         example="us-east-1",
         changelog=[


### PR DESCRIPTION
## Summary
- Add OTel-aligned cloud resource attributes: `cloud.provider`, `cloud.account.id`, `cloud.region`, `cloud.availability_zone`, `cloud.platform`
- All marked `is_in_otel: true` per OTel resource semantic conventions
- Needed by the JS SDK (JS-2221) for span streaming