### PR TITLE
feat: Add missing GCP and FaaS attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4285,6 +4285,69 @@ export const FAAS_CRON = 'faas.cron';
  */
 export type FAAS_CRON_TYPE = string;
 
+// Path: model/attributes/faas/faas__duration_in_ms.json
+
+/**
+ * The duration a function took to run, in milliseconds. `faas.duration_in_ms`
+ *
+ * Attribute Value Type: `number` {@link FAAS_DURATION_IN_MS_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example 1573817250172
+ */
+export const FAAS_DURATION_IN_MS = 'faas.duration_in_ms';
+
+/**
+ * Type for {@link FAAS_DURATION_IN_MS} faas.duration_in_ms
+ */
+export type FAAS_DURATION_IN_MS_TYPE = number;
+
+// Path: model/attributes/faas/faas__entry_point.json
+
+/**
+ * The code that's fun when the cloud provider invokes your function. `faas.entry_point`
+ *
+ * Attribute Value Type: `string` {@link FAAS_ENTRY_POINT_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "my_main_function"
+ */
+export const FAAS_ENTRY_POINT = 'faas.entry_point';
+
+/**
+ * Type for {@link FAAS_ENTRY_POINT} faas.entry_point
+ */
+export type FAAS_ENTRY_POINT_TYPE = string;
+
+// Path: model/attributes/faas/faas__identity.json
+
+/**
+ * The Service Account (GCP), IAM Execution Role (AWS), or Managed Identity (Azure) used by the serverless function when interacting with other cloud services `faas.identity`
+ *
+ * Attribute Value Type: `string` {@link FAAS_IDENTITY_TYPE}
+ *
+ * Contains PII: true
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "ame@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)"
+ */
+export const FAAS_IDENTITY = 'faas.identity';
+
+/**
+ * Type for {@link FAAS_IDENTITY} faas.identity
+ */
+export type FAAS_IDENTITY_TYPE = string;
+
 // Path: model/attributes/faas/faas__time.json
 
 /**
@@ -4742,6 +4805,27 @@ export const GCP_FUNCTION_CONTEXT_TYPE = 'gcp.function.context.type';
  * Type for {@link GCP_FUNCTION_CONTEXT_TYPE} gcp.function.context.type
  */
 export type GCP_FUNCTION_CONTEXT_TYPE_TYPE = string;
+
+// Path: model/attributes/gcp/gcp__project__id.json
+
+/**
+ * The ID of the project in GCP that this resource is associated with `gcp.project.id`
+ *
+ * Attribute Value Type: `string` {@link GCP_PROJECT_ID_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "my-project-123"
+ */
+export const GCP_PROJECT_ID = 'gcp.project.id';
+
+/**
+ * Type for {@link GCP_PROJECT_ID} gcp.project.id
+ */
+export type GCP_PROJECT_ID_TYPE = string;
 
 // Path: model/attributes/gen_ai/gen_ai__agent__name.json
 
@@ -13428,6 +13512,9 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [EXCEPTION_TYPE]: 'string',
   [FAAS_COLDSTART]: 'boolean',
   [FAAS_CRON]: 'string',
+  [FAAS_DURATION_IN_MS]: 'integer',
+  [FAAS_ENTRY_POINT]: 'string',
+  [FAAS_IDENTITY]: 'string',
   [FAAS_TIME]: 'string',
   [FAAS_TRIGGER]: 'string',
   [FCP]: 'double',
@@ -13449,6 +13536,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [GCP_FUNCTION_CONTEXT_TIME]: 'string',
   [GCP_FUNCTION_CONTEXT_TIMESTAMP]: 'string',
   [GCP_FUNCTION_CONTEXT_TYPE]: 'string',
+  [GCP_PROJECT_ID]: 'string',
   [GEN_AI_AGENT_NAME]: 'string',
   [GEN_AI_CONTEXT_UTILIZATION]: 'double',
   [GEN_AI_CONTEXT_WINDOW_SIZE]: 'integer',
@@ -14032,6 +14120,9 @@ export type AttributeName =
   | typeof EXCEPTION_TYPE
   | typeof FAAS_COLDSTART
   | typeof FAAS_CRON
+  | typeof FAAS_DURATION_IN_MS
+  | typeof FAAS_ENTRY_POINT
+  | typeof FAAS_IDENTITY
   | typeof FAAS_TIME
   | typeof FAAS_TRIGGER
   | typeof FCP
