### PR TITLE
chore(publish): Automatically add PR numbers to attribute changelogs

### DIFF
--- a/scripts/bump_attribute_changelog.ts
+++ b/scripts/bump_attribute_changelog.ts
@@ -3,19 +3,55 @@
  *
  * - Scans all JSON files under model/attributes/
  * - Finds changelog entries with version "next" and replaces them with the given version
+ * - If a "next" entry has no PRs, looks up git history to fill them in automatically
  * - Merges PRs and descriptions if an entry for the target version already exists
  * - Re-sorts the changelog newest-first
  * - Called by craft-pre-release.sh before `yarn generate`
  */
 
+import { execSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { AttributeJson } from './types';
-import { getAllJsonFiles, compareVersions, type ChangelogEntry } from './generate_attribute_changelog';
+import {
+  getAllJsonFiles,
+  compareVersions,
+  getCommitsInRange,
+  extractPrNumber,
+  isCommitIgnored,
+  type ChangelogEntry,
+} from './generate_attribute_changelog';
 
 const SEMVER_RE = /^\d+\.\d+\.\d+$/;
 
 type Changelog = NonNullable<AttributeJson['changelog']>;
+
+function getLatestTag(): string | null {
+  try {
+    const output = execSync('git tag --sort=-version:refname', { encoding: 'utf-8' });
+    const tags = output
+      .trim()
+      .split('\n')
+      .filter((tag) => SEMVER_RE.test(tag));
+    return tags[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function lookupPrsFromGit(gitPath: string, latestTag: string | null): number[] {
+  const range = latestTag ? `${latestTag}..HEAD` : 'HEAD';
+  const commits = getCommitsInRange(gitPath, range);
+  const prs = new Set<number>();
+
+  for (const commit of commits) {
+    if (isCommitIgnored(commit.hash)) continue;
+    const pr = extractPrNumber(commit.message);
+    if (pr !== undefined) prs.add(pr);
+  }
+
+  return Array.from(prs).sort((a, b) => a - b);
+}
 
 function mergeEntries(entries: ChangelogEntry[], targetVersion: string): ChangelogEntry {
   const prs = new Set<number>();
@@ -62,7 +98,9 @@ function bumpChangelog(changelog: Changelog, targetVersion: string): Changelog |
 async function bumpNextChangelog(targetVersion: string): Promise<void> {
   const attributesDir = path.join(__dirname, '..', 'model', 'attributes');
   const files = await getAllJsonFiles(attributesDir);
+  const latestTag = getLatestTag();
   let updatedCount = 0;
+  let prsFilledCount = 0;
 
   for (const relativeFile of files) {
     const filePath = path.join(attributesDir, relativeFile);
@@ -71,6 +109,20 @@ async function bumpNextChangelog(targetVersion: string): Promise<void> {
 
     if (!json.changelog || !json.changelog.length) {
       continue;
+    }
+
+    const nextEntry = json.changelog.find((e) => e.version === 'next');
+    if (!nextEntry) {
+      continue;
+    }
+
+    if (!nextEntry.prs || nextEntry.prs.length === 0) {
+      const gitPath = path.join('model', 'attributes', relativeFile);
+      const prs = lookupPrsFromGit(gitPath, latestTag);
+      if (prs.length > 0) {
+        nextEntry.prs = prs;
+        prsFilledCount++;
+      }
     }
 
     const bumped = bumpChangelog(json.changelog, targetVersion);
@@ -84,6 +136,9 @@ async function bumpNextChangelog(targetVersion: string): Promise<void> {
   }
 
   console.log(`Bumped "next" to "${targetVersion}" in ${updatedCount} attribute file(s).`);
+  if (prsFilledCount > 0) {
+    console.log(`Filled in PRs from git history for ${prsFilledCount} file(s).`);
+  }
 }
 
 const targetVersion = process.argv[2];

--- a/scripts/generate_attribute_changelog.ts
+++ b/scripts/generate_attribute_changelog.ts
@@ -12,7 +12,7 @@ const IGNORED_COMMIT_HASHES = new Set<string>([
   '0db15becb4b06b592d53bd18aa9f945d7b065a71',
 ]);
 
-function isCommitIgnored(hash: string): boolean {
+export function isCommitIgnored(hash: string): boolean {
   const h = hash.trim().toLowerCase();
   if (!h) return false;
   for (const ignored of IGNORED_COMMIT_HASHES) {
@@ -262,12 +262,12 @@ function promoteNextEntries(existing: ChangelogEntry[], generated: ChangelogEntr
   return existing.map((e) => (e.version === 'next' ? { ...e, version: highestVersion } : e));
 }
 
-interface CommitInfo {
+export interface CommitInfo {
   hash: string;
   message: string;
 }
 
-function getCommitsInRange(gitPath: string, range: string): CommitInfo[] {
+export function getCommitsInRange(gitPath: string, range: string): CommitInfo[] {
   try {
     const output = execSync(`git log --no-merges --format="%H %s" ${range} -- "${gitPath}"`, { encoding: 'utf-8' });
     return output
@@ -286,7 +286,7 @@ function getCommitsInRange(gitPath: string, range: string): CommitInfo[] {
   }
 }
 
-function extractPrNumber(message: string): number | undefined {
+export function extractPrNumber(message: string): number | undefined {
   const match = message.match(/\(#(\d+)\)\s*$/);
   return match ? Number(match[1]) : undefined;
 }


### PR DESCRIPTION
As discussed in https://github.com/getsentry/sentry-conventions/pull/401#discussion_r3287523766, it would be helpful to automatically add PR numbers to the `prs` array of attribute changelogs at release time. This PR reuses the PR extraction logic from the manual changelog population script to apply it to all attributes with a "next" changelog entry that gets converted to the new version via the pre-release script. 

This means, we don't have to manually reference PRs when making changes/adding attributes to conventions.