### PR TITLE
fix: Change type of sentry.dsc.project_id to string

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -10248,21 +10248,21 @@ export type SENTRY_DSC_ENVIRONMENT_TYPE = string;
 /**
  * The ID of the project where the trace originated (i.e. the project of the SDK that started the trace). Propagated through the dynamic sampling context and set by Relay during ingestion. `sentry.dsc.project_id`
  *
- * Attribute Value Type: `number` {@link SENTRY_DSC_PROJECT_ID_TYPE}
+ * Attribute Value Type: `string` {@link SENTRY_DSC_PROJECT_ID_TYPE}
  *
  * Contains PII: false
  *
  * Attribute defined in OTEL: No
  * Visibility: internal
  *
- * @example 12345
+ * @example "12345"
  */
 export const SENTRY_DSC_PROJECT_ID = 'sentry.dsc.project_id';
 
 /**
  * Type for {@link SENTRY_DSC_PROJECT_ID} sentry.dsc.project_id
  */
-export type SENTRY_DSC_PROJECT_ID_TYPE = number;
+export type SENTRY_DSC_PROJECT_ID_TYPE = string;
 
 // Path: model/attributes/sentry/sentry__dsc__public_key.json
 
@@ -13699,7 +13699,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SENTRY_DIST]: 'string',
   [SENTRY_DOMAIN]: 'string',
   [SENTRY_DSC_ENVIRONMENT]: 'string',
-  [SENTRY_DSC_PROJECT_ID]: 'integer',
+  [SENTRY_DSC_PROJECT_ID]: 'string',
   [SENTRY_DSC_PUBLIC_KEY]: 'string',
   [SENTRY_DSC_RELEASE]: 'string',
   [SENTRY_DSC_SAMPLED]: 'boolean',
@@ -20785,13 +20785,13 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   [SENTRY_DSC_PROJECT_ID]: {
     brief:
       'The ID of the project where the trace originated (i.e. the project of the SDK that started the trace). Propagated through the dynamic sampling context and set by Relay during ingestion.',
-    type: 'integer',
+    type: 'string',
     pii: {
       isPii: 'false',
     },
     isInOtel: false,
     visibility: 'internal',
-    example: 12345,
+    example: '12345',
     changelog: [{ version: '0.7.0', prs: [358], description: 'Add sentry.dsc.project_id as an attribute' }],
   },
   [SENTRY_DSC_PUBLIC_KEY]: {

--- a/model/attributes/sentry/sentry__dsc__project_id.json
+++ b/model/attributes/sentry/sentry__dsc__project_id.json
@@ -1,12 +1,12 @@
 {
   "key": "sentry.dsc.project_id",
   "brief": "The ID of the project where the trace originated (i.e. the project of the SDK that started the trace). Propagated through the dynamic sampling context and set by Relay during ingestion.",
-  "type": "integer",
+  "type": "string",
   "pii": {
     "key": "false"
   },
   "is_in_otel": false,
-  "example": 12345,
+  "example": "12345",
   "visibility": "internal",
   "changelog": [
     {

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5987,11 +5987,11 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     SENTRY_DSC_PROJECT_ID: Literal["sentry.dsc.project_id"] = "sentry.dsc.project_id"
     """The ID of the project where the trace originated (i.e. the project of the SDK that started the trace). Propagated through the dynamic sampling context and set by Relay during ingestion.
 
-    Type: int
+    Type: str
     Contains PII: false
     Defined in OTEL: No
     Visibility: internal
-    Example: 12345
+    Example: "12345"
     """
 
     # Path: model/attributes/sentry/sentry__dsc__public_key.json
@@ -14334,11 +14334,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     ),
     "sentry.dsc.project_id": AttributeMetadata(
         brief="The ID of the project where the trace originated (i.e. the project of the SDK that started the trace). Propagated through the dynamic sampling context and set by Relay during ingestion.",
-        type=AttributeType.INTEGER,
+        type=AttributeType.STRING,
         pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=False,
         visibility=Visibility.INTERNAL,
-        example=12345,
+        example="12345",
         changelog=[
             ChangelogEntry(
                 version="0.7.0",
@@ -16525,7 +16525,7 @@ Attributes = TypedDict(
         "sentry.dist": str,
         "sentry.domain": str,
         "sentry.dsc.environment": str,
-        "sentry.dsc.project_id": int,
+        "sentry.dsc.project_id": str,
         "sentry.dsc.public_key": str,
         "sentry.dsc.release": str,
         "sentry.dsc.sample_rate": str,


### PR DESCRIPTION
## Description
Change the type of `sentry.dsc.project_id` from integer to string as there is no guarantee that a project id will fit in an i64 (u64 isn't supported by EAP). This prevents issues if we were to change the project id generation logic in the future.

Fixes [INGEST-927](https://linear.app/getsentry/issue/INGEST-927/update-sentrydscproject-id-in-sentry-conventions)

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.
