### PR TITLE
feat(attributes): Add Cloudflare SDK attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8002,6 +8002,26 @@ export const MESSAGING_MESSAGE_RETRY_COUNT = 'messaging.message.retry.count';
  */
 export type MESSAGING_MESSAGE_RETRY_COUNT_TYPE = number;
 
+// Path: model/attributes/messaging/messaging__operation__name.json
+
+/**
+ * The name of the messaging operation being performed `messaging.operation.name`
+ *
+ * Attribute Value Type: `string` {@link MESSAGING_OPERATION_NAME_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ *
+ * @example "send"
+ */
+export const MESSAGING_OPERATION_NAME = 'messaging.operation.name';
+
+/**
+ * Type for {@link MESSAGING_OPERATION_NAME} messaging.operation.name
+ */
+export type MESSAGING_OPERATION_NAME_TYPE = string;
+
 // Path: model/attributes/messaging/messaging__operation__type.json
 
 /**
@@ -13108,6 +13128,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [MESSAGING_MESSAGE_ID]: 'string',
   [MESSAGING_MESSAGE_RECEIVE_LATENCY]: 'integer',
   [MESSAGING_MESSAGE_RETRY_COUNT]: 'integer',
+  [MESSAGING_OPERATION_NAME]: 'string',
   [MESSAGING_OPERATION_TYPE]: 'string',
   [MESSAGING_SYSTEM]: 'string',
   [METHOD]: 'string',
@@ -13717,6 +13738,7 @@ export type AttributeName =
   | typeof MESSAGING_MESSAGE_ID
   | typeof MESSAGING_MESSAGE_RECEIVE_LATENCY
   | typeof MESSAGING_MESSAGE_RETRY_COUNT
+  | typeof MESSAGING_OPERATION_NAME
   | typeof MESSAGING_OPERATION_TYPE
   | typeof MESSAGING_SYSTEM
   | typeof METHOD
@@ -18737,6 +18759,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     sdks: ['php-laravel'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
+  [MESSAGING_OPERATION_NAME]: {
+    brief: 'The name of the messaging operation being performed',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: true,
+    example: 'send',
+    sdks: ['javascript-cloudflare'],
+    changelog: [{ version: 'next', prs: [392], description: 'Added messaging.operation.name attribute' }],
+  },
   [MESSAGING_OPERATION_TYPE]: {
     brief: 'A string identifying the type of the messaging operation',
     type: 'string',
@@ -21700,6 +21733,7 @@ export type Attributes = {
   [MESSAGING_MESSAGE_ID]?: MESSAGING_MESSAGE_ID_TYPE;
   [MESSAGING_MESSAGE_RECEIVE_LATENCY]?: MESSAGING_MESSAGE_RECEIVE_LATENCY_TYPE;
   [MESSAGING_MESSAGE_RETRY_COUNT]?: MESSAGING_MESSAGE_RETRY_COUNT_TYPE;
+  [MESSAGING_OPERATION_NAME]?: MESSAGING_OPERATION_NAME_TYPE;
   [MESSAGING_OPERATION_TYPE]?: MESSAGING_OPERATION_TYPE_TYPE;
   [MESSAGING_SYSTEM]?: MESSAGING_SYSTEM_TYPE;
   [METHOD]?: METHOD_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2225,6 +2225,26 @@ export const CLOUDFLARE_D1_DURATION = 'cloudflare.d1.duration';
  */
 export type CLOUDFLARE_D1_DURATION_TYPE = number;
 
+// Path: model/attributes/cloudflare/cloudflare__d1__query_type.json
+
+/**
+ * The type of query executed in a Cloudflare D1 operation `cloudflare.d1.query_type`
+ *
+ * Attribute Value Type: `string` {@link CLOUDFLARE_D1_QUERY_TYPE_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "run"
+ */
+export const CLOUDFLARE_D1_QUERY_TYPE = 'cloudflare.d1.query_type';
+
+/**
+ * Type for {@link CLOUDFLARE_D1_QUERY_TYPE} cloudflare.d1.query_type
+ */
+export type CLOUDFLARE_D1_QUERY_TYPE_TYPE = string;
+
 // Path: model/attributes/cloudflare/cloudflare__d1__rows_read.json
 
 /**
@@ -2264,6 +2284,106 @@ export const CLOUDFLARE_D1_ROWS_WRITTEN = 'cloudflare.d1.rows_written';
  * Type for {@link CLOUDFLARE_D1_ROWS_WRITTEN} cloudflare.d1.rows_written
  */
 export type CLOUDFLARE_D1_ROWS_WRITTEN_TYPE = number;
