### PR TITLE
feat(attributes): Add several deprecated measurements attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1100,7 +1100,7 @@ export type APP_VITALS_FRAMES_DELAY_VALUE_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * Aliases: {@link FRAMES_FROZEN} `frames.frozen`
+ * Aliases: {@link FRAMES_FROZEN} `frames.frozen`, {@link _FRAMES_FROZEN} `frames_frozen`
  *
  * @example 3
  */
@@ -1122,7 +1122,7 @@ export type APP_VITALS_FRAMES_FROZEN_COUNT_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * Aliases: {@link FRAMES_SLOW} `frames.slow`
+ * Aliases: {@link FRAMES_SLOW} `frames.slow`, {@link _FRAMES_SLOW} `frames_slow`
  *
  * @example 1
  */
@@ -1144,7 +1144,7 @@ export type APP_VITALS_FRAMES_SLOW_COUNT_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * Aliases: {@link FRAMES_TOTAL} `frames.total`
+ * Aliases: {@link FRAMES_TOTAL} `frames.total`, {@link _FRAMES_TOTAL} `frames_total`
  *
  * @example 60
  */
@@ -4234,7 +4234,7 @@ export type FRAMES_DELAY_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * Aliases: {@link APP_VITALS_FRAMES_FROZEN_COUNT} `app.vitals.frames.frozen.count`
+ * Aliases: {@link APP_VITALS_FRAMES_FROZEN_COUNT} `app.vitals.frames.frozen.count`, {@link _FRAMES_FROZEN} `frames_frozen`
  *
  * @deprecated Use {@link APP_VITALS_FRAMES_FROZEN_COUNT} (app.vitals.frames.frozen.count) instead - Replaced by app.vitals.frames.frozen.count to align with the app.vitals.* namespace for mobile performance attributes
  * @example 3
@@ -4245,6 +4245,29 @@ export const FRAMES_FROZEN = 'frames.frozen';
  * Type for {@link FRAMES_FROZEN} frames.frozen
  */
 export type FRAMES_FROZEN_TYPE = number;
+
+// Path: model/attributes/frames_frozen.json
+
+/**
+ * The number of frozen frames rendered during the lifetime of the span. `frames_frozen`
+ *
+ * Attribute Value Type: `number` {@link _FRAMES_FROZEN_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Aliases: {@link APP_VITALS_FRAMES_FROZEN_COUNT} `app.vitals.frames.frozen.count`, {@link FRAMES_FROZEN} `frames.frozen`
+ *
+ * @deprecated Use {@link APP_VITALS_FRAMES_FROZEN_COUNT} (app.vitals.frames.frozen.count) instead - Replaced by app.vitals.frames.frozen.count to align with the app.vitals.* namespace for mobile performance attributes
+ * @example 3
+ */
+export const _FRAMES_FROZEN = 'frames_frozen';
+
+/**
+ * Type for {@link _FRAMES_FROZEN} frames_frozen
+ */
+export type _FRAMES_FROZEN_TYPE = number;
 
 // Path: model/attributes/frames_frozen_rate.json
 
@@ -4275,7 +4298,7 @@ export type FRAMES_FROZEN_RATE_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * Aliases: {@link APP_VITALS_FRAMES_SLOW_COUNT} `app.vitals.frames.slow.count`
+ * Aliases: {@link APP_VITALS_FRAMES_SLOW_COUNT} `app.vitals.frames.slow.count`, {@link _FRAMES_SLOW} `frames_slow`
  *
  * @deprecated Use {@link APP_VITALS_FRAMES_SLOW_COUNT} (app.vitals.frames.slow.count) instead - Replaced by app.vitals.frames.slow.count to align with the app.vitals.* namespace for mobile performance attributes
  * @example 1
@@ -4286,6 +4309,29 @@ export const FRAMES_SLOW = 'frames.slow';
  * Type for {@link FRAMES_SLOW} frames.slow
  */
 export type FRAMES_SLOW_TYPE = number;
+
+// Path: model/attributes/frames_slow.json
+
+/**
+ * The number of slow frames rendered during the lifetime of the span. `frames_slow`
+ *
+ * Attribute Value Type: `number` {@link _FRAMES_SLOW_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Aliases: {@link APP_VITALS_FRAMES_SLOW_COUNT} `app.vitals.frames.slow.count`, {@link FRAMES_SLOW} `frames.slow`
+ *
+ * @deprecated Use {@link APP_VITALS_FRAMES_SLOW_COUNT} (app.vitals.frames.slow.count) instead - Replaced by app.vitals.frames.slow.count to align with the app.vitals.* namespace for mobile performance attributes
+ * @example 1
+ */
+export const _FRAMES_SLOW = 'frames_slow';
+
+/**
+ * Type for {@link _FRAMES_SLOW} frames_slow
+ */
+export type _FRAMES_SLOW_TYPE = number;
 
 // Path: model/attributes/frames_slow_rate.json
 
@@ -4316,7 +4362,7 @@ export type FRAMES_SLOW_RATE_TYPE = number;
  *
  * Attribute defined in OTEL: No
  *
- * Aliases: {@link APP_VITALS_FRAMES_TOTAL_COUNT} `app.vitals.frames.total.count`
+ * Aliases: {@link APP_VITALS_FRAMES_TOTAL_COUNT} `app.vitals.frames.total.count`, {@link _FRAMES_TOTAL} `frames_total`
  *
  * @deprecated Use {@link APP_VITALS_FRAMES_TOTAL_COUNT} (app.vitals.frames.total.count) instead - Replaced by app.vitals.frames.total.count to align with the app.vitals.* namespace for mobile performance attributes
  * @example 60