@@ -14053,6 +14144,7 @@ export type AttributeName =
   | typeof GCP_FUNCTION_CONTEXT_TIME
   | typeof GCP_FUNCTION_CONTEXT_TIMESTAMP
   | typeof GCP_FUNCTION_CONTEXT_TYPE
+  | typeof GCP_PROJECT_ID
   | typeof GEN_AI_AGENT_NAME
   | typeof GEN_AI_CONTEXT_UTILIZATION
   | typeof GEN_AI_CONTEXT_WINDOW_SIZE
@@ -17084,6 +17176,41 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '0/5 * * * ? *',
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
+  [FAAS_DURATION_IN_MS]: {
+    brief: 'The duration a function took to run, in milliseconds.',
+    type: 'integer',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 1573817250172,
+    changelog: [{ version: 'next' }],
+  },
+  [FAAS_ENTRY_POINT]: {
+    brief: "The code that's fun when the cloud provider invokes your function.",
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'my_main_function',
+    changelog: [{ version: 'next' }],
+  },
+  [FAAS_IDENTITY]: {
+    brief:
+      'The Service Account (GCP), IAM Execution Role (AWS), or Managed Identity (Azure) used by the serverless function when interacting with other cloud services',
+    type: 'string',
+    pii: {
+      isPii: 'true',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example:
+      'ame@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)',
+    changelog: [{ version: 'next' }],
+  },
   [FAAS_TIME]: {
     brief: 'A string containing the function invocation time in the ISO 8601 format expressed in UTC.',
     type: 'string',
@@ -17374,6 +17501,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'cloud_functions.context',
     changelog: [{ version: '0.7.0', prs: [371], description: 'Added gcp.function.context.type attribute' }],
+  },
+  [GCP_PROJECT_ID]: {
+    brief: 'The ID of the project in GCP that this resource is associated with',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'my-project-123',
+    changelog: [{ version: 'next' }],
   },
   [GEN_AI_AGENT_NAME]: {
     brief: 'The name of the agent being used.',
@@ -22626,6 +22764,9 @@ export type Attributes = {
   [EXCEPTION_TYPE]?: EXCEPTION_TYPE_TYPE;
   [FAAS_COLDSTART]?: FAAS_COLDSTART_TYPE;
   [FAAS_CRON]?: FAAS_CRON_TYPE;
+  [FAAS_DURATION_IN_MS]?: FAAS_DURATION_IN_MS_TYPE;
+  [FAAS_ENTRY_POINT]?: FAAS_ENTRY_POINT_TYPE;
+  [FAAS_IDENTITY]?: FAAS_IDENTITY_TYPE;
   [FAAS_TIME]?: FAAS_TIME_TYPE;
   [FAAS_TRIGGER]?: FAAS_TRIGGER_TYPE;
   [FCP]?: FCP_TYPE;
@@ -22647,6 +22788,7 @@ export type Attributes = {
   [GCP_FUNCTION_CONTEXT_TIME]?: GCP_FUNCTION_CONTEXT_TIME_TYPE;
   [GCP_FUNCTION_CONTEXT_TIMESTAMP]?: GCP_FUNCTION_CONTEXT_TIMESTAMP_TYPE;
   [GCP_FUNCTION_CONTEXT_TYPE]?: GCP_FUNCTION_CONTEXT_TYPE_TYPE;
+  [GCP_PROJECT_ID]?: GCP_PROJECT_ID_TYPE;
   [GEN_AI_AGENT_NAME]?: GEN_AI_AGENT_NAME_TYPE;
   [GEN_AI_CONTEXT_UTILIZATION]?: GEN_AI_CONTEXT_UTILIZATION_TYPE;
   [GEN_AI_CONTEXT_WINDOW_SIZE]?: GEN_AI_CONTEXT_WINDOW_SIZE_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4297,7 +4297,7 @@ export type FAAS_CRON_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * @example 1573817250172
+ * @example 120
  */
 export const FAAS_DURATION_IN_MS = 'faas.duration_in_ms';
 
@@ -4309,7 +4309,7 @@ export type FAAS_DURATION_IN_MS_TYPE = number;
 // Path: model/attributes/faas/faas__entry_point.json
 
 /**
- * The code that's fun when the cloud provider invokes your function. `faas.entry_point`
+ * The code that's run when the cloud provider invokes your function. `faas.entry_point`
  *
  * Attribute Value Type: `string` {@link FAAS_ENTRY_POINT_TYPE}
  *
@@ -4339,7 +4339,7 @@ export type FAAS_ENTRY_POINT_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * @example "ame@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)"
+ * @example "name@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)"
  */
 export const FAAS_IDENTITY = 'faas.identity';
 
@@ -17207,11 +17207,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     visibility: 'public',
-    example: 1573817250172,
+    example: 120,
     changelog: [{ version: 'next' }],
   },
   [FAAS_ENTRY_POINT]: {
-    brief: "The code that's fun when the cloud provider invokes your function.",
+    brief: "The code that's run when the cloud provider invokes your function.",
     type: 'string',
     pii: {
       isPii: 'false',
@@ -17231,7 +17231,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example:
-      'ame@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)',
+      'name@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)',
     changelog: [{ version: 'next' }],
   },
   [FAAS_NAME]: {

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4348,6 +4348,27 @@ export const FAAS_IDENTITY = 'faas.identity';
  */
 export type FAAS_IDENTITY_TYPE = string;
 
+// Path: model/attributes/faas/faas__name.json
+
+/**
+ * The name of the serverless function `faas.name`
+ *
+ * Attribute Value Type: `string` {@link FAAS_NAME_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "my_function"
+ */
+export const FAAS_NAME = 'faas.name';
+
+/**
+ * Type for {@link FAAS_NAME} faas.name
+ */
+export type FAAS_NAME_TYPE = string;
+
 // Path: model/attributes/faas/faas__time.json
 
 /**
@@ -13515,6 +13536,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [FAAS_DURATION_IN_MS]: 'integer',
   [FAAS_ENTRY_POINT]: 'string',
   [FAAS_IDENTITY]: 'string',
+  [FAAS_NAME]: 'string',
   [FAAS_TIME]: 'string',
   [FAAS_TRIGGER]: 'string',
   [FCP]: 'double',
@@ -14123,6 +14145,7 @@ export type AttributeName =
   | typeof FAAS_DURATION_IN_MS
   | typeof FAAS_ENTRY_POINT
   | typeof FAAS_IDENTITY
+  | typeof FAAS_NAME
   | typeof FAAS_TIME
   | typeof FAAS_TRIGGER
   | typeof FCP
@@ -17209,6 +17232,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example:
       'ame@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)',
+    changelog: [{ version: 'next' }],
+  },
+  [FAAS_NAME]: {
+    brief: 'The name of the serverless function',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'my_function',
     changelog: [{ version: 'next' }],
   },
   [FAAS_TIME]: {
@@ -22767,6 +22801,7 @@ export type Attributes = {
   [FAAS_DURATION_IN_MS]?: FAAS_DURATION_IN_MS_TYPE;
   [FAAS_ENTRY_POINT]?: FAAS_ENTRY_POINT_TYPE;
   [FAAS_IDENTITY]?: FAAS_IDENTITY_TYPE;
+  [FAAS_NAME]?: FAAS_NAME_TYPE;
   [FAAS_TIME]?: FAAS_TIME_TYPE;
   [FAAS_TRIGGER]?: FAAS_TRIGGER_TYPE;
   [FCP]?: FCP_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4357,7 +4357,7 @@ export type FAAS_IDENTITY_TYPE = string;
  *
  * Contains PII: false
  *
- * Attribute defined in OTEL: No
+ * Attribute defined in OTEL: Yes
  * Visibility: public
  *
  * @example "my_function"
@@ -17240,7 +17240,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     pii: {
       isPii: 'false',
     },
-    isInOtel: false,
+    isInOtel: true,
     visibility: 'public',
     example: 'my_function',
     changelog: [{ version: 'next' }],

--- a/model/attributes/faas/faas__duration_in_ms.json
+++ b/model/attributes/faas/faas__duration_in_ms.json
@@ -6,7 +6,7 @@
     "key": "false"
   },
   "is_in_otel": false,
-  "example": 1573817250172,
+  "example": 120,
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/faas/faas__duration_in_ms.json
+++ b/model/attributes/faas/faas__duration_in_ms.json
@@ -1,0 +1,16 @@
+{
+  "key": "faas.duration_in_ms",
+  "brief": "The duration a function took to run, in milliseconds.",
+  "type": "integer",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": 1573817250172,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/faas/faas__entry_point.json
+++ b/model/attributes/faas/faas__entry_point.json
@@ -1,6 +1,6 @@
 {
   "key": "faas.entry_point",
-  "brief": "The code that's fun when the cloud provider invokes your function.",
+  "brief": "The code that's run when the cloud provider invokes your function.",
   "type": "string",
   "pii": {
     "key": "false"

--- a/model/attributes/faas/faas__entry_point.json
+++ b/model/attributes/faas/faas__entry_point.json
@@ -1,0 +1,16 @@
+{
+  "key": "faas.entry_point",
+  "brief": "The code that's fun when the cloud provider invokes your function.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "my_main_function",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/faas/faas__identity.json
+++ b/model/attributes/faas/faas__identity.json
@@ -6,7 +6,7 @@
     "key": "true"
   },
   "is_in_otel": false,
-  "example": "ame@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)",
+  "example": "name@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)",
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/faas/faas__identity.json
+++ b/model/attributes/faas/faas__identity.json
@@ -1,0 +1,16 @@
+{
+  "key": "faas.identity",
+  "brief": "The Service Account (GCP), IAM Execution Role (AWS), or Managed Identity (Azure) used by the serverless function when interacting with other cloud services",
+  "type": "string",
+  "pii": {
+    "key": "true"
+  },
+  "is_in_otel": false,
+  "example": "ame@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/faas/faas__name.json
+++ b/model/attributes/faas/faas__name.json
@@ -1,0 +1,16 @@
+{
+  "key": "faas.name",
+  "brief": "The name of the serverless function",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "example": "my_function",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/faas/faas__name.json
+++ b/model/attributes/faas/faas__name.json
@@ -5,7 +5,7 @@
   "pii": {
     "key": "false"
   },
-  "is_in_otel": false,
+  "is_in_otel": true,
   "example": "my_function",
   "visibility": "public",
   "changelog": [

--- a/model/attributes/gcp/gcp__project__id.json
+++ b/model/attributes/gcp/gcp__project__id.json
@@ -1,0 +1,16 @@
+{
+  "key": "gcp.project.id",
+  "brief": "The ID of the project in GCP that this resource is associated with",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "example": "my-project-123",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2669,6 +2669,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "ame@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)"
     """
 
+    # Path: model/attributes/faas/faas__name.json
+    FAAS_NAME: Literal["faas.name"] = "faas.name"
+    """The name of the serverless function
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Visibility: public
+    Example: "my_function"
+    """
+
     # Path: model/attributes/faas/faas__time.json
     FAAS_TIME: Literal["faas.time"] = "faas.time"
     """A string containing the function invocation time in the ISO 8601 format expressed in UTC.
@@ -10628,6 +10639,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="next"),
         ],
     ),
+    "faas.name": AttributeMetadata(
+        brief="The name of the serverless function",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="my_function",
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
     "faas.time": AttributeMetadata(
         brief="A string containing the function invocation time in the ISO 8601 format expressed in UTC.",
         type=AttributeType.STRING,
@@ -16345,6 +16367,7 @@ Attributes = TypedDict(
         "faas.duration_in_ms": int,
         "faas.entry_point": str,
         "faas.identity": str,
+        "faas.name": str,
         "faas.time": str,
         "faas.trigger": str,
         "fcp": float,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2636,6 +2636,39 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "0/5 * * * ? *"
     """
 
+    # Path: model/attributes/faas/faas__duration_in_ms.json
+    FAAS_DURATION_IN_MS: Literal["faas.duration_in_ms"] = "faas.duration_in_ms"
+    """The duration a function took to run, in milliseconds.
+
+    Type: int
+    Contains PII: false
+    Defined in OTEL: No
+    Visibility: public
+    Example: 1573817250172
+    """
+
+    # Path: model/attributes/faas/faas__entry_point.json
+    FAAS_ENTRY_POINT: Literal["faas.entry_point"] = "faas.entry_point"
+    """The code that's fun when the cloud provider invokes your function.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Visibility: public
+    Example: "my_main_function"
+    """
+
+    # Path: model/attributes/faas/faas__identity.json
+    FAAS_IDENTITY: Literal["faas.identity"] = "faas.identity"
+    """The Service Account (GCP), IAM Execution Role (AWS), or Managed Identity (Azure) used by the serverless function when interacting with other cloud services
+
+    Type: str
+    Contains PII: true
+    Defined in OTEL: No
+    Visibility: public
+    Example: "ame@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)"
+    """
+
     # Path: model/attributes/faas/faas__time.json
     FAAS_TIME: Literal["faas.time"] = "faas.time"
     """A string containing the function invocation time in the ISO 8601 format expressed in UTC.
@@ -2895,6 +2928,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Visibility: public
     Example: "cloud_functions.context"
+    """
+
+    # Path: model/attributes/gcp/gcp__project__id.json
+    GCP_PROJECT_ID: Literal["gcp.project.id"] = "gcp.project.id"
+    """The ID of the project in GCP that this resource is associated with
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Visibility: public
+    Example: "my-project-123"
     """
 
     # Path: model/attributes/gen_ai/gen_ai__agent__name.json
@@ -10551,6 +10595,39 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "faas.duration_in_ms": AttributeMetadata(
+        brief="The duration a function took to run, in milliseconds.",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=1573817250172,
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
+    "faas.entry_point": AttributeMetadata(
+        brief="The code that's fun when the cloud provider invokes your function.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="my_main_function",
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
+    "faas.identity": AttributeMetadata(
+        brief="The Service Account (GCP), IAM Execution Role (AWS), or Managed Identity (Azure) used by the serverless function when interacting with other cloud services",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.TRUE),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="ame@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)",
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
     "faas.time": AttributeMetadata(
         brief="A string containing the function invocation time in the ISO 8601 format expressed in UTC.",
         type=AttributeType.STRING,
@@ -10893,6 +10970,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
                 prs=[371],
                 description="Added gcp.function.context.type attribute",
             ),
+        ],
+    ),
+    "gcp.project.id": AttributeMetadata(
+        brief="The ID of the project in GCP that this resource is associated with",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="my-project-123",
+        changelog=[
+            ChangelogEntry(version="next"),
         ],
     ),
     "gen_ai.agent.name": AttributeMetadata(
@@ -16254,6 +16342,9 @@ Attributes = TypedDict(
         "exception.type": str,
         "faas.coldstart": bool,
         "faas.cron": str,
+        "faas.duration_in_ms": int,
+        "faas.entry_point": str,
+        "faas.identity": str,
         "faas.time": str,
         "faas.trigger": str,
         "fcp": float,
@@ -16275,6 +16366,7 @@ Attributes = TypedDict(
         "gcp.function.context.time": str,
         "gcp.function.context.timestamp": str,
         "gcp.function.context.type": str,
+        "gcp.project.id": str,
         "gen_ai.agent.name": str,
         "gen_ai.context.utilization": float,
         "gen_ai.context.window_size": int,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2675,7 +2675,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     Type: str
     Contains PII: false
-    Defined in OTEL: No
+    Defined in OTEL: Yes
     Visibility: public
     Example: "my_function"
     """
@@ -10643,7 +10643,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="The name of the serverless function",
         type=AttributeType.STRING,
         pii=PiiInfo(isPii=IsPii.FALSE),
-        is_in_otel=False,
+        is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="my_function",
         changelog=[

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2644,12 +2644,12 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: false
     Defined in OTEL: No
     Visibility: public
-    Example: 1573817250172
+    Example: 120
     """
 
     # Path: model/attributes/faas/faas__entry_point.json
     FAAS_ENTRY_POINT: Literal["faas.entry_point"] = "faas.entry_point"
-    """The code that's fun when the cloud provider invokes your function.
+    """The code that's run when the cloud provider invokes your function.
 
     Type: str
     Contains PII: false
@@ -2666,7 +2666,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: true
     Defined in OTEL: No
     Visibility: public
-    Example: "ame@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)"
+    Example: "name@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)"
     """
 
     # Path: model/attributes/faas/faas__name.json
@@ -10612,13 +10612,13 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
-        example=1573817250172,
+        example=120,
         changelog=[
             ChangelogEntry(version="next"),
         ],
     ),
     "faas.entry_point": AttributeMetadata(
-        brief="The code that's fun when the cloud provider invokes your function.",
+        brief="The code that's run when the cloud provider invokes your function.",
         type=AttributeType.STRING,
         pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=False,
@@ -10634,7 +10634,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         pii=PiiInfo(isPii=IsPii.TRUE),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
-        example="ame@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)",
+        example="name@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)",
         changelog=[
             ChangelogEntry(version="next"),
         ],


### PR DESCRIPTION
Add faas.duration_in_ms, faas.entry_point, faas.identity, and gcp.project.id to the model and regenerate JS and Python attribute files.

These attributes were missing from the conventions despite being used in GCP and FaaS instrumentation. Adding them ensures SDKs have consistent, typed constants to reference rather than relying on raw strings.