### PR TITLE
feat(attributes): Add `aws.lambda.*` and `aws.cloudwatch.logs.*` attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1292,7 +1292,7 @@ export type APP_VITALS_TTID_VALUE_TYPE = number;
  *
  * Attribute Value Type: `string` {@link AWS_CLOUDWATCH_LOGS_LOG_GROUP_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -1312,7 +1312,7 @@ export type AWS_CLOUDWATCH_LOGS_LOG_GROUP_TYPE = string;
  *
  * Attribute Value Type: `string` {@link AWS_CLOUDWATCH_LOGS_LOG_STREAM_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -1332,7 +1332,7 @@ export type AWS_CLOUDWATCH_LOGS_LOG_STREAM_TYPE = string;
  *
  * Attribute Value Type: `string` {@link AWS_CLOUDWATCH_LOGS_URL_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -1352,7 +1352,7 @@ export type AWS_CLOUDWATCH_LOGS_URL_TYPE = string;
  *
  * Attribute Value Type: `string` {@link AWS_LAMBDA_AWS_REQUEST_ID_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -1372,7 +1372,7 @@ export type AWS_LAMBDA_AWS_REQUEST_ID_TYPE = string;
  *
  * Attribute Value Type: `number` {@link AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -1392,7 +1392,7 @@ export type AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS_TYPE = number;
  *
  * Attribute Value Type: `string` {@link AWS_LAMBDA_FUNCTION_NAME_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -1412,7 +1412,7 @@ export type AWS_LAMBDA_FUNCTION_NAME_TYPE = string;
  *
  * Attribute Value Type: `string` {@link AWS_LAMBDA_FUNCTION_VERSION_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -1432,7 +1432,7 @@ export type AWS_LAMBDA_FUNCTION_VERSION_TYPE = string;
  *
  * Attribute Value Type: `string` {@link AWS_LAMBDA_INVOKED_FUNCTION_ARN_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -1452,7 +1452,7 @@ export type AWS_LAMBDA_INVOKED_FUNCTION_ARN_TYPE = string;
  *
  * Attribute Value Type: `number` {@link AWS_LAMBDA_REMAINING_TIME_IN_MILLIS_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -14177,7 +14177,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The name of the CloudWatch Logs log group',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: '/aws/lambda/my-function',
@@ -14187,7 +14187,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The name of the CloudWatch Logs log stream',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: '2024/01/01/[$LATEST]abcdef1234567890',
@@ -14197,7 +14197,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The URL to the CloudWatch Logs log group',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 'https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/my-log-group',
@@ -14207,7 +14207,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The AWS request ID as received by the Lambda function runtime',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: '8476a536-e9f4-11e8-9739-2dfe598c3fcd',
@@ -14217,7 +14217,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The execution duration of the Lambda function invocation in milliseconds',
     type: 'double',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 1234.56,
@@ -14229,7 +14229,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The name of the Lambda function',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 'my-function',
@@ -14239,7 +14239,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The version of the Lambda function',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: '$LATEST',
@@ -14249,7 +14249,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The full ARN of the Lambda function that was invoked',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 'arn:aws:lambda:us-east-1:123456789012:function:my-function',
@@ -14259,7 +14259,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The remaining time in milliseconds before the Lambda function times out',
     type: 'double',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 5000,

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1285,6 +1285,186 @@ export const APP_VITALS_TTID_VALUE = 'app.vitals.ttid.value';
  */
 export type APP_VITALS_TTID_VALUE_TYPE = number;
 
+// Path: model/attributes/aws/aws__cloudwatch__logs__log_group.json
+
+/**
+ * The name of the CloudWatch Logs log group `aws.cloudwatch.logs.log_group`
+ *
+ * Attribute Value Type: `string` {@link AWS_CLOUDWATCH_LOGS_LOG_GROUP_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "/aws/lambda/my-function"
+ */
+export const AWS_CLOUDWATCH_LOGS_LOG_GROUP = 'aws.cloudwatch.logs.log_group';
+
+/**
+ * Type for {@link AWS_CLOUDWATCH_LOGS_LOG_GROUP} aws.cloudwatch.logs.log_group
+ */
+export type AWS_CLOUDWATCH_LOGS_LOG_GROUP_TYPE = string;
+
+// Path: model/attributes/aws/aws__cloudwatch__logs__log_stream.json
+
+/**
+ * The name of the CloudWatch Logs log stream `aws.cloudwatch.logs.log_stream`
+ *
+ * Attribute Value Type: `string` {@link AWS_CLOUDWATCH_LOGS_LOG_STREAM_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "2024/01/01/[$LATEST]abcdef1234567890"
+ */
+export const AWS_CLOUDWATCH_LOGS_LOG_STREAM = 'aws.cloudwatch.logs.log_stream';
+
+/**
+ * Type for {@link AWS_CLOUDWATCH_LOGS_LOG_STREAM} aws.cloudwatch.logs.log_stream
+ */
+export type AWS_CLOUDWATCH_LOGS_LOG_STREAM_TYPE = string;
+
+// Path: model/attributes/aws/aws__cloudwatch__logs__url.json
+
+/**
+ * The URL to the CloudWatch Logs log group `aws.cloudwatch.logs.url`
+ *
+ * Attribute Value Type: `string` {@link AWS_CLOUDWATCH_LOGS_URL_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/my-log-group"
+ */
+export const AWS_CLOUDWATCH_LOGS_URL = 'aws.cloudwatch.logs.url';
+
+/**
+ * Type for {@link AWS_CLOUDWATCH_LOGS_URL} aws.cloudwatch.logs.url
+ */
+export type AWS_CLOUDWATCH_LOGS_URL_TYPE = string;
+
+// Path: model/attributes/aws/aws__lambda__aws_request_id.json
+
+/**
+ * The AWS request ID as received by the Lambda function runtime `aws.lambda.aws_request_id`
+ *
+ * Attribute Value Type: `string` {@link AWS_LAMBDA_AWS_REQUEST_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "8476a536-e9f4-11e8-9739-2dfe598c3fcd"
+ */
+export const AWS_LAMBDA_AWS_REQUEST_ID = 'aws.lambda.aws_request_id';
+
+/**
+ * Type for {@link AWS_LAMBDA_AWS_REQUEST_ID} aws.lambda.aws_request_id
+ */
+export type AWS_LAMBDA_AWS_REQUEST_ID_TYPE = string;
+
+// Path: model/attributes/aws/aws__lambda__execution_duration_in_millis.json
+
+/**
+ * The execution duration of the Lambda function invocation in milliseconds `aws.lambda.execution_duration_in_millis`
+ *
+ * Attribute Value Type: `number` {@link AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 1234.56
+ */
+export const AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS = 'aws.lambda.execution_duration_in_millis';
+
+/**
+ * Type for {@link AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS} aws.lambda.execution_duration_in_millis
+ */
+export type AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS_TYPE = number;
+
+// Path: model/attributes/aws/aws__lambda__function_name.json
+
+/**
+ * The name of the Lambda function `aws.lambda.function_name`
+ *
+ * Attribute Value Type: `string` {@link AWS_LAMBDA_FUNCTION_NAME_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "my-function"
+ */
+export const AWS_LAMBDA_FUNCTION_NAME = 'aws.lambda.function_name';
+
+/**
+ * Type for {@link AWS_LAMBDA_FUNCTION_NAME} aws.lambda.function_name
+ */
+export type AWS_LAMBDA_FUNCTION_NAME_TYPE = string;
+
+// Path: model/attributes/aws/aws__lambda__function_version.json
+
+/**
+ * The version of the Lambda function `aws.lambda.function_version`
+ *
+ * Attribute Value Type: `string` {@link AWS_LAMBDA_FUNCTION_VERSION_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "$LATEST"
+ */
+export const AWS_LAMBDA_FUNCTION_VERSION = 'aws.lambda.function_version';
+
+/**
+ * Type for {@link AWS_LAMBDA_FUNCTION_VERSION} aws.lambda.function_version
+ */
+export type AWS_LAMBDA_FUNCTION_VERSION_TYPE = string;
+
+// Path: model/attributes/aws/aws__lambda__invoked_function_arn.json
+
+/**
+ * The full ARN of the Lambda function that was invoked `aws.lambda.invoked_function_arn`
+ *
+ * Attribute Value Type: `string` {@link AWS_LAMBDA_INVOKED_FUNCTION_ARN_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "arn:aws:lambda:us-east-1:123456789012:function:my-function"
+ */
+export const AWS_LAMBDA_INVOKED_FUNCTION_ARN = 'aws.lambda.invoked_function_arn';
+
+/**
+ * Type for {@link AWS_LAMBDA_INVOKED_FUNCTION_ARN} aws.lambda.invoked_function_arn
+ */
+export type AWS_LAMBDA_INVOKED_FUNCTION_ARN_TYPE = string;
+
+// Path: model/attributes/aws/aws__lambda__remaining_time_in_millis.json
+
+/**
+ * The remaining time in milliseconds before the Lambda function times out `aws.lambda.remaining_time_in_millis`
+ *
+ * Attribute Value Type: `number` {@link AWS_LAMBDA_REMAINING_TIME_IN_MILLIS_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 5000
+ */
+export const AWS_LAMBDA_REMAINING_TIME_IN_MILLIS = 'aws.lambda.remaining_time_in_millis';
+
+/**
+ * Type for {@link AWS_LAMBDA_REMAINING_TIME_IN_MILLIS} aws.lambda.remaining_time_in_millis
+ */
+export type AWS_LAMBDA_REMAINING_TIME_IN_MILLIS_TYPE = number;
+
 // Path: model/attributes/blocked_main_thread.json
 
 /**
@@ -12014,6 +12194,15 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [APP_VITALS_START_WARM_VALUE]: 'double',
   [APP_VITALS_TTFD_VALUE]: 'double',
   [APP_VITALS_TTID_VALUE]: 'double',
+  [AWS_CLOUDWATCH_LOGS_LOG_GROUP]: 'string',
+  [AWS_CLOUDWATCH_LOGS_LOG_STREAM]: 'string',
+  [AWS_CLOUDWATCH_LOGS_URL]: 'string',
+  [AWS_LAMBDA_AWS_REQUEST_ID]: 'string',
+  [AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS]: 'double',
+  [AWS_LAMBDA_FUNCTION_NAME]: 'string',
+  [AWS_LAMBDA_FUNCTION_VERSION]: 'string',
+  [AWS_LAMBDA_INVOKED_FUNCTION_ARN]: 'string',
+  [AWS_LAMBDA_REMAINING_TIME_IN_MILLIS]: 'double',
   [BLOCKED_MAIN_THREAD]: 'boolean',
   [BROWSER_NAME]: 'string',
   [BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START]: 'double',
@@ -12584,6 +12773,15 @@ export type AttributeName =
   | typeof APP_VITALS_START_WARM_VALUE
   | typeof APP_VITALS_TTFD_VALUE
   | typeof APP_VITALS_TTID_VALUE
+  | typeof AWS_CLOUDWATCH_LOGS_LOG_GROUP
+  | typeof AWS_CLOUDWATCH_LOGS_LOG_STREAM
+  | typeof AWS_CLOUDWATCH_LOGS_URL
+  | typeof AWS_LAMBDA_AWS_REQUEST_ID
+  | typeof AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS
+  | typeof AWS_LAMBDA_FUNCTION_NAME
+  | typeof AWS_LAMBDA_FUNCTION_VERSION
+  | typeof AWS_LAMBDA_INVOKED_FUNCTION_ARN
+  | typeof AWS_LAMBDA_REMAINING_TIME_IN_MILLIS
   | typeof BLOCKED_MAIN_THREAD
   | typeof BROWSER_NAME
   | typeof BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START
@@ -13974,6 +14172,98 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: [TIME_TO_INITIAL_DISPLAY],
     sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: '0.5.0', prs: [313], description: 'Added app.vitals.ttid.value attribute' }],
+  },
+  [AWS_CLOUDWATCH_LOGS_LOG_GROUP]: {
+    brief: 'The name of the CloudWatch Logs log group',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '/aws/lambda/my-function',
+    changelog: [{ version: 'next', prs: [363], description: 'Added aws.cloudwatch.logs.log_group attribute' }],
+  },
+  [AWS_CLOUDWATCH_LOGS_LOG_STREAM]: {
+    brief: 'The name of the CloudWatch Logs log stream',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '2024/01/01/[$LATEST]abcdef1234567890',
+    changelog: [{ version: 'next', prs: [363], description: 'Added aws.cloudwatch.logs.log_stream attribute' }],
+  },
+  [AWS_CLOUDWATCH_LOGS_URL]: {
+    brief: 'The URL to the CloudWatch Logs log group',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 'https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/my-log-group',
+    changelog: [{ version: 'next', prs: [363], description: 'Added aws.cloudwatch.logs.url attribute' }],
+  },
+  [AWS_LAMBDA_AWS_REQUEST_ID]: {
+    brief: 'The AWS request ID as received by the Lambda function runtime',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '8476a536-e9f4-11e8-9739-2dfe598c3fcd',
+    changelog: [{ version: 'next', prs: [363], description: 'Added aws.lambda.aws_request_id attribute' }],
+  },
+  [AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS]: {
+    brief: 'The execution duration of the Lambda function invocation in milliseconds',
+    type: 'double',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 1234.56,
+    changelog: [
+      { version: 'next', prs: [363], description: 'Added aws.lambda.execution_duration_in_millis attribute' },
+    ],
+  },
+  [AWS_LAMBDA_FUNCTION_NAME]: {
+    brief: 'The name of the Lambda function',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 'my-function',
+    changelog: [{ version: 'next', prs: [363], description: 'Added aws.lambda.function_name attribute' }],
+  },
+  [AWS_LAMBDA_FUNCTION_VERSION]: {
+    brief: 'The version of the Lambda function',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '$LATEST',
+    changelog: [{ version: 'next', prs: [363], description: 'Added aws.lambda.function_version attribute' }],
+  },
+  [AWS_LAMBDA_INVOKED_FUNCTION_ARN]: {
+    brief: 'The full ARN of the Lambda function that was invoked',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 'arn:aws:lambda:us-east-1:123456789012:function:my-function',
+    changelog: [{ version: 'next', prs: [363], description: 'Added aws.lambda.invoked_function_arn attribute' }],
+  },
+  [AWS_LAMBDA_REMAINING_TIME_IN_MILLIS]: {
+    brief: 'The remaining time in milliseconds before the Lambda function times out',
+    type: 'double',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 5000,
+    changelog: [{ version: 'next', prs: [363], description: 'Added aws.lambda.remaining_time_in_millis attribute' }],
   },
   [BLOCKED_MAIN_THREAD]: {
     brief: 'Whether the main thread was blocked by the span.',
@@ -20130,6 +20420,15 @@ export type Attributes = {
   [APP_VITALS_START_WARM_VALUE]?: APP_VITALS_START_WARM_VALUE_TYPE;
   [APP_VITALS_TTFD_VALUE]?: APP_VITALS_TTFD_VALUE_TYPE;
   [APP_VITALS_TTID_VALUE]?: APP_VITALS_TTID_VALUE_TYPE;
+  [AWS_CLOUDWATCH_LOGS_LOG_GROUP]?: AWS_CLOUDWATCH_LOGS_LOG_GROUP_TYPE;
+  [AWS_CLOUDWATCH_LOGS_LOG_STREAM]?: AWS_CLOUDWATCH_LOGS_LOG_STREAM_TYPE;
+  [AWS_CLOUDWATCH_LOGS_URL]?: AWS_CLOUDWATCH_LOGS_URL_TYPE;
+  [AWS_LAMBDA_AWS_REQUEST_ID]?: AWS_LAMBDA_AWS_REQUEST_ID_TYPE;
+  [AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS]?: AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS_TYPE;
+  [AWS_LAMBDA_FUNCTION_NAME]?: AWS_LAMBDA_FUNCTION_NAME_TYPE;
+  [AWS_LAMBDA_FUNCTION_VERSION]?: AWS_LAMBDA_FUNCTION_VERSION_TYPE;
+  [AWS_LAMBDA_INVOKED_FUNCTION_ARN]?: AWS_LAMBDA_INVOKED_FUNCTION_ARN_TYPE;
+  [AWS_LAMBDA_REMAINING_TIME_IN_MILLIS]?: AWS_LAMBDA_REMAINING_TIME_IN_MILLIS_TYPE;
   [BLOCKED_MAIN_THREAD]?: BLOCKED_MAIN_THREAD_TYPE;
   [BROWSER_NAME]?: BROWSER_NAME_TYPE;
   [BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START]?: BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START_TYPE;

--- a/model/attributes/aws/aws__cloudwatch__logs__log_group.json
+++ b/model/attributes/aws/aws__cloudwatch__logs__log_group.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.cloudwatch.logs.log_group",
+  "brief": "The name of the CloudWatch Logs log group",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "/aws/lambda/my-function",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added aws.cloudwatch.logs.log_group attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__cloudwatch__logs__log_group.json
+++ b/model/attributes/aws/aws__cloudwatch__logs__log_group.json
@@ -3,7 +3,7 @@
   "brief": "The name of the CloudWatch Logs log group",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": "/aws/lambda/my-function",

--- a/model/attributes/aws/aws__cloudwatch__logs__log_stream.json
+++ b/model/attributes/aws/aws__cloudwatch__logs__log_stream.json
@@ -3,7 +3,7 @@
   "brief": "The name of the CloudWatch Logs log stream",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": "2024/01/01/[$LATEST]abcdef1234567890",

--- a/model/attributes/aws/aws__cloudwatch__logs__log_stream.json
+++ b/model/attributes/aws/aws__cloudwatch__logs__log_stream.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.cloudwatch.logs.log_stream",
+  "brief": "The name of the CloudWatch Logs log stream",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "2024/01/01/[$LATEST]abcdef1234567890",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added aws.cloudwatch.logs.log_stream attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__cloudwatch__logs__url.json
+++ b/model/attributes/aws/aws__cloudwatch__logs__url.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.cloudwatch.logs.url",
+  "brief": "The URL to the CloudWatch Logs log group",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/my-log-group",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added aws.cloudwatch.logs.url attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__cloudwatch__logs__url.json
+++ b/model/attributes/aws/aws__cloudwatch__logs__url.json
@@ -3,7 +3,7 @@
   "brief": "The URL to the CloudWatch Logs log group",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/my-log-group",

--- a/model/attributes/aws/aws__lambda__aws_request_id.json
+++ b/model/attributes/aws/aws__lambda__aws_request_id.json
@@ -3,7 +3,7 @@
   "brief": "The AWS request ID as received by the Lambda function runtime",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": "8476a536-e9f4-11e8-9739-2dfe598c3fcd",

--- a/model/attributes/aws/aws__lambda__aws_request_id.json
+++ b/model/attributes/aws/aws__lambda__aws_request_id.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.lambda.aws_request_id",
+  "brief": "The AWS request ID as received by the Lambda function runtime",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "8476a536-e9f4-11e8-9739-2dfe598c3fcd",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added aws.lambda.aws_request_id attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__lambda__execution_duration_in_millis.json
+++ b/model/attributes/aws/aws__lambda__execution_duration_in_millis.json
@@ -3,7 +3,7 @@
   "brief": "The execution duration of the Lambda function invocation in milliseconds",
   "type": "double",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": 1234.56,

--- a/model/attributes/aws/aws__lambda__execution_duration_in_millis.json
+++ b/model/attributes/aws/aws__lambda__execution_duration_in_millis.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.lambda.execution_duration_in_millis",
+  "brief": "The execution duration of the Lambda function invocation in milliseconds",
+  "type": "double",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": 1234.56,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added aws.lambda.execution_duration_in_millis attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__lambda__function_name.json
+++ b/model/attributes/aws/aws__lambda__function_name.json
@@ -3,7 +3,7 @@
   "brief": "The name of the Lambda function",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": "my-function",

--- a/model/attributes/aws/aws__lambda__function_name.json
+++ b/model/attributes/aws/aws__lambda__function_name.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.lambda.function_name",
+  "brief": "The name of the Lambda function",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "my-function",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added aws.lambda.function_name attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__lambda__function_version.json
+++ b/model/attributes/aws/aws__lambda__function_version.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.lambda.function_version",
+  "brief": "The version of the Lambda function",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "$LATEST",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added aws.lambda.function_version attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__lambda__function_version.json
+++ b/model/attributes/aws/aws__lambda__function_version.json
@@ -3,7 +3,7 @@
   "brief": "The version of the Lambda function",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": "$LATEST",

--- a/model/attributes/aws/aws__lambda__invoked_function_arn.json
+++ b/model/attributes/aws/aws__lambda__invoked_function_arn.json
@@ -3,7 +3,7 @@
   "brief": "The full ARN of the Lambda function that was invoked",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": "arn:aws:lambda:us-east-1:123456789012:function:my-function",

--- a/model/attributes/aws/aws__lambda__invoked_function_arn.json
+++ b/model/attributes/aws/aws__lambda__invoked_function_arn.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.lambda.invoked_function_arn",
+  "brief": "The full ARN of the Lambda function that was invoked",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "arn:aws:lambda:us-east-1:123456789012:function:my-function",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added aws.lambda.invoked_function_arn attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__lambda__remaining_time_in_millis.json
+++ b/model/attributes/aws/aws__lambda__remaining_time_in_millis.json
@@ -3,7 +3,7 @@
   "brief": "The remaining time in milliseconds before the Lambda function times out",
   "type": "double",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": 5000,

--- a/model/attributes/aws/aws__lambda__remaining_time_in_millis.json
+++ b/model/attributes/aws/aws__lambda__remaining_time_in_millis.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.lambda.remaining_time_in_millis",
+  "brief": "The remaining time in milliseconds before the Lambda function times out",
+  "type": "double",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": 5000,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added aws.lambda.remaining_time_in_millis attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -944,7 +944,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The name of the CloudWatch Logs log group
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: "/aws/lambda/my-function"
     """
@@ -956,7 +956,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The name of the CloudWatch Logs log stream
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: "2024/01/01/[$LATEST]abcdef1234567890"
     """
@@ -968,7 +968,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The URL to the CloudWatch Logs log group
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/my-log-group"
     """
@@ -980,7 +980,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The AWS request ID as received by the Lambda function runtime
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: "8476a536-e9f4-11e8-9739-2dfe598c3fcd"
     """
@@ -992,7 +992,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The execution duration of the Lambda function invocation in milliseconds
 
     Type: float
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: 1234.56
     """
@@ -1004,7 +1004,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The name of the Lambda function
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: "my-function"
     """
@@ -1016,7 +1016,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The version of the Lambda function
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: "$LATEST"
     """
@@ -1028,7 +1028,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The full ARN of the Lambda function that was invoked
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: "arn:aws:lambda:us-east-1:123456789012:function:my-function"
     """
@@ -1040,7 +1040,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The remaining time in milliseconds before the Lambda function times out
 
     Type: float
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: 5000
     """
@@ -7719,7 +7719,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "aws.cloudwatch.logs.log_group": AttributeMetadata(
         brief="The name of the CloudWatch Logs log group",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="/aws/lambda/my-function",
         changelog=[
@@ -7733,7 +7733,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "aws.cloudwatch.logs.log_stream": AttributeMetadata(
         brief="The name of the CloudWatch Logs log stream",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="2024/01/01/[$LATEST]abcdef1234567890",
         changelog=[
@@ -7747,7 +7747,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "aws.cloudwatch.logs.url": AttributeMetadata(
         brief="The URL to the CloudWatch Logs log group",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/my-log-group",
         changelog=[
@@ -7761,7 +7761,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "aws.lambda.aws_request_id": AttributeMetadata(
         brief="The AWS request ID as received by the Lambda function runtime",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="8476a536-e9f4-11e8-9739-2dfe598c3fcd",
         changelog=[
@@ -7775,7 +7775,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "aws.lambda.execution_duration_in_millis": AttributeMetadata(
         brief="The execution duration of the Lambda function invocation in milliseconds",
         type=AttributeType.DOUBLE,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=1234.56,
         changelog=[
@@ -7789,7 +7789,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "aws.lambda.function_name": AttributeMetadata(
         brief="The name of the Lambda function",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="my-function",
         changelog=[
@@ -7803,7 +7803,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "aws.lambda.function_version": AttributeMetadata(
         brief="The version of the Lambda function",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="$LATEST",
         changelog=[
@@ -7817,7 +7817,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "aws.lambda.invoked_function_arn": AttributeMetadata(
         brief="The full ARN of the Lambda function that was invoked",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="arn:aws:lambda:us-east-1:123456789012:function:my-function",
         changelog=[
@@ -7831,7 +7831,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "aws.lambda.remaining_time_in_millis": AttributeMetadata(
         brief="The remaining time in milliseconds before the Lambda function times out",
         type=AttributeType.DOUBLE,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=5000,
         changelog=[

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -937,6 +937,114 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 1234.56
     """
 
+    # Path: model/attributes/aws/aws__cloudwatch__logs__log_group.json
+    AWS_CLOUDWATCH_LOGS_LOG_GROUP: Literal["aws.cloudwatch.logs.log_group"] = (
+        "aws.cloudwatch.logs.log_group"
+    )
+    """The name of the CloudWatch Logs log group
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "/aws/lambda/my-function"
+    """
+
+    # Path: model/attributes/aws/aws__cloudwatch__logs__log_stream.json
+    AWS_CLOUDWATCH_LOGS_LOG_STREAM: Literal["aws.cloudwatch.logs.log_stream"] = (
+        "aws.cloudwatch.logs.log_stream"
+    )
+    """The name of the CloudWatch Logs log stream
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "2024/01/01/[$LATEST]abcdef1234567890"
+    """
+
+    # Path: model/attributes/aws/aws__cloudwatch__logs__url.json
+    AWS_CLOUDWATCH_LOGS_URL: Literal["aws.cloudwatch.logs.url"] = (
+        "aws.cloudwatch.logs.url"
+    )
+    """The URL to the CloudWatch Logs log group
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/my-log-group"
+    """
+
+    # Path: model/attributes/aws/aws__lambda__aws_request_id.json
+    AWS_LAMBDA_AWS_REQUEST_ID: Literal["aws.lambda.aws_request_id"] = (
+        "aws.lambda.aws_request_id"
+    )
+    """The AWS request ID as received by the Lambda function runtime
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "8476a536-e9f4-11e8-9739-2dfe598c3fcd"
+    """
+
+    # Path: model/attributes/aws/aws__lambda__execution_duration_in_millis.json
+    AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS: Literal[
+        "aws.lambda.execution_duration_in_millis"
+    ] = "aws.lambda.execution_duration_in_millis"
+    """The execution duration of the Lambda function invocation in milliseconds
+
+    Type: float
+    Contains PII: false
+    Defined in OTEL: No
+    Example: 1234.56
+    """
+
+    # Path: model/attributes/aws/aws__lambda__function_name.json
+    AWS_LAMBDA_FUNCTION_NAME: Literal["aws.lambda.function_name"] = (
+        "aws.lambda.function_name"
+    )
+    """The name of the Lambda function
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "my-function"
+    """
+
+    # Path: model/attributes/aws/aws__lambda__function_version.json
+    AWS_LAMBDA_FUNCTION_VERSION: Literal["aws.lambda.function_version"] = (
+        "aws.lambda.function_version"
+    )
+    """The version of the Lambda function
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "$LATEST"
+    """
+
+    # Path: model/attributes/aws/aws__lambda__invoked_function_arn.json
+    AWS_LAMBDA_INVOKED_FUNCTION_ARN: Literal["aws.lambda.invoked_function_arn"] = (
+        "aws.lambda.invoked_function_arn"
+    )
+    """The full ARN of the Lambda function that was invoked
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "arn:aws:lambda:us-east-1:123456789012:function:my-function"
+    """
+
+    # Path: model/attributes/aws/aws__lambda__remaining_time_in_millis.json
+    AWS_LAMBDA_REMAINING_TIME_IN_MILLIS: Literal[
+        "aws.lambda.remaining_time_in_millis"
+    ] = "aws.lambda.remaining_time_in_millis"
+    """The remaining time in milliseconds before the Lambda function times out
+
+    Type: float
+    Contains PII: false
+    Defined in OTEL: No
+    Example: 5000
+    """
+
     # Path: model/attributes/blocked_main_thread.json
     BLOCKED_MAIN_THREAD: Literal["blocked_main_thread"] = "blocked_main_thread"
     """Whether the main thread was blocked by the span.
@@ -7608,6 +7716,132 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "aws.cloudwatch.logs.log_group": AttributeMetadata(
+        brief="The name of the CloudWatch Logs log group",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="/aws/lambda/my-function",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added aws.cloudwatch.logs.log_group attribute",
+            ),
+        ],
+    ),
+    "aws.cloudwatch.logs.log_stream": AttributeMetadata(
+        brief="The name of the CloudWatch Logs log stream",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="2024/01/01/[$LATEST]abcdef1234567890",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added aws.cloudwatch.logs.log_stream attribute",
+            ),
+        ],
+    ),
+    "aws.cloudwatch.logs.url": AttributeMetadata(
+        brief="The URL to the CloudWatch Logs log group",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/my-log-group",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added aws.cloudwatch.logs.url attribute",
+            ),
+        ],
+    ),
+    "aws.lambda.aws_request_id": AttributeMetadata(
+        brief="The AWS request ID as received by the Lambda function runtime",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="8476a536-e9f4-11e8-9739-2dfe598c3fcd",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added aws.lambda.aws_request_id attribute",
+            ),
+        ],
+    ),
+    "aws.lambda.execution_duration_in_millis": AttributeMetadata(
+        brief="The execution duration of the Lambda function invocation in milliseconds",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example=1234.56,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added aws.lambda.execution_duration_in_millis attribute",
+            ),
+        ],
+    ),
+    "aws.lambda.function_name": AttributeMetadata(
+        brief="The name of the Lambda function",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="my-function",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added aws.lambda.function_name attribute",
+            ),
+        ],
+    ),
+    "aws.lambda.function_version": AttributeMetadata(
+        brief="The version of the Lambda function",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="$LATEST",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added aws.lambda.function_version attribute",
+            ),
+        ],
+    ),
+    "aws.lambda.invoked_function_arn": AttributeMetadata(
+        brief="The full ARN of the Lambda function that was invoked",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="arn:aws:lambda:us-east-1:123456789012:function:my-function",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added aws.lambda.invoked_function_arn attribute",
+            ),
+        ],
+    ),
+    "aws.lambda.remaining_time_in_millis": AttributeMetadata(
+        brief="The remaining time in milliseconds before the Lambda function times out",
+        type=AttributeType.DOUBLE,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example=5000,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added aws.lambda.remaining_time_in_millis attribute",
+            ),
+        ],
+    ),
     "blocked_main_thread": AttributeMetadata(
         brief="Whether the main thread was blocked by the span.",
         type=AttributeType.BOOLEAN,
@@ -13993,6 +14227,15 @@ Attributes = TypedDict(
         "app_start_cold": float,
         "app_start_type": str,
         "app_start_warm": float,
+        "aws.cloudwatch.logs.log_group": str,
+        "aws.cloudwatch.logs.log_stream": str,
+        "aws.cloudwatch.logs.url": str,
+        "aws.lambda.aws_request_id": str,
+        "aws.lambda.execution_duration_in_millis": float,
+        "aws.lambda.function_name": str,
+        "aws.lambda.function_version": str,
+        "aws.lambda.invoked_function_arn": str,
+        "aws.lambda.remaining_time_in_millis": float,
         "blocked_main_thread": bool,
         "browser.name": str,
         "browser.performance.navigation.activation_start": float,


### PR DESCRIPTION
## Summary
- Add 6 AWS Lambda attributes: `aws_request_id`, `function_name`, `function_version`, `invoked_function_arn`, `execution_duration_in_millis`, `remaining_time_in_millis`
- Add 3 AWS CloudWatch Logs attributes: `log_group`, `log_stream`, `url`
- Needed by the JS SDK (JS-2221) for span streaming