### PR TITLE
fix(attributes): Increase some PII values

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -495,7 +495,7 @@ export type AI_SEED_TYPE = string;
  *
  * Attribute Value Type: `boolean` {@link AI_STREAMING_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -6039,7 +6039,7 @@ export type HTTP_TARGET_TYPE = string;
  *
  * Attribute Value Type: `string` {@link HTTP_URL_TYPE}
  *
- * Contains PII: maybe
+ * Contains PII: true
  *
  * Attribute defined in OTEL: Yes
  *
@@ -10728,7 +10728,7 @@ export type UI_ELEMENT_WIDTH_TYPE = number;
  *
  * Attribute Value Type: `string` {@link URL_TYPE}
  *
- * Contains PII: maybe
+ * Contains PII: true
  *
  * Attribute defined in OTEL: No
  *
@@ -13427,7 +13427,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'Whether the request was streamed back.',
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: true,
@@ -16801,7 +16801,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The URL of the resource that was fetched.',
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'true',
     },
     isInOtel: true,
     example: 'https://example.com/test?foo=bar#buzz',
@@ -19461,7 +19461,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The URL of the resource that was fetched.',
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'true',
     },
     isInOtel: false,
     example: 'https://example.com/test?foo=bar#buzz',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4631,7 +4631,7 @@ export type GEN_AI_RESPONSE_MODEL_TYPE = string;
  *
  * Attribute Value Type: `boolean` {@link GEN_AI_RESPONSE_STREAMING_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  *
@@ -5364,7 +5364,7 @@ export type HTTP_METHOD_TYPE = string;
  *
  * Attribute Value Type: `string` {@link HTTP_QUERY_TYPE}
  *
- * Contains PII: maybe - Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.
+ * Contains PII: true - Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.
  *
  * Attribute defined in OTEL: No
  *
@@ -10293,7 +10293,7 @@ export type SERVICE_VERSION_TYPE = string;
  *
  * Attribute Value Type: `number` {@link THREAD_ID_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: Yes
  *
@@ -10791,7 +10791,7 @@ export type URL_FRAGMENT_TYPE = string;
  *
  * Attribute Value Type: `string` {@link URL_FULL_TYPE}
  *
- * Contains PII: maybe
+ * Contains PII: true
  *
  * Attribute defined in OTEL: Yes
  *
@@ -10877,7 +10877,7 @@ export type URL_PORT_TYPE = number;
  *
  * Attribute Value Type: `string` {@link URL_QUERY_TYPE}
  *
- * Contains PII: maybe - Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.
+ * Contains PII: true - Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.
  *
  * Attribute defined in OTEL: Yes
  *
@@ -15928,7 +15928,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: "Whether or not the AI model call's response was streamed back asynchronously",
     type: 'boolean',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     example: true,
@@ -16400,7 +16400,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       'The query string present in the URL. Note that this contains the leading ? character, while the `url.query` attribute does not.',
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'true',
       reason:
         'Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.',
     },
@@ -19197,7 +19197,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'Current “managed” thread ID.',
     type: 'integer',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: true,
     example: 56,
@@ -19498,7 +19498,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The URL of the resource that was fetched.',
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'true',
     },
     isInOtel: true,
     example: 'https://example.com/test?foo=bar#buzz',
@@ -19543,7 +19543,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       'The query string present in the URL. Note that this does not contain the leading ? character, while the `http.query` attribute does.',
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'true',
       reason:
         'Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.',
     },

--- a/model/attributes/ai/ai__streaming.json
+++ b/model/attributes/ai/ai__streaming.json
@@ -3,7 +3,7 @@
   "brief": "Whether the request was streamed back.",
   "type": "boolean",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": true,

--- a/model/attributes/gen_ai/gen_ai__response__streaming.json
+++ b/model/attributes/gen_ai/gen_ai__response__streaming.json
@@ -3,7 +3,7 @@
   "brief": "Whether or not the AI model call's response was streamed back asynchronously",
   "type": "boolean",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": true,

--- a/model/attributes/http/http__query.json
+++ b/model/attributes/http/http__query.json
@@ -3,7 +3,7 @@
   "brief": "The query string present in the URL. Note that this contains the leading ? character, while the `url.query` attribute does not.",
   "type": "string",
   "pii": {
-    "key": "maybe",
+    "key": "true",
     "reason": "Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information."
   },
   "is_in_otel": false,

--- a/model/attributes/http/http__url.json
+++ b/model/attributes/http/http__url.json
@@ -3,7 +3,7 @@
   "brief": "The URL of the resource that was fetched.",
   "type": "string",
   "pii": {
-    "key": "maybe"
+    "key": "true"
   },
   "is_in_otel": true,
   "example": "https://example.com/test?foo=bar#buzz",

--- a/model/attributes/thread/thread__id.json
+++ b/model/attributes/thread/thread__id.json
@@ -3,7 +3,7 @@
   "brief": "Current “managed” thread ID.",
   "type": "integer",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": true,
   "example": 56,

--- a/model/attributes/url.json
+++ b/model/attributes/url.json
@@ -3,7 +3,7 @@
   "brief": "The URL of the resource that was fetched.",
   "type": "string",
   "pii": {
-    "key": "maybe"
+    "key": "true"
   },
   "is_in_otel": false,
   "example": "https://example.com/test?foo=bar#buzz",

--- a/model/attributes/url/url__full.json
+++ b/model/attributes/url/url__full.json
@@ -3,7 +3,7 @@
   "brief": "The URL of the resource that was fetched.",
   "type": "string",
   "pii": {
-    "key": "maybe"
+    "key": "true"
   },
   "is_in_otel": true,
   "example": "https://example.com/test?foo=bar#buzz",