@@ -4327,6 +4373,29 @@ export const FRAMES_TOTAL = 'frames.total';
  * Type for {@link FRAMES_TOTAL} frames.total
  */
 export type FRAMES_TOTAL_TYPE = number;
+
+// Path: model/attributes/frames_total.json
+
+/**
+ * The number of total frames rendered during the lifetime of the span. `frames_total`
+ *
+ * Attribute Value Type: `number` {@link _FRAMES_TOTAL_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ *
+ * Aliases: {@link APP_VITALS_FRAMES_TOTAL_COUNT} `app.vitals.frames.total.count`, {@link FRAMES_TOTAL} `frames.total`
+ *
+ * @deprecated Use {@link APP_VITALS_FRAMES_TOTAL_COUNT} (app.vitals.frames.total.count) instead - Replaced by app.vitals.frames.total.count to align with the app.vitals.* namespace for mobile performance attributes
+ * @example 60
+ */
+export const _FRAMES_TOTAL = 'frames_total';
+
+/**
+ * Type for {@link _FRAMES_TOTAL} frames_total
+ */
+export type _FRAMES_TOTAL_TYPE = number;
 
 // Path: model/attributes/fs_error.json
 
@@ -12808,10 +12877,13 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [FP]: 'double',
   [FRAMES_DELAY]: 'integer',
   [FRAMES_FROZEN]: 'integer',
+  [_FRAMES_FROZEN]: 'integer',
   [FRAMES_FROZEN_RATE]: 'double',
   [FRAMES_SLOW]: 'integer',
+  [_FRAMES_SLOW]: 'integer',
   [FRAMES_SLOW_RATE]: 'double',
   [FRAMES_TOTAL]: 'integer',
+  [_FRAMES_TOTAL]: 'integer',
   [FS_ERROR]: 'string',
   [GCP_FUNCTION_CONTEXT_EVENT_ID]: 'string',
   [GCP_FUNCTION_CONTEXT_EVENT_TYPE]: 'string',
@@ -13411,10 +13483,13 @@ export type AttributeName =
   | typeof FP
   | typeof FRAMES_DELAY
   | typeof FRAMES_FROZEN
+  | typeof _FRAMES_FROZEN
   | typeof FRAMES_FROZEN_RATE
   | typeof FRAMES_SLOW
+  | typeof _FRAMES_SLOW
   | typeof FRAMES_SLOW_RATE
   | typeof FRAMES_TOTAL
+  | typeof _FRAMES_TOTAL
   | typeof FS_ERROR
   | typeof GCP_FUNCTION_CONTEXT_EVENT_ID
   | typeof GCP_FUNCTION_CONTEXT_EVENT_TYPE
@@ -14574,7 +14649,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 3,
-    aliases: [FRAMES_FROZEN],
+    aliases: [FRAMES_FROZEN, _FRAMES_FROZEN],
     sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       { version: '0.5.0', prs: [313], description: 'Added app.vitals.frames.frozen.count to replace frames.frozen' },
@@ -14588,7 +14663,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 1,
-    aliases: [FRAMES_SLOW],
+    aliases: [FRAMES_SLOW, _FRAMES_SLOW],
     sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       { version: '0.5.0', prs: [313], description: 'Added app.vitals.frames.slow.count to replace frames.slow' },
@@ -14602,7 +14677,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     example: 60,
-    aliases: [FRAMES_TOTAL],
+    aliases: [FRAMES_TOTAL, _FRAMES_TOTAL],
     sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       { version: '0.5.0', prs: [313], description: 'Added app.vitals.frames.total.count to replace frames.total' },
@@ -16360,12 +16435,27 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason:
         'Replaced by app.vitals.frames.frozen.count to align with the app.vitals.* namespace for mobile performance attributes',
     },
-    aliases: [APP_VITALS_FRAMES_FROZEN_COUNT],
+    aliases: [APP_VITALS_FRAMES_FROZEN_COUNT, _FRAMES_FROZEN],
     changelog: [
       { version: '0.5.0', prs: [313], description: 'Deprecated in favor of app.vitals.frames.frozen.count' },
       { version: '0.4.0', prs: [228] },
       { version: '0.0.0' },
     ],
+  },
+  [_FRAMES_FROZEN]: {
+    brief: 'The number of frozen frames rendered during the lifetime of the span.',
+    type: 'integer',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 3,
+    deprecation: {
+      replacement: 'app.vitals.frames.frozen.count',
+      reason:
+        'Replaced by app.vitals.frames.frozen.count to align with the app.vitals.* namespace for mobile performance attributes',
+    },
+    aliases: [APP_VITALS_FRAMES_FROZEN_COUNT, FRAMES_FROZEN],
   },
   [FRAMES_FROZEN_RATE]: {
     brief:
@@ -16390,12 +16480,27 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason:
         'Replaced by app.vitals.frames.slow.count to align with the app.vitals.* namespace for mobile performance attributes',
     },
-    aliases: [APP_VITALS_FRAMES_SLOW_COUNT],
+    aliases: [APP_VITALS_FRAMES_SLOW_COUNT, _FRAMES_SLOW],
     changelog: [
       { version: '0.5.0', prs: [313], description: 'Deprecated in favor of app.vitals.frames.slow.count' },
       { version: '0.4.0', prs: [228] },
       { version: '0.0.0' },
     ],
