### PR TITLE
feat(attributes): Add `react.version` attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8700,6 +8700,26 @@ export const QUERY_KEY = 'query.<key>';
  */
 export type QUERY_KEY_TYPE = string;
 
+// Path: model/attributes/react/react__version.json
+
+/**
+ * The version of the React framework `react.version`
+ *
+ * Attribute Value Type: `string` {@link REACT_VERSION_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "18.2.0"
+ */
+export const REACT_VERSION = 'react.version';
+
+/**
+ * Type for {@link REACT_VERSION} react.version
+ */
+export type REACT_VERSION_TYPE = string;
+
 // Path: model/attributes/release.json
 
 /**
@@ -12367,6 +12387,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [PROCESS_RUNTIME_NAME]: 'string',
   [PROCESS_RUNTIME_VERSION]: 'string',
   [QUERY_KEY]: 'string',
+  [REACT_VERSION]: 'string',
   [RELEASE]: 'string',
   [REMIX_ACTION_FORM_DATA_KEY]: 'string',
   [REPLAY_ID]: 'string',
@@ -12937,6 +12958,7 @@ export type AttributeName =
   | typeof PROCESS_RUNTIME_NAME
   | typeof PROCESS_RUNTIME_VERSION
   | typeof QUERY_KEY
+  | typeof REACT_VERSION
   | typeof RELEASE
   | typeof REMIX_ACTION_FORM_DATA_KEY
   | typeof REPLAY_ID
@@ -18330,6 +18352,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     changelog: [{ version: '0.1.0', prs: [103] }],
   },
+  [REACT_VERSION]: {
+    brief: 'The version of the React framework',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '18.2.0',
+    changelog: [{ version: 'next', prs: [363], description: 'Added react.version attribute' }],
+  },
   [RELEASE]: {
     brief: 'The sentry release.',
     type: 'string',
@@ -20483,6 +20515,7 @@ export type Attributes = {
   [PROCESS_RUNTIME_NAME]?: PROCESS_RUNTIME_NAME_TYPE;
   [PROCESS_RUNTIME_VERSION]?: PROCESS_RUNTIME_VERSION_TYPE;
   [QUERY_KEY]?: QUERY_KEY_TYPE;
+  [REACT_VERSION]?: REACT_VERSION_TYPE;
   [RELEASE]?: RELEASE_TYPE;
   [REMIX_ACTION_FORM_DATA_KEY]?: REMIX_ACTION_FORM_DATA_KEY_TYPE;
   [REPLAY_ID]?: REPLAY_ID_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8707,7 +8707,7 @@ export type QUERY_KEY_TYPE = string;
  *
  * Attribute Value Type: `string` {@link REACT_VERSION_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -18356,7 +18356,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The version of the React framework',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: '18.2.0',

--- a/model/attributes/react/react__version.json
+++ b/model/attributes/react/react__version.json
@@ -1,0 +1,17 @@
+{
+  "key": "react.version",
+  "brief": "The version of the React framework",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "18.2.0",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added react.version attribute"
+    }
+  ]
+}

--- a/model/attributes/react/react__version.json
+++ b/model/attributes/react/react__version.json
@@ -3,7 +3,7 @@
   "brief": "The version of the React framework",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": "18.2.0",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4918,7 +4918,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The version of the React framework
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: "18.2.0"
     """
@@ -12140,7 +12140,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "react.version": AttributeMetadata(
         brief="The version of the React framework",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="18.2.0",
         changelog=[

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4913,6 +4913,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "query.id='123'"
     """
 
+    # Path: model/attributes/react/react__version.json
+    REACT_VERSION: Literal["react.version"] = "react.version"
+    """The version of the React framework
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "18.2.0"
+    """
+
     # Path: model/attributes/release.json
     RELEASE: Literal["release"] = "release"
     """The sentry release.
@@ -12127,6 +12137,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[103]),
         ],
     ),
+    "react.version": AttributeMetadata(
+        brief="The version of the React framework",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="18.2.0",
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[363], description="Added react.version attribute"
+            ),
+        ],
+    ),
     "release": AttributeMetadata(
         brief="The sentry release.",
         type=AttributeType.STRING,
@@ -14346,6 +14368,7 @@ Attributes = TypedDict(
         "process.runtime.name": str,
         "process.runtime.version": str,
         "query.<key>": str,
+        "react.version": str,
         "release": str,
         "remix.action_form_data.<key>": str,
         "replay_id": str,


### PR DESCRIPTION
## Summary
- Add `react.version` (string) attribute for recording the React framework version
- Needed by the JS SDK (JS-2221) for span streaming