### PR TITLE
feat(docs): Add measurements page

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -68,7 +68,7 @@ const names = defineCollection({
 const measurementSchema = z.object({
   key: z.string(),
   full_name: z.string(),
-  brief: z.string(),
+  brief: z.string().optional(),
   unit: z.string(),
   platform: z.enum(['web', 'mobile']),
   attribute: z.string().optional(),

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -64,9 +64,26 @@ const names = defineCollection({
   schema: nameSchema,
 });
 
-export const collections = { attributes, names };
+// Schema matching schemas/measurements.schema.json
+const measurementSchema = z.object({
+  key: z.string(),
+  full_name: z.string(),
+  brief: z.string(),
+  unit: z.string(),
+  platform: z.enum(['web', 'mobile']),
+  attribute: z.string().optional(),
+});
+
+// Define the measurements collection - loads all JSON files from model/measurements
+const measurements = defineCollection({
+  loader: glob({ pattern: '*.json', base: '../model/measurements' }),
+  schema: measurementSchema,
+});
+
+export const collections = { attributes, names, measurements };
 
 // Export types for use in pages
 export type Attribute = z.infer<typeof attributeSchema>;
 export type SpanName = z.infer<typeof nameSchema>;
 export type SpanOperation = z.infer<typeof spanOperationSchema>;
+export type Measurement = z.infer<typeof measurementSchema>;

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -50,8 +50,11 @@ const categories = new Set(
         View on GitHub
       </a>
     </div>
-    <p class="text-sm text-text-muted mt-4">
+    <p class="text-sm text-text-muted mt-4 mb-1">
       LLM-friendly: <a href={`${import.meta.env.BASE_URL}llms.txt`} class="text-accent hover:text-accent-hover">llms.txt</a> · <a href={`${import.meta.env.BASE_URL}llms-full.txt`} class="text-accent hover:text-accent-hover">llms-full.txt</a>
+    </p>
+    <p class="text-sm text-text-muted">
+      See also: <a href={`${import.meta.env.BASE_URL}measurements/`} class="text-text-muted hover:text-text-secondary">Measurements (legacy)</a>
     </p>
   </div>
   

--- a/docs/src/pages/measurements/index.astro
+++ b/docs/src/pages/measurements/index.astro
@@ -1,0 +1,99 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getCollection } from 'astro:content';
+
+const allMeasurements = await getCollection('measurements');
+
+const platformMap = new Map<string, typeof allMeasurements>();
+for (const m of allMeasurements) {
+  const platform = m.data.platform;
+  if (!platformMap.has(platform)) {
+    platformMap.set(platform, []);
+  }
+  platformMap.get(platform)!.push(m);
+}
+
+for (const measurements of platformMap.values()) {
+  measurements.sort((a, b) => a.data.key.localeCompare(b.data.key));
+}
+
+const sortedPlatforms = Array.from(platformMap.keys()).sort();
+
+function attributeUrl(key: string): string {
+  const category = key.includes('.') ? key.split('.')[0] : 'general';
+  const anchor = key.replace(/\./g, '-').replace(/</g, '').replace(/>/g, '');
+  return `${import.meta.env.BASE_URL}attributes/${category}/#${anchor}`;
+}
+---
+
+<BaseLayout title="Measurements (Legacy)" description="Legacy Sentry span measurements reference">
+  <div class="mb-8">
+    <div class="flex items-start gap-3 p-4 mb-6 rounded-md bg-warning-soft border border-warning text-sm">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="flex-shrink-0 mt-0.5 text-warning">
+        <path d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      </svg>
+      <span class="text-text-secondary">
+        <strong class="text-text-primary">Measurements are being phased out.</strong>
+        They are replaced by <a href={`${import.meta.env.BASE_URL}attributes/`} class="text-accent hover:text-accent-hover font-medium">span attributes</a>.
+        For measurements sent by legacy SDKs, Relay automatically converts them to span attributes.
+      </span>
+    </div>
+    <h1>Measurements <span class="text-lg text-text-muted font-normal align-middle">(Legacy)</span></h1>
+    <p class="text-lg text-text-secondary max-w-3xl">
+      Measurements are numeric values attached to transactions that capture performance metrics.
+    </p>
+  </div>
+
+  <div class="flex flex-col gap-12">
+    {sortedPlatforms.map((platform) => {
+      const measurements = platformMap.get(platform)!;
+      return (
+        <section class="scroll-mt-20" id={platform}>
+          <div class="flex items-baseline gap-4 mb-6 pb-3 border-b border-border">
+            <h2 class="m-0 text-2xl capitalize">{platform}</h2>
+            <span class="text-sm text-text-muted">{measurements.length} measurements</span>
+          </div>
+
+          <div class="overflow-x-auto">
+            <table>
+              <thead>
+                <tr>
+                  <th>Key</th>
+                  <th>Name</th>
+                  <th>Description</th>
+                  <th>Unit</th>
+                  <th>Attribute</th>
+                </tr>
+              </thead>
+              <tbody>
+                {measurements.map((m) => (
+                  <tr>
+                    <td><code class="text-xs">{m.data.key}</code></td>
+                    <td class="whitespace-nowrap text-text-primary font-medium">{m.data.full_name}</td>
+                    <td class="text-text-secondary">{m.data.brief}</td>
+                    <td class="whitespace-nowrap">
+                      {m.data.unit === 'none' ? (
+                        <span class="text-text-muted">—</span>
+                      ) : (
+                        <code class="text-xs">{m.data.unit}</code>
+                      )}
+                    </td>
+                    <td>
+                      {m.data.attribute ? (
+                        <a href={attributeUrl(m.data.attribute)} class="text-accent hover:text-accent-hover">
+                          <code class="text-xs">{m.data.attribute}</code>
+                        </a>
+                      ) : (
+                        <span class="text-text-muted">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      );
+    })}
+  </div>
+</BaseLayout>

--- a/docs/src/pages/measurements/index.astro
+++ b/docs/src/pages/measurements/index.astro
@@ -70,7 +70,7 @@ function attributeUrl(key: string): string {
                   <tr>
                     <td><code class="text-xs">{m.data.key}</code></td>
                     <td class="whitespace-nowrap text-text-primary font-medium">{m.data.full_name}</td>
-                    <td class="text-text-secondary">{m.data.brief}</td>
+                    <td class="text-text-secondary">{m.data.brief || <span class="text-text-muted">—</span>}</td>
                     <td class="whitespace-nowrap">
                       {m.data.unit === 'none' ? (
                         <span class="text-text-muted">—</span>

--- a/docs/src/pages/measurements/index.astro
+++ b/docs/src/pages/measurements/index.astro
@@ -10,7 +10,7 @@ for (const m of allMeasurements) {
   if (!platformMap.has(platform)) {
     platformMap.set(platform, []);
   }
-  platformMap.get(platform)!.push(m);
+  platformMap.get(platform)?.push(m);
 }
 
 for (const measurements of platformMap.values()) {


### PR DESCRIPTION
Adds a previously missing page to the convention docs listing all measurements. This already includes the changes from #388 where we added the `attribute` field that replaces the respective measurement. I opted to not include this page in the top navigation bar because we're phasing out measurements and they're not as important as attributes.

<img width="1298" height="1097" alt="image" src="https://github.com/user-attachments/assets/c3976523-5e6f-45e4-8cc6-7248d8b2e4db" />
