### PR TITLE
feat(attributes): Add db.operation.batch.size

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3330,6 +3330,27 @@ export const DB_OPERATION = 'db.operation';
  */
 export type DB_OPERATION_TYPE = string;
 
+// Path: model/attributes/db/db__operation__batch__size.json
+
+/**
+ * The number of queries included in a batch operation. Operations are only considered batches when they contain two or more operations, and so db.operation.batch.size SHOULD never be 1. `db.operation.batch.size`
+ *
+ * Attribute Value Type: `number` {@link DB_OPERATION_BATCH_SIZE_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 3
+ */
+export const DB_OPERATION_BATCH_SIZE = 'db.operation.batch.size';
+
+/**
+ * Type for {@link DB_OPERATION_BATCH_SIZE} db.operation.batch.size
+ */
+export type DB_OPERATION_BATCH_SIZE_TYPE = number;
+
 // Path: model/attributes/db/db__operation__name.json
 
 /**
@@ -14209,6 +14230,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [DB_NAME]: 'string',
   [DB_NAMESPACE]: 'string',
   [DB_OPERATION]: 'string',
+  [DB_OPERATION_BATCH_SIZE]: 'integer',
   [DB_OPERATION_NAME]: 'string',
   [DB_QUERY_PARAMETER_KEY]: 'string',
   [DB_QUERY_SUMMARY]: 'string',
@@ -14850,6 +14872,7 @@ export type AttributeName =
   | typeof DB_NAME
   | typeof DB_NAMESPACE
   | typeof DB_OPERATION
+  | typeof DB_OPERATION_BATCH_SIZE
   | typeof DB_OPERATION_NAME
   | typeof DB_QUERY_PARAMETER_KEY
   | typeof DB_QUERY_SUMMARY
@@ -17427,6 +17450,19 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     aliases: [DB_OPERATION_NAME],
     changelog: [{ version: '0.4.0', prs: [199] }, { version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+  },
+  [DB_OPERATION_BATCH_SIZE]: {
+    brief:
+      'The number of queries included in a batch operation. Operations are only considered batches when they contain two or more operations, and so db.operation.batch.size SHOULD never be 1.',
+    type: 'integer',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 3,
+    sdks: ['javascript-node', 'javascript-deno', 'javascript-bun', 'javascript-cloudflare'],
+    changelog: [{ version: 'next', prs: [407], description: 'Added db.operation.batch.size attribute' }],
   },
   [DB_OPERATION_NAME]: {
     brief: 'The name of the operation being executed.',
@@ -23984,6 +24020,7 @@ export type Attributes = {
   [DB_NAME]?: DB_NAME_TYPE;
   [DB_NAMESPACE]?: DB_NAMESPACE_TYPE;
   [DB_OPERATION]?: DB_OPERATION_TYPE;
+  [DB_OPERATION_BATCH_SIZE]?: DB_OPERATION_BATCH_SIZE_TYPE;
   [DB_OPERATION_NAME]?: DB_OPERATION_NAME_TYPE;
   [DB_QUERY_PARAMETER_KEY]?: DB_QUERY_PARAMETER_KEY_TYPE;
   [DB_QUERY_SUMMARY]?: DB_QUERY_SUMMARY_TYPE;

--- a/model/attributes/db/db__operation__batch__size.json
+++ b/model/attributes/db/db__operation__batch__size.json
@@ -1,0 +1,19 @@
+{
+  "key": "db.operation.batch.size",
+  "brief": "The number of queries included in a batch operation. Operations are only considered batches when they contain two or more operations, and so db.operation.batch.size SHOULD never be 1.",
+  "type": "integer",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": true,
+  "visibility": "public",
+  "example": 3,
+  "sdks": ["javascript-node", "javascript-deno", "javascript-bun", "javascript-cloudflare"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [407],
+      "description": "Added db.operation.batch.size attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2145,6 +2145,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "SELECT"
     """
 
+    # Path: model/attributes/db/db__operation__batch__size.json
+    DB_OPERATION_BATCH_SIZE: Literal["db.operation.batch.size"] = (
+        "db.operation.batch.size"
+    )
+    """The number of queries included in a batch operation. Operations are only considered batches when they contain two or more operations, and so db.operation.batch.size SHOULD never be 1.
+
+    Type: int
+    Contains PII: maybe
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 3
+    """
+
     # Path: model/attributes/db/db__operation__name.json
     DB_OPERATION_NAME: Literal["db.operation.name"] = "db.operation.name"
     """The name of the operation being executed.
@@ -10426,6 +10439,27 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "db.operation.batch.size": AttributeMetadata(
+        brief="The number of queries included in a batch operation. Operations are only considered batches when they contain two or more operations, and so db.operation.batch.size SHOULD never be 1.",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=3,
+        sdks=[
+            "javascript-node",
+            "javascript-deno",
+            "javascript-bun",
+            "javascript-cloudflare",
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[407],
+                description="Added db.operation.batch.size attribute",
+            ),
+        ],
+    ),
     "db.operation.name": AttributeMetadata(
         brief="The name of the operation being executed.",
         type=AttributeType.STRING,
@@ -17234,6 +17268,7 @@ Attributes = TypedDict(
         "db.name": str,
         "db.namespace": str,
         "db.operation": str,
+        "db.operation.batch.size": int,
         "db.operation.name": str,
         "db.query.parameter.<key>": str,
         "db.query.summary": str,


### PR DESCRIPTION
## Description

Add the OTel span attribute [`db.operation.batch.size`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/db/#db-operation-batch-size)

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ x I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
