### PR TITLE
feat(attributes): Add `trpc.*` attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -10415,6 +10415,46 @@ export const TRANSACTION = 'transaction';
  */
 export type TRANSACTION_TYPE = string;
 
+// Path: model/attributes/trpc/trpc__procedure_path.json
+
+/**
+ * The path of the tRPC procedure being called `trpc.procedure_path`
+ *
+ * Attribute Value Type: `string` {@link TRPC_PROCEDURE_PATH_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "user.getById"
+ */
+export const TRPC_PROCEDURE_PATH = 'trpc.procedure_path';
+
+/**
+ * Type for {@link TRPC_PROCEDURE_PATH} trpc.procedure_path
+ */
+export type TRPC_PROCEDURE_PATH_TYPE = string;
+
+// Path: model/attributes/trpc/trpc__procedure_type.json
+
+/**
+ * The type of the tRPC procedure `trpc.procedure_type`
+ *
+ * Attribute Value Type: `string` {@link TRPC_PROCEDURE_TYPE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "query"
+ */
+export const TRPC_PROCEDURE_TYPE = 'trpc.procedure_type';
+
+/**
+ * Type for {@link TRPC_PROCEDURE_TYPE} trpc.procedure_type
+ */
+export type TRPC_PROCEDURE_TYPE_TYPE = string;
+
 // Path: model/attributes/ttfb.json
 
 /**
@@ -12450,6 +12490,8 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [TIME_TO_FULL_DISPLAY]: 'double',
   [TIME_TO_INITIAL_DISPLAY]: 'double',
   [TRANSACTION]: 'string',
+  [TRPC_PROCEDURE_PATH]: 'string',
+  [TRPC_PROCEDURE_TYPE]: 'string',
   [TTFB]: 'double',
   [TTFB_REQUESTTIME]: 'double',
   [TYPE]: 'string',
@@ -13020,6 +13062,8 @@ export type AttributeName =
   | typeof TIME_TO_FULL_DISPLAY
   | typeof TIME_TO_INITIAL_DISPLAY
   | typeof TRANSACTION
+  | typeof TRPC_PROCEDURE_PATH
+  | typeof TRPC_PROCEDURE_TYPE
   | typeof TTFB
   | typeof TTFB_REQUESTTIME
   | typeof TYPE
@@ -19284,6 +19328,26 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: '0.0.0' },
     ],
   },
+  [TRPC_PROCEDURE_PATH]: {
+    brief: 'The path of the tRPC procedure being called',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 'user.getById',
+    changelog: [{ version: 'next', prs: [363], description: 'Added trpc.procedure_path attribute' }],
+  },
+  [TRPC_PROCEDURE_TYPE]: {
+    brief: 'The type of the tRPC procedure',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 'query',
+    changelog: [{ version: 'next', prs: [363], description: 'Added trpc.procedure_type attribute' }],
+  },
   [TTFB]: {
     brief: 'The value of the recorded Time To First Byte (TTFB) web vital in milliseconds',
     type: 'double',
@@ -20566,6 +20630,8 @@ export type Attributes = {
   [TIME_TO_FULL_DISPLAY]?: TIME_TO_FULL_DISPLAY_TYPE;
   [TIME_TO_INITIAL_DISPLAY]?: TIME_TO_INITIAL_DISPLAY_TYPE;
   [TRANSACTION]?: TRANSACTION_TYPE;
+  [TRPC_PROCEDURE_PATH]?: TRPC_PROCEDURE_PATH_TYPE;
+  [TRPC_PROCEDURE_TYPE]?: TRPC_PROCEDURE_TYPE_TYPE;
   [TTFB]?: TTFB_TYPE;
   [TTFB_REQUESTTIME]?: TTFB_REQUESTTIME_TYPE;
   [TYPE]?: TYPE_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -10422,7 +10422,7 @@ export type TRANSACTION_TYPE = string;
  *
  * Attribute Value Type: `string` {@link TRPC_PROCEDURE_PATH_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -10442,7 +10442,7 @@ export type TRPC_PROCEDURE_PATH_TYPE = string;
  *
  * Attribute Value Type: `string` {@link TRPC_PROCEDURE_TYPE_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -19332,7 +19332,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The path of the tRPC procedure being called',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 'user.getById',
@@ -19342,7 +19342,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The type of the tRPC procedure',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: 'query',

--- a/model/attributes/trpc/trpc__procedure_path.json
+++ b/model/attributes/trpc/trpc__procedure_path.json
@@ -1,0 +1,17 @@
+{
+  "key": "trpc.procedure_path",
+  "brief": "The path of the tRPC procedure being called",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "user.getById",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added trpc.procedure_path attribute"
+    }
+  ]
+}

--- a/model/attributes/trpc/trpc__procedure_path.json
+++ b/model/attributes/trpc/trpc__procedure_path.json
@@ -3,7 +3,7 @@
   "brief": "The path of the tRPC procedure being called",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": "user.getById",

--- a/model/attributes/trpc/trpc__procedure_type.json
+++ b/model/attributes/trpc/trpc__procedure_type.json
@@ -1,0 +1,17 @@
+{
+  "key": "trpc.procedure_type",
+  "brief": "The type of the tRPC procedure",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "query",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [363],
+      "description": "Added trpc.procedure_type attribute"
+    }
+  ]
+}

--- a/model/attributes/trpc/trpc__procedure_type.json
+++ b/model/attributes/trpc/trpc__procedure_type.json
@@ -3,7 +3,7 @@
   "brief": "The type of the tRPC procedure",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": "query",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5829,7 +5829,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The path of the tRPC procedure being called
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: "user.getById"
     """
@@ -5839,7 +5839,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The type of the tRPC procedure
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Example: "query"
     """
@@ -13136,7 +13136,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "trpc.procedure_path": AttributeMetadata(
         brief="The path of the tRPC procedure being called",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="user.getById",
         changelog=[
@@ -13150,7 +13150,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "trpc.procedure_type": AttributeMetadata(
         brief="The type of the tRPC procedure",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example="query",
         changelog=[

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5824,6 +5824,26 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "GET /"
     """
 
+    # Path: model/attributes/trpc/trpc__procedure_path.json
+    TRPC_PROCEDURE_PATH: Literal["trpc.procedure_path"] = "trpc.procedure_path"
+    """The path of the tRPC procedure being called
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "user.getById"
+    """
+
+    # Path: model/attributes/trpc/trpc__procedure_type.json
+    TRPC_PROCEDURE_TYPE: Literal["trpc.procedure_type"] = "trpc.procedure_type"
+    """The type of the tRPC procedure
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "query"
+    """
+
     # Path: model/attributes/ttfb/ttfb__requestTime.json
     TTFB_REQUESTTIME: Literal["ttfb.requestTime"] = "ttfb.requestTime"
     """The time it takes for the server to process the initial request and send the first byte of a response to the user's browser
@@ -13113,6 +13133,34 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "trpc.procedure_path": AttributeMetadata(
+        brief="The path of the tRPC procedure being called",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="user.getById",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added trpc.procedure_path attribute",
+            ),
+        ],
+    ),
+    "trpc.procedure_type": AttributeMetadata(
+        brief="The type of the tRPC procedure",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="query",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[363],
+                description="Added trpc.procedure_type attribute",
+            ),
+        ],
+    ),
     "ttfb.requestTime": AttributeMetadata(
         brief="The time it takes for the server to process the initial request and send the first byte of a response to the user's browser",
         type=AttributeType.DOUBLE,
@@ -14429,6 +14477,8 @@ Attributes = TypedDict(
         "time_to_full_display": float,
         "time_to_initial_display": float,
         "transaction": str,
+        "trpc.procedure_path": str,
+        "trpc.procedure_type": str,
         "ttfb.requestTime": float,
         "ttfb": float,
         "type": str,


### PR DESCRIPTION
## Summary
- Add `trpc.procedure_path` (string) — the path of the tRPC procedure being called
- Add `trpc.procedure_type` (string) — the type of the tRPC procedure (e.g. "query", "mutation")
- Needed by the JS SDK (JS-2221) for span streaming