### PR TITLE
feat(measurements): Add attribute field

### DIFF
--- a/model/measurements/app_start_cold.json
+++ b/model/measurements/app_start_cold.json
@@ -3,5 +3,6 @@
   "full_name": "App Start Cold",
   "brief": "The time it takes for the app to start from a cold state",
   "unit": "millisecond",
-  "platform": "mobile"
+  "platform": "mobile",
+  "attribute": "app.vitals.start.cold.value"
 }

--- a/model/measurements/app_start_warm.json
+++ b/model/measurements/app_start_warm.json
@@ -3,5 +3,6 @@
   "full_name": "App Start Warm",
   "brief": "The time it takes for the app to start from a warm state",
   "unit": "millisecond",
-  "platform": "mobile"
+  "platform": "mobile",
+  "attribute": "app.vitals.start.warm.value"
 }

--- a/model/measurements/cls.json
+++ b/model/measurements/cls.json
@@ -3,5 +3,6 @@
   "full_name": "Cumulative Layout Shift",
   "brief": "Tthe sum total of all individual layout shift scores for every unexpected layout shift that occurs during the entire lifespan of the page",
   "unit": "none",
-  "platform": "web"
+  "platform": "web",
+  "attribute": "browser.web_vital.cls.value"
 }

--- a/model/measurements/fcp.json
+++ b/model/measurements/fcp.json
@@ -3,5 +3,6 @@
   "full_name": "First Contentful Paint",
   "brief": "The time it takes for the browser to render the first piece of meaningful content on the screen",
   "unit": "millisecond",
-  "platform": "web"
+  "platform": "web",
+  "attribute": "browser.web_vital.fcp.value"
 }

--- a/model/measurements/fp.json
+++ b/model/measurements/fp.json
@@ -3,5 +3,6 @@
   "full_name": "First Paint",
   "brief": "The time it takes for the browser to render the first pixel on the screen",
   "unit": "millisecond",
-  "platform": "web"
+  "platform": "web",
+  "attribute": "browser.web_vital.fp.value"
 }

--- a/model/measurements/frames_frozen.json
+++ b/model/measurements/frames_frozen.json
@@ -3,5 +3,6 @@
   "full_name": "Frozen Frames",
   "brief": "The number of frames that took longer than 700ms to render",
   "unit": "none",
-  "platform": "mobile"
+  "platform": "mobile",
+  "attribute": "app.vitals.frames.frozen.count"
 }

--- a/model/measurements/frames_frozen_rate.json
+++ b/model/measurements/frames_frozen_rate.json
@@ -3,5 +3,6 @@
   "full_name": "The rate of frozen frames",
   "brief": "measurements.frames_frozen divided by the measurements.frames_total",
   "unit": "none",
-  "platform": "mobile"
+  "platform": "mobile",
+  "attribute": "frames_frozen_rate"
 }

--- a/model/measurements/frames_slow.json
+++ b/model/measurements/frames_slow.json
@@ -3,5 +3,6 @@
   "full_name": "Slow Frames",
   "brief": "The number of frames that took longer than 16ms (Android) or 16.67 (iOS) to render",
   "unit": "none",
-  "platform": "mobile"
+  "platform": "mobile",
+  "attribute": "app.vitals.frames.slow.count"
 }

--- a/model/measurements/frames_slow_rate.json
+++ b/model/measurements/frames_slow_rate.json
@@ -3,5 +3,6 @@
   "full_name": "The rate of slow frames",
   "brief": "measurements.frames_slow divided by the measurements.frames_total",
   "unit": "none",
-  "platform": "mobile"
+  "platform": "mobile",
+  "attribute": "frames_slow_rate"
 }

--- a/model/measurements/frames_total.json
+++ b/model/measurements/frames_total.json
@@ -3,5 +3,6 @@
   "full_name": "Total Frames",
   "brief": "Total frames rendered.",
   "unit": "none",
-  "platform": "mobile"
+  "platform": "mobile",
+  "attribute": "app.vitals.frames.total.count"
 }

--- a/model/measurements/inp.json
+++ b/model/measurements/inp.json
@@ -3,5 +3,6 @@
   "full_name": "Interaction to Next Paint",
   "brief": "The time it takes for the browser to render the next frame after a user interacts with the page.",
   "unit": "millisecond",