+  },
+  [_FRAMES_SLOW]: {
+    brief: 'The number of slow frames rendered during the lifetime of the span.',
+    type: 'integer',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 1,
+    deprecation: {
+      replacement: 'app.vitals.frames.slow.count',
+      reason:
+        'Replaced by app.vitals.frames.slow.count to align with the app.vitals.* namespace for mobile performance attributes',
+    },
+    aliases: [APP_VITALS_FRAMES_SLOW_COUNT, FRAMES_SLOW],
   },
   [FRAMES_SLOW_RATE]: {
     brief:
@@ -16420,12 +16525,27 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason:
         'Replaced by app.vitals.frames.total.count to align with the app.vitals.* namespace for mobile performance attributes',
     },
-    aliases: [APP_VITALS_FRAMES_TOTAL_COUNT],
+    aliases: [APP_VITALS_FRAMES_TOTAL_COUNT, _FRAMES_TOTAL],
     changelog: [
       { version: '0.5.0', prs: [313], description: 'Deprecated in favor of app.vitals.frames.total.count' },
       { version: '0.4.0', prs: [228] },
       { version: '0.0.0' },
     ],
+  },
+  [_FRAMES_TOTAL]: {
+    brief: 'The number of total frames rendered during the lifetime of the span.',
+    type: 'integer',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    example: 60,
+    deprecation: {
+      replacement: 'app.vitals.frames.total.count',
+      reason:
+        'Replaced by app.vitals.frames.total.count to align with the app.vitals.* namespace for mobile performance attributes',
+    },
+    aliases: [APP_VITALS_FRAMES_TOTAL_COUNT, FRAMES_TOTAL],
   },
   [FS_ERROR]: {
     brief: 'The error message of a file system error.',
@@ -21322,10 +21442,13 @@ export type Attributes = {
   [FP]?: FP_TYPE;
   [FRAMES_DELAY]?: FRAMES_DELAY_TYPE;
   [FRAMES_FROZEN]?: FRAMES_FROZEN_TYPE;
+  [_FRAMES_FROZEN]?: _FRAMES_FROZEN_TYPE;
   [FRAMES_FROZEN_RATE]?: FRAMES_FROZEN_RATE_TYPE;
   [FRAMES_SLOW]?: FRAMES_SLOW_TYPE;
+  [_FRAMES_SLOW]?: _FRAMES_SLOW_TYPE;
   [FRAMES_SLOW_RATE]?: FRAMES_SLOW_RATE_TYPE;
   [FRAMES_TOTAL]?: FRAMES_TOTAL_TYPE;
+  [_FRAMES_TOTAL]?: _FRAMES_TOTAL_TYPE;
   [FS_ERROR]?: FS_ERROR_TYPE;
   [GCP_FUNCTION_CONTEXT_EVENT_ID]?: GCP_FUNCTION_CONTEXT_EVENT_ID_TYPE;
   [GCP_FUNCTION_CONTEXT_EVENT_TYPE]?: GCP_FUNCTION_CONTEXT_EVENT_TYPE_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -14652,6 +14652,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: [FRAMES_FROZEN, _FRAMES_FROZEN],
     sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
+      { version: 'next', prs: [385], description: 'Added frames_frozen as a deprecated alias' },
       { version: '0.5.0', prs: [313], description: 'Added app.vitals.frames.frozen.count to replace frames.frozen' },
     ],
   },
@@ -14666,6 +14667,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: [FRAMES_SLOW, _FRAMES_SLOW],
     sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
+      { version: 'next', prs: [385], description: 'Added frames_slow as a deprecated alias' },
       { version: '0.5.0', prs: [313], description: 'Added app.vitals.frames.slow.count to replace frames.slow' },
     ],
   },
@@ -14680,6 +14682,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: [FRAMES_TOTAL, _FRAMES_TOTAL],
     sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
+      { version: 'next', prs: [385], description: 'Added frames_total as a deprecated alias' },
       { version: '0.5.0', prs: [313], description: 'Added app.vitals.frames.total.count to replace frames.total' },
     ],
   },
@@ -16437,6 +16440,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     aliases: [APP_VITALS_FRAMES_FROZEN_COUNT, _FRAMES_FROZEN],
     changelog: [
+      { version: 'next', prs: [385], description: 'Added frames_frozen as a deprecated alias' },
       { version: '0.5.0', prs: [313], description: 'Deprecated in favor of app.vitals.frames.frozen.count' },
       { version: '0.4.0', prs: [228] },
       { version: '0.0.0' },
@@ -16456,6 +16460,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
         'Replaced by app.vitals.frames.frozen.count to align with the app.vitals.* namespace for mobile performance attributes',
     },
     aliases: [APP_VITALS_FRAMES_FROZEN_COUNT, FRAMES_FROZEN],
