### PR TITLE
ref(conventions): Remove `sdks` field from attribute schema and definitions

### DIFF
--- a/docs/src/components/AttributeCard.astro
+++ b/docs/src/components/AttributeCard.astro
@@ -90,17 +90,6 @@ const rawJson = JSON.stringify(attribute, null, 2);
       </div>
     )}
     
-    {attribute.sdks && attribute.sdks.length > 0 && (
-      <div class="flex items-baseline gap-3 text-sm">
-        <span class="text-text-muted min-w-[100px] flex-shrink-0">SDKs</span>
-        <span class="inline-flex flex-wrap gap-2">
-          {attribute.sdks.map((sdk) => (
-            <span class="px-2 py-0.5 bg-bg-elevated border border-border rounded-sm text-xs text-text-secondary">{sdk}</span>
-          ))}
-        </span>
-      </div>
-    )}
-    
     {attribute.has_dynamic_suffix && (
       <div class="flex items-baseline gap-3 text-sm">
         <span class="text-text-muted min-w-[100px] flex-shrink-0">Dynamic Suffix</span>

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -25,7 +25,6 @@ const attributeSchema = z.object({
     })
     .optional(),
   alias: z.array(z.string()).optional(),
-  sdks: z.array(z.string()).optional(),
   additional_context: z.array(z.string()).optional(),
   changelog: z
     .array(

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -14197,8 +14197,6 @@ export interface AttributeMetadata {
   deprecation?: DeprecationInfo;
   /** If there are attributes that alias to this attribute */
   aliases?: AttributeName[];
-  /** If an attribute is SDK specific, list the SDKs that use this attribute */
-  sdks?: string[];
   /** Changelog entries tracking how this attribute has changed across versions */
   changelog?: ChangelogEntry[];
   /** A list of freeform notes providing additional context about how this attribute behaves, common pitfalls, or query-time nuances */
@@ -15527,7 +15525,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.usage.output_tokens',
     },
     aliases: [GEN_AI_USAGE_OUTPUT_TOKENS, GEN_AI_USAGE_COMPLETION_TOKENS],
-    sdks: ['python'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [57, 61] }, { version: '0.0.0' }],
   },
   [AI_DOCUMENTS]: {
@@ -15623,7 +15620,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.input.messages',
     },
     aliases: [GEN_AI_REQUEST_MESSAGES],
-    sdks: ['python'],
     changelog: [{ version: '0.1.0', prs: [65, 119] }, { version: '0.0.0' }],
   },
   [AI_IS_SEARCH_REQUIRED]: {
@@ -15669,7 +15665,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.response.model',
     },
     aliases: [GEN_AI_RESPONSE_MODEL],
-    sdks: ['python'],
     changelog: [{ version: '0.1.0', prs: [57, 61, 127] }, { version: '0.0.0' }],
   },
   [AI_MODEL_PROVIDER]: {
@@ -15756,7 +15751,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.usage.input_tokens',
     },
     aliases: [GEN_AI_USAGE_PROMPT_TOKENS, GEN_AI_USAGE_INPUT_TOKENS],
-    sdks: ['python'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [57, 61] }, { version: '0.0.0' }],
   },
   [AI_RAW_PROMPTING]: {
@@ -15786,7 +15780,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'gen_ai.output.messages',
     },
-    sdks: ['python'],
     changelog: [{ version: '0.1.0', prs: [65, 127] }, { version: '0.0.0' }],
   },
   [AI_RESPONSE_FORMAT]: {
@@ -15862,7 +15855,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.response.streaming',
     },
     aliases: [GEN_AI_RESPONSE_STREAMING],
-    sdks: ['python'],
     changelog: [{ version: '0.1.0', prs: [76, 108] }, { version: '0.0.0' }],
   },
   [AI_TAGS]: {
@@ -16015,7 +16007,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.usage.total_tokens',
     },
     aliases: [GEN_AI_USAGE_TOTAL_TOKENS],
-    sdks: ['python'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [57, 61, 108] }, { version: '0.0.0' }],
   },
   [AI_WARNINGS]: {
@@ -16058,7 +16049,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'Deprecated in favor of app.build',
     },
     aliases: [APP_BUILD],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       { version: '0.5.0', prs: [296], description: 'Added and deprecated app.app_build in favor of app.build' },
     ],
@@ -16077,7 +16067,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'Deprecated in favor of app.identifier',
     },
     aliases: [APP_IDENTIFIER],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       {
         version: '0.5.0',
@@ -16100,7 +16089,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'Deprecated in favor of app.name',
     },
     aliases: [APP_NAME],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       { version: '0.5.0', prs: [296], description: 'Added and deprecated app.app_name in favor of app.name' },
     ],
@@ -16119,7 +16107,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'Deprecated in favor of app.start_time',
     },
     aliases: [APP_START_TIME],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       {
         version: '0.5.0',
@@ -16142,7 +16129,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'Deprecated in favor of app.version',
     },
     aliases: [APP_VERSION],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       { version: '0.5.0', prs: [296], description: 'Added and deprecated app.app_version in favor of app.version' },
     ],
@@ -16157,7 +16143,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: '1',
     aliases: [APP_APP_BUILD],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: '0.5.0', prs: [296], description: 'Added app.build attribute' }],
   },
   [APP_IDENTIFIER]: {
@@ -16170,7 +16155,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'com.example.myapp',
     aliases: [APP_APP_IDENTIFIER],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: '0.5.0', prs: [296], description: 'Added app.identifier attribute' }],
   },
   [APP_IN_FOREGROUND]: {
@@ -16182,7 +16166,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: true,
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: '0.5.0', prs: [296], description: 'Added app.in_foreground attribute' }],
   },
   [APP_NAME]: {
@@ -16195,7 +16178,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'My App',
     aliases: [APP_APP_NAME],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: '0.5.0', prs: [296], description: 'Added app.name attribute' }],
   },
   [APP_START_COLD]: {
@@ -16213,7 +16195,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
         'Replaced by app.vitals.start.cold.value to align with the app.vitals.* namespace for mobile performance attributes',
     },
     aliases: [APP_VITALS_START_COLD_VALUE],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       { version: '0.5.0', prs: [323], description: 'Added and deprecated in favor of app.vitals.start.cold.value' },
     ],
@@ -16228,7 +16209,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: '2025-01-01T00:00:00.000Z',
     aliases: [APP_APP_START_TIME],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: '0.5.0', prs: [296], description: 'Added app.start_time attribute' }],
   },
   [APP_START_TYPE]: {
@@ -16267,7 +16247,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
         'Replaced by app.vitals.start.warm.value to align with the app.vitals.* namespace for mobile performance attributes',
     },
     aliases: [APP_VITALS_START_WARM_VALUE],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       { version: '0.5.0', prs: [323], description: 'Added and deprecated in favor of app.vitals.start.warm.value' },
     ],
@@ -16282,7 +16261,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: '1.0.0',
     aliases: [APP_APP_VERSION],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: '0.5.0', prs: [296], description: 'Added app.version attribute' }],
   },
   [APP_VITALS_FRAMES_DELAY_VALUE]: {
@@ -16296,7 +16274,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 5,
     aliases: [FRAMES_DELAY],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       { version: '0.5.0', prs: [313], description: 'Added app.vitals.frames.delay.value to replace frames.delay' },
     ],
@@ -16311,7 +16288,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 3,
     aliases: [FRAMES_FROZEN],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       { version: '0.5.0', prs: [313], description: 'Added app.vitals.frames.frozen.count to replace frames.frozen' },
     ],
@@ -16326,7 +16302,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 1,
     aliases: [FRAMES_SLOW],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       { version: '0.5.0', prs: [313], description: 'Added app.vitals.frames.slow.count to replace frames.slow' },
     ],
@@ -16341,7 +16316,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 60,
     aliases: [FRAMES_TOTAL],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       { version: '0.5.0', prs: [313], description: 'Added app.vitals.frames.total.count to replace frames.total' },
     ],