-  "platform": "web"
+  "platform": "web",
+  "attribute": "browser.web_vital.inp.value"
 }

--- a/model/measurements/lcp.json
+++ b/model/measurements/lcp.json
@@ -3,5 +3,6 @@
   "full_name": "Largest Contentful Paint",
   "brief": "The time it takes for the largest contentful paint element to be rendered on the screen",
   "unit": "millisecond",
-  "platform": "web"
+  "platform": "web",
+  "attribute": "browser.web_vital.lcp.value"
 }

--- a/model/measurements/stall_percentage.json
+++ b/model/measurements/stall_percentage.json
@@ -3,5 +3,6 @@
   "full_name": "Stall Percentage",
   "brief": "Stall percentage is equal to the stall_total_time divided by the transaction.duration. Only applies to React Native.",
   "unit": "none",
-  "platform": "mobile"
+  "platform": "mobile",
+  "attribute": "stall_percentage"
 }

--- a/model/measurements/stall_total_time.json
+++ b/model/measurements/stall_total_time.json
@@ -3,5 +3,6 @@
   "full_name": "Total Stall Time",
   "brief": "The total stall time is the total combined time of all stalls. Only applies to React Native.",
   "unit": "milliseconds",
-  "platform": "mobile"
+  "platform": "mobile",
+  "attribute": "stall_total_time"
 }

--- a/model/measurements/ttfb.json
+++ b/model/measurements/ttfb.json
@@ -3,5 +3,6 @@
   "full_name": "Time to First Byte",
   "brief": "The time it takes for the first byte of a response from the server to reach the user's browser after a request is made",
   "unit": "millisecond",
-  "platform": "web"
+  "platform": "web",
+  "attribute": "browser.web_vital.ttfb.value"
 }

--- a/model/measurements/ttfb__requesttime.json
+++ b/model/measurements/ttfb__requesttime.json
@@ -3,5 +3,6 @@
   "full_name": "Time to First Byte (Request Time)",
   "brief": "The time it takes for the server to process the initial request and send the first byte of a response to the user's browser",
   "unit": "millisecond",
-  "platform": "web"
+  "platform": "web",
+  "attribute": "browser.web_vital.ttfb.request_time"
 }

--- a/schemas/measurements.schema.json
+++ b/schemas/measurements.schema.json
@@ -24,6 +24,10 @@
     "platform": {
       "description": "What platform the measurement is collected in",
       "enum": ["web", "mobile"]
+    },
+    "attribute": {
+      "description": "The name of the attribute corresponding to this measurement",
+      "type": "string"
     }
   },
   "required": ["key", "full_name", "unit", "platform"]

--- a/test/validate-measurements.test.ts
+++ b/test/validate-measurements.test.ts
@@ -7,30 +7,30 @@ import { describe, expect, it } from 'vitest';
 import schema from '../schemas/measurements.schema.json';
 
 const traceFolders = path.resolve(__dirname, '../model/measurements');
