### PR TITLE
feat(replays): Define `replayId` as a deprecated attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -9742,6 +9742,30 @@ export const REMIX_ACTION_FORM_DATA_KEY = 'remix.action_form_data.<key>';
  */
 export type REMIX_ACTION_FORM_DATA_KEY_TYPE = string;
 
+// Path: model/attributes/replayId.json
+
+/**
+ * The id of the sentry replay. `replayId`
+ *
+ * Attribute Value Type: `string` {@link REPLAYID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link SENTRY_REPLAY_ID} `sentry.replay_id`
+ *
+ * @deprecated Use {@link SENTRY_REPLAY_ID} (sentry.replay_id) instead
+ * @example "123e4567e89b12d3a456426614174000"
+ */
+export const REPLAYID = 'replayId';
+
+/**
+ * Type for {@link REPLAYID} replayId
+ */
+export type REPLAYID_TYPE = string;
+
 // Path: model/attributes/replay_id.json
 
 /**
@@ -10929,7 +10953,7 @@ export type SENTRY_RELEASE_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link REPLAY_ID} `replay_id`
+ * Aliases: {@link REPLAY_ID} `replay_id`, {@link REPLAYID} `replayId`
  *
  * @example "123e4567e89b12d3a456426614174000"
  */
@@ -13676,6 +13700,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [REACT_VERSION]: 'string',
   [RELEASE]: 'string',
   [REMIX_ACTION_FORM_DATA_KEY]: 'string',
+  [REPLAYID]: 'string',
   [REPLAY_ID]: 'string',
   [RESOURCE_DEPLOYMENT_ENVIRONMENT]: 'string',
   [RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME]: 'string',
@@ -14280,6 +14305,7 @@ export type AttributeName =
   | typeof REACT_VERSION
   | typeof RELEASE
   | typeof REMIX_ACTION_FORM_DATA_KEY
+  | typeof REPLAYID
   | typeof REPLAY_ID
   | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT
   | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME
@@ -20497,6 +20523,21 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     sdks: ['javascript-remix'],
     changelog: [{ version: '0.1.0', prs: [103] }],
   },