@@ -16356,7 +16330,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 1234.56,
     aliases: [APP_START_COLD],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: '0.5.0', prs: [313], description: 'Added app.vitals.start.cold.value attribute' }],
   },
   [APP_VITALS_START_PREWARMED]: {
@@ -16368,7 +16341,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: true,
-    sdks: ['sentry.cocoa'],
     changelog: [{ version: 'next', prs: [379], description: 'Added app.vitals.start.prewarmed attribute' }],
   },
   [APP_VITALS_START_REASON]: {
@@ -16380,13 +16352,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'push',
-    sdks: [
-      'sentry.cocoa',
-      'sentry.java.android',
-      'sentry.javascript.react-native',
-      'sentry.dart.flutter',
-      'sentry.dotnet.maui',
-    ],
     changelog: [{ version: '0.7.0', prs: [353], description: 'Added app.vitals.start.reason attribute' }],
   },
   [APP_VITALS_START_SCREEN]: {
@@ -16399,13 +16364,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'MainActivity',
-    sdks: [
-      'sentry.cocoa',
-      'sentry.java.android',
-      'sentry.javascript.react-native',
-      'sentry.dart.flutter',
-      'sentry.dotnet.maui',
-    ],
     changelog: [{ version: '0.7.0', prs: [353], description: 'Added app.vitals.start.screen attribute' }],
   },
   [APP_VITALS_START_TYPE]: {
@@ -16418,7 +16376,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'cold',
     aliases: [APP_START_TYPE],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: '0.5.0', prs: [313], description: 'Added app.vitals.start.type attribute' }],
   },
   [APP_VITALS_START_WARM_VALUE]: {
@@ -16431,7 +16388,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 1234.56,
     aliases: [APP_START_WARM],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: '0.5.0', prs: [313], description: 'Added app.vitals.start.warm.value attribute' }],
   },
   [APP_VITALS_TTFD_VALUE]: {
@@ -16444,7 +16400,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 1234.56,
     aliases: [TIME_TO_FULL_DISPLAY],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: '0.5.0', prs: [313], description: 'Added app.vitals.ttfd.value attribute' }],
   },
   [APP_VITALS_TTID_VALUE]: {
@@ -16457,7 +16412,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 1234.56,
     aliases: [TIME_TO_INITIAL_DISPLAY],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [{ version: '0.5.0', prs: [313], description: 'Added app.vitals.ttid.value attribute' }],
   },
   [ART_GC_BLOCKING_COUNT]: {
@@ -16469,7 +16423,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1,
-    sdks: ['sentry.java.android'],
     changelog: [{ version: 'next', prs: [382], description: 'Added art.gc.blocking_count attribute' }],
   },
   [ART_GC_BLOCKING_TIME]: {
@@ -16481,7 +16434,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 11.873,
-    sdks: ['sentry.java.android'],
     changelog: [{ version: 'next', prs: [382], description: 'Added art.gc.blocking_time attribute' }],
   },
   [ART_GC_PRE_OOME_COUNT]: {
@@ -16494,7 +16446,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 0,
-    sdks: ['sentry.java.android'],
     changelog: [{ version: 'next', prs: [382], description: 'Added art.gc.pre_oome_count attribute' }],
   },
   [ART_GC_TOTAL_COUNT]: {
@@ -16506,7 +16457,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1,
-    sdks: ['sentry.java.android'],
     changelog: [{ version: 'next', prs: [382], description: 'Added art.gc.total_count attribute' }],
   },
   [ART_GC_TOTAL_TIME]: {
@@ -16518,7 +16468,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 11.807,
-    sdks: ['sentry.java.android'],
     changelog: [{ version: 'next', prs: [382], description: 'Added art.gc.total_time attribute' }],
   },
   [ART_GC_WAITING_TIME]: {
@@ -16531,7 +16480,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 8.054,
-    sdks: ['sentry.java.android'],
     changelog: [{ version: 'next', prs: [382], description: 'Added art.gc.waiting_time attribute' }],
   },
   [ART_MEMORY_FREE]: {
@@ -16543,7 +16491,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 3181568,
-    sdks: ['sentry.java.android'],
     changelog: [{ version: 'next', prs: [382], description: 'Added art.memory.free attribute' }],
   },
   [ART_MEMORY_FREE_UNTIL_GC]: {
@@ -16555,7 +16502,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 3181568,
-    sdks: ['sentry.java.android'],
     changelog: [{ version: 'next', prs: [382], description: 'Added art.memory.free_until_gc attribute' }],
   },
   [ART_MEMORY_FREE_UNTIL_OOME]: {
@@ -16567,7 +16513,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 196083712,
-    sdks: ['sentry.java.android'],
     changelog: [{ version: 'next', prs: [382], description: 'Added art.memory.free_until_oome attribute' }],
   },
   [ART_MEMORY_MAX]: {
@@ -16579,7 +16524,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 201326592,
-    sdks: ['sentry.java.android'],
     changelog: [{ version: 'next', prs: [382], description: 'Added art.memory.max attribute' }],
   },
   [ART_MEMORY_TOTAL]: {
@@ -16591,7 +16535,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 7774208,
-    sdks: ['sentry.java.android'],
     changelog: [{ version: 'next', prs: [382], description: 'Added art.memory.total attribute' }],
   },
   [AWS_CLOUDWATCH_LOGS_LOG_GROUP]: {
@@ -16728,7 +16671,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 1.983,
     aliases: [PERFORMANCE_ACTIVATIONSTART],
-    sdks: ['javascript-browser'],
     changelog: [
       { version: '0.5.0', prs: [321], description: 'Added browser.performance.navigation.activation_start attribute' },
     ],
@@ -16743,7 +16685,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 1776185678.886,
     aliases: [PERFORMANCE_TIMEORIGIN],
-    sdks: ['javascript-browser'],
     changelog: [
       { version: '0.5.0', prs: [321], description: 'Added browser.performance.time_origin attribute attribute' },
     ],
@@ -16768,7 +16709,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'Window.requestAnimationFrame',
-    sdks: ['browser'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [BROWSER_SCRIPT_INVOKER_TYPE]: {
@@ -16780,7 +16720,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'event-listener',
-    sdks: ['browser'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [BROWSER_SCRIPT_SOURCE_CHAR_POSITION]: {
@@ -16792,7 +16731,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 678,
-    sdks: ['browser'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [BROWSER_VERSION]: {
@@ -16816,7 +16754,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'navigation',
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [319], description: 'Added browser.web_vital.cls.report_event attribute' }],
   },
   [BROWSER_WEB_VITAL_CLS_SOURCE_KEY]: {
@@ -16830,7 +16767,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     hasDynamicSuffix: true,
     example: 'body > div#app',
     aliases: [CLS_SOURCE_KEY],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [234] }],
   },
   [BROWSER_WEB_VITAL_CLS_VALUE]: {
@@ -16843,7 +16779,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 0.2361,
     aliases: [CLS],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [229], description: 'Added browser.web_vital.cls.value attribute' }],
   },
   [BROWSER_WEB_VITAL_FCP_VALUE]: {
@@ -16856,7 +16791,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 547.6951,
     aliases: [FCP],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [235] }],
   },
   [BROWSER_WEB_VITAL_FP_VALUE]: {
@@ -16869,7 +16803,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 477.1926,
     aliases: [FP],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [235] }],
   },
   [BROWSER_WEB_VITAL_INP_VALUE]: {
@@ -16882,7 +16815,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 200,
     aliases: [INP],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [229], description: 'Added browser.web_vital.inp.value attribute' }],
   },
   [BROWSER_WEB_VITAL_LCP_ELEMENT]: {
@@ -16895,7 +16827,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'body > div#app > div#container > div',
     aliases: [LCP_ELEMENT],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [233] }],
   },
   [BROWSER_WEB_VITAL_LCP_ID]: {
@@ -16908,7 +16839,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: '#gero',
     aliases: [LCP_ID],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [233] }],
   },
   [BROWSER_WEB_VITAL_LCP_LOAD_TIME]: {
@@ -16921,7 +16851,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 1402,
     aliases: [LCP_LOADTIME],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [233] }],
   },
   [BROWSER_WEB_VITAL_LCP_RENDER_TIME]: {
@@ -16934,7 +16863,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 1685,
     aliases: [LCP_RENDERTIME],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [233] }],
   },
   [BROWSER_WEB_VITAL_LCP_REPORT_EVENT]: {
@@ -16946,7 +16874,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'pagehide',
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [319], description: 'Added browser.web_vital.lcp.report_event attribute' }],
   },
   [BROWSER_WEB_VITAL_LCP_SIZE]: {
@@ -16959,7 +16886,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 1024,
     aliases: [LCP_SIZE],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [233] }],
   },
   [BROWSER_WEB_VITAL_LCP_URL]: {
@@ -16972,7 +16898,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'https://example.com/static/img.png',
     aliases: [LCP_URL],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [233] }],
   },
   [BROWSER_WEB_VITAL_LCP_VALUE]: {
@@ -16985,7 +16910,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 2500,
     aliases: [LCP],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [229], description: 'Added browser.web_vital.lcp.value attribute' }],
   },
   [BROWSER_WEB_VITAL_TTFB_REQUEST_TIME]: {
@@ -16999,7 +16923,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 1554.5814,
     aliases: [TTFB_REQUESTTIME],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [235] }],
   },
   [BROWSER_WEB_VITAL_TTFB_VALUE]: {
@@ -17012,7 +16935,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 194.3322,
     aliases: [TTFB],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [235] }],
   },
   [CACHE_HIT]: {
@@ -17024,7 +16946,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: true,
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.0.0' }],
   },
   [CACHE_ITEM_SIZE]: {
@@ -17047,7 +16968,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: ['my-cache-key', 'my-other-cache-key'],
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.0.0' }],
   },
   [CACHE_OPERATION]: {
@@ -17059,7 +16979,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'get',
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [CACHE_TTL]: {
@@ -17071,7 +16990,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 120,
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [CACHE_WRITE]: {
@@ -17083,7 +17001,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: true,
-    sdks: ['java'],
     changelog: [{ version: '0.5.0' }],
   },
   [CHANNEL]: {
@@ -17095,7 +17012,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'mail',
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [CLIENT_ADDRESS]: {
@@ -17131,7 +17047,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 543,
-    sdks: ['javascript-cloudflare'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [CLOUDFLARE_D1_QUERY_TYPE]: {
@@ -17143,7 +17058,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'run',
-    sdks: ['javascript-cloudflare'],
     changelog: [{ version: 'next', prs: [392], description: 'Added cloudflare.d1.query_type attribute' }],
   },
   [CLOUDFLARE_D1_ROWS_READ]: {
@@ -17155,7 +17069,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 12,
-    sdks: ['javascript-cloudflare'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [CLOUDFLARE_D1_ROWS_WRITTEN]: {
@@ -17167,7 +17080,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 12,
-    sdks: ['javascript-cloudflare'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [CLOUDFLARE_WORKFLOW_ATTEMPT]: {
@@ -17179,7 +17091,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1,
-    sdks: ['javascript-cloudflare'],
     changelog: [{ version: 'next', prs: [392], description: 'Added cloudflare.workflow.attempt attribute' }],
   },
   [CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF]: {
@@ -17191,7 +17102,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'exponential',
-    sdks: ['javascript-cloudflare'],
     changelog: [{ version: 'next', prs: [392], description: 'Added cloudflare.workflow.retries.backoff attribute' }],
   },
   [CLOUDFLARE_WORKFLOW_RETRIES_DELAY]: {
@@ -17203,7 +17113,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: '5 seconds',
-    sdks: ['javascript-cloudflare'],
     changelog: [{ version: 'next', prs: [392], description: 'Added cloudflare.workflow.retries.delay attribute' }],
   },
   [CLOUDFLARE_WORKFLOW_RETRIES_LIMIT]: {
@@ -17215,7 +17124,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 3,
-    sdks: ['javascript-cloudflare'],
     changelog: [{ version: 'next', prs: [392], description: 'Added cloudflare.workflow.retries.limit attribute' }],
   },
   [CLOUDFLARE_WORKFLOW_TIMEOUT]: {
@@ -17227,7 +17135,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: '1 minute',
-    sdks: ['javascript-cloudflare'],
     changelog: [{ version: 'next', prs: [392], description: 'Added cloudflare.workflow.timeout attribute' }],
   },
   [CLOUD_ACCOUNT_ID]: {
@@ -17299,7 +17206,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'The CLS web vital is now recorded as a browser.web_vital.cls.value attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_CLS_VALUE],
-    sdks: ['javascript-browser'],
     changelog: [
       {
         version: '0.5.0',
@@ -17323,7 +17229,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'The CLS source is now recorded as a browser.web_vital.cls.source.<key> attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_CLS_SOURCE_KEY],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [234] }],
   },
   [CODE_FILEPATH]: {
@@ -17434,7 +17339,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'Old namespace-less attribute, to be replaced with network.connection.type for span-first future',
     },
     aliases: [NETWORK_CONNECTION_TYPE, DEVICE_CONNECTION_TYPE],
-    sdks: ['javascript-browser'],
     changelog: [
       {
         version: '0.5.0',
@@ -17458,7 +17362,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
         'Old attribute name (no official namespace), to be replaced with network.connection.rtt for span-first future',
     },
     aliases: [NETWORK_CONNECTION_RTT],
-    sdks: ['javascript-browser'],
     changelog: [
       {
         version: '0.5.0',
@@ -17658,7 +17561,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'my-redis-instance',
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [DB_REDIS_KEY]: {
@@ -17670,7 +17572,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'user:2047:city',
-    sdks: ['python'],
     changelog: [{ version: '0.6.0', prs: [326], description: 'Added db.redis.key attribute' }],
   },
   [DB_REDIS_PARAMETERS]: {
@@ -17682,7 +17583,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: ['test', '*'],
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.0.0' }],
   },
   [DB_SQL_BINDINGS]: {
@@ -17699,7 +17599,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason:
         'Instead of adding every binding in the db.sql.bindings attribute, add them as individual entires with db.query.parameter.<key>.',
     },
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [DB_STATEMENT]: {
@@ -17783,7 +17682,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
         'Old namespace-less attribute, to be replaced with device.memory.estimated_capacity for span-first future',
     },
     aliases: [DEVICE_MEMORY_ESTIMATED_CAPACITY],
-    sdks: ['javascript-browser'],
     changelog: [
       {
         version: '0.5.0',
@@ -18011,7 +17909,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: true,
-    sdks: ['sentry.cocoa'],
     changelog: [{ version: '0.6.0', prs: [314], description: 'Added device.low_power_mode attribute' }],
   },
   [DEVICE_MANUFACTURER]: {
@@ -18036,7 +17933,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 8,
     aliases: [DEVICEMEMORY],
-    sdks: ['javascript-browser'],
     changelog: [
       {
         version: '0.5.0',
@@ -18256,7 +18152,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
         'Old namespace-less attribute, to be replaced with network.connection.effective_type for span-first future',
     },
     aliases: [NETWORK_CONNECTION_EFFECTIVE_TYPE],
-    sdks: ['javascript-browser'],
     changelog: [
       {
         version: '0.5.0',
@@ -18465,7 +18360,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'This attribute is being deprecated in favor of browser.web_vital.fcp.value',
     },
     aliases: [BROWSER_WEB_VITAL_FCP_VALUE],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [235] }],
   },
   [FLAG_EVALUATION_KEY]: {
@@ -18495,7 +18389,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'This attribute is being deprecated in favor of browser.web_vital.fp.value',
     },
     aliases: [BROWSER_WEB_VITAL_FP_VALUE],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [235] }],
   },
   [FRAMES_DELAY]: {
@@ -18618,7 +18511,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'error.type',
       reason: 'This attribute is not part of the OpenTelemetry specification and error.type fits much better.',
     },
-    sdks: ['javascript-node'],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [GCP_FUNCTION_CONTEXT_EVENT_ID]: {
@@ -19707,7 +19599,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'Old namespace-less attribute, to be replaced with device.processor_count for span-first future',
     },
     aliases: [DEVICE_PROCESSOR_COUNT],
-    sdks: ['javascript-browser'],
     changelog: [
       {
         version: '0.5.0',
@@ -19741,7 +19632,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 456,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [HTTP_FLAVOR]: {
@@ -19837,7 +19727,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1732829555.15,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_CONNECT_START]: {
@@ -19850,7 +19739,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1732829555.111,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_DOMAIN_LOOKUP_END]: {
@@ -19863,7 +19751,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1732829555.201,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_DOMAIN_LOOKUP_START]: {
@@ -19876,7 +19763,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1732829555.322,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_FETCH_START]: {
@@ -19888,7 +19774,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1732829555.389,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_HEADER_KEY]: {
@@ -19944,7 +19829,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1732829558.502,
-    sdks: ['javascript-browser'],
     changelog: [
       { version: '0.4.0', prs: [228] },
       { version: '0.1.0', prs: [130, 134] },
@@ -19959,7 +19843,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1732829555.495,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_REQUEST_START]: {
@@ -19972,7 +19855,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1732829555.51,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_RESEND_COUNT]: {
@@ -19996,7 +19878,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1732829555.89,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_RESPONSE_START]: {
@@ -20009,7 +19890,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1732829555.7,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_SECURE_CONNECTION_START]: {
@@ -20022,7 +19902,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1732829555.73,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
   },
   [HTTP_REQUEST_TIME_TO_FIRST_BYTE]: {
@@ -20035,7 +19914,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1.032,
-    sdks: ['javascript-browser'],
     changelog: [
       { version: '0.4.0', prs: [228] },
       { version: '0.1.0', prs: [131] },
@@ -20051,7 +19929,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1732829553.68,
-    sdks: ['javascript-browser'],
     changelog: [
       { version: '0.4.0', prs: [228] },
       { version: '0.1.0', prs: [130, 134] },
@@ -20203,7 +20080,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 50,
-    sdks: ['ruby'],
     changelog: [{ version: '0.5.0', prs: [267] }],
   },
   [HTTP_STATUS_CODE]: {
@@ -20276,7 +20152,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'f47ac10b58cc4372a5670e02b2c3d479',
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.0.0' }],
   },
   [INP]: {
@@ -20293,7 +20168,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'The INP web vital is now recorded as a browser.web_vital.inp.value attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_INP_VALUE],
-    sdks: ['javascript-browser'],
     changelog: [
       {
         version: '0.5.0',
@@ -20382,7 +20256,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'The LCP web vital is now recorded as a browser.web_vital.lcp.value attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_LCP_VALUE],
-    sdks: ['javascript-browser'],
     changelog: [
       {
         version: '0.5.0',
@@ -20437,7 +20310,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'The LCP load time is now recorded as a browser.web_vital.lcp.load_time attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_LCP_LOAD_TIME],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [233] }],
   },
   [LCP_RENDERTIME]: {
@@ -20454,7 +20326,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'The LCP render time is now recorded as a browser.web_vital.lcp.render_time attribute.',
     },
     aliases: [BROWSER_WEB_VITAL_LCP_RENDER_TIME],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [233] }],
   },
   [LCP_SIZE]: {
@@ -20964,7 +20835,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     hasDynamicSuffix: true,
     example: "mdc.some_key='some_value'",
-    sdks: ['java', 'java.logback', 'java.jul', 'java.log4j2'],
     changelog: [{ version: '0.3.0', prs: [176] }],
   },
   [MESSAGING_BATCH_MESSAGE_COUNT]: {
@@ -20976,7 +20846,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 10,
-    sdks: ['javascript-cloudflare'],
     changelog: [{ version: '0.6.0', prs: [341], description: 'Added messaging.batch.message_count attribute' }],
   },
   [MESSAGING_DESTINATION_CONNECTION]: {
@@ -20988,7 +20857,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'BestTopic',
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [MESSAGING_DESTINATION_NAME]: {
@@ -21000,7 +20868,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'BestTopic',
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [MESSAGING_MESSAGE_BODY_SIZE]: {
@@ -21012,7 +20879,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 839,
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [MESSAGING_MESSAGE_ENVELOPE_SIZE]: {
@@ -21024,7 +20890,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 1045,
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [MESSAGING_MESSAGE_ID]: {
@@ -21036,7 +20901,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'f47ac10b58cc4372a5670e02b2c3d479',
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [MESSAGING_MESSAGE_RECEIVE_LATENCY]: {
@@ -21048,7 +20912,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1732847252,
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [MESSAGING_MESSAGE_RETRY_COUNT]: {
@@ -21060,7 +20923,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 2,
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   [MESSAGING_OPERATION_NAME]: {
@@ -21072,7 +20934,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'send',
-    sdks: ['javascript-cloudflare'],
     changelog: [{ version: 'next', prs: [392], description: 'Added messaging.operation.name attribute' }],
   },
   [MESSAGING_OPERATION_TYPE]: {
@@ -21095,7 +20956,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'activemq',
-    sdks: ['php-laravel'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [METHOD]: {
@@ -21111,7 +20971,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'http.request.method',
     },
     aliases: [HTTP_REQUEST_METHOD, _HTTP_REQUEST_METHOD, HTTP_METHOD],
-    sdks: ['javascript-browser', 'javascript-node'],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [MIDDLEWARE_NAME]: {
@@ -21123,7 +20982,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'AuthenticationMiddleware',
-    sdks: ['python'],
     changelog: [{ version: '0.6.0', prs: [336], description: 'Added middleware.name attribute' }],
   },
   [NAVIGATION_TYPE]: {
@@ -21209,7 +21067,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: '4g',
     aliases: [EFFECTIVECONNECTIONTYPE],
-    sdks: ['javascript-browser'],
     changelog: [
       {
         version: '0.5.0',
@@ -21228,7 +21085,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 100,
     aliases: [CONNECTION_RTT],
-    sdks: ['javascript-browser'],
     changelog: [
       {
         version: '0.5.0',
@@ -21247,7 +21103,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'wifi',
     aliases: [DEVICE_CONNECTION_TYPE, CONNECTIONTYPE],
-    sdks: ['javascript-browser'],
     changelog: [
       {
         version: '0.5.0',
@@ -21770,7 +21625,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'The activationStart is now recorded as the browser.performance.navigation.activation_start attribute.',
     },
     aliases: [BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [321], description: 'Added performance.activationStart attribute' }],
   },
   [PERFORMANCE_TIMEORIGIN]: {
@@ -21787,7 +21641,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'The timeOrigin is now recorded as the browser.performance.time_origin attribute.',
     },
     aliases: [BROWSER_PERFORMANCE_TIME_ORIGIN],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [321], description: 'Added performance.timeOrigin attribute' }],
   },
   [PREVIOUS_ROUTE]: {
@@ -21799,7 +21652,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'HomeScreen',
-    sdks: ['javascript-reactnative'],
     changelog: [{ version: '0.1.0', prs: [74] }, { version: '0.0.0' }],
   },
   [PROCESS_COMMAND_ARGS]: {
@@ -21811,7 +21663,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: ['cmd/otecol', '--config=config.yaml'],
-    sdks: ['python'],
     changelog: [{ version: '0.6.0', prs: [327], description: 'Added process.command_args attribute' }],
   },
   [PROCESS_EXECUTABLE_NAME]: {
@@ -21948,7 +21799,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     hasDynamicSuffix: true,
     example: "http.response.header.text='test'",
-    sdks: ['javascript-remix'],
     changelog: [{ version: '0.1.0', prs: [103] }],
   },
   [REPLAY_ID]: {
@@ -22003,7 +21853,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'non-blocking',
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [ROUTE]: {
@@ -22020,7 +21869,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'http.route',
     },
     aliases: [HTTP_ROUTE],
-    sdks: ['php-laravel', 'javascript-reactnative'],
     changelog: [{ version: '0.1.0', prs: [61, 74] }, { version: '0.0.0' }],
   },
   [RPC_GRPC_STATUS_CODE]: {
@@ -22553,7 +22401,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: '/posts/[id]/layout',
-    sdks: ['javascript'],
     changelog: [{ version: '0.1.0', prs: [54, 106] }],
   },
   [SENTRY_NEXTJS_SSR_FUNCTION_TYPE]: {
@@ -22566,7 +22413,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'generateMetadata',
-    sdks: ['javascript'],
     changelog: [{ version: '0.1.0', prs: [54, 106] }],
   },
   [SENTRY_NORMALIZED_DB_QUERY]: {
@@ -22721,7 +22567,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason:
         'The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required.',
     },
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [320], description: 'Added sentry.report_event attribute' }],
   },
   [SENTRY_SDK_INTEGRATIONS]: {
@@ -23143,7 +22988,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'MyTag',
-    sdks: ['sentry.java.android'],
     changelog: [{ version: '0.3.0', prs: [183] }],
   },
   [TIME_TO_FULL_DISPLAY]: {
@@ -23161,7 +23005,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
         'Replaced by app.vitals.ttfd.value to align with the app.vitals.* namespace for mobile performance attributes',
     },
     aliases: [APP_VITALS_TTFD_VALUE],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       { version: '0.5.0', prs: [313], description: 'Added and deprecated in favor of app.vitals.ttfd.value' },
     ],
@@ -23181,7 +23024,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
         'Replaced by app.vitals.ttid.value to align with the app.vitals.* namespace for mobile performance attributes',
     },
     aliases: [APP_VITALS_TTID_VALUE],
-    sdks: ['sentry.cocoa', 'sentry.java.android', 'sentry.javascript.react-native', 'sentry.dart.flutter'],
     changelog: [
       { version: '0.5.0', prs: [313], description: 'Added and deprecated in favor of app.vitals.ttid.value' },
     ],
@@ -23245,7 +23087,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'This attribute is being deprecated in favor of browser.web_vital.ttfb.value',
     },
     aliases: [BROWSER_WEB_VITAL_TTFB_VALUE],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [235] }],
   },
   [TTFB_REQUESTTIME]: {
@@ -23263,7 +23104,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'This attribute is being deprecated in favor of browser.web_vital.ttfb.request_time',
     },
     aliases: [BROWSER_WEB_VITAL_TTFB_REQUEST_TIME],
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [235] }],
   },
   [TYPE]: {
@@ -23275,7 +23115,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'fetch',
-    sdks: ['javascript-browser', 'javascript-node'],
     changelog: [{ version: '0.0.0' }],
   },
   [UI_COMPONENT_NAME]: {
@@ -23320,7 +23159,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 256,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [284], description: 'Added ui.element.height attribute' }],
   },
   [UI_ELEMENT_ID]: {
@@ -23332,7 +23170,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'btn-login',
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [284], description: 'Added ui.element.id attribute' }],
   },
   [UI_ELEMENT_IDENTIFIER]: {
@@ -23344,7 +23181,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'heroImage',
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [284], description: 'Added ui.element.identifier attribute' }],
   },
   [UI_ELEMENT_LOAD_TIME]: {
@@ -23356,7 +23192,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 998.2234,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [284], description: 'Added ui.element.load_time attribute' }],
   },
   [UI_ELEMENT_PAINT_TYPE]: {
@@ -23368,7 +23203,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'image-paint',
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [284], description: 'Added ui.element.paint_type attribute' }],
   },
   [UI_ELEMENT_RENDER_TIME]: {
@@ -23380,7 +23214,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 1023.1124,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [284], description: 'Added ui.element.render_time attribute' }],
   },
   [UI_ELEMENT_TYPE]: {
@@ -23392,7 +23225,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'img',
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [284], description: 'Added ui.element.type attribute' }],
   },
   [UI_ELEMENT_URL]: {
@@ -23404,7 +23236,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'https://assets.myapp.com/hero.png',
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [284], description: 'Added ui.element.url attribute' }],
   },
   [UI_ELEMENT_WIDTH]: {
@@ -23416,7 +23247,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 512,
-    sdks: ['javascript-browser'],
     changelog: [{ version: '0.5.0', prs: [284], description: 'Added ui.element.width attribute' }],
   },
   [URL]: {
@@ -23432,7 +23262,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'url.full',
     },
     aliases: [URL_FULL, HTTP_URL],
