### PR TITLE
feat(attributes): Ensure replacements aren't deprecated

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -170,7 +170,7 @@ export type AI_GENERATION_ID_TYPE = string;
  *
  * Aliases: {@link GEN_AI_REQUEST_MESSAGES} `gen_ai.request.messages`
  *
- * @deprecated Use {@link GEN_AI_REQUEST_MESSAGES} (gen_ai.request.messages) instead
+ * @deprecated Use {@link GEN_AI_INPUT_MESSAGES} (gen_ai.input.messages) instead
  * @example "[{\"role\": \"user\", \"message\": \"hello\"}]"
  */
 export const AI_INPUT_MESSAGES = 'ai.input_messages';
@@ -392,7 +392,7 @@ export type AI_RAW_PROMPTING_TYPE = boolean;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated Use {@link GEN_AI_RESPONSE_TEXT} (gen_ai.response.text) instead
+ * @deprecated Use {@link GEN_AI_OUTPUT_MESSAGES} (gen_ai.output.messages) instead
  * @example ["hello","world"]
  */
 export const AI_RESPONSES = 'ai.responses';
@@ -589,7 +589,7 @@ export type AI_TEXTS_TYPE = Array<string>;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated Use {@link GEN_AI_REQUEST_AVAILABLE_TOOLS} (gen_ai.request.available_tools) instead
+ * @deprecated Use {@link GEN_AI_TOOL_DEFINITIONS} (gen_ai.tool.definitions) instead
  * @example ["function_1","function_2"]
  */
 export const AI_TOOLS = 'ai.tools';
@@ -610,7 +610,7 @@ export type AI_TOOLS_TYPE = Array<string>;
  *
  * Attribute defined in OTEL: No
  *
- * @deprecated Use {@link GEN_AI_RESPONSE_TOOL_CALLS} (gen_ai.response.tool_calls) instead
+ * @deprecated Use {@link GEN_AI_OUTPUT_MESSAGES} (gen_ai.output.messages) instead
  * @example ["tool_call_1","tool_call_2"]
  */
 export const AI_TOOL_CALLS = 'ai.tool_calls';
@@ -13926,7 +13926,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: '[{"role": "user", "message": "hello"}]',
     deprecation: {
-      replacement: 'gen_ai.request.messages',
+      replacement: 'gen_ai.input.messages',
     },
     aliases: [GEN_AI_REQUEST_MESSAGES],
     sdks: ['python'],
@@ -14080,7 +14080,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: ['hello', 'world'],
     deprecation: {
-      replacement: 'gen_ai.response.text',
+      replacement: 'gen_ai.output.messages',
     },
     sdks: ['python'],
     changelog: [{ version: '0.1.0', prs: [65, 127] }, { version: '0.0.0' }],
@@ -14214,7 +14214,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: ['function_1', 'function_2'],
     deprecation: {
-      replacement: 'gen_ai.request.available_tools',
+      replacement: 'gen_ai.tool.definitions',
     },
     changelog: [{ version: '0.1.0', prs: [55, 65, 127] }],
   },
@@ -14227,7 +14227,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     example: ['tool_call_1', 'tool_call_2'],
     deprecation: {
-      replacement: 'gen_ai.response.tool_calls',
+      replacement: 'gen_ai.output.messages',
     },
     changelog: [{ version: '0.1.0', prs: [55, 65] }],
   },

