### PR TITLE
feat(attributes): Add additional_context to gen_ai cost and usage attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -17430,8 +17430,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 123.45,
     changelog: [
+      { version: 'next', prs: [397], description: 'Add additional_context' },
       { version: '0.4.0', prs: [228] },
       { version: '0.1.0', prs: [112] },
+    ],
+    additionalContext: [
+      'This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to calculate total cost, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.',
+      "Despite the name 'cost.input_tokens', this value is cost in USD, not a token count. For token counts, use gen_ai.usage.input_tokens.",
+      'This is the cost of non-cached input tokens only. The cost of cached tokens is excluded from this value.',
     ],
   },
   [GEN_AI_COST_OUTPUT_TOKENS]: {
@@ -17444,8 +17450,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 123.45,
     changelog: [
+      { version: 'next', prs: [397], description: 'Add additional_context' },
       { version: '0.4.0', prs: [228] },
       { version: '0.1.0', prs: [112] },
+    ],
+    additionalContext: [
+      'This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to calculate total cost, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.',
+      "Despite the name 'cost.output_tokens', this value is cost in USD, not a token count. For token counts, use gen_ai.usage.output_tokens.",
+      'This is the cost of non-reasoning output tokens only. The cost of reasoning tokens is excluded from this value.',
     ],
   },
   [GEN_AI_COST_TOTAL_TOKENS]: {
@@ -17459,9 +17471,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 12.34,
     aliases: [AI_TOTAL_COST],
     changelog: [
+      { version: 'next', prs: [397], description: 'Add additional_context' },
       { version: '0.5.0', prs: [264] },
       { version: '0.4.0', prs: [228] },
       { version: '0.1.0', prs: [126] },
+    ],
+    additionalContext: [
+      'This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to calculate total cost, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.',
+      "Despite the name 'cost.total_tokens', this value is cost in USD, not a token count. For token counts, use gen_ai.usage.total_tokens.",
     ],
   },
   [GEN_AI_EMBEDDINGS_INPUT]: {
@@ -18045,7 +18062,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.usage.output_tokens',
     },
     aliases: [AI_COMPLETION_TOKENS_USED, GEN_AI_USAGE_OUTPUT_TOKENS],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      { version: 'next', prs: [397], description: 'Add additional_context' },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [61] },
+      { version: '0.0.0' },
+    ],
+    additionalContext: [
+      'This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.',
+    ],
   },
   [GEN_AI_USAGE_INPUT_TOKENS]: {
     brief: 'The number of tokens used to process the AI input (prompt) including cached input tokens.',
@@ -18058,10 +18083,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 10,
     aliases: [AI_PROMPT_TOKENS_USED, GEN_AI_USAGE_PROMPT_TOKENS],
     changelog: [
+      { version: 'next', prs: [397], description: 'Add additional_context' },
       { version: '0.5.0', prs: [261] },
       { version: '0.4.0', prs: [228] },
       { version: '0.1.0', prs: [112] },
       { version: '0.0.0' },
+    ],
+    additionalContext: [
+      'This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.',
+      'This count includes cached input tokens. gen_ai.usage.input_tokens.cached is a subset of this value, not an independent count — do not sum them together.',
     ],
   },
   [GEN_AI_USAGE_INPUT_TOKENS_CACHED]: {
@@ -18074,8 +18104,13 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 50,
     changelog: [
+      { version: 'next', prs: [397], description: 'Add additional_context' },
       { version: '0.4.0', prs: [228] },
       { version: '0.1.0', prs: [62, 112] },
+    ],
+    additionalContext: [
+      'This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.',
+      'This is a subset of gen_ai.usage.input_tokens, not an independent count. Do not sum this with gen_ai.usage.input_tokens — it is already included.',
     ],
   },
   [GEN_AI_USAGE_INPUT_TOKENS_CACHE_WRITE]: {
@@ -18087,7 +18122,13 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 100,
-    changelog: [{ version: '0.4.0', prs: [217, 228] }],
+    changelog: [
+      { version: 'next', prs: [397], description: 'Add additional_context' },
+      { version: '0.4.0', prs: [217, 228] },
+    ],
+    additionalContext: [
+      'This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.',
+    ],
   },
   [GEN_AI_USAGE_OUTPUT_TOKENS]: {
     brief: 'The number of tokens used for creating the AI output (including reasoning tokens).',
@@ -18100,10 +18141,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 10,
     aliases: [AI_COMPLETION_TOKENS_USED, GEN_AI_USAGE_COMPLETION_TOKENS],
     changelog: [
+      { version: 'next', prs: [397], description: 'Add additional_context' },
       { version: '0.5.0', prs: [261] },
       { version: '0.4.0', prs: [228] },
       { version: '0.1.0', prs: [112] },
       { version: '0.0.0' },
+    ],
+    additionalContext: [
+      'This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.',
+      'This count includes reasoning tokens. gen_ai.usage.output_tokens.reasoning is a subset of this value, not an independent count — do not sum them together.',
     ],
   },
   [GEN_AI_USAGE_OUTPUT_TOKENS_REASONING]: {
@@ -18116,8 +18162,13 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 75,
     changelog: [
+      { version: 'next', prs: [397], description: 'Add additional_context' },
       { version: '0.4.0', prs: [228] },
       { version: '0.1.0', prs: [62, 112] },
+    ],
+    additionalContext: [
+      'This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.',
+      'This is a subset of gen_ai.usage.output_tokens, not an independent count. Do not sum this with gen_ai.usage.output_tokens — it is already included.',
     ],
   },
   [GEN_AI_USAGE_PROMPT_TOKENS]: {
@@ -18133,7 +18184,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.usage.input_tokens',
     },
     aliases: [AI_PROMPT_TOKENS_USED, GEN_AI_USAGE_INPUT_TOKENS],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      { version: 'next', prs: [397], description: 'Add additional_context' },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [61] },
