### PR TITLE
feat(attributes): Add `angular.version` attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -733,6 +733,26 @@ export const AI_WARNINGS = 'ai.warnings';
  */
 export type AI_WARNINGS_TYPE = Array<string>;
 
+// Path: model/attributes/angular/angular__version.json
+
+/**
+ * The version of the Angular framework `angular.version`
+ *
+ * Attribute Value Type: `string` {@link ANGULAR_VERSION_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "17.1.0"
+ */
+export const ANGULAR_VERSION = 'angular.version';
+
+/**
+ * Type for {@link ANGULAR_VERSION} angular.version
+ */
+export type ANGULAR_VERSION_TYPE = string;
+
 // Path: model/attributes/app/app__app_build.json
 
 /**
@@ -11989,6 +12009,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [AI_TOTAL_COST]: 'double',
   [AI_TOTAL_TOKENS_USED]: 'integer',
   [AI_WARNINGS]: 'string[]',
+  [ANGULAR_VERSION]: 'string',
   [APP_APP_BUILD]: 'string',
   [APP_APP_IDENTIFIER]: 'string',
   [APP_APP_NAME]: 'string',
@@ -12559,6 +12580,7 @@ export type AttributeName =
   | typeof AI_TOTAL_COST
   | typeof AI_TOTAL_TOKENS_USED
   | typeof AI_WARNINGS
+  | typeof ANGULAR_VERSION
   | typeof APP_APP_BUILD
   | typeof APP_APP_IDENTIFIER
   | typeof APP_APP_NAME
@@ -13595,6 +13617,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: '0.5.0', prs: [264] },
       { version: '0.1.0', prs: [55] },
     ],
+  },
+  [ANGULAR_VERSION]: {
+    brief: 'The version of the Angular framework',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '17.1.0',
+    changelog: [{ version: 'next', prs: [363], description: 'Added angular.version attribute' }],
   },
   [APP_APP_BUILD]: {
     brief: 'Internal build identifier, as it appears on the platform.',
@@ -20105,6 +20137,7 @@ export type Attributes = {
   [AI_TOTAL_COST]?: AI_TOTAL_COST_TYPE;
   [AI_TOTAL_TOKENS_USED]?: AI_TOTAL_TOKENS_USED_TYPE;
   [AI_WARNINGS]?: AI_WARNINGS_TYPE;
+  [ANGULAR_VERSION]?: ANGULAR_VERSION_TYPE;
   [APP_APP_BUILD]?: APP_APP_BUILD_TYPE;
   [APP_APP_IDENTIFIER]?: APP_APP_IDENTIFIER_TYPE;
   [APP_APP_NAME]?: APP_APP_NAME_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -740,7 +740,7 @@ export type AI_WARNINGS_TYPE = Array<string>;
  *
  * Attribute Value Type: `string` {@link ANGULAR_VERSION_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -13622,7 +13622,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The version of the Angular framework',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: '17.1.0',

--- a/model/attributes/angular/angular__version.json
+++ b/model/attributes/angular/angular__version.json
@@ -1,0 +1,17 @@
+{
+  "key": "angular.version",
+  "brief": "The version of the Angular framework",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "17.1.0",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added angular.version attribute"
+    }
+  ]
+}

--- a/model/attributes/angular/angular__version.json
+++ b/model/attributes/angular/angular__version.json
@@ -3,7 +3,7 @@
   "brief": "The version of the Angular framework",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": "17.1.0",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -641,6 +641,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: ["Token limit exceeded"]
     """
 
+    # Path: model/attributes/angular/angular__version.json
+    ANGULAR_VERSION: Literal["angular.version"] = "angular.version"
+    """The version of the Angular framework
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "17.1.0"
+    """
+
     # Path: model/attributes/app/app__app_build.json
     APP_APP_BUILD: Literal["app.app_build"] = "app.app_build"
     """Internal build identifier, as it appears on the platform.
@@ -7056,6 +7066,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[264]),
             ChangelogEntry(version="0.1.0", prs=[55]),
+        ],
+    ),
+    "angular.version": AttributeMetadata(
+        brief="The version of the Angular framework",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="17.1.0",
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[363], description="Added angular.version attribute"
+            ),
         ],
     ),
     "app.app_build": AttributeMetadata(
@@ -13968,6 +13990,7 @@ Attributes = TypedDict(
         "ai.total_cost": float,
         "ai.total_tokens.used": int,
         "ai.warnings": List[str],
+        "angular.version": str,
         "app.app_build": str,
         "app.app_identifier": str,
         "app.app_name": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -646,7 +646,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The version of the Angular framework
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: "17.1.0"
     """
@@ -7071,7 +7071,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "angular.version": AttributeMetadata(
         brief="The version of the Angular framework",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="17.1.0",
         changelog=[


### PR DESCRIPTION
## Summary
- Add `angular.version` (string) attribute for recording the Angular framework version
- Needed by the JS SDK (JS-2221) for span streaming