+    changelog: [{ version: 'next', prs: [385], description: 'Added frames_frozen' }],
   },
   [FRAMES_FROZEN_RATE]: {
     brief:
@@ -16482,6 +16487,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     aliases: [APP_VITALS_FRAMES_SLOW_COUNT, _FRAMES_SLOW],
     changelog: [
+      { version: 'next', prs: [385], description: 'Added frames_slow as a deprecated alias' },
       { version: '0.5.0', prs: [313], description: 'Deprecated in favor of app.vitals.frames.slow.count' },
       { version: '0.4.0', prs: [228] },
       { version: '0.0.0' },
@@ -16501,6 +16507,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
         'Replaced by app.vitals.frames.slow.count to align with the app.vitals.* namespace for mobile performance attributes',
     },
     aliases: [APP_VITALS_FRAMES_SLOW_COUNT, FRAMES_SLOW],
+    changelog: [{ version: 'next', prs: [385], description: 'Added frames_slow' }],
   },
   [FRAMES_SLOW_RATE]: {
     brief:
@@ -16527,6 +16534,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     aliases: [APP_VITALS_FRAMES_TOTAL_COUNT, _FRAMES_TOTAL],
     changelog: [
+      { version: 'next', prs: [385], description: 'Added frames_total as a deprecated alias' },
       { version: '0.5.0', prs: [313], description: 'Deprecated in favor of app.vitals.frames.total.count' },
       { version: '0.4.0', prs: [228] },
       { version: '0.0.0' },
@@ -16546,6 +16554,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
         'Replaced by app.vitals.frames.total.count to align with the app.vitals.* namespace for mobile performance attributes',
     },
     aliases: [APP_VITALS_FRAMES_TOTAL_COUNT, FRAMES_TOTAL],
+    changelog: [{ version: 'next', prs: [385], description: 'Added frames_total' }],
   },
   [FS_ERROR]: {
     brief: 'The error message of a file system error.',

--- a/model/attributes/app/app__vitals__frames__frozen__count.json
+++ b/model/attributes/app/app__vitals__frames__frozen__count.json
@@ -6,7 +6,7 @@
     "key": "maybe"
   },
   "is_in_otel": false,
