### PR TITLE
feat(attributes): Add graphql.document attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -5678,6 +5678,26 @@ export const GEN_AI_USAGE_TOTAL_TOKENS = 'gen_ai.usage.total_tokens';
  */
 export type GEN_AI_USAGE_TOTAL_TOKENS_TYPE = number;
 
+// Path: model/attributes/graphql/graphql__document.json
+
+/**
+ * The GraphQL document being executed. `graphql.document`
+ *
+ * Attribute Value Type: `string` {@link GRAPHQL_DOCUMENT_TYPE}
+ *
+ * Contains PII: maybe - The document may contain sensitive information in arguments or variables. Instrumentation should redact sensitive information when possible.
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * @example "query findBookById { bookById(id: ?) { name } }"
+ */
+export const GRAPHQL_DOCUMENT = 'graphql.document';
+
+/**
+ * Type for {@link GRAPHQL_DOCUMENT} graphql.document
+ */
+export type GRAPHQL_DOCUMENT_TYPE = string;
+
 // Path: model/attributes/graphql/graphql__operation__name.json
 
 /**
@@ -12876,6 +12896,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [GEN_AI_USAGE_OUTPUT_TOKENS_REASONING]: 'integer',
   [GEN_AI_USAGE_PROMPT_TOKENS]: 'integer',
   [GEN_AI_USAGE_TOTAL_TOKENS]: 'integer',
+  [GRAPHQL_DOCUMENT]: 'string',
   [GRAPHQL_OPERATION_NAME]: 'string',
   [GRAPHQL_OPERATION_TYPE]: 'string',
   [HARDWARECONCURRENCY]: 'string',
@@ -13479,6 +13500,7 @@ export type AttributeName =
   | typeof GEN_AI_USAGE_OUTPUT_TOKENS_REASONING
   | typeof GEN_AI_USAGE_PROMPT_TOKENS
   | typeof GEN_AI_USAGE_TOTAL_TOKENS
+  | typeof GRAPHQL_DOCUMENT
   | typeof GRAPHQL_OPERATION_NAME
   | typeof GRAPHQL_OPERATION_TYPE
   | typeof HARDWARECONCURRENCY
@@ -17252,6 +17274,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: '0.4.0', prs: [228] },
       { version: '0.1.0', prs: [57] },
     ],
+  },
+  [GRAPHQL_DOCUMENT]: {
+    brief: 'The GraphQL document being executed.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+      reason:
+        'The document may contain sensitive information in arguments or variables. Instrumentation should redact sensitive information when possible.',
+    },
+    isInOtel: true,
+    example: 'query findBookById { bookById(id: ?) { name } }',
+    changelog: [{ version: '0.0.0' }],
   },
   [GRAPHQL_OPERATION_NAME]: {
     brief: 'The name of the operation being executed.',
@@ -21390,6 +21424,7 @@ export type Attributes = {
   [GEN_AI_USAGE_OUTPUT_TOKENS_REASONING]?: GEN_AI_USAGE_OUTPUT_TOKENS_REASONING_TYPE;
   [GEN_AI_USAGE_PROMPT_TOKENS]?: GEN_AI_USAGE_PROMPT_TOKENS_TYPE;
   [GEN_AI_USAGE_TOTAL_TOKENS]?: GEN_AI_USAGE_TOTAL_TOKENS_TYPE;
+  [GRAPHQL_DOCUMENT]?: GRAPHQL_DOCUMENT_TYPE;
   [GRAPHQL_OPERATION_NAME]?: GRAPHQL_OPERATION_NAME_TYPE;
   [GRAPHQL_OPERATION_TYPE]?: GRAPHQL_OPERATION_TYPE_TYPE;
   [HARDWARECONCURRENCY]?: HARDWARECONCURRENCY_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -17285,7 +17285,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: true,
     example: 'query findBookById { bookById(id: ?) { name } }',
-    changelog: [{ version: '0.0.0' }],
+    changelog: [
+      {
+        version: 'next',
+        description: 'Adds the `graphql.document` attribute to track the GraphQL document being executed.',
+      },
+    ],
   },
   [GRAPHQL_OPERATION_NAME]: {
     brief: 'The name of the operation being executed.',

--- a/model/attributes/graphql/graphql__document.json
+++ b/model/attributes/graphql/graphql__document.json
@@ -10,7 +10,8 @@
   "example": "query findBookById { bookById(id: ?) { name } }",
   "changelog": [
     {
-      "version": "0.0.0"
+      "version": "next",
+      "description": "Adds the `graphql.document` attribute to track the GraphQL document being executed."
     }
   ]
 }

--- a/model/attributes/graphql/graphql__document.json
+++ b/model/attributes/graphql/graphql__document.json
@@ -1,0 +1,16 @@
+{
+  "key": "graphql.document",
+  "brief": "The GraphQL document being executed.",
+  "type": "string",
+  "pii": {
+    "key": "maybe",
+    "reason": "The document may contain sensitive information in arguments or variables. Instrumentation should redact sensitive information when possible."
+  },
+  "is_in_otel": true,
+  "example": "query findBookById { bookById(id: ?) { name } }",
+  "changelog": [
+    {
+      "version": "0.0.0"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -10738,7 +10738,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         example="query findBookById { bookById(id: ?) { name } }",
         changelog=[
-            ChangelogEntry(version="0.0.0"),
+            ChangelogEntry(
+                version="next",
+                description="Adds the `graphql.document` attribute to track the GraphQL document being executed.",
+            ),
         ],
     ),
     "graphql.operation.name": AttributeMetadata(

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3313,6 +3313,16 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 20
     """
 
+    # Path: model/attributes/graphql/graphql__document.json
+    GRAPHQL_DOCUMENT: Literal["graphql.document"] = "graphql.document"
+    """The GraphQL document being executed.
+
+    Type: str
+    Contains PII: maybe - The document may contain sensitive information in arguments or variables. Instrumentation should redact sensitive information when possible.
+    Defined in OTEL: Yes
+    Example: "query findBookById { bookById(id: ?) { name } }"
+    """
+
     # Path: model/attributes/graphql/graphql__operation__name.json
     GRAPHQL_OPERATION_NAME: Literal["graphql.operation.name"] = "graphql.operation.name"
     """The name of the operation being executed.
@@ -10718,6 +10728,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[57]),
         ],
     ),
+    "graphql.document": AttributeMetadata(
+        brief="The GraphQL document being executed.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(
+            isPii=IsPii.MAYBE,
+            reason="The document may contain sensitive information in arguments or variables. Instrumentation should redact sensitive information when possible.",
+        ),
+        is_in_otel=True,
+        example="query findBookById { bookById(id: ?) { name } }",
+        changelog=[
+            ChangelogEntry(version="0.0.0"),
+        ],
+    ),
     "graphql.operation.name": AttributeMetadata(
         brief="The name of the operation being executed.",
         type=AttributeType.STRING,
@@ -15013,6 +15036,7 @@ Attributes = TypedDict(
         "gen_ai.usage.output_tokens.reasoning": int,
         "gen_ai.usage.prompt_tokens": int,
         "gen_ai.usage.total_tokens": int,
+        "graphql.document": str,
         "graphql.operation.name": str,
         "graphql.operation.type": str,
         "hardwareConcurrency": str,


### PR DESCRIPTION
Add the `graphql.document` span attribute to capture the GraphQL document being executed.

This new attribute is part of the GraphQL semantic conventions and allows instrumentation to capture the full GraphQL operation string. Since documents may contain sensitive information in arguments or variables, instrumentation implementations should redact sensitive values when possible.

Includes attribute definitions across JavaScript, Python, and the model specification.

Refs #2366