+
+// Path: model/attributes/cloudflare/cloudflare__workflow__attempt.json
+
+/**
+ * The current attempt number for a Cloudflare Workflow step `cloudflare.workflow.attempt`
+ *
+ * Attribute Value Type: `number` {@link CLOUDFLARE_WORKFLOW_ATTEMPT_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 1
+ */
+export const CLOUDFLARE_WORKFLOW_ATTEMPT = 'cloudflare.workflow.attempt';
+
+/**
+ * Type for {@link CLOUDFLARE_WORKFLOW_ATTEMPT} cloudflare.workflow.attempt
+ */
+export type CLOUDFLARE_WORKFLOW_ATTEMPT_TYPE = number;
+
+// Path: model/attributes/cloudflare/cloudflare__workflow__retries__backoff.json
+
+/**
+ * The backoff strategy for Cloudflare Workflow step retries `cloudflare.workflow.retries.backoff`
+ *
+ * Attribute Value Type: `string` {@link CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "exponential"
+ */
+export const CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF = 'cloudflare.workflow.retries.backoff';
+
+/**
+ * Type for {@link CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF} cloudflare.workflow.retries.backoff
+ */
+export type CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF_TYPE = string;
+
+// Path: model/attributes/cloudflare/cloudflare__workflow__retries__delay.json
+
+/**
+ * The delay between Cloudflare Workflow step retries `cloudflare.workflow.retries.delay`
+ *
+ * Attribute Value Type: `string` {@link CLOUDFLARE_WORKFLOW_RETRIES_DELAY_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "5 seconds"
+ */
+export const CLOUDFLARE_WORKFLOW_RETRIES_DELAY = 'cloudflare.workflow.retries.delay';
+
+/**
+ * Type for {@link CLOUDFLARE_WORKFLOW_RETRIES_DELAY} cloudflare.workflow.retries.delay
+ */
+export type CLOUDFLARE_WORKFLOW_RETRIES_DELAY_TYPE = string;
+
+// Path: model/attributes/cloudflare/cloudflare__workflow__retries__limit.json
+
+/**
+ * The maximum number of retries for a Cloudflare Workflow step `cloudflare.workflow.retries.limit`
+ *
+ * Attribute Value Type: `number` {@link CLOUDFLARE_WORKFLOW_RETRIES_LIMIT_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example 3
+ */
+export const CLOUDFLARE_WORKFLOW_RETRIES_LIMIT = 'cloudflare.workflow.retries.limit';
+
+/**
+ * Type for {@link CLOUDFLARE_WORKFLOW_RETRIES_LIMIT} cloudflare.workflow.retries.limit
+ */
+export type CLOUDFLARE_WORKFLOW_RETRIES_LIMIT_TYPE = number;
+
+// Path: model/attributes/cloudflare/cloudflare__workflow__timeout.json
+
+/**
+ * The timeout duration for a Cloudflare Workflow step `cloudflare.workflow.timeout`
+ *
+ * Attribute Value Type: `string` {@link CLOUDFLARE_WORKFLOW_TIMEOUT_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ *
+ * @example "1 minute"
+ */
+export const CLOUDFLARE_WORKFLOW_TIMEOUT = 'cloudflare.workflow.timeout';
+
+/**
+ * Type for {@link CLOUDFLARE_WORKFLOW_TIMEOUT} cloudflare.workflow.timeout
+ */
+export type CLOUDFLARE_WORKFLOW_TIMEOUT_TYPE = string;
 
 // Path: model/attributes/cloud/cloud__account__id.json
 
@@ -12711,8 +12831,14 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [CLIENT_ADDRESS]: 'string',
   [CLIENT_PORT]: 'integer',
   [CLOUDFLARE_D1_DURATION]: 'integer',