-    sdks: ['javascript-browser', 'javascript-node'],
     changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   [URL_DOMAIN]: {

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -17499,7 +17499,6 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 3,
-    sdks: ['javascript-node', 'javascript-deno', 'javascript-bun', 'javascript-cloudflare'],
     changelog: [{ version: 'next', prs: [407], description: 'Added db.operation.batch.size attribute' }],
   },
   [DB_OPERATION_NAME]: {

--- a/model/attributes/ai/ai__completion_tokens__used.json
+++ b/model/attributes/ai/ai__completion_tokens__used.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 10,
   "alias": ["gen_ai.usage.output_tokens", "gen_ai.usage.completion_tokens"],
-  "sdks": ["python"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.usage.output_tokens"

--- a/model/attributes/ai/ai__input_messages.json
+++ b/model/attributes/ai/ai__input_messages.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "[{\"role\": \"user\", \"message\": \"hello\"}]",
   "alias": ["gen_ai.request.messages"],
-  "sdks": ["python"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.input.messages"

--- a/model/attributes/ai/ai__model_id.json
+++ b/model/attributes/ai/ai__model_id.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "gpt-4",
   "alias": ["gen_ai.response.model"],
-  "sdks": ["python"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.response.model"

--- a/model/attributes/ai/ai__prompt_tokens__used.json
+++ b/model/attributes/ai/ai__prompt_tokens__used.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 20,
   "alias": ["gen_ai.usage.prompt_tokens", "gen_ai.usage.input_tokens"],
-  "sdks": ["python"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.usage.input_tokens"

--- a/model/attributes/ai/ai__responses.json
+++ b/model/attributes/ai/ai__responses.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": ["hello", "world"],
-  "sdks": ["python"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.output.messages"

--- a/model/attributes/ai/ai__streaming.json
+++ b/model/attributes/ai/ai__streaming.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": true,
   "alias": ["gen_ai.response.streaming"],
-  "sdks": ["python"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.response.streaming"

--- a/model/attributes/ai/ai__total_tokens__used.json
+++ b/model/attributes/ai/ai__total_tokens__used.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 30,
   "alias": ["gen_ai.usage.total_tokens"],
-  "sdks": ["python"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.usage.total_tokens"

--- a/model/attributes/app/app__app_build.json
+++ b/model/attributes/app/app__app_build.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "1",
   "alias": ["app.build"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "deprecation": {
     "replacement": "app.build",
     "reason": "Deprecated in favor of app.build",

--- a/model/attributes/app/app__app_identifier.json
+++ b/model/attributes/app/app__app_identifier.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "com.example.myapp",
   "alias": ["app.identifier"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "deprecation": {
     "replacement": "app.identifier",
     "reason": "Deprecated in favor of app.identifier",

--- a/model/attributes/app/app__app_name.json
+++ b/model/attributes/app/app__app_name.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "My App",
   "alias": ["app.name"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "deprecation": {
     "replacement": "app.name",
     "reason": "Deprecated in favor of app.name",

--- a/model/attributes/app/app__app_start_time.json
+++ b/model/attributes/app/app__app_start_time.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "2025-01-01T00:00:00.000Z",
   "alias": ["app.start_time"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "deprecation": {
     "replacement": "app.start_time",
     "reason": "Deprecated in favor of app.start_time",

--- a/model/attributes/app/app__app_version.json
+++ b/model/attributes/app/app__app_version.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "1.0.0",
   "alias": ["app.version"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "deprecation": {
     "replacement": "app.version",
     "reason": "Deprecated in favor of app.version",

--- a/model/attributes/app/app__build.json
+++ b/model/attributes/app/app__build.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "1",
   "alias": ["app.app_build"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__identifier.json
+++ b/model/attributes/app/app__identifier.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "com.example.myapp",
   "alias": ["app.app_identifier"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__in_foreground.json
+++ b/model/attributes/app/app__in_foreground.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": true,
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__name.json
+++ b/model/attributes/app/app__name.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "My App",
   "alias": ["app.app_name"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__start_time.json
+++ b/model/attributes/app/app__start_time.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "2025-01-01T00:00:00.000Z",
   "alias": ["app.app_start_time"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__version.json
+++ b/model/attributes/app/app__version.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "1.0.0",
   "alias": ["app.app_version"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__vitals__frames__delay__value.json
+++ b/model/attributes/app/app__vitals__frames__delay__value.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 5,
   "alias": ["frames.delay"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__vitals__frames__frozen__count.json
+++ b/model/attributes/app/app__vitals__frames__frozen__count.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 3,
   "alias": ["frames.frozen"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__vitals__frames__slow__count.json
+++ b/model/attributes/app/app__vitals__frames__slow__count.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1,
   "alias": ["frames.slow"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__vitals__frames__total__count.json
+++ b/model/attributes/app/app__vitals__frames__total__count.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 60,
   "alias": ["frames.total"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__vitals__start__cold__value.json
+++ b/model/attributes/app/app__vitals__start__cold__value.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1234.56,
   "alias": ["app_start_cold"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__vitals__start__prewarmed.json
+++ b/model/attributes/app/app__vitals__start__prewarmed.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": true,
-  "sdks": ["sentry.cocoa"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__vitals__start__reason.json
+++ b/model/attributes/app/app__vitals__start__reason.json
@@ -7,13 +7,6 @@
   },
   "is_in_otel": false,
   "example": "push",
-  "sdks": [
-    "sentry.cocoa",
-    "sentry.java.android",
-    "sentry.javascript.react-native",
-    "sentry.dart.flutter",
-    "sentry.dotnet.maui"
-  ],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__vitals__start__screen.json
+++ b/model/attributes/app/app__vitals__start__screen.json
@@ -7,13 +7,6 @@
   },
   "is_in_otel": false,
   "example": "MainActivity",
-  "sdks": [
-    "sentry.cocoa",
-    "sentry.java.android",
-    "sentry.javascript.react-native",
-    "sentry.dart.flutter",
-    "sentry.dotnet.maui"
-  ],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__vitals__start__type.json
+++ b/model/attributes/app/app__vitals__start__type.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "cold",
   "alias": ["app_start_type"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__vitals__start__warm__value.json
+++ b/model/attributes/app/app__vitals__start__warm__value.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1234.56,
   "alias": ["app_start_warm"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__vitals__ttfd__value.json
+++ b/model/attributes/app/app__vitals__ttfd__value.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1234.56,
   "alias": ["time_to_full_display"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app/app__vitals__ttid__value.json
+++ b/model/attributes/app/app__vitals__ttid__value.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1234.56,
   "alias": ["time_to_initial_display"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/app_start_cold.json
+++ b/model/attributes/app_start_cold.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1234.56,
   "alias": ["app.vitals.start.cold.value"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "deprecation": {
     "replacement": "app.vitals.start.cold.value",
     "reason": "Replaced by app.vitals.start.cold.value to align with the app.vitals.* namespace for mobile performance attributes",

--- a/model/attributes/app_start_warm.json
+++ b/model/attributes/app_start_warm.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1234.56,
   "alias": ["app.vitals.start.warm.value"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "deprecation": {
     "replacement": "app.vitals.start.warm.value",
     "reason": "Replaced by app.vitals.start.warm.value to align with the app.vitals.* namespace for mobile performance attributes",

--- a/model/attributes/art/art__gc__blocking_count.json
+++ b/model/attributes/art/art__gc__blocking_count.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "visibility": "public",
   "example": 1,
-  "sdks": ["sentry.java.android"],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/art/art__gc__blocking_time.json
+++ b/model/attributes/art/art__gc__blocking_time.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "visibility": "public",
   "example": 11.873,
-  "sdks": ["sentry.java.android"],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/art/art__gc__pre_oome_count.json
+++ b/model/attributes/art/art__gc__pre_oome_count.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "visibility": "public",
   "example": 0,
-  "sdks": ["sentry.java.android"],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/art/art__gc__total_count.json
+++ b/model/attributes/art/art__gc__total_count.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "visibility": "public",
   "example": 1,
-  "sdks": ["sentry.java.android"],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/art/art__gc__total_time.json
+++ b/model/attributes/art/art__gc__total_time.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "visibility": "public",
   "example": 11.807,
-  "sdks": ["sentry.java.android"],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/art/art__gc__waiting_time.json
+++ b/model/attributes/art/art__gc__waiting_time.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "visibility": "public",
   "example": 8.054,
-  "sdks": ["sentry.java.android"],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/art/art__memory__free.json
+++ b/model/attributes/art/art__memory__free.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "visibility": "public",
   "example": 3181568,
-  "sdks": ["sentry.java.android"],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/art/art__memory__free_until_gc.json
+++ b/model/attributes/art/art__memory__free_until_gc.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "visibility": "public",
   "example": 3181568,
-  "sdks": ["sentry.java.android"],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/art/art__memory__free_until_oome.json
+++ b/model/attributes/art/art__memory__free_until_oome.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "visibility": "public",
   "example": 196083712,
-  "sdks": ["sentry.java.android"],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/art/art__memory__max.json
+++ b/model/attributes/art/art__memory__max.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "visibility": "public",
   "example": 201326592,
-  "sdks": ["sentry.java.android"],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/art/art__memory__total.json
+++ b/model/attributes/art/art__memory__total.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "visibility": "public",
   "example": 7774208,
-  "sdks": ["sentry.java.android"],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/browser/browser__performance__navigation__activation_start.json
+++ b/model/attributes/browser/browser__performance__navigation__activation_start.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1.983,
   "alias": ["performance.activationStart"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__performance__time_origin.json
+++ b/model/attributes/browser/browser__performance__time_origin.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1776185678.886,
   "alias": ["performance.timeOrigin"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__script__invoker.json
+++ b/model/attributes/browser/browser__script__invoker.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "Window.requestAnimationFrame",
-  "sdks": ["browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__script__invoker_type.json
+++ b/model/attributes/browser/browser__script__invoker_type.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "event-listener",
-  "sdks": ["browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__script__source_char_position.json
+++ b/model/attributes/browser/browser__script__source_char_position.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 678,
-  "sdks": ["browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__cls__report_event.json
+++ b/model/attributes/browser/browser__web_vital__cls__report_event.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "navigation",
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__cls__source__[key].json
+++ b/model/attributes/browser/browser__web_vital__cls__source__[key].json
@@ -9,7 +9,6 @@
   "is_in_otel": false,
   "example": "body > div#app",
   "alias": ["cls.source.<key>"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__cls__value.json
+++ b/model/attributes/browser/browser__web_vital__cls__value.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 0.2361,
   "alias": ["cls"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__fcp__value.json
+++ b/model/attributes/browser/browser__web_vital__fcp__value.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 547.6951,
   "alias": ["fcp"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__fp__value.json
+++ b/model/attributes/browser/browser__web_vital__fp__value.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 477.1926,
   "alias": ["fp"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__inp__value.json
+++ b/model/attributes/browser/browser__web_vital__inp__value.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 200,
   "alias": ["inp"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__lcp__element.json
+++ b/model/attributes/browser/browser__web_vital__lcp__element.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "body > div#app > div#container > div",
   "alias": ["lcp.element"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__lcp__id.json
+++ b/model/attributes/browser/browser__web_vital__lcp__id.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "#gero",
   "alias": ["lcp.id"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__lcp__load_time.json
+++ b/model/attributes/browser/browser__web_vital__lcp__load_time.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1402,
   "alias": ["lcp.loadTime"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__lcp__render_time.json
+++ b/model/attributes/browser/browser__web_vital__lcp__render_time.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1685,
   "alias": ["lcp.renderTime"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__lcp__report_event.json
+++ b/model/attributes/browser/browser__web_vital__lcp__report_event.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "pagehide",
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__lcp__size.json
+++ b/model/attributes/browser/browser__web_vital__lcp__size.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1024,
   "alias": ["lcp.size"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__lcp__url.json
+++ b/model/attributes/browser/browser__web_vital__lcp__url.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "https://example.com/static/img.png",
   "alias": ["lcp.url"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__lcp__value.json
+++ b/model/attributes/browser/browser__web_vital__lcp__value.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 2500,
   "alias": ["lcp"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__ttfb__request_time.json
+++ b/model/attributes/browser/browser__web_vital__ttfb__request_time.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1554.5814,
   "alias": ["ttfb.requestTime"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/browser/browser__web_vital__ttfb__value.json
+++ b/model/attributes/browser/browser__web_vital__ttfb__value.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 194.3322,
   "alias": ["ttfb"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cache/cache__hit.json
+++ b/model/attributes/cache/cache__hit.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": true,
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cache/cache__key.json
+++ b/model/attributes/cache/cache__key.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": ["my-cache-key", "my-other-cache-key"],
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cache/cache__operation.json
+++ b/model/attributes/cache/cache__operation.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "get",
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cache/cache__ttl.json
+++ b/model/attributes/cache/cache__ttl.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 120,
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cache/cache__write.json
+++ b/model/attributes/cache/cache__write.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": true,
-  "sdks": ["java"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/channel.json
+++ b/model/attributes/channel.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "mail",
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cloudflare/cloudflare__d1__duration.json
+++ b/model/attributes/cloudflare/cloudflare__d1__duration.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 543,
-  "sdks": ["javascript-cloudflare"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cloudflare/cloudflare__d1__query_type.json
+++ b/model/attributes/cloudflare/cloudflare__d1__query_type.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "run",
-  "sdks": ["javascript-cloudflare"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cloudflare/cloudflare__d1__rows_read.json
+++ b/model/attributes/cloudflare/cloudflare__d1__rows_read.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 12,
-  "sdks": ["javascript-cloudflare"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cloudflare/cloudflare__d1__rows_written.json
+++ b/model/attributes/cloudflare/cloudflare__d1__rows_written.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 12,
-  "sdks": ["javascript-cloudflare"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cloudflare/cloudflare__workflow__attempt.json
+++ b/model/attributes/cloudflare/cloudflare__workflow__attempt.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1,
-  "sdks": ["javascript-cloudflare"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cloudflare/cloudflare__workflow__retries__backoff.json
+++ b/model/attributes/cloudflare/cloudflare__workflow__retries__backoff.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "exponential",
-  "sdks": ["javascript-cloudflare"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cloudflare/cloudflare__workflow__retries__delay.json
+++ b/model/attributes/cloudflare/cloudflare__workflow__retries__delay.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "5 seconds",
-  "sdks": ["javascript-cloudflare"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cloudflare/cloudflare__workflow__retries__limit.json
+++ b/model/attributes/cloudflare/cloudflare__workflow__retries__limit.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 3,
-  "sdks": ["javascript-cloudflare"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cloudflare/cloudflare__workflow__timeout.json
+++ b/model/attributes/cloudflare/cloudflare__workflow__timeout.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "1 minute",
-  "sdks": ["javascript-cloudflare"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cls.json
+++ b/model/attributes/cls.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 0.2361,
   "alias": ["browser.web_vital.cls.value"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "replacement": "browser.web_vital.cls.value",
     "reason": "The CLS web vital is now recorded as a browser.web_vital.cls.value attribute.",

--- a/model/attributes/cls/cls__source__[key].json
+++ b/model/attributes/cls/cls__source__[key].json
@@ -9,7 +9,6 @@
   "is_in_otel": false,
   "example": "body > div#app",
   "alias": ["browser.web_vital.cls.source.<key>"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "replacement": "browser.web_vital.cls.source.<key>",
     "reason": "The CLS source is now recorded as a browser.web_vital.cls.source.<key> attribute.",

--- a/model/attributes/connection/connection__rtt.json
+++ b/model/attributes/connection/connection__rtt.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 100,
   "alias": ["network.connection.rtt"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "replacement": "network.connection.rtt",
     "reason": "Old attribute name (no official namespace), to be replaced with network.connection.rtt for span-first future",

--- a/model/attributes/connectionType.json
+++ b/model/attributes/connectionType.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "wifi",
   "alias": ["network.connection.type", "device.connection_type"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "replacement": "network.connection.type",
     "reason": "Old namespace-less attribute, to be replaced with network.connection.type for span-first future",

--- a/model/attributes/db/db__operation__batch__size.json
+++ b/model/attributes/db/db__operation__batch__size.json
@@ -8,7 +8,6 @@
   "is_in_otel": true,
   "visibility": "public",
   "example": 3,
-  "sdks": ["javascript-node", "javascript-deno", "javascript-bun", "javascript-cloudflare"],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/db/db__redis__connection.json
+++ b/model/attributes/db/db__redis__connection.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "my-redis-instance",
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/db/db__redis__key.json
+++ b/model/attributes/db/db__redis__key.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "user:2047:city",
-  "sdks": ["python"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/db/db__redis__parameters.json
+++ b/model/attributes/db/db__redis__parameters.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": ["test", "*"],
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/db/db__sql__bindings.json
+++ b/model/attributes/db/db__sql__bindings.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": ["1", "foo"],
-  "sdks": ["php-laravel"],
   "deprecation": {
     "_status": null,
     "replacement": "db.query.parameter.<key>",

--- a/model/attributes/device/device__low_power_mode.json
+++ b/model/attributes/device/device__low_power_mode.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": true,
-  "sdks": ["sentry.cocoa"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/device/device__memory__estimated_capacity.json
+++ b/model/attributes/device/device__memory__estimated_capacity.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 8,
   "alias": ["deviceMemory"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/deviceMemory.json
+++ b/model/attributes/deviceMemory.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "8 GB",
   "alias": ["device.memory.estimated_capacity"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "replacement": "device.memory.estimated_capacity",
     "reason": "Old namespace-less attribute, to be replaced with device.memory.estimated_capacity for span-first future",

--- a/model/attributes/effectiveConnectionType.json
+++ b/model/attributes/effectiveConnectionType.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "4g",
   "alias": ["network.connection.effective_type"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "replacement": "network.connection.effective_type",
     "reason": "Old namespace-less attribute, to be replaced with network.connection.effective_type for span-first future",

--- a/model/attributes/fcp.json
+++ b/model/attributes/fcp.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 547.6951,
   "alias": ["browser.web_vital.fcp.value"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "browser.web_vital.fcp.value",

--- a/model/attributes/fp.json
+++ b/model/attributes/fp.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 477.1926,
   "alias": ["browser.web_vital.fp.value"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "browser.web_vital.fp.value",

--- a/model/attributes/fs_error.json
+++ b/model/attributes/fs_error.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "ENOENT: no such file or directory",
-  "sdks": ["javascript-node"],
   "deprecation": {
     "_status": null,
     "replacement": "error.type",

--- a/model/attributes/hardwareConcurrency.json
+++ b/model/attributes/hardwareConcurrency.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "14",
   "alias": ["device.processor_count"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "replacement": "device.processor_count",
     "reason": "Old namespace-less attribute, to be replaced with device.processor_count for span-first future",

--- a/model/attributes/http/http__decoded_response_content_length.json
+++ b/model/attributes/http/http__decoded_response_content_length.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 456,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__request__connect_start.json
+++ b/model/attributes/http/http__request__connect_start.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1732829555.111,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__request__connection_end.json
+++ b/model/attributes/http/http__request__connection_end.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1732829555.15,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__request__domain_lookup_end.json
+++ b/model/attributes/http/http__request__domain_lookup_end.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1732829555.201,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__request__domain_lookup_start.json
+++ b/model/attributes/http/http__request__domain_lookup_start.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1732829555.322,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__request__fetch_start.json
+++ b/model/attributes/http/http__request__fetch_start.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1732829555.389,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__request__redirect_end.json
+++ b/model/attributes/http/http__request__redirect_end.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1732829558.502,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__request__redirect_start.json
+++ b/model/attributes/http/http__request__redirect_start.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1732829555.495,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__request__request_start.json
+++ b/model/attributes/http/http__request__request_start.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1732829555.51,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__request__response_end.json
+++ b/model/attributes/http/http__request__response_end.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1732829555.89,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__request__response_start.json
+++ b/model/attributes/http/http__request__response_start.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1732829555.7,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__request__secure_connection_start.json
+++ b/model/attributes/http/http__request__secure_connection_start.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1732829555.73,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__request__time_to_first_byte.json
+++ b/model/attributes/http/http__request__time_to_first_byte.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1.032,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__request__worker_start.json
+++ b/model/attributes/http/http__request__worker_start.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1732829553.68,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__server__request__time_in_queue.json
+++ b/model/attributes/http/http__server__request__time_in_queue.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 50,
-  "sdks": ["ruby"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/id.json
+++ b/model/attributes/id.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "f47ac10b58cc4372a5670e02b2c3d479",
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/inp.json
+++ b/model/attributes/inp.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 200,
   "alias": ["browser.web_vital.inp.value"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "replacement": "browser.web_vital.inp.value",
     "reason": "The INP web vital is now recorded as a browser.web_vital.inp.value attribute.",

--- a/model/attributes/lcp.json
+++ b/model/attributes/lcp.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 2500,
   "alias": ["browser.web_vital.lcp.value"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "replacement": "browser.web_vital.lcp.value",
     "reason": "The LCP web vital is now recorded as a browser.web_vital.lcp.value attribute.",

--- a/model/attributes/lcp/lcp__loadTime.json
+++ b/model/attributes/lcp/lcp__loadTime.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1402,
   "alias": ["browser.web_vital.lcp.load_time"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "replacement": "browser.web_vital.lcp.load_time",
     "reason": "The LCP load time is now recorded as a browser.web_vital.lcp.load_time attribute.",

--- a/model/attributes/lcp/lcp__renderTime.json
+++ b/model/attributes/lcp/lcp__renderTime.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1685,
   "alias": ["browser.web_vital.lcp.render_time"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "replacement": "browser.web_vital.lcp.render_time",
     "reason": "The LCP render time is now recorded as a browser.web_vital.lcp.render_time attribute.",

--- a/model/attributes/mdc/mdc__[key].json
+++ b/model/attributes/mdc/mdc__[key].json
@@ -8,7 +8,6 @@
   },
   "is_in_otel": false,
   "example": "mdc.some_key='some_value'",
-  "sdks": ["java", "java.logback", "java.jul", "java.log4j2"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/messaging/messaging__batch__message_count.json
+++ b/model/attributes/messaging/messaging__batch__message_count.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": true,
   "example": 10,
-  "sdks": ["javascript-cloudflare"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/messaging/messaging__destination__connection.json
+++ b/model/attributes/messaging/messaging__destination__connection.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "BestTopic",
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/messaging/messaging__destination__name.json
+++ b/model/attributes/messaging/messaging__destination__name.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": true,
   "example": "BestTopic",
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/messaging/messaging__message__body__size.json
+++ b/model/attributes/messaging/messaging__message__body__size.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": true,
   "example": 839,
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/messaging/messaging__message__envelope__size.json
+++ b/model/attributes/messaging/messaging__message__envelope__size.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": true,
   "example": 1045,
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/messaging/messaging__message__id.json
+++ b/model/attributes/messaging/messaging__message__id.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": true,
   "example": "f47ac10b58cc4372a5670e02b2c3d479",
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/messaging/messaging__message__receive__latency.json
+++ b/model/attributes/messaging/messaging__message__receive__latency.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1732847252,
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/messaging/messaging__message__retry__count.json
+++ b/model/attributes/messaging/messaging__message__retry__count.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 2,
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/messaging/messaging__operation__name.json
+++ b/model/attributes/messaging/messaging__operation__name.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": true,
   "example": "send",
-  "sdks": ["javascript-cloudflare"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/messaging/messaging__system.json
+++ b/model/attributes/messaging/messaging__system.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": true,
   "example": "activemq",
-  "sdks": ["php-laravel"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/method.json
+++ b/model/attributes/method.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "GET",
   "alias": ["http.request.method", "http.request_method", "http.method"],
-  "sdks": ["javascript-browser", "javascript-node"],
   "deprecation": {
     "_status": null,
     "replacement": "http.request.method"

--- a/model/attributes/middleware/middleware__name.json
+++ b/model/attributes/middleware/middleware__name.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "AuthenticationMiddleware",
-  "sdks": ["python"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/network/network__connection__effective_type.json
+++ b/model/attributes/network/network__connection__effective_type.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "4g",
   "alias": ["effectiveConnectionType"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/network/network__connection__rtt.json
+++ b/model/attributes/network/network__connection__rtt.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 100,
   "alias": ["connection.rtt"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/network/network__connection__type.json
+++ b/model/attributes/network/network__connection__type.json
@@ -8,7 +8,6 @@
   "is_in_otel": true,
   "example": "wifi",
   "alias": ["device.connection_type", "connectionType"],
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/performance/performance__activationStart.json
+++ b/model/attributes/performance/performance__activationStart.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1.983,
   "alias": ["browser.performance.navigation.activation_start"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "reason": "The activationStart is now recorded as the browser.performance.navigation.activation_start attribute.",
     "replacement": "browser.performance.navigation.activation_start",

--- a/model/attributes/performance/performance__timeOrigin.json
+++ b/model/attributes/performance/performance__timeOrigin.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1776185678.886,
   "alias": ["browser.performance.time_origin"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "reason": "The timeOrigin is now recorded as the browser.performance.time_origin attribute.",
     "replacement": "browser.performance.time_origin",

--- a/model/attributes/previous_route.json
+++ b/model/attributes/previous_route.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "HomeScreen",
-  "sdks": ["javascript-reactnative"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/process/process__command_args.json
+++ b/model/attributes/process/process__command_args.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": true,
   "example": ["cmd/otecol", "--config=config.yaml"],
-  "sdks": ["python"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/remix/remix__action_form_data__[key].json
+++ b/model/attributes/remix/remix__action_form_data__[key].json
@@ -8,7 +8,6 @@
   },
   "is_in_otel": false,
   "example": "http.response.header.text='test'",
-  "sdks": ["javascript-remix"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/resource/resource__render_blocking_status.json
+++ b/model/attributes/resource/resource__render_blocking_status.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "non-blocking",
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/route.json
+++ b/model/attributes/route.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "App\\Controller::indexAction",
   "alias": ["http.route"],
-  "sdks": ["php-laravel", "javascript-reactnative"],
   "deprecation": {
     "_status": null,
     "replacement": "http.route"

--- a/model/attributes/sentry/sentry__nextjs__ssr__function__route.json
+++ b/model/attributes/sentry/sentry__nextjs__ssr__function__route.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "/posts/[id]/layout",
-  "sdks": ["javascript"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/sentry/sentry__nextjs__ssr__function__type.json
+++ b/model/attributes/sentry/sentry__nextjs__ssr__function__type.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "generateMetadata",
-  "sdks": ["javascript"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/sentry/sentry__report_event.json
+++ b/model/attributes/sentry/sentry__report_event.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "pagehide",
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "reason": "The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required.",
     "_status": null

--- a/model/attributes/timber/timber__tag.json
+++ b/model/attributes/timber/timber__tag.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "MyTag",
-  "sdks": ["sentry.java.android"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/time_to_full_display.json
+++ b/model/attributes/time_to_full_display.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1234.56,
   "alias": ["app.vitals.ttfd.value"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "deprecation": {
     "replacement": "app.vitals.ttfd.value",
     "reason": "Replaced by app.vitals.ttfd.value to align with the app.vitals.* namespace for mobile performance attributes",

--- a/model/attributes/time_to_initial_display.json
+++ b/model/attributes/time_to_initial_display.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1234.56,
   "alias": ["app.vitals.ttid.value"],
-  "sdks": ["sentry.cocoa", "sentry.java.android", "sentry.javascript.react-native", "sentry.dart.flutter"],
   "deprecation": {
     "replacement": "app.vitals.ttid.value",
     "reason": "Replaced by app.vitals.ttid.value to align with the app.vitals.* namespace for mobile performance attributes",

--- a/model/attributes/ttfb.json
+++ b/model/attributes/ttfb.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 194,
   "alias": ["browser.web_vital.ttfb.value"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "browser.web_vital.ttfb.value",

--- a/model/attributes/ttfb/ttfb__requestTime.json
+++ b/model/attributes/ttfb/ttfb__requestTime.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": 1554.5814,
   "alias": ["browser.web_vital.ttfb.request_time"],
-  "sdks": ["javascript-browser"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "browser.web_vital.ttfb.request_time",

--- a/model/attributes/type.json
+++ b/model/attributes/type.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "fetch",
-  "sdks": ["javascript-browser", "javascript-node"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/ui/ui__element__height.json
+++ b/model/attributes/ui/ui__element__height.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 256,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/ui/ui__element__id.json
+++ b/model/attributes/ui/ui__element__id.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "btn-login",
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/ui/ui__element__identifier.json
+++ b/model/attributes/ui/ui__element__identifier.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "heroImage",
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/ui/ui__element__load_time.json
+++ b/model/attributes/ui/ui__element__load_time.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 998.2234,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/ui/ui__element__paint_type.json
+++ b/model/attributes/ui/ui__element__paint_type.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "image-paint",
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/ui/ui__element__render_time.json
+++ b/model/attributes/ui/ui__element__render_time.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 1023.1124,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/ui/ui__element__type.json
+++ b/model/attributes/ui/ui__element__type.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "img",
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/ui/ui__element__url.json
+++ b/model/attributes/ui/ui__element__url.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": "https://assets.myapp.com/hero.png",
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/ui/ui__element__width.json
+++ b/model/attributes/ui/ui__element__width.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": false,
   "example": 512,
-  "sdks": ["javascript-browser"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/url.json
+++ b/model/attributes/url.json
@@ -8,7 +8,6 @@
   "is_in_otel": false,
   "example": "https://example.com/test?foo=bar#buzz",
   "alias": ["url.full", "http.url"],
-  "sdks": ["javascript-browser", "javascript-node"],
   "deprecation": {
     "_status": null,
     "replacement": "url.full"

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -10317,12 +10317,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example=3,
-        sdks=[
-            "javascript-node",
-            "javascript-deno",
-            "javascript-bun",
-            "javascript-cloudflare",
-        ],
         changelog=[
             ChangelogEntry(
                 version="next",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -102,9 +102,6 @@ class AttributeMetadata:
     aliases: Optional[List[str]] = None
     """If there are attributes that alias to this attribute"""
 
-    sdks: Optional[List[str]] = None
-    """If an attribute is SDK specific, list the SDKs that use this attribute. This is not an exhaustive list, there might be SDKs that send this attribute that are is not documented here."""
-
     changelog: Optional[List[ChangelogEntry]] = None
     """Changelog entries tracking how this attribute has changed across versions"""
 
@@ -8163,7 +8160,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             replacement="gen_ai.usage.output_tokens", status=DeprecationStatus.BACKFILL
         ),
         aliases=["gen_ai.usage.output_tokens", "gen_ai.usage.completion_tokens"],
-        sdks=["python"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[57, 61]),
@@ -8257,7 +8253,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             replacement="gen_ai.input.messages", status=DeprecationStatus.BACKFILL
         ),
         aliases=["gen_ai.request.messages"],
-        sdks=["python"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[65, 119]),
             ChangelogEntry(version="0.0.0"),
@@ -8316,7 +8311,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             replacement="gen_ai.response.model", status=DeprecationStatus.BACKFILL
         ),
         aliases=["gen_ai.response.model"],
-        sdks=["python"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[57, 61, 127]),
             ChangelogEntry(version="0.0.0"),
@@ -8381,7 +8375,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             replacement="gen_ai.usage.input_tokens", status=DeprecationStatus.BACKFILL
         ),
         aliases=["gen_ai.usage.prompt_tokens", "gen_ai.usage.input_tokens"],
-        sdks=["python"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[57, 61]),
@@ -8424,7 +8417,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="gen_ai.output.messages", status=DeprecationStatus.BACKFILL
         ),
-        sdks=["python"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[65, 127]),
             ChangelogEntry(version="0.0.0"),
@@ -8482,7 +8474,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             replacement="gen_ai.response.streaming", status=DeprecationStatus.BACKFILL
         ),
         aliases=["gen_ai.response.streaming"],
-        sdks=["python"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[76, 108]),
             ChangelogEntry(version="0.0.0"),
@@ -8621,7 +8612,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             replacement="gen_ai.usage.total_tokens", status=DeprecationStatus.BACKFILL
         ),
         aliases=["gen_ai.usage.total_tokens"],
-        sdks=["python"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[57, 61, 108]),
@@ -8669,12 +8659,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["app.build"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -8696,12 +8680,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["app.identifier"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -8723,12 +8701,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["app.name"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -8750,12 +8722,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["app.start_time"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -8777,12 +8743,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["app.version"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -8799,12 +8759,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="1",
         aliases=["app.app_build"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0", prs=[296], description="Added app.build attribute"
@@ -8819,12 +8773,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="com.example.myapp",
         aliases=["app.app_identifier"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0", prs=[296], description="Added app.identifier attribute"
@@ -8838,12 +8786,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=True,
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -8860,12 +8802,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="My App",
         aliases=["app.app_name"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0", prs=[296], description="Added app.name attribute"
@@ -8880,12 +8816,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="2025-01-01T00:00:00.000Z",
         aliases=["app.app_start_time"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0", prs=[296], description="Added app.start_time attribute"
@@ -8900,12 +8830,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="1.0.0",
         aliases=["app.app_version"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0", prs=[296], description="Added app.version attribute"
@@ -8920,12 +8844,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=5,
         aliases=["frames.delay"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -8942,12 +8860,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=3,
         aliases=["frames.frozen"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -8964,12 +8876,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=1,
         aliases=["frames.slow"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -8986,12 +8892,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=60,
         aliases=["frames.total"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9008,12 +8908,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=1234.56,
         aliases=["app_start_cold"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9029,7 +8923,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=True,
-        sdks=["sentry.cocoa"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -9045,13 +8938,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="push",
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-            "sentry.dotnet.maui",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.7.0",
@@ -9067,13 +8953,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="MainActivity",
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-            "sentry.dotnet.maui",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.7.0",
@@ -9090,12 +8969,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="cold",
         aliases=["app_start_type"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9112,12 +8985,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=1234.56,
         aliases=["app_start_warm"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9134,12 +9001,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=1234.56,
         aliases=["time_to_full_display"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9156,12 +9017,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=1234.56,
         aliases=["time_to_initial_display"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9183,12 +9038,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["app.vitals.start.cold.value"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9233,12 +9082,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["app.vitals.start.warm.value"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9254,7 +9097,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1,
-        sdks=["sentry.java.android"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -9270,7 +9112,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=11.873,
-        sdks=["sentry.java.android"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -9286,7 +9127,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=0,
-        sdks=["sentry.java.android"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -9302,7 +9142,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1,
-        sdks=["sentry.java.android"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -9318,7 +9157,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=11.807,
-        sdks=["sentry.java.android"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -9334,7 +9172,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=8.054,
-        sdks=["sentry.java.android"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -9350,7 +9187,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=3181568,
-        sdks=["sentry.java.android"],
         changelog=[
             ChangelogEntry(
                 version="next", prs=[382], description="Added art.memory.free attribute"
@@ -9364,7 +9200,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=3181568,
-        sdks=["sentry.java.android"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -9380,7 +9215,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=196083712,
-        sdks=["sentry.java.android"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -9396,7 +9230,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=201326592,
-        sdks=["sentry.java.android"],
         changelog=[
             ChangelogEntry(
                 version="next", prs=[382], description="Added art.memory.max attribute"
@@ -9410,7 +9243,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=7774208,
-        sdks=["sentry.java.android"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -9586,7 +9418,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=1.983,
         aliases=["performance.activationStart"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9603,7 +9434,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=1776185678.886,
         aliases=["performance.timeOrigin"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9630,7 +9460,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="Window.requestAnimationFrame",
-        sdks=["browser"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -9643,7 +9472,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="event-listener",
-        sdks=["browser"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -9656,7 +9484,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=678,
-        sdks=["browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
@@ -9681,7 +9508,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="navigation",
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9699,7 +9525,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         has_dynamic_suffix=True,
         example="body > div#app",
         aliases=["cls.source.<key>"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[234]),
         ],
@@ -9712,7 +9537,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=0.2361,
         aliases=["cls"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9729,7 +9553,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=547.6951,
         aliases=["fcp"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[235]),
         ],
@@ -9742,7 +9565,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=477.1926,
         aliases=["fp"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[235]),
         ],
@@ -9755,7 +9577,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=200,
         aliases=["inp"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9772,7 +9593,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="body > div#app > div#container > div",
         aliases=["lcp.element"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[233]),
         ],
@@ -9785,7 +9605,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="#gero",
         aliases=["lcp.id"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[233]),
         ],
@@ -9798,7 +9617,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=1402,
         aliases=["lcp.loadTime"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[233]),
         ],
@@ -9811,7 +9629,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=1685,
         aliases=["lcp.renderTime"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[233]),
         ],
@@ -9823,7 +9640,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="pagehide",
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9840,7 +9656,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=1024,
         aliases=["lcp.size"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[233]),
         ],
@@ -9853,7 +9668,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="https://example.com/static/img.png",
         aliases=["lcp.url"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[233]),
         ],
@@ -9866,7 +9680,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=2500,
         aliases=["lcp"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -9883,7 +9696,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=1554.5814,
         aliases=["ttfb.requestTime"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[235]),
         ],
@@ -9896,7 +9708,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=194.3322,
         aliases=["ttfb"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[235]),
         ],
@@ -9908,7 +9719,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=True,
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.0.0"),
         ],
@@ -9932,7 +9742,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=["my-cache-key", "my-other-cache-key"],
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.0.0"),
         ],
@@ -9944,7 +9753,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="get",
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -9957,7 +9765,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=120,
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
@@ -9970,7 +9777,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=True,
-        sdks=["java"],
         changelog=[
             ChangelogEntry(version="0.5.0"),
         ],
@@ -9982,7 +9788,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="mail",
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -10089,7 +9894,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=543,
-        sdks=["javascript-cloudflare"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
@@ -10102,7 +9906,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="run",
-        sdks=["javascript-cloudflare"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -10118,7 +9921,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=12,
-        sdks=["javascript-cloudflare"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
@@ -10131,7 +9933,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=12,
-        sdks=["javascript-cloudflare"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
@@ -10144,7 +9945,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1,
-        sdks=["javascript-cloudflare"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -10160,7 +9960,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="exponential",
-        sdks=["javascript-cloudflare"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -10176,7 +9975,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="5 seconds",
-        sdks=["javascript-cloudflare"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -10192,7 +9990,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=3,
-        sdks=["javascript-cloudflare"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -10208,7 +10005,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="1 minute",
-        sdks=["javascript-cloudflare"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -10231,7 +10027,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["browser.web_vital.cls.source.<key>"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[234]),
         ],
@@ -10249,7 +10044,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["browser.web_vital.cls.value"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -10363,7 +10157,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["network.connection.rtt"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -10385,7 +10178,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["network.connection.type", "device.connection_type"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -10598,7 +10390,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="my-redis-instance",
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -10611,7 +10402,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="user:2047:city",
-        sdks=["python"],
         changelog=[
             ChangelogEntry(
                 version="0.6.0", prs=[326], description="Added db.redis.key attribute"
@@ -10625,7 +10415,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=["test", "*"],
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.0.0"),
         ],
@@ -10641,7 +10430,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             replacement="db.query.parameter.<key>",
             reason="Instead of adding every binding in the db.sql.bindings attribute, add them as individual entires with db.query.parameter.<key>.",
         ),
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61]),
             ChangelogEntry(version="0.0.0"),
@@ -10981,7 +10769,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=True,
-        sdks=["sentry.cocoa"],
         changelog=[
             ChangelogEntry(
                 version="0.6.0",
@@ -11013,7 +10800,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=8,
         aliases=["deviceMemory"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -11283,7 +11069,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["device.memory.estimated_capacity"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -11305,7 +11090,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["network.connection.effective_type"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -11513,7 +11297,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["browser.web_vital.fcp.value"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[235]),
         ],
@@ -11543,7 +11326,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["browser.web_vital.fp.value"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[235]),
         ],
@@ -11679,7 +11461,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             replacement="error.type",
             reason="This attribute is not part of the OpenTelemetry specification and error.type fits much better.",
         ),
-        sdks=["javascript-node"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
             ChangelogEntry(version="0.0.0"),
@@ -12790,7 +12571,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["device.processor_count"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -12820,7 +12600,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=456,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
@@ -12925,7 +12704,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1732829555.111,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[134]),
@@ -12939,7 +12717,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1732829555.15,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[134]),
@@ -12953,7 +12730,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1732829555.201,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[134]),
@@ -12967,7 +12743,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1732829555.322,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[134]),
@@ -12981,7 +12756,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1732829555.389,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[134]),
@@ -13021,7 +12795,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1732829558.502,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[130, 134]),
@@ -13034,7 +12807,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1732829555.495,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[134]),
@@ -13048,7 +12820,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1732829555.51,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[134]),
@@ -13074,7 +12845,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1732829555.89,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[134]),
@@ -13088,7 +12858,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1732829555.7,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[134]),
@@ -13102,7 +12871,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1732829555.73,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[134]),
@@ -13116,7 +12884,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1.032,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[131]),
@@ -13129,7 +12896,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1732829553.68,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[130, 134]),
@@ -13288,7 +13054,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=50,
-        sdks=["ruby"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[267]),
         ],
@@ -13373,7 +13138,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="f47ac10b58cc4372a5670e02b2c3d479",
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.0.0"),
         ],
@@ -13391,7 +13155,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["browser.web_vital.inp.value"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -13522,7 +13285,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["browser.web_vital.lcp.load_time"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[233]),
         ],
@@ -13540,7 +13302,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["browser.web_vital.lcp.render_time"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[233]),
         ],
@@ -13596,7 +13357,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["browser.web_vital.lcp.value"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -14069,7 +13829,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         has_dynamic_suffix=True,
         example="mdc.some_key='some_value'",
-        sdks=["java", "java.logback", "java.jul", "java.log4j2"],
         changelog=[
             ChangelogEntry(version="0.3.0", prs=[176]),
         ],
@@ -14081,7 +13840,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example=10,
-        sdks=["javascript-cloudflare"],
         changelog=[
             ChangelogEntry(
                 version="0.6.0",
@@ -14097,7 +13855,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="BestTopic",
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -14110,7 +13867,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="BestTopic",
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -14123,7 +13879,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example=839,
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
@@ -14136,7 +13891,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example=1045,
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
@@ -14149,7 +13903,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="f47ac10b58cc4372a5670e02b2c3d479",
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -14162,7 +13915,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1732847252,
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
@@ -14175,7 +13927,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=2,
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
@@ -14188,7 +13939,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="send",
-        sdks=["javascript-cloudflare"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -14215,7 +13965,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="activemq",
-        sdks=["php-laravel"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -14230,7 +13979,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="GET",
         deprecation=DeprecationInfo(replacement="http.request.method"),
         aliases=["http.request.method", "http.request_method", "http.method"],
-        sdks=["javascript-browser", "javascript-node"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
             ChangelogEntry(version="0.0.0"),
@@ -14243,7 +13991,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="AuthenticationMiddleware",
-        sdks=["python"],
         changelog=[
             ChangelogEntry(
                 version="0.6.0",
@@ -14549,7 +14296,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="4g",
         aliases=["effectiveConnectionType"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -14566,7 +14312,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=100,
         aliases=["connection.rtt"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -14583,7 +14328,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="wifi",
         aliases=["device.connection_type", "connectionType"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -14907,7 +14651,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["browser.performance.navigation.activation_start"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -14929,7 +14672,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["browser.performance.time_origin"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -14945,7 +14687,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="HomeScreen",
-        sdks=["javascript-reactnative"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[74]),
             ChangelogEntry(version="0.0.0"),
@@ -14958,7 +14699,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example=["cmd/otecol", "--config=config.yaml"],
-        sdks=["python"],
         changelog=[
             ChangelogEntry(
                 version="0.6.0",
@@ -15103,7 +14843,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         has_dynamic_suffix=True,
         example="http.response.header.text='test'",
-        sdks=["javascript-remix"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[103]),
         ],
@@ -15157,7 +14896,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="non-blocking",
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -15172,7 +14910,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="App\\Controller::indexAction",
         deprecation=DeprecationInfo(replacement="http.route"),
         aliases=["http.route"],
-        sdks=["php-laravel", "javascript-reactnative"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 74]),
             ChangelogEntry(version="0.0.0"),
@@ -15714,7 +15451,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="/posts/[id]/layout",
-        sdks=["javascript"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[54, 106]),
         ],
@@ -15726,7 +15462,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="generateMetadata",
-        sdks=["javascript"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[54, 106]),
         ],
@@ -15880,7 +15615,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             reason="The report event is now recorded as a browser.web_vital.lcp.report_event or browser.web_vital.cls.report_event attribute. No backfill required."
         ),
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -16313,7 +16047,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="MyTag",
-        sdks=["sentry.java.android"],
         changelog=[
             ChangelogEntry(version="0.3.0", prs=[183]),
         ],
@@ -16331,12 +16064,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["app.vitals.ttfd.value"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -16358,12 +16085,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["app.vitals.ttid.value"],
-        sdks=[
-            "sentry.cocoa",
-            "sentry.java.android",
-            "sentry.javascript.react-native",
-            "sentry.dart.flutter",
-        ],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -16436,7 +16157,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["browser.web_vital.ttfb.request_time"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[235]),
         ],
@@ -16454,7 +16174,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             status=DeprecationStatus.BACKFILL,
         ),
         aliases=["browser.web_vital.ttfb.value"],
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[235]),
         ],
@@ -16466,7 +16185,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="fetch",
-        sdks=["javascript-browser", "javascript-node"],
         changelog=[
             ChangelogEntry(version="0.0.0"),
         ],
@@ -16512,7 +16230,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=256,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -16528,7 +16245,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="btn-login",
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0", prs=[284], description="Added ui.element.id attribute"
@@ -16542,7 +16258,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="heroImage",
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -16558,7 +16273,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=998.2234,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -16574,7 +16288,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="image-paint",
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -16590,7 +16303,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1023.1124,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -16606,7 +16318,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="img",
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -16622,7 +16333,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="https://assets.myapp.com/hero.png",
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0", prs=[284], description="Added ui.element.url attribute"
@@ -16636,7 +16346,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=512,
-        sdks=["javascript-browser"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0",
@@ -16766,7 +16475,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="https://example.com/test?foo=bar#buzz",
         deprecation=DeprecationInfo(replacement="url.full"),
         aliases=["url.full", "http.url"],
-        sdks=["javascript-browser", "javascript-node"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61]),
             ChangelogEntry(version="0.0.0"),

--- a/schemas/attribute.schema.json
+++ b/schemas/attribute.schema.json
@@ -99,13 +99,6 @@
         "type": "string"
       }
     },
-    "sdks": {
-      "description": "If an attribute is SDK specific, list the SDKs that use this attribute. This is not an exhaustive list, there might be SDKs that send this attribute that are is not documented here.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
     "additional_context": {
       "description": "A list of freeform notes providing additional context about how this attribute behaves, common pitfalls, or query-time nuances",
       "type": "array",

--- a/scripts/create_attribute.ts
+++ b/scripts/create_attribute.ts
@@ -33,7 +33,6 @@ Options:
   --visibility, -v   The visibility of the attribute (public/internal)
   --example, -e       An example value (optional)
   --alias, -a         Comma-separated list of attributes that alias to this attribute (optional)
-  --sdks, -s          Comma-separated list of SDKs that use this attribute (optional)
 
 Examples:
   # Interactive mode
@@ -68,7 +67,6 @@ const createAttribute = async () => {
         visibility: { type: 'string', short: 'v' },
         example: { type: 'string', short: 'e' },
         alias: { type: 'string', short: 'a' },
-        sdks: { type: 'string', short: 's' },
       },
       allowPositionals: true,
     });
@@ -98,7 +96,6 @@ const createAttribute = async () => {
     let visibility: string | undefined;
     let example: string | undefined;
     let alias: string | undefined;
-    let sdks: string | undefined;
 
     if (isInteractive) {
       key = await askForAttributeName();
@@ -109,7 +106,6 @@ const createAttribute = async () => {
       visibility = await askForAttributeVisibility();
       example = await askForAttributeExample();
       alias = await askForAttributeAlias();
-      sdks = await askForAttributeSdks();
     } else {
       key = values.key;
       description = values.description;
@@ -119,7 +115,6 @@ const createAttribute = async () => {
       visibility = values.visibility;
       example = values.example;
       alias = values.alias;
-      sdks = values.sdks;
     }
 
     // Validate required fields
@@ -163,7 +158,6 @@ const createAttribute = async () => {
       visibility,
       ...(example && { example: exampleValue }),
       ...(alias && alias.trim() !== '' && { alias: alias.split(',').map((s) => s.trim()) }),
-      ...(sdks && sdks.trim() !== '' && { sdks: sdks.split(',').map((s) => s.trim()) }),
       changelog: [
         {
           version: 'next',
@@ -317,15 +311,6 @@ async function askForAttributeAlias() {
     text({
       message: 'Enter attributes that alias to this attribute (comma-separated, optional)',
       placeholder: 'url.route,http.routename',
-    }),
-  );
-}
-
-async function askForAttributeSdks() {
-  return abortIfCancelled(
-    text({
-      message: 'Enter SDKs that use this attribute (comma-separated, optional)',
-      placeholder: 'javascript-browser,javascript-node',
     }),
   );
 }

--- a/scripts/generate_attributes.ts
+++ b/scripts/generate_attributes.ts
@@ -111,7 +111,7 @@ function writeToJs(attributesDir: string, attributeFiles: string[]) {
 
   // Generate individual attribute constants with documentation AND build the explicit type map
   for (const { file, key, constantName, attributeJson, isDeprecated } of allAttributes) {
-    const { brief, type, pii, is_in_otel, example, has_dynamic_suffix, deprecation, alias, sdks } = attributeJson;
+    const { brief, type, pii, is_in_otel, example, has_dynamic_suffix, deprecation, alias } = attributeJson;
     const visibility = getVisibility(attributeJson);
 
     const tsType = getTsType(type);
@@ -370,10 +370,6 @@ function writeToPython(attributesDir: string, attributeFiles: string[]) {
   content += '    aliases: Optional[List[str]] = None\n';
   content += '    """If there are attributes that alias to this attribute"""\n';
   content += '    \n';
-  content += '    sdks: Optional[List[str]] = None\n';
-  content +=
-    '    """If an attribute is SDK specific, list the SDKs that use this attribute. This is not an exhaustive list, there might be SDKs that send this attribute that are is not documented here."""\n';
-  content += '    \n';
   content += '    changelog: Optional[List[ChangelogEntry]] = None\n';
   content += '    """Changelog entries tracking how this attribute has changed across versions"""\n';
   content += '    \n';
@@ -535,10 +531,6 @@ function writeToPython(attributesDir: string, attributeFiles: string[]) {
 
     if (alias && alias.length > 0) {
       metadataDict += `        aliases=${JSON.stringify(alias)},\n`;
-    }
-
-    if (attributeJson.sdks && attributeJson.sdks.length > 0) {
-      metadataDict += `        sdks=${JSON.stringify(attributeJson.sdks)},\n`;
     }
 
     if (attributeJson.changelog && attributeJson.changelog.length > 0) {
@@ -724,8 +716,6 @@ export interface AttributeMetadata {
   deprecation?: DeprecationInfo;
   /** If there are attributes that alias to this attribute */
   aliases?: AttributeName[];
-  /** If an attribute is SDK specific, list the SDKs that use this attribute */
-  sdks?: string[];
   /** Changelog entries tracking how this attribute has changed across versions */
   changelog?: ChangelogEntry[];
   /** A list of freeform notes providing additional context about how this attribute behaves, common pitfalls, or query-time nuances */
@@ -822,10 +812,6 @@ function generateMetadataDict(
         })
         .join(', ');
       metadataDict += `    aliases: [${constantAliases}],\n`;
-    }
-
-    if (attributeJson.sdks && attributeJson.sdks.length > 0) {
-      metadataDict += `    sdks: ${JSON.stringify(attributeJson.sdks)},\n`;
     }
 
     if (attributeJson.changelog && attributeJson.changelog.length > 0) {

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -16,7 +16,6 @@ export interface AttributeJson {
     _status: string;
   };
   alias?: string[];
-  sdks?: string[];
   additional_context?: string[];
   changelog?: { version: string; prs?: number[]; description?: string }[];
 }


### PR DESCRIPTION
Our attributes schema definition lists an "sdks" property that should be used to specify which SDK sends the attribute. While well-intended, this almost inevitably will diverge from reality when more SDKs adapt an attribute. This PR proposes that we delete this field to avoid anyone building logic on it/relying on the information in there. 

Discussed with @cleptric but happy to get other reviewers' thoughts! 