### PR TITLE
fix(attributes): Correct PR references in attribute changelogs

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -14242,7 +14242,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: '17.1.0',
-    changelog: [{ version: 'next', prs: [363], description: 'Added angular.version attribute' }],
+    changelog: [{ version: 'next', prs: [367], description: 'Added angular.version attribute' }],
   },
   [APP_APP_BUILD]: {
     brief: 'Internal build identifier, as it appears on the platform.',
@@ -14631,7 +14631,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: '/aws/lambda/my-function',
-    changelog: [{ version: 'next', prs: [363], description: 'Added aws.cloudwatch.logs.log_group attribute' }],
+    changelog: [{ version: 'next', prs: [369], description: 'Added aws.cloudwatch.logs.log_group attribute' }],
   },
   [AWS_CLOUDWATCH_LOGS_LOG_STREAM]: {
     brief: 'The name of the CloudWatch Logs log stream',
@@ -14641,7 +14641,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: '2024/01/01/[$LATEST]abcdef1234567890',
-    changelog: [{ version: 'next', prs: [363], description: 'Added aws.cloudwatch.logs.log_stream attribute' }],
+    changelog: [{ version: 'next', prs: [369], description: 'Added aws.cloudwatch.logs.log_stream attribute' }],
   },
   [AWS_CLOUDWATCH_LOGS_URL]: {
     brief: 'The URL to the CloudWatch Logs log group',
@@ -14651,7 +14651,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 'https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/my-log-group',
-    changelog: [{ version: 'next', prs: [363], description: 'Added aws.cloudwatch.logs.url attribute' }],
+    changelog: [{ version: 'next', prs: [369], description: 'Added aws.cloudwatch.logs.url attribute' }],
   },
   [AWS_LAMBDA_AWS_REQUEST_ID]: {
     brief: 'The AWS request ID as received by the Lambda function runtime',
@@ -14661,7 +14661,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: '8476a536-e9f4-11e8-9739-2dfe598c3fcd',
-    changelog: [{ version: 'next', prs: [363], description: 'Added aws.lambda.aws_request_id attribute' }],
+    changelog: [{ version: 'next', prs: [369], description: 'Added aws.lambda.aws_request_id attribute' }],
   },
   [AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS]: {
     brief: 'The execution duration of the Lambda function invocation in milliseconds',
@@ -14672,7 +14672,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: 1234.56,
     changelog: [
-      { version: 'next', prs: [363], description: 'Added aws.lambda.execution_duration_in_millis attribute' },
+      { version: 'next', prs: [369], description: 'Added aws.lambda.execution_duration_in_millis attribute' },
     ],
   },
   [AWS_LAMBDA_FUNCTION_NAME]: {
@@ -14683,7 +14683,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 'my-function',
-    changelog: [{ version: 'next', prs: [363], description: 'Added aws.lambda.function_name attribute' }],
+    changelog: [{ version: 'next', prs: [369], description: 'Added aws.lambda.function_name attribute' }],
   },
   [AWS_LAMBDA_FUNCTION_VERSION]: {
     brief: 'The version of the Lambda function',
@@ -14693,7 +14693,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: '$LATEST',
-    changelog: [{ version: 'next', prs: [363], description: 'Added aws.lambda.function_version attribute' }],
+    changelog: [{ version: 'next', prs: [369], description: 'Added aws.lambda.function_version attribute' }],
   },
   [AWS_LAMBDA_INVOKED_FUNCTION_ARN]: {
     brief: 'The full ARN of the Lambda function that was invoked',
@@ -14703,7 +14703,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 'arn:aws:lambda:us-east-1:123456789012:function:my-function',
-    changelog: [{ version: 'next', prs: [363], description: 'Added aws.lambda.invoked_function_arn attribute' }],
+    changelog: [{ version: 'next', prs: [369], description: 'Added aws.lambda.invoked_function_arn attribute' }],
   },
   [AWS_LAMBDA_REMAINING_TIME_IN_MILLIS]: {
     brief: 'The remaining time in milliseconds before the Lambda function times out',
@@ -14713,7 +14713,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 5000,
-    changelog: [{ version: 'next', prs: [363], description: 'Added aws.lambda.remaining_time_in_millis attribute' }],
+    changelog: [{ version: 'next', prs: [369], description: 'Added aws.lambda.remaining_time_in_millis attribute' }],
   },
   [BLOCKED_MAIN_THREAD]: {
     brief: 'Whether the main thread was blocked by the span.',
@@ -15149,7 +15149,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: true,
     example: '123456789012',
-    changelog: [{ version: 'next', prs: [363], description: 'Added cloud.account.id attribute' }],
+    changelog: [{ version: 'next', prs: [364], description: 'Added cloud.account.id attribute' }],
   },
   [CLOUD_AVAILABILITY_ZONE]: {
     brief: 'Cloud regions often have multiple, isolated locations known as zones to increase availability',
@@ -15159,7 +15159,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: true,
     example: 'us-east-1c',
-    changelog: [{ version: 'next', prs: [363], description: 'Added cloud.availability_zone attribute' }],
+    changelog: [{ version: 'next', prs: [364], description: 'Added cloud.availability_zone attribute' }],
   },
   [CLOUD_PLATFORM]: {
     brief: 'The cloud platform in use',
@@ -15169,7 +15169,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: true,
     example: 'aws_lambda',
-    changelog: [{ version: 'next', prs: [363], description: 'Added cloud.platform attribute' }],
+    changelog: [{ version: 'next', prs: [364], description: 'Added cloud.platform attribute' }],
   },
   [CLOUD_PROVIDER]: {
     brief: 'Name of the cloud provider',
@@ -15179,7 +15179,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: true,
     example: 'aws',
-    changelog: [{ version: 'next', prs: [363], description: 'Added cloud.provider attribute' }],
+    changelog: [{ version: 'next', prs: [364], description: 'Added cloud.provider attribute' }],
   },
   [CLOUD_REGION]: {
     brief: 'The geographical region the resource is running',
@@ -15189,7 +15189,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: true,
     example: 'us-east-1',
-    changelog: [{ version: 'next', prs: [363], description: 'Added cloud.region attribute' }],
+    changelog: [{ version: 'next', prs: [364], description: 'Added cloud.region attribute' }],
   },
   [CLS]: {
     brief: 'The value of the recorded Cumulative Layout Shift (CLS) web vital',
@@ -19218,7 +19218,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: '18.2.0',
-    changelog: [{ version: 'next', prs: [363], description: 'Added react.version attribute' }],
+    changelog: [{ version: 'next', prs: [368], description: 'Added react.version attribute' }],
   },
   [RELEASE]: {
     brief: 'The sentry release.',
@@ -20102,7 +20102,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 'redux',
-    changelog: [{ version: 'next', prs: [363], description: 'Added state.type attribute' }],
+    changelog: [{ version: 'next', prs: [365], description: 'Added state.type attribute' }],
   },
   [THREAD_ID]: {
     brief: 'Current “managed” thread ID.',
@@ -20203,7 +20203,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 'user.getById',
-    changelog: [{ version: 'next', prs: [363], description: 'Added trpc.procedure_path attribute' }],
+    changelog: [{ version: 'next', prs: [370], description: 'Added trpc.procedure_path attribute' }],
   },
   [TRPC_PROCEDURE_TYPE]: {
     brief: 'The type of the tRPC procedure',
@@ -20213,7 +20213,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 'query',
-    changelog: [{ version: 'next', prs: [363], description: 'Added trpc.procedure_type attribute' }],
+    changelog: [{ version: 'next', prs: [370], description: 'Added trpc.procedure_type attribute' }],
   },
   [TTFB]: {
     brief: 'The value of the recorded Time To First Byte (TTFB) web vital in milliseconds',

--- a/model/attributes/angular/angular__version.json
+++ b/model/attributes/angular/angular__version.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [367],
       "description": "Added angular.version attribute"
     }
   ]