+  [CLOUDFLARE_D1_QUERY_TYPE]: 'string',
   [CLOUDFLARE_D1_ROWS_READ]: 'integer',
   [CLOUDFLARE_D1_ROWS_WRITTEN]: 'integer',
+  [CLOUDFLARE_WORKFLOW_ATTEMPT]: 'integer',
+  [CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF]: 'string',
+  [CLOUDFLARE_WORKFLOW_RETRIES_DELAY]: 'string',
+  [CLOUDFLARE_WORKFLOW_RETRIES_LIMIT]: 'integer',
+  [CLOUDFLARE_WORKFLOW_TIMEOUT]: 'string',
   [CLOUD_ACCOUNT_ID]: 'string',
   [CLOUD_AVAILABILITY_ZONE]: 'string',
   [CLOUD_PLATFORM]: 'string',
@@ -13314,8 +13440,14 @@ export type AttributeName =
   | typeof CLIENT_ADDRESS
   | typeof CLIENT_PORT
   | typeof CLOUDFLARE_D1_DURATION
+  | typeof CLOUDFLARE_D1_QUERY_TYPE
   | typeof CLOUDFLARE_D1_ROWS_READ
   | typeof CLOUDFLARE_D1_ROWS_WRITTEN
+  | typeof CLOUDFLARE_WORKFLOW_ATTEMPT
+  | typeof CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF
+  | typeof CLOUDFLARE_WORKFLOW_RETRIES_DELAY
+  | typeof CLOUDFLARE_WORKFLOW_RETRIES_LIMIT
+  | typeof CLOUDFLARE_WORKFLOW_TIMEOUT
   | typeof CLOUD_ACCOUNT_ID
   | typeof CLOUD_AVAILABILITY_ZONE
   | typeof CLOUD_PLATFORM