--- a/model/attributes/ai/ai__input_messages.json
+++ b/model/attributes/ai/ai__input_messages.json
@@ -11,7 +11,7 @@
   "sdks": ["python"],
   "deprecation": {
     "_status": "backfill",
-    "replacement": "gen_ai.request.messages"
+    "replacement": "gen_ai.input.messages"
   },
   "changelog": [
     {

--- a/model/attributes/ai/ai__responses.json
+++ b/model/attributes/ai/ai__responses.json
@@ -10,7 +10,7 @@
   "sdks": ["python"],
   "deprecation": {
     "_status": "backfill",
-    "replacement": "gen_ai.response.text"
+    "replacement": "gen_ai.output.messages"
   },
   "changelog": [
     {

--- a/model/attributes/ai/ai__tool_calls.json
+++ b/model/attributes/ai/ai__tool_calls.json
@@ -9,7 +9,7 @@
   "example": ["tool_call_1", "tool_call_2"],
   "deprecation": {
     "_status": "backfill",
-    "replacement": "gen_ai.response.tool_calls"
+    "replacement": "gen_ai.output.messages"
   },
   "changelog": [
     {

--- a/model/attributes/ai/ai__tools.json
+++ b/model/attributes/ai/ai__tools.json
@@ -9,7 +9,7 @@
   "example": ["function_1", "function_2"],
   "deprecation": {
     "_status": "backfill",
-    "replacement": "gen_ai.request.available_tools"
+    "replacement": "gen_ai.tool.definitions"
   },
   "changelog": [
     {

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -348,7 +348,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Aliases: gen_ai.request.messages
-    DEPRECATED: Use gen_ai.request.messages instead
+    DEPRECATED: Use gen_ai.input.messages instead
     Example: "[{\"role\": \"user\", \"message\": \"hello\"}]"
     """
 
@@ -475,7 +475,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: List[str]
     Contains PII: maybe
     Defined in OTEL: No
-    DEPRECATED: Use gen_ai.response.text instead
+    DEPRECATED: Use gen_ai.output.messages instead
     Example: ["hello","world"]
     """
 
@@ -567,7 +567,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: List[str]
     Contains PII: true
     Defined in OTEL: No
-    DEPRECATED: Use gen_ai.response.tool_calls instead
+    DEPRECATED: Use gen_ai.output.messages instead
     Example: ["tool_call_1","tool_call_2"]
     """
 
@@ -578,7 +578,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Type: List[str]
     Contains PII: maybe
     Defined in OTEL: No
-    DEPRECATED: Use gen_ai.request.available_tools instead
+    DEPRECATED: Use gen_ai.tool.definitions instead
     Example: ["function_1","function_2"]
     """
 
@@ -7059,7 +7059,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example='[{"role": "user", "message": "hello"}]',
         deprecation=DeprecationInfo(
-            replacement="gen_ai.request.messages", status=DeprecationStatus.BACKFILL
+            replacement="gen_ai.input.messages", status=DeprecationStatus.BACKFILL
         ),
         aliases=["gen_ai.request.messages"],
         sdks=["python"],
@@ -7216,7 +7216,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example=["hello", "world"],
         deprecation=DeprecationInfo(
-            replacement="gen_ai.response.text", status=DeprecationStatus.BACKFILL
+            replacement="gen_ai.output.messages", status=DeprecationStatus.BACKFILL
         ),
         sdks=["python"],
         changelog=[
@@ -7327,7 +7327,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example=["tool_call_1", "tool_call_2"],
         deprecation=DeprecationInfo(
-            replacement="gen_ai.response.tool_calls", status=DeprecationStatus.BACKFILL
+            replacement="gen_ai.output.messages", status=DeprecationStatus.BACKFILL
         ),
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[55, 65]),
@@ -7340,8 +7340,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         example=["function_1", "function_2"],
         deprecation=DeprecationInfo(
-            replacement="gen_ai.request.available_tools",
-            status=DeprecationStatus.BACKFILL,
+            replacement="gen_ai.tool.definitions", status=DeprecationStatus.BACKFILL
         ),
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[55, 65, 127]),

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -741,7 +741,7 @@
       "sdks": ["python"],
       "deprecation": {
         "_status": "backfill",
-        "replacement": "gen_ai.request.messages"
+        "replacement": "gen_ai.input.messages"
       },
       "changelog": [
         {
@@ -1007,7 +1007,7 @@
       "sdks": ["python"],
       "deprecation": {
         "_status": "backfill",
-        "replacement": "gen_ai.response.text"
+        "replacement": "gen_ai.output.messages"
       },
       "changelog": [
         {
@@ -1195,7 +1195,7 @@
       "example": ["tool_call_1", "tool_call_2"],
       "deprecation": {
         "_status": "backfill",
-        "replacement": "gen_ai.response.tool_calls"
+        "replacement": "gen_ai.output.messages"
       },
       "changelog": [
         {
@@ -1215,7 +1215,7 @@
       "example": ["function_1", "function_2"],
       "deprecation": {
         "_status": "backfill",
-        "replacement": "gen_ai.request.available_tools"
+        "replacement": "gen_ai.tool.definitions"
       },
       "changelog": [
         {

--- a/test/attributes.test.ts
+++ b/test/attributes.test.ts
@@ -123,6 +123,25 @@ describe('attribute json', async () => {
         expect(missingAliases).toEqual([]);
       });
 
+      it('its replacement should not be deprecated', async () => {
+        if (!content.deprecation?.replacement) {
+          return;
+        }
+        const replacement = content.deprecation.replacement;
+        const replacementFileName = attributeKeyToFileName(replacement);
+        let replacementFilePath: string;
+
+        if (replacement.includes('.')) {
+          const namespace = replacement.split('.')[0] as string;
+          replacementFilePath = path.join(traceFolders, namespace, replacementFileName);
+        } else {
+          replacementFilePath = path.join(traceFolders, replacementFileName);
+        }
+
+        const replacementContent: AttributeJson = JSON.parse(await fs.promises.readFile(replacementFilePath, 'utf-8'));
+        expect(replacementContent.deprecation, `replacement "${replacement}" is itself deprecated`).toBeUndefined();
+      });
+
       it('is not be a replacement of itself', async () => {
         if (!content.deprecation?.replacement) {
           return;


### PR DESCRIPTION
When an attribute is deprecated, it should point to a non-deprecated replacement.

This should obviously be true for newly introduced deprecations, but is a tradeoff for the case where:
- attribute A is deprecated and replaced by B
- later, attribute B is deprecated and replaced by C

This would now cause a test failure, and A would need to also be updated to point to C instead of B.

However, on the plus side:
- much easier to programatically translate or replace attribute with their latest replacement, since you don't have to follow a chain of attribute definitions
- avoids the trap where a human sees a deprecated attribute and replaces it with the advertised replacement, not realizing that it's _also_ deprecated

I think on the whole this is worth it.

---

🤖: Claude (Opus 4.6) used to write the test; validated by hand. All words my own.