--- a/model/attributes/aws/aws__cloudwatch__logs__log_group.json
+++ b/model/attributes/aws/aws__cloudwatch__logs__log_group.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [369],
       "description": "Added aws.cloudwatch.logs.log_group attribute"
     }
   ]

--- a/model/attributes/aws/aws__cloudwatch__logs__log_stream.json
+++ b/model/attributes/aws/aws__cloudwatch__logs__log_stream.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [369],
       "description": "Added aws.cloudwatch.logs.log_stream attribute"
     }
   ]

--- a/model/attributes/aws/aws__cloudwatch__logs__url.json
+++ b/model/attributes/aws/aws__cloudwatch__logs__url.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [369],
       "description": "Added aws.cloudwatch.logs.url attribute"
     }
   ]

--- a/model/attributes/aws/aws__lambda__aws_request_id.json
+++ b/model/attributes/aws/aws__lambda__aws_request_id.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [369],
       "description": "Added aws.lambda.aws_request_id attribute"
     }
   ]

--- a/model/attributes/aws/aws__lambda__execution_duration_in_millis.json
+++ b/model/attributes/aws/aws__lambda__execution_duration_in_millis.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [369],
       "description": "Added aws.lambda.execution_duration_in_millis attribute"
     }
   ]

--- a/model/attributes/aws/aws__lambda__function_name.json
+++ b/model/attributes/aws/aws__lambda__function_name.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [369],
       "description": "Added aws.lambda.function_name attribute"
     }
   ]