--- a/model/attributes/url/url__query.json
+++ b/model/attributes/url/url__query.json
@@ -3,7 +3,7 @@
   "brief": "The query string present in the URL. Note that this does not contain the leading ? character, while the `http.query` attribute does.",
   "type": "string",
   "pii": {
-    "key": "maybe",
+    "key": "true",
     "reason": "Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information."
   },
   "is_in_otel": true,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2716,7 +2716,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """Whether or not the AI model call's response was streamed back asynchronously
 
     Type: bool
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Aliases: ai.streaming
     Example: true
@@ -3124,7 +3124,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The query string present in the URL. Note that this contains the leading ? character, while the `url.query` attribute does not.
 
     Type: str
-    Contains PII: maybe - Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.
+    Contains PII: true - Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.
     Defined in OTEL: No
     Example: "?foo=bar&bar=baz"
     """
@@ -5761,7 +5761,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """Current “managed” thread ID.
 
     Type: int
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: Yes
     Example: 56
     """
@@ -6003,7 +6003,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The URL of the resource that was fetched.
 
     Type: str
-    Contains PII: maybe
+    Contains PII: true
     Defined in OTEL: Yes
     Aliases: http.url, url
     Example: "https://example.com/test?foo=bar#buzz"
@@ -6048,7 +6048,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The query string present in the URL. Note that this does not contain the leading ? character, while the `http.query` attribute does.
 
     Type: str
-    Contains PII: maybe - Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.
+    Contains PII: true - Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.
     Defined in OTEL: Yes
     Example: "foo=bar&bar=baz"
     """
@@ -9685,7 +9685,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "gen_ai.response.streaming": AttributeMetadata(
         brief="Whether or not the AI model call's response was streamed back asynchronously",
         type=AttributeType.BOOLEAN,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=True,
         aliases=["ai.streaming"],
@@ -10131,7 +10131,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="The query string present in the URL. Note that this contains the leading ? character, while the `url.query` attribute does not.",
         type=AttributeType.STRING,
         pii=PiiInfo(
-            isPii=IsPii.MAYBE,
+            isPii=IsPii.TRUE,
             reason="Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.",
         ),
         is_in_otel=False,
@@ -13012,7 +13012,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "thread.id": AttributeMetadata(
         brief="Current “managed” thread ID.",
         type=AttributeType.INTEGER,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         example=56,
         changelog=[
@@ -13344,7 +13344,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "url.full": AttributeMetadata(
         brief="The URL of the resource that was fetched.",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.MAYBE),
+        pii=PiiInfo(isPii=IsPii.TRUE),
         is_in_otel=True,
         example="https://example.com/test?foo=bar#buzz",
         aliases=["http.url", "url"],
@@ -13390,7 +13390,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="The query string present in the URL. Note that this does not contain the leading ? character, while the `http.query` attribute does.",
         type=AttributeType.STRING,
         pii=PiiInfo(
-            isPii=IsPii.MAYBE,
+            isPii=IsPii.TRUE,
             reason="Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.",
         ),
         is_in_otel=True,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -518,7 +518,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """Whether the request was streamed back.
 
     Type: bool
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Aliases: gen_ai.response.streaming
     DEPRECATED: Use gen_ai.response.streaming instead
@@ -3509,7 +3509,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The URL of the resource that was fetched.
 
     Type: str
-    Contains PII: maybe
+    Contains PII: true
     Defined in OTEL: Yes
     Aliases: url.full, url
     DEPRECATED: Use url.full instead
@@ -6080,7 +6080,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The URL of the resource that was fetched.
 
     Type: str
-    Contains PII: maybe
+    Contains PII: true
     Defined in OTEL: No
     Aliases: url.full, http.url
     DEPRECATED: Use url.full instead
@@ -6901,7 +6901,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "ai.streaming": AttributeMetadata(
         brief="Whether the request was streamed back.",
         type=AttributeType.BOOLEAN,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=True,
         deprecation=DeprecationInfo(
@@ -10547,7 +10547,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "http.url": AttributeMetadata(
         brief="The URL of the resource that was fetched.",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.MAYBE),
+        pii=PiiInfo(isPii=IsPii.TRUE),
         is_in_otel=True,
         example="https://example.com/test?foo=bar#buzz",
         deprecation=DeprecationInfo(replacement="url.full"),
@@ -13426,7 +13426,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "url": AttributeMetadata(
         brief="The URL of the resource that was fetched.",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.MAYBE),
+        pii=PiiInfo(isPii=IsPii.TRUE),
         is_in_otel=False,
         example="https://example.com/test?foo=bar#buzz",
         deprecation=DeprecationInfo(replacement="url.full"),

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -545,7 +545,7 @@
       "brief": "The URL of the resource that was fetched.",
       "type": "string",
       "pii": {
-        "key": "maybe"
+        "key": "true"
       },
       "is_in_otel": false,
       "example": "https://example.com/test?foo=bar#buzz",
@@ -1091,7 +1091,7 @@
       "brief": "Whether the request was streamed back.",
       "type": "boolean",
       "pii": {
-        "key": "false"
+        "key": "maybe"
       },
       "is_in_otel": false,
       "example": true,
@@ -2454,7 +2454,7 @@
       "brief": "The URL of the resource that was fetched.",
       "type": "string",
       "pii": {
-        "key": "maybe"
+        "key": "true"
       },
       "is_in_otel": true,
       "example": "https://example.com/test?foo=bar#buzz",


### PR DESCRIPTION
## Description
* There is no good reason `thread.id` and `gen_ai.response.streaming` should be excluded from PII.
* `http.query`, `url.query`, and `url.full` should be considered sensitive by default.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

Closes INGEST-918.