@@ -15199,6 +15331,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     sdks: ['javascript-cloudflare'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
+  [CLOUDFLARE_D1_QUERY_TYPE]: {
+    brief: 'The type of query executed in a Cloudflare D1 operation',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 'run',
+    sdks: ['javascript-cloudflare'],
+    changelog: [{ version: 'next', prs: [392], description: 'Added cloudflare.d1.query_type attribute' }],
+  },
   [CLOUDFLARE_D1_ROWS_READ]: {
     brief: 'The number of rows read in a Cloudflare D1 operation.',
     type: 'integer',
@@ -15220,6 +15363,61 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 12,
     sdks: ['javascript-cloudflare'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+  },
+  [CLOUDFLARE_WORKFLOW_ATTEMPT]: {
+    brief: 'The current attempt number for a Cloudflare Workflow step',
+    type: 'integer',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 1,
+    sdks: ['javascript-cloudflare'],
+    changelog: [{ version: 'next', prs: [392], description: 'Added cloudflare.workflow.attempt attribute' }],
+  },
+  [CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF]: {
+    brief: 'The backoff strategy for Cloudflare Workflow step retries',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 'exponential',
+    sdks: ['javascript-cloudflare'],
+    changelog: [{ version: 'next', prs: [392], description: 'Added cloudflare.workflow.retries.backoff attribute' }],
+  },
+  [CLOUDFLARE_WORKFLOW_RETRIES_DELAY]: {
+    brief: 'The delay between Cloudflare Workflow step retries',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '5 seconds',
+    sdks: ['javascript-cloudflare'],
+    changelog: [{ version: 'next', prs: [392], description: 'Added cloudflare.workflow.retries.delay attribute' }],
+  },
+  [CLOUDFLARE_WORKFLOW_RETRIES_LIMIT]: {
+    brief: 'The maximum number of retries for a Cloudflare Workflow step',
+    type: 'integer',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: 3,
+    sdks: ['javascript-cloudflare'],
+    changelog: [{ version: 'next', prs: [392], description: 'Added cloudflare.workflow.retries.limit attribute' }],
+  },
+  [CLOUDFLARE_WORKFLOW_TIMEOUT]: {
+    brief: 'The timeout duration for a Cloudflare Workflow step',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    example: '1 minute',
+    sdks: ['javascript-cloudflare'],
+    changelog: [{ version: 'next', prs: [392], description: 'Added cloudflare.workflow.timeout attribute' }],
   },
   [CLOUD_ACCOUNT_ID]: {
     brief: 'The cloud account ID the resource is assigned to',
@@ -21225,8 +21423,14 @@ export type Attributes = {
   [CLIENT_ADDRESS]?: CLIENT_ADDRESS_TYPE;
   [CLIENT_PORT]?: CLIENT_PORT_TYPE;
   [CLOUDFLARE_D1_DURATION]?: CLOUDFLARE_D1_DURATION_TYPE;
+  [CLOUDFLARE_D1_QUERY_TYPE]?: CLOUDFLARE_D1_QUERY_TYPE_TYPE;
   [CLOUDFLARE_D1_ROWS_READ]?: CLOUDFLARE_D1_ROWS_READ_TYPE;
   [CLOUDFLARE_D1_ROWS_WRITTEN]?: CLOUDFLARE_D1_ROWS_WRITTEN_TYPE;
+  [CLOUDFLARE_WORKFLOW_ATTEMPT]?: CLOUDFLARE_WORKFLOW_ATTEMPT_TYPE;
+  [CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF]?: CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF_TYPE;
+  [CLOUDFLARE_WORKFLOW_RETRIES_DELAY]?: CLOUDFLARE_WORKFLOW_RETRIES_DELAY_TYPE;
+  [CLOUDFLARE_WORKFLOW_RETRIES_LIMIT]?: CLOUDFLARE_WORKFLOW_RETRIES_LIMIT_TYPE;
+  [CLOUDFLARE_WORKFLOW_TIMEOUT]?: CLOUDFLARE_WORKFLOW_TIMEOUT_TYPE;
   [CLOUD_ACCOUNT_ID]?: CLOUD_ACCOUNT_ID_TYPE;
   [CLOUD_AVAILABILITY_ZONE]?: CLOUD_AVAILABILITY_ZONE_TYPE;
   [CLOUD_PLATFORM]?: CLOUD_PLATFORM_TYPE;

--- a/model/attributes/cloudflare/cloudflare__d1__query_type.json
+++ b/model/attributes/cloudflare/cloudflare__d1__query_type.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.d1.query_type",
+  "brief": "The type of query executed in a Cloudflare D1 operation",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "run",
+  "sdks": ["javascript-cloudflare"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [392],
+      "description": "Added cloudflare.d1.query_type attribute"
+    }
+  ]
+}

--- a/model/attributes/cloudflare/cloudflare__workflow__attempt.json
+++ b/model/attributes/cloudflare/cloudflare__workflow__attempt.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.workflow.attempt",
+  "brief": "The current attempt number for a Cloudflare Workflow step",
+  "type": "integer",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": 1,
+  "sdks": ["javascript-cloudflare"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [392],
+      "description": "Added cloudflare.workflow.attempt attribute"
+    }
+  ]
+}

--- a/model/attributes/cloudflare/cloudflare__workflow__retries__backoff.json
+++ b/model/attributes/cloudflare/cloudflare__workflow__retries__backoff.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.workflow.retries.backoff",
+  "brief": "The backoff strategy for Cloudflare Workflow step retries",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "exponential",
+  "sdks": ["javascript-cloudflare"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [392],
+      "description": "Added cloudflare.workflow.retries.backoff attribute"
+    }
+  ]
+}

--- a/model/attributes/cloudflare/cloudflare__workflow__retries__delay.json
+++ b/model/attributes/cloudflare/cloudflare__workflow__retries__delay.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.workflow.retries.delay",
+  "brief": "The delay between Cloudflare Workflow step retries",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "5 seconds",
+  "sdks": ["javascript-cloudflare"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [392],
+      "description": "Added cloudflare.workflow.retries.delay attribute"
+    }
+  ]
+}

--- a/model/attributes/cloudflare/cloudflare__workflow__retries__limit.json
+++ b/model/attributes/cloudflare/cloudflare__workflow__retries__limit.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.workflow.retries.limit",
+  "brief": "The maximum number of retries for a Cloudflare Workflow step",
+  "type": "integer",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": 3,
+  "sdks": ["javascript-cloudflare"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [392],
+      "description": "Added cloudflare.workflow.retries.limit attribute"
+    }
+  ]
+}

