### PR TITLE
feat(schema): Add `additional_context` field to attribute definitions

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -12605,6 +12605,8 @@ export interface AttributeMetadata {
   sdks?: string[];
   /** Changelog entries tracking how this attribute has changed across versions */
   changelog?: ChangelogEntry[];
+  /** A list of freeform notes providing additional context about how this attribute behaves, common pitfalls, or query-time nuances */
+  additionalContext?: string[];
 }
 
 export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -100,6 +100,9 @@ class AttributeMetadata:
     changelog: Optional[List[ChangelogEntry]] = None
     """Changelog entries tracking how this attribute has changed across versions"""
 
+    additional_context: Optional[List[str]] = None
+    """A list of freeform notes providing additional context about how this attribute behaves, common pitfalls, or query-time nuances"""
+
 
 class _AttributeNamesMeta(type):
     _deprecated_names = {

--- a/schemas/attribute.schema.json
+++ b/schemas/attribute.schema.json
@@ -102,6 +102,13 @@
         "type": "string"
       }
     },
+    "additional_context": {
+      "description": "A list of freeform notes providing additional context about how this attribute behaves, common pitfalls, or query-time nuances",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "changelog": {
       "description": "A list of changelog entries tracking how this attribute has changed across versions",
       "type": "array",

--- a/scripts/generate_attributes.ts
+++ b/scripts/generate_attributes.ts
@@ -362,7 +362,11 @@ function writeToPython(attributesDir: string, attributeFiles: string[]) {
     '    """If an attribute is SDK specific, list the SDKs that use this attribute. This is not an exhaustive list, there might be SDKs that send this attribute that are is not documented here."""\n';
   content += '    \n';
   content += '    changelog: Optional[List[ChangelogEntry]] = None\n';
-  content += '    """Changelog entries tracking how this attribute has changed across versions"""\n\n';
+  content += '    """Changelog entries tracking how this attribute has changed across versions"""\n';
+  content += '    \n';
+  content += '    additional_context: Optional[List[str]] = None\n';
+  content +=
+    '    """A list of freeform notes providing additional context about how this attribute behaves, common pitfalls, or query-time nuances"""\n\n';
 
   let attributesTypeMembers = '';
   let deprecatedAttributesTypeMembers = '';
@@ -537,6 +541,10 @@ function writeToPython(attributesDir: string, attributeFiles: string[]) {
       metadataDict += '        ],\n';
     }
 
+    if (attributeJson.additional_context && attributeJson.additional_context.length > 0) {
+      metadataDict += `        additional_context=${JSON.stringify(attributeJson.additional_context)},\n`;
+    }
+
     metadataDict += '    ),\n';
   }
 
@@ -698,6 +706,8 @@ export interface AttributeMetadata {
   sdks?: string[];
   /** Changelog entries tracking how this attribute has changed across versions */
   changelog?: ChangelogEntry[];
+  /** A list of freeform notes providing additional context about how this attribute behaves, common pitfalls, or query-time nuances */
+  additionalContext?: string[];
 }
 
 `;
@@ -808,6 +818,10 @@ function generateMetadataDict(
         metadataDict += ' },\n';
       }
       metadataDict += '    ],\n';
+    }
+
+    if (attributeJson.additional_context && attributeJson.additional_context.length > 0) {
+      metadataDict += `    additionalContext: ${JSON.stringify(attributeJson.additional_context)},\n`;
     }
 
     metadataDict += '  },\n';

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -16,6 +16,7 @@ export interface AttributeJson {
   };
   alias?: string[];
   sdks?: string[];
+  additional_context?: string[];
   changelog?: { version: string; prs?: number[]; description?: string }[];
 }
 


### PR DESCRIPTION
Adds a new optional `additional_context` field to attribute definitions — a list of freeform notes capturing query-time nuances, common pitfalls, or behavioral context that isn't covered by `brief`.

## Motivation

Span attributes can have subtleties that trip up both users and AI agents when querying. For example, `gen_ai.cost.total_tokens` appears on both agent parent spans and LLM child spans, causing `sum()` queries to double-count. Today there's nowhere to capture this kind of context — `brief` describes *what* the attribute is, not *how to use it correctly*.

This is the foundation for surfacing attribute context to Explore UI (via Seer) and AI agent tooling. A follow-up PR will populate the field for gen_ai cost and usage attributes.

See proposal: https://www.notion.so/sentry/Proposal-Query-Guidance-for-Span-Attributes-3598b10e4b5d806d8c75e2a5b1caa42c

## Changes

- **Schema**: New optional `additional_context` property (array of strings) in `attribute.schema.json`
- **Types**: Added to `AttributeJson` interface in `types.ts`
- **Codegen**: Updated JS and Python generators to propagate the field into `AttributeMetadata` (as `additionalContext` in JS, `additional_context` in Python)
- **Generated code**: Regenerated JS and Python packages with the new field

Closes TET-2319, TET-2315