--- a/model/attributes/aws/aws__lambda__function_version.json
+++ b/model/attributes/aws/aws__lambda__function_version.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [369],
       "description": "Added aws.lambda.function_version attribute"
     }
   ]

--- a/model/attributes/aws/aws__lambda__invoked_function_arn.json
+++ b/model/attributes/aws/aws__lambda__invoked_function_arn.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [369],
       "description": "Added aws.lambda.invoked_function_arn attribute"
     }
   ]

--- a/model/attributes/aws/aws__lambda__remaining_time_in_millis.json
+++ b/model/attributes/aws/aws__lambda__remaining_time_in_millis.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [369],
       "description": "Added aws.lambda.remaining_time_in_millis attribute"
     }
   ]

--- a/model/attributes/cloud/cloud__account__id.json
+++ b/model/attributes/cloud/cloud__account__id.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [364],
       "description": "Added cloud.account.id attribute"
     }
   ]

--- a/model/attributes/cloud/cloud__availability_zone.json
+++ b/model/attributes/cloud/cloud__availability_zone.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [364],
       "description": "Added cloud.availability_zone attribute"
     }
   ]

--- a/model/attributes/cloud/cloud__platform.json
+++ b/model/attributes/cloud/cloud__platform.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [364],
       "description": "Added cloud.platform attribute"
     }
   ]

--- a/model/attributes/cloud/cloud__provider.json
+++ b/model/attributes/cloud/cloud__provider.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [364],
       "description": "Added cloud.provider attribute"
     }
   ]

--- a/model/attributes/cloud/cloud__region.json
+++ b/model/attributes/cloud/cloud__region.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [364],
       "description": "Added cloud.region attribute"
     }
   ]

--- a/model/attributes/react/react__version.json
+++ b/model/attributes/react/react__version.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [368],
       "description": "Added react.version attribute"
     }
   ]

--- a/model/attributes/state/state__type.json
+++ b/model/attributes/state/state__type.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [365],
       "description": "Added state.type attribute"
     }
   ]

--- a/model/attributes/trpc/trpc__procedure_path.json
+++ b/model/attributes/trpc/trpc__procedure_path.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [370],
       "description": "Added trpc.procedure_path attribute"
     }
   ]