-const attributeFolder = path.resolve(__dirname, '../model/attributes')
+const attributeFolder = path.resolve(__dirname, '../model/attributes');
 
 function attribute_path(key: string): string {
-    // Replace angle brackets for Windows path safety
-    const fileKey = key.replaceAll('<', '[').replaceAll('>', ']');
-    // Create the directory structure based on the key
-    const parts = fileKey.split('.');
-    let filePath: string;
+  // Replace angle brackets for Windows path safety
+  const fileKey = key.replaceAll('<', '[').replaceAll('>', ']');
+  // Create the directory structure based on the key
+  const parts = fileKey.split('.');
+  let filePath: string;
 
-    if (parts.length === 1) {
-      // Handle simple keys like 'replay_id'
-      filePath = path.join(attributeFolder, `${fileKey}.json`);
-    } else {
-      // Handle dotted keys like 'http.route'
-      const dirPath = path.join(attributeFolder, parts[0] ?? '');
-      if (!fs.existsSync(dirPath)) {
-        fs.mkdirSync(dirPath, { recursive: true });
-      }
-      // Convert rest parts to use double underscores instead of dots
-      const fileName = parts.join('__');
-      filePath = path.join(dirPath, `${fileName}.json`);
+  if (parts.length === 1) {
+    // Handle simple keys like 'replay_id'
+    filePath = path.join(attributeFolder, `${fileKey}.json`);
+  } else {
+    // Handle dotted keys like 'http.route'
+    const dirPath = path.join(attributeFolder, parts[0] ?? '');
+    if (!fs.existsSync(dirPath)) {
+      fs.mkdirSync(dirPath, { recursive: true });
     }
-  
-    return filePath
+    // Convert rest parts to use double underscores instead of dots
+    const fileName = parts.join('__');
+    filePath = path.join(dirPath, `${fileName}.json`);
+  }
+
+  return filePath;
 }
 
 describe('measurements json', async () => {
@@ -53,12 +53,12 @@ describe('measurements json', async () => {
 
         if (attribute !== undefined) {
           const attributeContent = JSON.parse(await fs.promises.readFile(attribute_path(attribute), 'utf-8'));
-          const deprecation = attributeContent.deprecation
+          const deprecation = attributeContent.deprecation;
           if (deprecation !== undefined) {
-            expect(deprecation.replacement).toBe(undefined)
+            expect(deprecation.replacement).toBe(undefined);
           }
         }
-      })
+      });
     });
   }
 });

--- a/test/validate-measurements.test.ts
+++ b/test/validate-measurements.test.ts
@@ -7,9 +7,34 @@ import { describe, expect, it } from 'vitest';
 import schema from '../schemas/measurements.schema.json';
 
 const traceFolders = path.resolve(__dirname, '../model/measurements');
+const attributeFolder = path.resolve(__dirname, '../model/attributes')
+
+function attribute_path(key: string): string {
+    // Replace angle brackets for Windows path safety
+    const fileKey = key.replaceAll('<', '[').replaceAll('>', ']');
+    // Create the directory structure based on the key
+    const parts = fileKey.split('.');
+    let filePath: string;
+
+    if (parts.length === 1) {
+      // Handle simple keys like 'replay_id'
+      filePath = path.join(attributeFolder, `${fileKey}.json`);
+    } else {
+      // Handle dotted keys like 'http.route'
+      const dirPath = path.join(attributeFolder, parts[0] ?? '');
+      if (!fs.existsSync(dirPath)) {
+        fs.mkdirSync(dirPath, { recursive: true });
+      }
+      // Convert rest parts to use double underscores instead of dots
+      const fileName = parts.join('__');
+      filePath = path.join(dirPath, `${fileName}.json`);
+    }
+  
+    return filePath
+}
 
 describe('measurements json', async () => {
-  const filesIterator = await fs.promises.glob(`${traceFolders}/**/*.json`);
+  const filesIterator = fs.promises.glob(`${traceFolders}/**/*.json`);
   const files = await Array.fromAsync(filesIterator);
 
   for (const file of files) {
@@ -22,6 +47,18 @@ describe('measurements json', async () => {
         ajv.validate(schema, content);
         expect(ajv.errors).toBe(null);
       });
+
+      it('should have a valid, non-deprecated attribute', async () => {
+        const attribute = content.attribute;
+
+        if (attribute !== undefined) {
+          const attributeContent = JSON.parse(await fs.promises.readFile(attribute_path(attribute), 'utf-8'));
+          const deprecation = attributeContent.deprecation
+          if (deprecation !== undefined) {
+            expect(deprecation.replacement).toBe(undefined)
+          }
+        }
+      })
     });
   }
 });


### PR DESCRIPTION
## Description
This adds an optional field `"attribute"` of type `string` to the measurements schema. This field is meant to contain the name of the attribute corresponding to this measurement, if any. All existing measurements with corresponding attributes have also had this field filled in.

It also tests that if an attribute is set for a measurement, that attribute exists and does not have a replacement. The intention is that if a measurement's current attribute gets deprecated in favor of a new one, the measurement should be updated to point to the replacement attribute.

The purpose of this change is primarily to allow Relay to be smarter when converting measurements to attributes.

Closes #386. Closes CON-94.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.