-  "alias": ["frames.frozen"],
+  "alias": ["frames.frozen", "frames_frozen"],
   "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "example": 3,
   "changelog": [

--- a/model/attributes/app/app__vitals__frames__frozen__count.json
+++ b/model/attributes/app/app__vitals__frames__frozen__count.json
@@ -11,6 +11,11 @@
   "example": 3,
   "changelog": [
     {
+      "version": "next",
+      "prs": [385],
+      "description": "Added frames_frozen as a deprecated alias"
+    },
+    {
       "version": "0.5.0",
       "prs": [313],
       "description": "Added app.vitals.frames.frozen.count to replace frames.frozen"

--- a/model/attributes/app/app__vitals__frames__slow__count.json
+++ b/model/attributes/app/app__vitals__frames__slow__count.json
@@ -11,6 +11,11 @@
   "example": 1,
   "changelog": [
     {
+      "version": "next",
+      "prs": [385],
+      "description": "Added frames_slow as a deprecated alias"
+    },
+    {
       "version": "0.5.0",
       "prs": [313],
       "description": "Added app.vitals.frames.slow.count to replace frames.slow"

--- a/model/attributes/app/app__vitals__frames__slow__count.json
+++ b/model/attributes/app/app__vitals__frames__slow__count.json
@@ -6,7 +6,7 @@
     "key": "maybe"
   },
   "is_in_otel": false,
-  "alias": ["frames.slow"],
+  "alias": ["frames.slow", "frames_slow"],
   "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "example": 1,
   "changelog": [

--- a/model/attributes/app/app__vitals__frames__total__count.json
+++ b/model/attributes/app/app__vitals__frames__total__count.json
@@ -11,6 +11,11 @@
   "example": 60,
   "changelog": [
     {
+      "version": "next",
+      "prs": [385],
+      "description": "Added frames_total as a deprecated alias"
+    },
+    {
       "version": "0.5.0",
       "prs": [313],
       "description": "Added app.vitals.frames.total.count to replace frames.total"

--- a/model/attributes/app/app__vitals__frames__total__count.json
+++ b/model/attributes/app/app__vitals__frames__total__count.json
@@ -6,7 +6,7 @@
     "key": "maybe"
   },
   "is_in_otel": false,
-  "alias": ["frames.total"],
+  "alias": ["frames.total", "frames_total"],
   "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "example": 60,
   "changelog": [

--- a/model/attributes/frames/frames__frozen.json
+++ b/model/attributes/frames/frames__frozen.json
@@ -15,6 +15,11 @@
   },
   "changelog": [
     {
+      "version": "next",
+      "prs": [385],
+      "description": "Added frames_frozen as a deprecated alias"
+    },
+    {
       "version": "0.5.0",
       "prs": [313],
       "description": "Deprecated in favor of app.vitals.frames.frozen.count"

--- a/model/attributes/frames/frames__slow.json
+++ b/model/attributes/frames/frames__slow.json
@@ -15,6 +15,11 @@
   },
   "changelog": [
     {
+      "version": "next",
+      "prs": [385],
+      "description": "Added frames_slow as a deprecated alias"
+    },
+    {
       "version": "0.5.0",
       "prs": [313],
       "description": "Deprecated in favor of app.vitals.frames.slow.count"

--- a/model/attributes/frames/frames__total.json
+++ b/model/attributes/frames/frames__total.json
@@ -15,6 +15,11 @@
   },
   "changelog": [
     {
+      "version": "next",
+      "prs": [385],
+      "description": "Added frames_total as a deprecated alias"
+    },
+    {
       "version": "0.5.0",
       "prs": [313],
       "description": "Deprecated in favor of app.vitals.frames.total.count"

--- a/model/attributes/frames_frozen.json
+++ b/model/attributes/frames_frozen.json
@@ -13,5 +13,11 @@
     "reason": "Replaced by app.vitals.frames.frozen.count to align with the app.vitals.* namespace for mobile performance attributes",
     "_status": "backfill"
   },
-  "changelog": []
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [385],
+      "description": "Added frames_frozen"
+    }
+  ]
 }

--- a/model/attributes/frames_frozen.json
+++ b/model/attributes/frames_frozen.json
@@ -1,5 +1,5 @@
 {
-  "key": "frames.frozen",
+  "key": "frames_frozen",
   "brief": "The number of frozen frames rendered during the lifetime of the span.",
   "type": "integer",
   "pii": {
@@ -7,24 +7,11 @@
   },
   "is_in_otel": false,
   "example": 3,
-  "alias": ["app.vitals.frames.frozen.count", "frames_frozen"],
+  "alias": ["app.vitals.frames.frozen.count", "frames.frozen"],
   "deprecation": {
     "replacement": "app.vitals.frames.frozen.count",
     "reason": "Replaced by app.vitals.frames.frozen.count to align with the app.vitals.* namespace for mobile performance attributes",
     "_status": "backfill"
   },
-  "changelog": [
-    {
-      "version": "0.5.0",
-      "prs": [313],
-      "description": "Deprecated in favor of app.vitals.frames.frozen.count"
-    },
-    {
-      "version": "0.4.0",
-      "prs": [228]
-    },
-    {
-      "version": "0.0.0"
-    }
-  ]
+  "changelog": []
 }

--- a/model/attributes/frames_slow.json
+++ b/model/attributes/frames_slow.json
@@ -13,5 +13,11 @@
     "reason": "Replaced by app.vitals.frames.slow.count to align with the app.vitals.* namespace for mobile performance attributes",
     "_status": "backfill"
   },
-  "changelog": []
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [385],
+      "description": "Added frames_slow"
+    }
+  ]
 }

--- a/model/attributes/frames_slow.json
+++ b/model/attributes/frames_slow.json
@@ -1,5 +1,5 @@
 {
-  "key": "frames.slow",
+  "key": "frames_slow",
   "brief": "The number of slow frames rendered during the lifetime of the span.",
   "type": "integer",
   "pii": {
@@ -7,24 +7,11 @@
   },
   "is_in_otel": false,
   "example": 1,
-  "alias": ["app.vitals.frames.slow.count", "frames_slow"],
+  "alias": ["app.vitals.frames.slow.count", "frames.slow"],
   "deprecation": {
     "replacement": "app.vitals.frames.slow.count",
     "reason": "Replaced by app.vitals.frames.slow.count to align with the app.vitals.* namespace for mobile performance attributes",
     "_status": "backfill"
   },
-  "changelog": [
-    {
-      "version": "0.5.0",
-      "prs": [313],
-      "description": "Deprecated in favor of app.vitals.frames.slow.count"
-    },
-    {
-      "version": "0.4.0",
-      "prs": [228]
-    },
-    {
-      "version": "0.0.0"
-    }
-  ]
+  "changelog": []
 }

--- a/model/attributes/frames_total.json
+++ b/model/attributes/frames_total.json
@@ -1,5 +1,5 @@
 {
-  "key": "frames.total",
+  "key": "frames_total",
   "brief": "The number of total frames rendered during the lifetime of the span.",
   "type": "integer",
   "pii": {
@@ -7,24 +7,11 @@
   },
   "is_in_otel": false,
   "example": 60,
-  "alias": ["app.vitals.frames.total.count", "frames_total"],
+  "alias": ["app.vitals.frames.total.count", "frames.total"],
   "deprecation": {
     "replacement": "app.vitals.frames.total.count",
     "reason": "Replaced by app.vitals.frames.total.count to align with the app.vitals.* namespace for mobile performance attributes",
     "_status": "backfill"
   },
-  "changelog": [
-    {
-      "version": "0.5.0",
-      "prs": [313],
-      "description": "Deprecated in favor of app.vitals.frames.total.count"
-    },
-    {
-      "version": "0.4.0",
-      "prs": [228]
-    },
-    {
-      "version": "0.0.0"
-    }
-  ]
+  "changelog": []
 }

--- a/model/attributes/frames_total.json
+++ b/model/attributes/frames_total.json
@@ -13,5 +13,11 @@
     "reason": "Replaced by app.vitals.frames.total.count to align with the app.vitals.* namespace for mobile performance attributes",
     "_status": "backfill"
   },
-  "changelog": []
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [385],
+      "description": "Added frames_total"
+    }
+  ]
 }

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -7754,6 +7754,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
         changelog=[
             ChangelogEntry(
+                version="next",
+                prs=[385],
+                description="Added frames_frozen as a deprecated alias",
+            ),
+            ChangelogEntry(
                 version="0.5.0",
                 prs=[313],
                 description="Added app.vitals.frames.frozen.count to replace frames.frozen",
@@ -7775,6 +7780,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
         changelog=[
             ChangelogEntry(
+                version="next",
+                prs=[385],
+                description="Added frames_slow as a deprecated alias",
+            ),
+            ChangelogEntry(
                 version="0.5.0",
                 prs=[313],
                 description="Added app.vitals.frames.slow.count to replace frames.slow",
@@ -7795,6 +7805,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "sentry.dart.flutter",
         ],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[385],
+                description="Added frames_total as a deprecated alias",
+            ),
             ChangelogEntry(
                 version="0.5.0",
                 prs=[313],
@@ -9877,6 +9892,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         aliases=["app.vitals.frames.frozen.count", "frames_frozen"],
         changelog=[
             ChangelogEntry(
+                version="next",
+                prs=[385],
+                description="Added frames_frozen as a deprecated alias",
+            ),
+            ChangelogEntry(
                 version="0.5.0",
                 prs=[313],
                 description="Deprecated in favor of app.vitals.frames.frozen.count",
@@ -9898,6 +9918,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ),
         aliases=["app.vitals.frames.slow.count", "frames_slow"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[385],
+                description="Added frames_slow as a deprecated alias",
+            ),
             ChangelogEntry(
                 version="0.5.0",
                 prs=[313],
@@ -9921,6 +9946,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         aliases=["app.vitals.frames.total.count", "frames_total"],
         changelog=[
             ChangelogEntry(
+                version="next",
+                prs=[385],
+                description="Added frames_total as a deprecated alias",
+            ),
+            ChangelogEntry(
                 version="0.5.0",
                 prs=[313],
                 description="Deprecated in favor of app.vitals.frames.total.count",
@@ -9941,6 +9971,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["app.vitals.frames.frozen.count", "frames.frozen"],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[385], description="Added frames_frozen"
+            ),
+        ],
     ),
     "frames_frozen_rate": AttributeMetadata(
         brief="The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`. This is computed by Relay.",
@@ -9967,6 +10002,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["app.vitals.frames.slow.count", "frames.slow"],
+        changelog=[
+            ChangelogEntry(version="next", prs=[385], description="Added frames_slow"),
+        ],
     ),
     "frames_slow_rate": AttributeMetadata(
         brief="The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`. This is computed by Relay.",
@@ -9993,6 +10031,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["app.vitals.frames.total.count", "frames.total"],
+        changelog=[
+            ChangelogEntry(version="next", prs=[385], description="Added frames_total"),
+        ],
     ),
     "fs_error": AttributeMetadata(
         brief="The error message of a file system error.",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -165,6 +165,9 @@ class _AttributeNamesMeta(type):
         "FRAMES_FROZEN",
         "FRAMES_SLOW",
         "FRAMES_TOTAL",
+        "_FRAMES_FROZEN",
+        "_FRAMES_SLOW",
+        "_FRAMES_TOTAL",
         "FS_ERROR",
         "GEN_AI_PROMPT",
         "GEN_AI_REQUEST_AVAILABLE_TOOLS",
@@ -798,7 +801,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: int
     Contains PII: maybe
     Defined in OTEL: No
-    Aliases: frames.frozen
+    Aliases: frames.frozen, frames_frozen
     Example: 3
     """
 
@@ -811,7 +814,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: int
     Contains PII: maybe
     Defined in OTEL: No
-    Aliases: frames.slow
+    Aliases: frames.slow, frames_slow
     Example: 1
     """
 
@@ -824,7 +827,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: int
     Contains PII: maybe
     Defined in OTEL: No
-    Aliases: frames.total
+    Aliases: frames.total, frames_total
     Example: 60
     """
 
@@ -2506,7 +2509,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: int
     Contains PII: maybe
     Defined in OTEL: No
-    Aliases: app.vitals.frames.frozen.count
+    Aliases: app.vitals.frames.frozen.count, frames_frozen
     DEPRECATED: Use app.vitals.frames.frozen.count instead - Replaced by app.vitals.frames.frozen.count to align with the app.vitals.* namespace for mobile performance attributes
     Example: 3
     """
@@ -2518,7 +2521,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: int
     Contains PII: maybe
     Defined in OTEL: No
-    Aliases: app.vitals.frames.slow.count
+    Aliases: app.vitals.frames.slow.count, frames_slow
     DEPRECATED: Use app.vitals.frames.slow.count instead - Replaced by app.vitals.frames.slow.count to align with the app.vitals.* namespace for mobile performance attributes
     Example: 1
     """
@@ -2530,9 +2533,21 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: int
     Contains PII: maybe
     Defined in OTEL: No
-    Aliases: app.vitals.frames.total.count
+    Aliases: app.vitals.frames.total.count, frames_total
     DEPRECATED: Use app.vitals.frames.total.count instead - Replaced by app.vitals.frames.total.count to align with the app.vitals.* namespace for mobile performance attributes
     Example: 60
+    """
+
+    # Path: model/attributes/frames_frozen.json
+    _FRAMES_FROZEN: Literal["frames_frozen"] = "frames_frozen"
+    """The number of frozen frames rendered during the lifetime of the span.
+
+    Type: int
+    Contains PII: maybe
+    Defined in OTEL: No
+    Aliases: app.vitals.frames.frozen.count, frames.frozen
+    DEPRECATED: Use app.vitals.frames.frozen.count instead - Replaced by app.vitals.frames.frozen.count to align with the app.vitals.* namespace for mobile performance attributes
+    Example: 3
     """
 
     # Path: model/attributes/frames_frozen_rate.json
@@ -2544,6 +2559,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     """
 
+    # Path: model/attributes/frames_slow.json
+    _FRAMES_SLOW: Literal["frames_slow"] = "frames_slow"
+    """The number of slow frames rendered during the lifetime of the span.
+
+    Type: int
+    Contains PII: maybe
+    Defined in OTEL: No
+    Aliases: app.vitals.frames.slow.count, frames.slow
+    DEPRECATED: Use app.vitals.frames.slow.count instead - Replaced by app.vitals.frames.slow.count to align with the app.vitals.* namespace for mobile performance attributes
+    Example: 1
+    """
+
     # Path: model/attributes/frames_slow_rate.json
     FRAMES_SLOW_RATE: Literal["frames_slow_rate"] = "frames_slow_rate"
     """The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`. This is computed by Relay.
@@ -2551,6 +2578,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: float
     Contains PII: maybe
     Defined in OTEL: No
+    """
+
+    # Path: model/attributes/frames_total.json
+    _FRAMES_TOTAL: Literal["frames_total"] = "frames_total"
+    """The number of total frames rendered during the lifetime of the span.
+
+    Type: int
+    Contains PII: maybe
+    Defined in OTEL: No
+    Aliases: app.vitals.frames.total.count, frames.total
+    DEPRECATED: Use app.vitals.frames.total.count instead - Replaced by app.vitals.frames.total.count to align with the app.vitals.* namespace for mobile performance attributes
+    Example: 60
     """
 
     # Path: model/attributes/fs_error.json
@@ -7706,7 +7745,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=3,
-        aliases=["frames.frozen"],
+        aliases=["frames.frozen", "frames_frozen"],
         sdks=[
             "sentry.cocoa",
             "sentry.java.android",
@@ -7727,7 +7766,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=1,
-        aliases=["frames.slow"],
+        aliases=["frames.slow", "frames_slow"],
         sdks=[
             "sentry.cocoa",
             "sentry.java.android",
@@ -7748,7 +7787,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         example=60,
-        aliases=["frames.total"],
+        aliases=["frames.total", "frames_total"],
         sdks=[
             "sentry.cocoa",
             "sentry.java.android",
@@ -9835,7 +9874,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             reason="Replaced by app.vitals.frames.frozen.count to align with the app.vitals.* namespace for mobile performance attributes",
             status=DeprecationStatus.BACKFILL,
         ),
-        aliases=["app.vitals.frames.frozen.count"],
+        aliases=["app.vitals.frames.frozen.count", "frames_frozen"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9857,7 +9896,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             reason="Replaced by app.vitals.frames.slow.count to align with the app.vitals.* namespace for mobile performance attributes",
             status=DeprecationStatus.BACKFILL,
         ),
-        aliases=["app.vitals.frames.slow.count"],
+        aliases=["app.vitals.frames.slow.count", "frames_slow"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9879,7 +9918,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             reason="Replaced by app.vitals.frames.total.count to align with the app.vitals.* namespace for mobile performance attributes",
             status=DeprecationStatus.BACKFILL,
         ),
-        aliases=["app.vitals.frames.total.count"],
+        aliases=["app.vitals.frames.total.count", "frames_total"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9889,6 +9928,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
         ],
+    ),
+    "frames_frozen": AttributeMetadata(
+        brief="The number of frozen frames rendered during the lifetime of the span.",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=3,
+        deprecation=DeprecationInfo(
+            replacement="app.vitals.frames.frozen.count",
+            reason="Replaced by app.vitals.frames.frozen.count to align with the app.vitals.* namespace for mobile performance attributes",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["app.vitals.frames.frozen.count", "frames.frozen"],
     ),
     "frames_frozen_rate": AttributeMetadata(
         brief="The rate of frozen frames, or `app_vitals.frames.frozen.count` divided by `app_vitals.frames.total.count`. This is computed by Relay.",
@@ -9903,6 +9955,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "frames_slow": AttributeMetadata(
+        brief="The number of slow frames rendered during the lifetime of the span.",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=1,
+        deprecation=DeprecationInfo(
+            replacement="app.vitals.frames.slow.count",
+            reason="Replaced by app.vitals.frames.slow.count to align with the app.vitals.* namespace for mobile performance attributes",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["app.vitals.frames.slow.count", "frames.slow"],
+    ),
     "frames_slow_rate": AttributeMetadata(
         brief="The rate of slow frames, or `app_vitals.frames.slow.count` divided by `app_vitals.frames.total.count`. This is computed by Relay.",
         type=AttributeType.DOUBLE,
@@ -9915,6 +9980,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
                 description="Added frames_slow_rate attribute",
             ),
         ],
+    ),
+    "frames_total": AttributeMetadata(
+        brief="The number of total frames rendered during the lifetime of the span.",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        example=60,
+        deprecation=DeprecationInfo(
+            replacement="app.vitals.frames.total.count",
+            reason="Replaced by app.vitals.frames.total.count to align with the app.vitals.* namespace for mobile performance attributes",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["app.vitals.frames.total.count", "frames.total"],
     ),
     "fs_error": AttributeMetadata(
         brief="The error message of a file system error.",
@@ -14947,8 +15025,11 @@ Attributes = TypedDict(
         "frames.frozen": int,
         "frames.slow": int,
         "frames.total": int,
+        "frames_frozen": int,
         "frames_frozen_rate": float,
+        "frames_slow": int,
         "frames_slow_rate": float,
+        "frames_total": int,
         "fs_error": str,
         "gcp.function.context.event_id": str,
         "gcp.function.context.event_type": str,

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -246,6 +246,57 @@
       ]
     },
     {
+      "key": "frames_frozen",
+      "brief": "The number of frozen frames rendered during the lifetime of the span.",
+      "type": "integer",
+      "pii": {
+        "key": "maybe"
+      },
+      "is_in_otel": false,
+      "example": 3,
+      "alias": ["app.vitals.frames.frozen.count", "frames.frozen"],
+      "deprecation": {
+        "replacement": "app.vitals.frames.frozen.count",
+        "reason": "Replaced by app.vitals.frames.frozen.count to align with the app.vitals.* namespace for mobile performance attributes",
+        "_status": "backfill"
+      },
+      "changelog": []
+    },
+    {
+      "key": "frames_slow",
+      "brief": "The number of slow frames rendered during the lifetime of the span.",
+      "type": "integer",
+      "pii": {
+        "key": "maybe"
+      },
+      "is_in_otel": false,
+      "example": 1,
+      "alias": ["app.vitals.frames.slow.count", "frames.slow"],
+      "deprecation": {
+        "replacement": "app.vitals.frames.slow.count",
+        "reason": "Replaced by app.vitals.frames.slow.count to align with the app.vitals.* namespace for mobile performance attributes",
+        "_status": "backfill"
+      },
+      "changelog": []
+    },
+    {
+      "key": "frames_total",
+      "brief": "The number of total frames rendered during the lifetime of the span.",
+      "type": "integer",
+      "pii": {
+        "key": "maybe"
+      },
+      "is_in_otel": false,
+      "example": 60,
+      "alias": ["app.vitals.frames.total.count", "frames.total"],
+      "deprecation": {
+        "replacement": "app.vitals.frames.total.count",
+        "reason": "Replaced by app.vitals.frames.total.count to align with the app.vitals.* namespace for mobile performance attributes",
+        "_status": "backfill"
+      },
+      "changelog": []
+    },
+    {
       "key": "fs_error",
       "brief": "The error message of a file system error.",
       "type": "string",
@@ -1770,7 +1821,7 @@
       },
       "is_in_otel": false,
       "example": 3,
-      "alias": ["app.vitals.frames.frozen.count"],
+      "alias": ["app.vitals.frames.frozen.count", "frames_frozen"],
       "deprecation": {
         "replacement": "app.vitals.frames.frozen.count",
         "reason": "Replaced by app.vitals.frames.frozen.count to align with the app.vitals.* namespace for mobile performance attributes",
@@ -1800,7 +1851,7 @@
       },
       "is_in_otel": false,
       "example": 1,
-      "alias": ["app.vitals.frames.slow.count"],
+      "alias": ["app.vitals.frames.slow.count", "frames_slow"],
       "deprecation": {
         "replacement": "app.vitals.frames.slow.count",
         "reason": "Replaced by app.vitals.frames.slow.count to align with the app.vitals.* namespace for mobile performance attributes",
@@ -1830,7 +1881,7 @@
       },
       "is_in_otel": false,
       "example": 60,
-      "alias": ["app.vitals.frames.total.count"],
+      "alias": ["app.vitals.frames.total.count", "frames_total"],
       "deprecation": {
         "replacement": "app.vitals.frames.total.count",
         "reason": "Replaced by app.vitals.frames.total.count to align with the app.vitals.* namespace for mobile performance attributes",

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -260,7 +260,13 @@
         "reason": "Replaced by app.vitals.frames.frozen.count to align with the app.vitals.* namespace for mobile performance attributes",
         "_status": "backfill"
       },
-      "changelog": []
+      "changelog": [
+        {
+          "version": "next",
+          "prs": [385],
+          "description": "Added frames_frozen"
+        }
+      ]
     },
     {
       "key": "frames_slow",
@@ -277,7 +283,13 @@
         "reason": "Replaced by app.vitals.frames.slow.count to align with the app.vitals.* namespace for mobile performance attributes",
         "_status": "backfill"
       },
-      "changelog": []
+      "changelog": [
+        {
+          "version": "next",
+          "prs": [385],
+          "description": "Added frames_slow"
+        }
+      ]
     },
     {
       "key": "frames_total",
@@ -294,7 +306,13 @@
         "reason": "Replaced by app.vitals.frames.total.count to align with the app.vitals.* namespace for mobile performance attributes",
         "_status": "backfill"
       },
-      "changelog": []
+      "changelog": [
+        {
+          "version": "next",
+          "prs": [385],
+          "description": "Added frames_total"
+        }
+      ]
     },
     {
       "key": "fs_error",
@@ -1829,6 +1847,11 @@
       },
       "changelog": [
         {
+          "version": "next",
+          "prs": [385],
+          "description": "Added frames_frozen as a deprecated alias"
+        },
+        {
           "version": "0.5.0",
           "prs": [313],
           "description": "Deprecated in favor of app.vitals.frames.frozen.count"
@@ -1859,6 +1882,11 @@
       },
       "changelog": [
         {
+          "version": "next",
+          "prs": [385],
+          "description": "Added frames_slow as a deprecated alias"
+        },
+        {
           "version": "0.5.0",
           "prs": [313],
           "description": "Deprecated in favor of app.vitals.frames.slow.count"
@@ -1888,6 +1916,11 @@
         "_status": "backfill"
       },
       "changelog": [
+        {
+          "version": "next",
+          "prs": [385],
+          "description": "Added frames_total as a deprecated alias"
+        },
         {
           "version": "0.5.0",
           "prs": [313],


### PR DESCRIPTION
## Description
This adds some attributes with the same names as existing measurements. The attributes are added as deprecated because they all already have updated names. The reason for adding them is because Relay converts measurements to attributes verbatim and it needs to access these attributes by name for calculations.

ref: INGEST-909

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