+  [REPLAYID]: {
+    brief: 'The id of the sentry replay.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '123e4567e89b12d3a456426614174000',
+    deprecation: {
+      replacement: 'sentry.replay_id',
+    },
+    aliases: [SENTRY_REPLAY_ID],
+    changelog: [{ version: 'next' }],
+  },
   [REPLAY_ID]: {
     brief: 'The id of the sentry replay.',
     type: 'string',
@@ -21157,7 +21198,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: '123e4567e89b12d3a456426614174000',
-    aliases: [REPLAY_ID],
+    aliases: [REPLAY_ID, REPLAYID],
     changelog: [{ version: '0.0.0' }],
   },
   [SENTRY_REPLAY_IS_BUFFERING]: {
@@ -22874,6 +22915,7 @@ export type Attributes = {
   [REACT_VERSION]?: REACT_VERSION_TYPE;
   [RELEASE]?: RELEASE_TYPE;
   [REMIX_ACTION_FORM_DATA_KEY]?: REMIX_ACTION_FORM_DATA_KEY_TYPE;
+  [REPLAYID]?: REPLAYID_TYPE;
   [REPLAY_ID]?: REPLAY_ID_TYPE;
   [RESOURCE_DEPLOYMENT_ENVIRONMENT]?: RESOURCE_DEPLOYMENT_ENVIRONMENT_TYPE;
   [RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME]?: RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -14070,6 +14070,30 @@ export const REMIX_ACTION_FORM_DATA_KEY_BASE = 'remix.action_form_data';
  */
 export type REMIX_ACTION_FORM_DATA_KEY_TYPE = string;
 
+// Path: model/attributes/replayId.json
+
+/**
+ * The id of the sentry replay. `replayId`
+ *
+ * Attribute Value Type: `string` {@link REPLAYID_TYPE}
+ *
+ * Apply Scrubbing: never
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link SENTRY_REPLAY_ID} `sentry.replay_id`
+ *
+ * @deprecated Use {@link SENTRY_REPLAY_ID} (sentry.replay_id) instead
+ * @example "123e4567e89b12d3a456426614174000"
+ */
+export const REPLAYID = 'replayId';
+
+/**
+ * Type for {@link REPLAYID} replayId
+ */
+export type REPLAYID_TYPE = string;
+
 // Path: model/attributes/replay_id.json
 
 /**
@@ -15736,7 +15760,7 @@ export type SENTRY_RELEASE_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link REPLAY_ID} `replay_id`
+ * Aliases: {@link REPLAY_ID} `replay_id`, {@link REPLAYID} `replayId`
  *
  * @example "123e4567e89b12d3a456426614174000"
  */
@@ -19358,6 +19382,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'redis.key': 'string',
   release: 'string',
   'remix.action_form_data.<key>': 'string',
+  replayId: 'string',
   replay_id: 'string',
   'resource.deployment.environment': 'string',
   'resource.deployment.environment.name': 'string',
@@ -20196,6 +20221,7 @@ export type AttributeName =
   | typeof REDIS_KEY
   | typeof RELEASE
   | typeof REMIX_ACTION_FORM_DATA_KEY
+  | typeof REPLAYID
   | typeof REPLAY_ID
   | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT
   | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME
@@ -30421,6 +30447,22 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: "http.response.header.text='test'",
     changelog: [{ version: '0.1.0', prs: [103] }],
   },
+  replayId: {
+    brief: 'The id of the sentry replay.',
+    type: 'string',
+    keys: ['replayId'],
+    applyScrubbing: {
+      key: 'never',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '123e4567e89b12d3a456426614174000',
+    deprecation: {
+      replacement: 'sentry.replay_id',
+    },
+    aliases: ['sentry.replay_id'],
+    changelog: [{ version: 'next' }],
+  },
   replay_id: {
     brief: 'The id of the sentry replay.',
     type: 'string',
@@ -31567,7 +31609,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: '123e4567e89b12d3a456426614174000',
-    aliases: ['replay_id'],
+    aliases: ['replay_id', 'replayId'],
     changelog: [{ version: '0.0.0' }],
     searchAlias: {
       name: 'replay.id',
@@ -34204,6 +34246,7 @@ export type Attributes = {
   [REDIS_KEY]?: REDIS_KEY_TYPE;
   [RELEASE]?: RELEASE_TYPE;
   [REMIX_ACTION_FORM_DATA_KEY]?: REMIX_ACTION_FORM_DATA_KEY_TYPE;
+  [REPLAYID]?: REPLAYID_TYPE;
   [REPLAY_ID]?: REPLAY_ID_TYPE;
   [RESOURCE_DEPLOYMENT_ENVIRONMENT]?: RESOURCE_DEPLOYMENT_ENVIRONMENT_TYPE;
   [RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME]?: RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME_TYPE;

--- a/javascript/sentry-conventions/src/search.ts
+++ b/javascript/sentry-conventions/src/search.ts
@@ -3603,6 +3603,13 @@ export const SEARCH_REMIX__ACTION_FORM_DATA__KEY = 'remix.action_form_data.<key>
 export const SEARCH_REPLAY__ID = 'replay.id';
 
 /**
+ * Search name for {@link attributes.REPLAYID}. `replayId`
+ *
+ * @deprecated Use {@link SEARCH_SENTRY__REPLAY_ID} (`sentry.replay_id`) instead
+ */
+export const SEARCH_REPLAYID = 'replayId';
+
+/**
  * Search name for {@link attributes.SENTRY_REPLAY_ID}. `replay_id`
  *
  * @deprecated Use {@link SEARCH_REPLAY__ID} (`replay.id`) instead
@@ -5453,6 +5460,7 @@ export type AttributeSearchName =
   | typeof SEARCH_RELEASE
   | typeof SEARCH_REMIX__ACTION_FORM_DATA__KEY
   | typeof SEARCH_REPLAY__ID
+  | typeof SEARCH_REPLAYID
   | typeof SEARCH_REPLAY_ID
   | typeof SEARCH_RESOURCE__DEPLOYMENT__ENVIRONMENT
   | typeof SEARCH_RESOURCE__DEPLOYMENT__ENVIRONMENT__NAME
@@ -9741,6 +9749,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief: 'The id of the sentry replay.',
     deprecationChain: ['sentry.replay_id', 'replay.id', 'replay_id'],
+  },
+  replayId: {
+    canonicalName: 'sentry.replay_id',
+    type: 'string',
+    brief: 'The id of the sentry replay.',
+    deprecationChain: ['replayId'],
   },
   replay_id: {
     canonicalName: 'sentry.replay_id',

--- a/model/attributes/replayId.json
+++ b/model/attributes/replayId.json
@@ -1,5 +1,5 @@
 {
-  "key": "sentry.replay_id",
+  "key": "replayId",
   "brief": "The id of the sentry replay.",
   "type": "string",
   "pii": {
@@ -7,11 +7,15 @@
   },
   "is_in_otel": false,
   "example": "123e4567e89b12d3a456426614174000",
-  "alias": ["replay_id", "replayId"],
+  "alias": ["sentry.replay_id"],
+  "deprecation": {
+    "_status": null,
+    "replacement": "sentry.replay_id"
+  },
   "visibility": "public",
   "changelog": [
     {
-      "version": "0.0.0"
+      "version": "next"
     }
   ]
 }

--- a/model/attributes/replayId.json
+++ b/model/attributes/replayId.json
@@ -1,5 +1,5 @@
 {
-  "key": "sentry.replay_id",
+  "key": "replayId",
   "brief": "The id of the sentry replay.",
   "type": "string",
   "apply_scrubbing": {
@@ -7,14 +7,15 @@
   },
   "is_in_otel": false,
   "example": "123e4567e89b12d3a456426614174000",
-  "alias": ["replay_id", "replayId"],
-  "visibility": "public",
-  "search_alias": {
-    "name": "replay.id"
+  "alias": ["sentry.replay_id"],
+  "deprecation": {
+    "_status": null,
+    "replacement": "sentry.replay_id"
   },
+  "visibility": "public",
   "changelog": [
     {
-      "version": "0.0.0"
+      "version": "next"
     }
   ]
 }

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -233,6 +233,7 @@ class _AttributeNamesMeta(type):
         "PERFORMANCE_TIMEORIGIN",
         "QUERY_KEY",
         "RELEASE",
+        "REPLAYID",
         "REPLAY_ID",
         "RESOURCE_DEPLOYMENT_ENVIRONMENT",
         "RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME",
@@ -5706,6 +5707,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "http.response.header.text='test'"
     """
 
+    # Path: model/attributes/replayId.json
+    REPLAYID: Literal["replayId"] = "replayId"
+    """The id of the sentry replay.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: sentry.replay_id
+    DEPRECATED: Use sentry.replay_id instead
+    Example: "123e4567e89b12d3a456426614174000"
+    """
+
     # Path: model/attributes/replay_id.json
     REPLAY_ID: Literal["replay_id"] = "replay_id"
     """The id of the sentry replay.
@@ -6364,7 +6378,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: false
     Defined in OTEL: No
     Visibility: public
-    Aliases: replay_id
+    Aliases: replay_id, replayId
     Example: "123e4567e89b12d3a456426614174000"
     """
 
@@ -14038,6 +14052,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[103]),
         ],
     ),
+    "replayId": AttributeMetadata(
+        brief="The id of the sentry replay.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="123e4567e89b12d3a456426614174000",
+        deprecation=DeprecationInfo(replacement="sentry.replay_id"),
+        aliases=["sentry.replay_id"],
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
     "replay_id": AttributeMetadata(
         brief="The id of the sentry replay.",
         type=AttributeType.STRING,
@@ -14706,7 +14733,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="123e4567e89b12d3a456426614174000",
-        aliases=["replay_id"],
+        aliases=["replay_id", "replayId"],
         changelog=[
             ChangelogEntry(version="0.0.0"),
         ],
@@ -16502,6 +16529,7 @@ Attributes = TypedDict(
         "react.version": str,
         "release": str,
         "remix.action_form_data.<key>": str,
+        "replayId": str,
         "replay_id": str,
         "resource.deployment.environment": str,
         "resource.deployment.environment.name": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -352,6 +352,7 @@ class _AttributeNamesMeta(type):
         "REDIS_COMMAND",
         "REDIS_KEY",
         "RELEASE",
+        "REPLAYID",
         "REPLAY_ID",
         "RESOURCE_DEPLOYMENT_ENVIRONMENT",
         "RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME",
@@ -8320,6 +8321,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "http.response.header.text='test'"
     """
 
+    # Path: model/attributes/replayId.json
+    REPLAYID: Literal["replayId"] = "replayId"
+    """The id of the sentry replay.
+
+    Type: str
+    Apply Scrubbing: never
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: sentry.replay_id
+    DEPRECATED: Use sentry.replay_id instead
+    Example: "123e4567e89b12d3a456426614174000"
+    """
+
     # Path: model/attributes/replay_id.json
     REPLAY_ID: Literal["replay_id"] = "replay_id"
     """The id of the sentry replay.
@@ -9240,7 +9254,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: never
     Defined in OTEL: No
     Visibility: public
-    Aliases: replay_id
+    Aliases: replay_id, replayId
     Example: "123e4567e89b12d3a456426614174000"
     """
 
@@ -22725,6 +22739,20 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[103]),
         ],
     ),
+    "replayId": AttributeMetadata(
+        brief="The id of the sentry replay.",
+        type=AttributeType.STRING,
+        keys=("replayId",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="123e4567e89b12d3a456426614174000",
+        deprecation=DeprecationInfo(replacement="sentry.replay_id"),
+        aliases=["sentry.replay_id"],
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
     "replay_id": AttributeMetadata(
         brief="The id of the sentry replay.",
         type=AttributeType.STRING,
@@ -23975,7 +24003,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="123e4567e89b12d3a456426614174000",
-        aliases=["replay_id"],
+        aliases=["replay_id", "replayId"],
         changelog=[
             ChangelogEntry(version="0.0.0"),
         ],
@@ -26850,6 +26878,7 @@ Attributes = TypedDict(
         "redis.key": str,
         "release": str,
         "remix.action_form_data.<key>": str,
+        "replayId": str,
         "replay_id": str,
         "resource.deployment.environment": str,
         "resource.deployment.environment.name": str,

--- a/shared/deprecated_attributes.json
+++ b/shared/deprecated_attributes.json
@@ -408,6 +408,27 @@
       ]
     },
     {
+      "key": "replayId",
+      "brief": "The id of the sentry replay.",
+      "type": "string",
+      "pii": {
+        "key": "false"
+      },
+      "is_in_otel": false,
+      "example": "123e4567e89b12d3a456426614174000",
+      "alias": ["sentry.replay_id"],
+      "deprecation": {
+        "_status": null,
+        "replacement": "sentry.replay_id"
+      },
+      "visibility": "public",
+      "changelog": [
+        {
+          "version": "next"
+        }
+      ]
+    },
+    {
       "key": "replay_id",
       "brief": "The id of the sentry replay.",
       "type": "string",


### PR DESCRIPTION
## Description
SDKs currently send `replayId` on spans, but we'd like to standardize on `sentry.replay_id` (already defined and in use for other telemetry types). Marking it as deprecated lets the product transparently query either name and return results for either attribute.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.