### PR TITLE
feat(attributes): Add `state.type` attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -10286,6 +10286,26 @@ export const SERVICE_VERSION = 'service.version';
  */
 export type SERVICE_VERSION_TYPE = string;
 
+// Path: model/attributes/state/state__type.json
+
+/**
+ * The type of state management library `state.type`
+ *
+ * Attribute Value Type: `string` {@link STATE_TYPE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "redux"
+ */
+export const STATE_TYPE = 'state.type';
+
+/**
+ * Type for {@link STATE_TYPE} state.type
+ */
+export type STATE_TYPE_TYPE = string;
+
 // Path: model/attributes/thread/thread__id.json
 
 /**
@@ -12444,6 +12464,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SERVER_PORT]: 'integer',
   [SERVICE_NAME]: 'string',
   [SERVICE_VERSION]: 'string',
+  [STATE_TYPE]: 'string',
   [THREAD_ID]: 'integer',
   [THREAD_NAME]: 'string',
   [TIMBER_TAG]: 'string',
@@ -13014,6 +13035,7 @@ export type AttributeName =
   | typeof SERVER_PORT
   | typeof SERVICE_NAME
   | typeof SERVICE_VERSION
+  | typeof STATE_TYPE
   | typeof THREAD_ID
   | typeof THREAD_NAME
   | typeof TIMBER_TAG
@@ -19193,6 +19215,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: [SENTRY_RELEASE],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
+  [STATE_TYPE]: {
+    brief: 'The type of state management library',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 'redux',
+    changelog: [{ version: 'next', prs: [363], description: 'Added state.type attribute' }],
+  },
   [THREAD_ID]: {
     brief: 'Current “managed” thread ID.',
     type: 'integer',
@@ -20560,6 +20592,7 @@ export type Attributes = {
   [SERVER_PORT]?: SERVER_PORT_TYPE;
   [SERVICE_NAME]?: SERVICE_NAME_TYPE;
   [SERVICE_VERSION]?: SERVICE_VERSION_TYPE;
+  [STATE_TYPE]?: STATE_TYPE_TYPE;
   [THREAD_ID]?: THREAD_ID_TYPE;
   [THREAD_NAME]?: THREAD_NAME_TYPE;
   [TIMBER_TAG]?: TIMBER_TAG_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -10293,7 +10293,7 @@ export type SERVICE_VERSION_TYPE = string;
  *
  * Attribute Value Type: `string` {@link STATE_TYPE_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -19219,7 +19219,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The type of state management library',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 'redux',

--- a/model/attributes/state/state__type.json
+++ b/model/attributes/state/state__type.json
@@ -1,0 +1,17 @@
+{
+  "key": "state.type",
+  "brief": "The type of state management library",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "redux",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added state.type attribute"
+    }
+  ]
+}

--- a/model/attributes/state/state__type.json
+++ b/model/attributes/state/state__type.json
@@ -3,7 +3,7 @@
   "brief": "The type of state management library",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": "redux",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5756,6 +5756,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "5.0.0"
     """
 
+    # Path: model/attributes/state/state__type.json
+    STATE_TYPE: Literal["state.type"] = "state.type"
+    """The type of state management library
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "redux"
+    """
+
     # Path: model/attributes/thread/thread__id.json
     THREAD_ID: Literal["thread.id"] = "thread.id"
     """Current “managed” thread ID.
@@ -13009,6 +13019,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "state.type": AttributeMetadata(
+        brief="The type of state management library",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="redux",
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[363], description="Added state.type attribute"
+            ),
+        ],
+    ),
     "thread.id": AttributeMetadata(
         brief="Current “managed” thread ID.",
         type=AttributeType.INTEGER,
@@ -14423,6 +14445,7 @@ Attributes = TypedDict(
         "server.port": int,
         "service.name": str,
         "service.version": str,
+        "state.type": str,
         "thread.id": int,
         "thread.name": str,
         "timber.tag": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5761,7 +5761,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The type of state management library
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: "redux"
     """
@@ -13022,7 +13022,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "state.type": AttributeMetadata(
         brief="The type of state management library",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="redux",
         changelog=[


### PR DESCRIPTION
## Summary
- Add `state.type` (string) attribute for identifying the state management library (e.g. "redux", "pinia")
- Needed by the JS SDK (JS-2221) for span streaming