--- a/model/attributes/trpc/trpc__procedure_type.json
+++ b/model/attributes/trpc/trpc__procedure_type.json
@@ -10,7 +10,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [363],
+      "prs": [370],
       "description": "Added trpc.procedure_type attribute"
     }
   ]

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -7394,7 +7394,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="17.1.0",
         changelog=[
             ChangelogEntry(
-                version="next", prs=[363], description="Added angular.version attribute"
+                version="next", prs=[367], description="Added angular.version attribute"
             ),
         ],
     ),
@@ -7957,7 +7957,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[363],
+                prs=[369],
                 description="Added aws.cloudwatch.logs.log_group attribute",
             ),
         ],
@@ -7971,7 +7971,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[363],
+                prs=[369],
                 description="Added aws.cloudwatch.logs.log_stream attribute",
             ),
         ],
@@ -7985,7 +7985,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[363],
+                prs=[369],
                 description="Added aws.cloudwatch.logs.url attribute",
             ),
         ],
@@ -7999,7 +7999,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[363],
+                prs=[369],
                 description="Added aws.lambda.aws_request_id attribute",
             ),
         ],
@@ -8013,7 +8013,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[363],
+                prs=[369],
                 description="Added aws.lambda.execution_duration_in_millis attribute",
             ),
         ],
@@ -8027,7 +8027,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[363],
+                prs=[369],
                 description="Added aws.lambda.function_name attribute",
             ),
         ],
@@ -8041,7 +8041,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[363],
+                prs=[369],
                 description="Added aws.lambda.function_version attribute",
             ),
         ],
@@ -8055,7 +8055,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[363],
+                prs=[369],
                 description="Added aws.lambda.invoked_function_arn attribute",
             ),
         ],
@@ -8069,7 +8069,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[363],
+                prs=[369],
                 description="Added aws.lambda.remaining_time_in_millis attribute",
             ),
         ],
@@ -8508,7 +8508,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[363],
+                prs=[364],
                 description="Added cloud.account.id attribute",
             ),
         ],
@@ -8522,7 +8522,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[363],
+                prs=[364],
                 description="Added cloud.availability_zone attribute",
             ),
         ],
@@ -8535,7 +8535,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="aws_lambda",
         changelog=[
             ChangelogEntry(
-                version="next", prs=[363], description="Added cloud.platform attribute"
+                version="next", prs=[364], description="Added cloud.platform attribute"
             ),
         ],
     ),
@@ -8547,7 +8547,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="aws",
         changelog=[
             ChangelogEntry(
-                version="next", prs=[363], description="Added cloud.provider attribute"
+                version="next", prs=[364], description="Added cloud.provider attribute"
             ),
         ],
     ),
@@ -8559,7 +8559,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="us-east-1",
         changelog=[
             ChangelogEntry(
-                version="next", prs=[363], description="Added cloud.region attribute"
+                version="next", prs=[364], description="Added cloud.region attribute"
             ),
         ],
     ),
@@ -12791,7 +12791,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="18.2.0",
         changelog=[
             ChangelogEntry(
-                version="next", prs=[363], description="Added react.version attribute"
+                version="next", prs=[368], description="Added react.version attribute"
             ),
         ],
     ),
@@ -13699,7 +13699,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="redux",
         changelog=[
             ChangelogEntry(
-                version="next", prs=[363], description="Added state.type attribute"
+                version="next", prs=[365], description="Added state.type attribute"
             ),
         ],
     ),
@@ -13816,7 +13816,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[363],
+                prs=[370],
                 description="Added trpc.procedure_path attribute",
             ),
         ],
@@ -13830,7 +13830,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[363],
+                prs=[370],
                 description="Added trpc.procedure_type attribute",
             ),
         ],


### PR DESCRIPTION
## Summary
- Fix incorrect `prs` references in changelog entries for recently added span attributes
- All attributes were created in a batch and got the same auto-generated PR number (363) instead of their actual PR numbers: cloud→364, state→365, angular→367, react→368, aws→369, trpc→370