### PR TITLE
feat(attributes): Add `missing_instrumentation.*` attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -7449,6 +7449,46 @@ export const MIDDLEWARE_NAME = 'middleware.name';
  */
 export type MIDDLEWARE_NAME_TYPE = string;
 
+// Path: model/attributes/missing_instrumentation/missing_instrumentation__javascript__is_cjs.json
+
+/**
+ * Whether the missing instrumentation is a CommonJS module `missing_instrumentation.javascript.is_cjs`
+ *
+ * Attribute Value Type: `boolean` {@link MISSING_INSTRUMENTATION_JAVASCRIPT_IS_CJS_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example true
+ */
+export const MISSING_INSTRUMENTATION_JAVASCRIPT_IS_CJS = 'missing_instrumentation.javascript.is_cjs';
+
+/**
+ * Type for {@link MISSING_INSTRUMENTATION_JAVASCRIPT_IS_CJS} missing_instrumentation.javascript.is_cjs
+ */
+export type MISSING_INSTRUMENTATION_JAVASCRIPT_IS_CJS_TYPE = boolean;
+
+// Path: model/attributes/missing_instrumentation/missing_instrumentation__package.json
+
+/**
+ * The package name of the missing instrumentation `missing_instrumentation.package`
+ *
+ * Attribute Value Type: `string` {@link MISSING_INSTRUMENTATION_PACKAGE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "express"
+ */
+export const MISSING_INSTRUMENTATION_PACKAGE = 'missing_instrumentation.package';
+
+/**
+ * Type for {@link MISSING_INSTRUMENTATION_PACKAGE} missing_instrumentation.package
+ */
+export type MISSING_INSTRUMENTATION_PACKAGE_TYPE = string;
+
 // Path: model/attributes/navigation/navigation__type.json
 
 /**
@@ -12308,6 +12348,8 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [MESSAGING_SYSTEM]: 'string',
   [METHOD]: 'string',
   [MIDDLEWARE_NAME]: 'string',
+  [MISSING_INSTRUMENTATION_JAVASCRIPT_IS_CJS]: 'boolean',
+  [MISSING_INSTRUMENTATION_PACKAGE]: 'string',
   [NAVIGATION_TYPE]: 'string',
   [NEL_ELAPSED_TIME]: 'integer',
   [NEL_PHASE]: 'string',
@@ -12878,6 +12920,8 @@ export type AttributeName =
   | typeof MESSAGING_SYSTEM
   | typeof METHOD
   | typeof MIDDLEWARE_NAME
+  | typeof MISSING_INSTRUMENTATION_JAVASCRIPT_IS_CJS
+  | typeof MISSING_INSTRUMENTATION_PACKAGE
   | typeof NAVIGATION_TYPE
   | typeof NEL_ELAPSED_TIME
   | typeof NEL_PHASE
@@ -17606,6 +17650,28 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     sdks: ['python'],
     changelog: [{ version: '0.6.0', prs: [336], description: 'Added middleware.name attribute' }],
   },
+  [MISSING_INSTRUMENTATION_JAVASCRIPT_IS_CJS]: {
+    brief: 'Whether the missing instrumentation is a CommonJS module',
+    type: 'boolean',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: true,
+    changelog: [
+      { version: 'next', prs: [363], description: 'Added missing_instrumentation.javascript.is_cjs attribute' },
+    ],
+  },
+  [MISSING_INSTRUMENTATION_PACKAGE]: {
+    brief: 'The package name of the missing instrumentation',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 'express',
+    changelog: [{ version: 'next', prs: [363], description: 'Added missing_instrumentation.package attribute' }],
+  },
   [NAVIGATION_TYPE]: {
     brief: 'The type of navigation done by a client-side router.',
     type: 'string',
@@ -20424,6 +20490,8 @@ export type Attributes = {
   [MESSAGING_SYSTEM]?: MESSAGING_SYSTEM_TYPE;
   [METHOD]?: METHOD_TYPE;
   [MIDDLEWARE_NAME]?: MIDDLEWARE_NAME_TYPE;
+  [MISSING_INSTRUMENTATION_JAVASCRIPT_IS_CJS]?: MISSING_INSTRUMENTATION_JAVASCRIPT_IS_CJS_TYPE;
+  [MISSING_INSTRUMENTATION_PACKAGE]?: MISSING_INSTRUMENTATION_PACKAGE_TYPE;
   [NAVIGATION_TYPE]?: NAVIGATION_TYPE_TYPE;
   [NEL_ELAPSED_TIME]?: NEL_ELAPSED_TIME_TYPE;
   [NEL_PHASE]?: NEL_PHASE_TYPE;

--- a/model/attributes/missing_instrumentation/missing_instrumentation__javascript__is_cjs.json
+++ b/model/attributes/missing_instrumentation/missing_instrumentation__javascript__is_cjs.json
@@ -1,0 +1,17 @@
+{
+  "key": "missing_instrumentation.javascript.is_cjs",
+  "brief": "Whether the missing instrumentation is a CommonJS module",
+  "type": "boolean",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": true,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added missing_instrumentation.javascript.is_cjs attribute"
+    }
+  ]
+}

--- a/model/attributes/missing_instrumentation/missing_instrumentation__package.json
+++ b/model/attributes/missing_instrumentation/missing_instrumentation__package.json
@@ -1,0 +1,17 @@
+{
+  "key": "missing_instrumentation.package",
+  "brief": "The package name of the missing instrumentation",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "express",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added missing_instrumentation.package attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4258,6 +4258,30 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "AuthenticationMiddleware"
     """
 
+    # Path: model/attributes/missing_instrumentation/missing_instrumentation__javascript__is_cjs.json
+    MISSING_INSTRUMENTATION_JAVASCRIPT_IS_CJS: Literal[
+        "missing_instrumentation.javascript.is_cjs"
+    ] = "missing_instrumentation.javascript.is_cjs"
+    """Whether the missing instrumentation is a CommonJS module
+
+    Type: bool
+    Contains PII: false
+    Defined in OTEL: No
+    Example: true
+    """
+
+    # Path: model/attributes/missing_instrumentation/missing_instrumentation__package.json
+    MISSING_INSTRUMENTATION_PACKAGE: Literal["missing_instrumentation.package"] = (
+        "missing_instrumentation.package"
+    )
+    """The package name of the missing instrumentation
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "express"
+    """
+
     # Path: model/attributes/navigation/navigation__type.json
     NAVIGATION_TYPE: Literal["navigation.type"] = "navigation.type"
     """The type of navigation done by a client-side router.
@@ -11373,6 +11397,34 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "missing_instrumentation.javascript.is_cjs": AttributeMetadata(
+        brief="Whether the missing instrumentation is a CommonJS module",
+        type=AttributeType.BOOLEAN,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example=True,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added missing_instrumentation.javascript.is_cjs attribute",
+            ),
+        ],
+    ),
+    "missing_instrumentation.package": AttributeMetadata(
+        brief="The package name of the missing instrumentation",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="express",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added missing_instrumentation.package attribute",
+            ),
+        ],
+    ),
     "navigation.type": AttributeMetadata(
         brief="The type of navigation done by a client-side router.",
         type=AttributeType.STRING,
@@ -14287,6 +14339,8 @@ Attributes = TypedDict(
         "messaging.system": str,
         "method": str,
         "middleware.name": str,
+        "missing_instrumentation.javascript.is_cjs": bool,
+        "missing_instrumentation.package": str,
         "navigation.type": str,
         "nel.elapsed_time": int,
         "nel.phase": str,


### PR DESCRIPTION
## Summary
- Add `missing_instrumentation.package` (string) — the name of the uninstrumented package
- Add `missing_instrumentation.javascript.is_cjs` (boolean) — whether the package was loaded as CommonJS
- Used by the JS SDK to detect missing OTel instrumentation packages, needed for span streaming (JS-2221)