--- a/model/attributes/cloudflare/cloudflare__workflow__timeout.json
+++ b/model/attributes/cloudflare/cloudflare__workflow__timeout.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.workflow.timeout",
+  "brief": "The timeout duration for a Cloudflare Workflow step",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "1 minute",
+  "sdks": ["javascript-cloudflare"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [392],
+      "description": "Added cloudflare.workflow.timeout attribute"
+    }
+  ]
+}

--- a/model/attributes/messaging/messaging__operation__name.json
+++ b/model/attributes/messaging/messaging__operation__name.json
@@ -1,0 +1,18 @@
+{
+  "key": "messaging.operation.name",
+  "brief": "The name of the messaging operation being performed",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": "send",
+  "sdks": ["javascript-cloudflare"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [392],
+      "description": "Added messaging.operation.name attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4582,6 +4582,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 2
     """
 
+    # Path: model/attributes/messaging/messaging__operation__name.json
+    MESSAGING_OPERATION_NAME: Literal["messaging.operation.name"] = (
+        "messaging.operation.name"
+    )
+    """The name of the messaging operation being performed
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: Yes
+    Example: "send"
+    """
+
     # Path: model/attributes/messaging/messaging__operation__type.json
     MESSAGING_OPERATION_TYPE: Literal["messaging.operation.type"] = (
         "messaging.operation.type"
@@ -12202,6 +12214,21 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "messaging.operation.name": AttributeMetadata(
+        brief="The name of the messaging operation being performed",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=True,
+        example="send",
+        sdks=["javascript-cloudflare"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[392],
+                description="Added messaging.operation.name attribute",
+            ),
+        ],
+    ),
     "messaging.operation.type": AttributeMetadata(
         brief="A string identifying the type of the messaging operation",
         type=AttributeType.STRING,
@@ -15287,6 +15314,7 @@ Attributes = TypedDict(
         "messaging.message.id": str,
         "messaging.message.receive.latency": int,
         "messaging.message.retry.count": int,
+        "messaging.operation.name": str,
         "messaging.operation.type": str,
         "messaging.system": str,
         "method": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1517,6 +1517,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 543
     """
 
+    # Path: model/attributes/cloudflare/cloudflare__d1__query_type.json
+    CLOUDFLARE_D1_QUERY_TYPE: Literal["cloudflare.d1.query_type"] = (
+        "cloudflare.d1.query_type"
+    )
+    """The type of query executed in a Cloudflare D1 operation
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "run"
+    """
+
     # Path: model/attributes/cloudflare/cloudflare__d1__rows_read.json
     CLOUDFLARE_D1_ROWS_READ: Literal["cloudflare.d1.rows_read"] = (
         "cloudflare.d1.rows_read"
@@ -1539,6 +1551,66 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Example: 12
+    """
+
+    # Path: model/attributes/cloudflare/cloudflare__workflow__attempt.json
+    CLOUDFLARE_WORKFLOW_ATTEMPT: Literal["cloudflare.workflow.attempt"] = (
+        "cloudflare.workflow.attempt"
+    )
+    """The current attempt number for a Cloudflare Workflow step
+
+    Type: int
+    Contains PII: false
+    Defined in OTEL: No
+    Example: 1
+    """
+
+    # Path: model/attributes/cloudflare/cloudflare__workflow__retries__backoff.json
+    CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF: Literal[
+        "cloudflare.workflow.retries.backoff"
+    ] = "cloudflare.workflow.retries.backoff"
+    """The backoff strategy for Cloudflare Workflow step retries
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "exponential"
+    """
+
+    # Path: model/attributes/cloudflare/cloudflare__workflow__retries__delay.json
+    CLOUDFLARE_WORKFLOW_RETRIES_DELAY: Literal["cloudflare.workflow.retries.delay"] = (
+        "cloudflare.workflow.retries.delay"
+    )
+    """The delay between Cloudflare Workflow step retries
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "5 seconds"
+    """
+
+    # Path: model/attributes/cloudflare/cloudflare__workflow__retries__limit.json
+    CLOUDFLARE_WORKFLOW_RETRIES_LIMIT: Literal["cloudflare.workflow.retries.limit"] = (
+        "cloudflare.workflow.retries.limit"
+    )
+    """The maximum number of retries for a Cloudflare Workflow step
+
+    Type: int
+    Contains PII: false
+    Defined in OTEL: No
+    Example: 3
+    """
+
+    # Path: model/attributes/cloudflare/cloudflare__workflow__timeout.json
+    CLOUDFLARE_WORKFLOW_TIMEOUT: Literal["cloudflare.workflow.timeout"] = (
+        "cloudflare.workflow.timeout"
+    )
+    """The timeout duration for a Cloudflare Workflow step
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Example: "1 minute"
     """
 
     # Path: model/attributes/cls/cls__source__[key].json
@@ -8611,6 +8683,21 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "cloudflare.d1.query_type": AttributeMetadata(
+        brief="The type of query executed in a Cloudflare D1 operation",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="run",
+        sdks=["javascript-cloudflare"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[392],
+                description="Added cloudflare.d1.query_type attribute",
+            ),
+        ],
+    ),
     "cloudflare.d1.rows_read": AttributeMetadata(
         brief="The number of rows read in a Cloudflare D1 operation.",
         type=AttributeType.INTEGER,
@@ -8633,6 +8720,81 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "cloudflare.workflow.attempt": AttributeMetadata(
+        brief="The current attempt number for a Cloudflare Workflow step",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example=1,
+        sdks=["javascript-cloudflare"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[392],
+                description="Added cloudflare.workflow.attempt attribute",
+            ),
+        ],
+    ),
+    "cloudflare.workflow.retries.backoff": AttributeMetadata(
+        brief="The backoff strategy for Cloudflare Workflow step retries",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="exponential",
+        sdks=["javascript-cloudflare"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[392],
+                description="Added cloudflare.workflow.retries.backoff attribute",
+            ),
+        ],
+    ),
+    "cloudflare.workflow.retries.delay": AttributeMetadata(
+        brief="The delay between Cloudflare Workflow step retries",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="5 seconds",
+        sdks=["javascript-cloudflare"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[392],
+                description="Added cloudflare.workflow.retries.delay attribute",
+            ),
+        ],
+    ),
+    "cloudflare.workflow.retries.limit": AttributeMetadata(
+        brief="The maximum number of retries for a Cloudflare Workflow step",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example=3,
+        sdks=["javascript-cloudflare"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[392],
+                description="Added cloudflare.workflow.retries.limit attribute",
+            ),
+        ],
+    ),
+    "cloudflare.workflow.timeout": AttributeMetadata(
+        brief="The timeout duration for a Cloudflare Workflow step",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        example="1 minute",
+        sdks=["javascript-cloudflare"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[392],
+                description="Added cloudflare.workflow.timeout attribute",
+            ),
         ],
     ),
     "cls.source.<key>": AttributeMetadata(
@@ -14853,8 +15015,14 @@ Attributes = TypedDict(
         "cloud.provider": str,
         "cloud.region": str,
         "cloudflare.d1.duration": int,
+        "cloudflare.d1.query_type": str,
         "cloudflare.d1.rows_read": int,
         "cloudflare.d1.rows_written": int,
+        "cloudflare.workflow.attempt": int,
+        "cloudflare.workflow.retries.backoff": str,
+        "cloudflare.workflow.retries.delay": str,
+        "cloudflare.workflow.retries.limit": int,
+        "cloudflare.workflow.timeout": str,
         "cls.source.<key>": str,
         "cls": float,
         "code.file.path": str,


### PR DESCRIPTION
Couple of attributes are using within the [Cloudflare SDK](https://www.npmjs.com/package/@sentry/cloudflare), but were not mentioned here. I added these via the script `yarn create:attribute`: 

- cloudflare.d1.query_type
- cloudflare.workflow.timeout
- cloudflare.workflow.retries.backoff
- cloudflare.workflow.retries.delay
- cloudflare.workflow.retries.limit
- cloudflare.workflow.attempt