+      { version: '0.0.0' },
+    ],
+    additionalContext: [
+      'This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.',
+    ],
   },
   [GEN_AI_USAGE_TOTAL_TOKENS]: {
     brief: 'The total number of tokens used to process the prompt. (input tokens plus output todkens)',
@@ -18146,8 +18205,13 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 20,
     aliases: [AI_TOTAL_TOKENS_USED],
     changelog: [
+      { version: 'next', prs: [397], description: 'Add additional_context' },
       { version: '0.4.0', prs: [228] },
       { version: '0.1.0', prs: [57] },
+    ],
+    additionalContext: [
+      'This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.',
+      'This is the sum of gen_ai.usage.input_tokens and gen_ai.usage.output_tokens. Do not sum this with either of them — they are already included.',
     ],
   },
   [GRAPHQL_DOCUMENT]: {

--- a/model/attributes/gen_ai/gen_ai__cost__input_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__cost__input_tokens.json
@@ -8,7 +8,17 @@
   "is_in_otel": false,
   "example": 123.45,
   "visibility": "public",
+  "additional_context": [
+    "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to calculate total cost, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+    "Despite the name 'cost.input_tokens', this value is cost in USD, not a token count. For token counts, use gen_ai.usage.input_tokens.",
+    "This is the cost of non-cached input tokens only. The cost of cached tokens is excluded from this value."
+  ],
   "changelog": [
+    {
+      "version": "next",
+      "prs": [397],
+      "description": "Add additional_context"
+    },
     {
       "version": "0.4.0",
       "prs": [228]

--- a/model/attributes/gen_ai/gen_ai__cost__output_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__cost__output_tokens.json
@@ -8,7 +8,17 @@
   "is_in_otel": false,
   "example": 123.45,
   "visibility": "public",
+  "additional_context": [
+    "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to calculate total cost, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+    "Despite the name 'cost.output_tokens', this value is cost in USD, not a token count. For token counts, use gen_ai.usage.output_tokens.",
+    "This is the cost of non-reasoning output tokens only. The cost of reasoning tokens is excluded from this value."
+  ],
   "changelog": [
+    {
+      "version": "next",
+      "prs": [397],
+      "description": "Add additional_context"
+    },
     {
       "version": "0.4.0",
       "prs": [228]

--- a/model/attributes/gen_ai/gen_ai__cost__total_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__cost__total_tokens.json
@@ -7,9 +7,18 @@
   },
   "is_in_otel": false,
   "example": 12.34,
+  "additional_context": [
+    "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to calculate total cost, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+    "Despite the name 'cost.total_tokens', this value is cost in USD, not a token count. For token counts, use gen_ai.usage.total_tokens."
+  ],
   "alias": ["ai.total_cost"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [397],
+      "description": "Add additional_context"
+    },
     {
       "version": "0.5.0",
       "prs": [264]

--- a/model/attributes/gen_ai/gen_ai__usage__completion_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__usage__completion_tokens.json
@@ -8,12 +8,20 @@
   "is_in_otel": true,
   "example": 10,
   "alias": ["ai.completion_tokens.used", "gen_ai.usage.output_tokens"],
+  "additional_context": [
+    "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans."
+  ],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.usage.output_tokens"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [397],
+      "description": "Add additional_context"
+    },
     {
       "version": "0.4.0",
       "prs": [228]

--- a/model/attributes/gen_ai/gen_ai__usage__input_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__usage__input_tokens.json
@@ -7,9 +7,18 @@
   },
   "is_in_otel": true,
   "example": 10,
+  "additional_context": [
+    "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+    "This count includes cached input tokens. gen_ai.usage.input_tokens.cached is a subset of this value, not an independent count \u2014 do not sum them together."
+  ],
   "alias": ["ai.prompt_tokens.used", "gen_ai.usage.prompt_tokens"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [397],
+      "description": "Add additional_context"
+    },
     {
       "version": "0.5.0",
       "prs": [261]

--- a/model/attributes/gen_ai/gen_ai__usage__input_tokens__cache_write.json
+++ b/model/attributes/gen_ai/gen_ai__usage__input_tokens__cache_write.json
@@ -8,7 +8,15 @@
   "is_in_otel": false,
   "example": 100,
   "visibility": "public",
+  "additional_context": [
+    "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans."
+  ],
   "changelog": [
+    {
+      "version": "next",
+      "prs": [397],
+      "description": "Add additional_context"
+    },
     {
       "version": "0.4.0",
       "prs": [217, 228]

--- a/model/attributes/gen_ai/gen_ai__usage__input_tokens__cached.json
+++ b/model/attributes/gen_ai/gen_ai__usage__input_tokens__cached.json
@@ -8,7 +8,16 @@
   "is_in_otel": false,
   "example": 50,
   "visibility": "public",
+  "additional_context": [
+    "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+    "This is a subset of gen_ai.usage.input_tokens, not an independent count. Do not sum this with gen_ai.usage.input_tokens \u2014 it is already included."
+  ],
   "changelog": [
+    {
+      "version": "next",
+      "prs": [397],
+      "description": "Add additional_context"
+    },
     {
       "version": "0.4.0",
       "prs": [228]

--- a/model/attributes/gen_ai/gen_ai__usage__output_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__usage__output_tokens.json
@@ -7,9 +7,18 @@
   },
   "is_in_otel": true,
   "example": 10,
+  "additional_context": [
+    "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+    "This count includes reasoning tokens. gen_ai.usage.output_tokens.reasoning is a subset of this value, not an independent count \u2014 do not sum them together."
+  ],
   "alias": ["ai.completion_tokens.used", "gen_ai.usage.completion_tokens"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [397],
+      "description": "Add additional_context"
+    },
     {
       "version": "0.5.0",
       "prs": [261]

--- a/model/attributes/gen_ai/gen_ai__usage__output_tokens__reasoning.json
+++ b/model/attributes/gen_ai/gen_ai__usage__output_tokens__reasoning.json
@@ -8,7 +8,16 @@
   "is_in_otel": false,
   "example": 75,
   "visibility": "public",
+  "additional_context": [
+    "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+    "This is a subset of gen_ai.usage.output_tokens, not an independent count. Do not sum this with gen_ai.usage.output_tokens \u2014 it is already included."
+  ],
   "changelog": [
+    {
+      "version": "next",
+      "prs": [397],
+      "description": "Add additional_context"
+    },
     {
       "version": "0.4.0",
       "prs": [228]

--- a/model/attributes/gen_ai/gen_ai__usage__prompt_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__usage__prompt_tokens.json
@@ -8,12 +8,20 @@
   "is_in_otel": true,
   "example": 20,
   "alias": ["ai.prompt_tokens.used", "gen_ai.usage.input_tokens"],
+  "additional_context": [
+    "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans."
+  ],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.usage.input_tokens"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [397],
+      "description": "Add additional_context"
+    },
     {
       "version": "0.4.0",
       "prs": [228]

--- a/model/attributes/gen_ai/gen_ai__usage__total_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__usage__total_tokens.json
@@ -7,9 +7,18 @@
   },
   "is_in_otel": false,
   "example": 20,
+  "additional_context": [
+    "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+    "This is the sum of gen_ai.usage.input_tokens and gen_ai.usage.output_tokens. Do not sum this with either of them \u2014 they are already included."
+  ],
   "alias": ["ai.total_tokens.used"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [397],
+      "description": "Add additional_context"
+    },
     {
       "version": "0.4.0",
       "prs": [228]

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -10955,8 +10955,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=123.45,
         changelog=[
+            ChangelogEntry(
+                version="next", prs=[397], description="Add additional_context"
+            ),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[112]),
+        ],
+        additional_context=[
+            "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to calculate total cost, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+            "Despite the name 'cost.input_tokens', this value is cost in USD, not a token count. For token counts, use gen_ai.usage.input_tokens.",
+            "This is the cost of non-cached input tokens only. The cost of cached tokens is excluded from this value.",
         ],
     ),
     "gen_ai.cost.output_tokens": AttributeMetadata(
@@ -10967,8 +10975,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=123.45,
         changelog=[
+            ChangelogEntry(
+                version="next", prs=[397], description="Add additional_context"
+            ),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[112]),
+        ],
+        additional_context=[
+            "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to calculate total cost, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+            "Despite the name 'cost.output_tokens', this value is cost in USD, not a token count. For token counts, use gen_ai.usage.output_tokens.",
+            "This is the cost of non-reasoning output tokens only. The cost of reasoning tokens is excluded from this value.",
         ],
     ),
     "gen_ai.cost.total_tokens": AttributeMetadata(
@@ -10980,9 +10996,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=12.34,
         aliases=["ai.total_cost"],
         changelog=[
+            ChangelogEntry(
+                version="next", prs=[397], description="Add additional_context"
+            ),
             ChangelogEntry(version="0.5.0", prs=[264]),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[126]),
+        ],
+        additional_context=[
+            "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to calculate total cost, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+            "Despite the name 'cost.total_tokens', this value is cost in USD, not a token count. For token counts, use gen_ai.usage.total_tokens.",
         ],
     ),
     "gen_ai.embeddings.input": AttributeMetadata(
@@ -11509,9 +11532,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ),
         aliases=["ai.completion_tokens.used", "gen_ai.usage.output_tokens"],
         changelog=[
+            ChangelogEntry(
+                version="next", prs=[397], description="Add additional_context"
+            ),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[61]),
             ChangelogEntry(version="0.0.0"),
+        ],
+        additional_context=[
+            "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans."
         ],
     ),
     "gen_ai.usage.input_tokens": AttributeMetadata(
@@ -11523,10 +11552,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=10,
         aliases=["ai.prompt_tokens.used", "gen_ai.usage.prompt_tokens"],
         changelog=[
+            ChangelogEntry(
+                version="next", prs=[397], description="Add additional_context"
+            ),
             ChangelogEntry(version="0.5.0", prs=[261]),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[112]),
             ChangelogEntry(version="0.0.0"),
+        ],
+        additional_context=[
+            "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+            "This count includes cached input tokens. gen_ai.usage.input_tokens.cached is a subset of this value, not an independent count — do not sum them together.",
         ],
     ),
     "gen_ai.usage.input_tokens.cache_write": AttributeMetadata(
@@ -11537,7 +11573,13 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=100,
         changelog=[
+            ChangelogEntry(
+                version="next", prs=[397], description="Add additional_context"
+            ),
             ChangelogEntry(version="0.4.0", prs=[217, 228]),
+        ],
+        additional_context=[
+            "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans."
         ],
     ),
     "gen_ai.usage.input_tokens.cached": AttributeMetadata(
@@ -11548,8 +11590,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=50,
         changelog=[
+            ChangelogEntry(
+                version="next", prs=[397], description="Add additional_context"
+            ),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[62, 112]),
+        ],
+        additional_context=[
+            "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+            "This is a subset of gen_ai.usage.input_tokens, not an independent count. Do not sum this with gen_ai.usage.input_tokens — it is already included.",
         ],
     ),
     "gen_ai.usage.output_tokens": AttributeMetadata(
@@ -11561,10 +11610,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=10,
         aliases=["ai.completion_tokens.used", "gen_ai.usage.completion_tokens"],
         changelog=[
+            ChangelogEntry(
+                version="next", prs=[397], description="Add additional_context"
+            ),
             ChangelogEntry(version="0.5.0", prs=[261]),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[112]),
             ChangelogEntry(version="0.0.0"),
+        ],
+        additional_context=[
+            "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+            "This count includes reasoning tokens. gen_ai.usage.output_tokens.reasoning is a subset of this value, not an independent count — do not sum them together.",
         ],
     ),
     "gen_ai.usage.output_tokens.reasoning": AttributeMetadata(
@@ -11575,8 +11631,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=75,
         changelog=[
+            ChangelogEntry(
+                version="next", prs=[397], description="Add additional_context"
+            ),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[62, 112]),
+        ],
+        additional_context=[
+            "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+            "This is a subset of gen_ai.usage.output_tokens, not an independent count. Do not sum this with gen_ai.usage.output_tokens — it is already included.",
         ],
     ),
     "gen_ai.usage.prompt_tokens": AttributeMetadata(
@@ -11591,9 +11654,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ),
         aliases=["ai.prompt_tokens.used", "gen_ai.usage.input_tokens"],
         changelog=[
+            ChangelogEntry(
+                version="next", prs=[397], description="Add additional_context"
+            ),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[61]),
             ChangelogEntry(version="0.0.0"),
+        ],
+        additional_context=[
+            "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans."
         ],
     ),
     "gen_ai.usage.total_tokens": AttributeMetadata(
@@ -11605,8 +11674,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=20,
         aliases=["ai.total_tokens.used"],
         changelog=[
+            ChangelogEntry(
+                version="next", prs=[397], description="Add additional_context"
+            ),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[57]),
+        ],
+        additional_context=[
+            "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+            "This is the sum of gen_ai.usage.input_tokens and gen_ai.usage.output_tokens. Do not sum this with either of them — they are already included.",
         ],
     ),
     "graphql.document": AttributeMetadata(

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -2214,12 +2214,20 @@
       "is_in_otel": true,
       "example": 10,
       "alias": ["ai.completion_tokens.used", "gen_ai.usage.output_tokens"],
+      "additional_context": [
+        "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans."
+      ],
       "deprecation": {
         "_status": "backfill",
         "replacement": "gen_ai.usage.output_tokens"
       },
       "visibility": "public",
       "changelog": [
+        {
+          "version": "next",
+          "prs": [397],
+          "description": "Add additional_context"
+        },
         {
           "version": "0.4.0",
           "prs": [228]
@@ -2243,12 +2251,20 @@
       "is_in_otel": true,
       "example": 20,
       "alias": ["ai.prompt_tokens.used", "gen_ai.usage.input_tokens"],
+      "additional_context": [
+        "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans."
+      ],
       "deprecation": {
         "_status": "backfill",
         "replacement": "gen_ai.usage.input_tokens"
       },
       "visibility": "public",
       "changelog": [
+        {
+          "version": "next",
+          "prs": [397],
+          "description": "Add additional_context"
+        },
         {
           "version": "0.4.0",
           "prs": [228]


### PR DESCRIPTION
Populates the `additional_context` field (introduced in #393) for all 11 gen_ai cost and usage attributes.

## Context

Each attribute gets notes about:

- **Double-counting**: all cost/usage attributes appear on both agent parent spans (aggregated totals) and LLM child spans (per-call values). Summing without filtering to `gen_ai.operation.type:ai_client` will over-report.
- **Naming confusion**: cost attributes contain USD values despite having "tokens" in the name.
- **Subset relationships**: cached input tokens are a subset of input tokens, reasoning tokens are a subset of output tokens, and total tokens is the sum of input + output. These should not be summed together.

## Attributes updated

| Attribute | Notes |
|-----------|-------|
| `gen_ai.cost.total_tokens` | Double-counting + "USD not tokens" |
| `gen_ai.cost.input_tokens` | Double-counting + "USD not tokens" + cached excluded |
| `gen_ai.cost.output_tokens` | Double-counting + "USD not tokens" + reasoning excluded |
| `gen_ai.usage.input_tokens` | Double-counting + cached is a subset |
| `gen_ai.usage.input_tokens.cached` | Double-counting + subset of input_tokens |
| `gen_ai.usage.input_tokens.cache_write` | Double-counting |
| `gen_ai.usage.output_tokens` | Double-counting + reasoning is a subset |
| `gen_ai.usage.output_tokens.reasoning` | Double-counting + subset of output_tokens |
| `gen_ai.usage.total_tokens` | Double-counting + sum of input + output |
| `gen_ai.usage.completion_tokens` _(deprecated)_ | Double-counting |
| `gen_ai.usage.prompt_tokens` _(deprecated)_ | Double-counting |

See proposal: https://www.notion.so/sentry/Proposal-Query-Guidance-for-Span-Attributes-3598b10e4b5d806d8c75e2a5b1caa42c

Closes TET-2316, TET-2317