### PR TITLE
feat(attributes): Deprecate cloudflare.d1.query_type

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2669,6 +2669,9 @@ export type CLOUDFLARE_D1_DURATION_TYPE = number;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link DB_OPERATION_NAME} `db.operation.name`, {@link DB_OPERATION} `db.operation`
+ *
+ * @deprecated Use {@link DB_OPERATION_NAME} (db.operation.name) instead
  * @example "run"
  */
 export const CLOUDFLARE_D1_QUERY_TYPE = 'cloudflare.d1.query_type';
@@ -3542,7 +3545,7 @@ export type DB_NAMESPACE_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link DB_OPERATION_NAME} `db.operation.name`
+ * Aliases: {@link DB_OPERATION_NAME} `db.operation.name`, {@link CLOUDFLARE_D1_QUERY_TYPE} `cloudflare.d1.query_type`
  *
  * @deprecated Use {@link DB_OPERATION_NAME} (db.operation.name) instead
  * @example "SELECT"
@@ -3587,7 +3590,7 @@ export type DB_OPERATION_BATCH_SIZE_TYPE = number;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link DB_OPERATION} `db.operation`
+ * Aliases: {@link DB_OPERATION} `db.operation`, {@link CLOUDFLARE_D1_QUERY_TYPE} `cloudflare.d1.query_type`
  *
  * @example "SELECT"
  */
@@ -17420,6 +17423,10 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'run',
+    deprecation: {
+      replacement: 'db.operation.name',
+    },
+    aliases: [DB_OPERATION_NAME, DB_OPERATION],
     changelog: [{ version: '0.11.0', prs: [392], description: 'Added cloudflare.d1.query_type attribute' }],
   },
   [CLOUDFLARE_D1_ROWS_READ]: {
@@ -17928,7 +17935,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'db.operation.name',
     },
-    aliases: [DB_OPERATION_NAME],
+    aliases: [DB_OPERATION_NAME, CLOUDFLARE_D1_QUERY_TYPE],
     changelog: [{ version: '0.4.0', prs: [199] }, { version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [DB_OPERATION_BATCH_SIZE]: {
@@ -17952,7 +17959,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'SELECT',
-    aliases: [DB_OPERATION],
+    aliases: [DB_OPERATION, CLOUDFLARE_D1_QUERY_TYPE],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [DB_QUERY_PARAMETER_KEY]: {

--- a/model/attributes/cloudflare/cloudflare__d1__query_type.json
+++ b/model/attributes/cloudflare/cloudflare__d1__query_type.json
@@ -7,6 +7,11 @@
   },
   "is_in_otel": false,
   "example": "run",
+  "alias": ["db.operation.name", "db.operation"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "db.operation.name"
+  },
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/db/db__operation.json
+++ b/model/attributes/db/db__operation.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "SELECT",
-  "alias": ["db.operation.name"],
+  "alias": ["db.operation.name", "cloudflare.d1.query_type"],
   "deprecation": {
     "_status": "normalize",
     "replacement": "db.operation.name"

--- a/model/attributes/db/db__operation__name.json
+++ b/model/attributes/db/db__operation__name.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "SELECT",
-  "alias": ["db.operation"],
+  "alias": ["db.operation", "cloudflare.d1.query_type"],
   "visibility": "public",
   "changelog": [
     {

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -156,6 +156,7 @@ class _AttributeNamesMeta(type):
         "AWS_LAMBDA_FUNCTION_NAME",
         "AWS_LAMBDA_FUNCTION_VERSION",
         "AWS_LAMBDA_INVOKED_FUNCTION_ARN",
+        "CLOUDFLARE_D1_QUERY_TYPE",
         "CLS_SOURCE_KEY",
         "CLS",
         "CODE_FILEPATH",
@@ -1854,6 +1855,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
+    Aliases: db.operation.name, db.operation
+    DEPRECATED: Use db.operation.name instead
     Example: "run"
     """
 
@@ -2274,7 +2277,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: db.operation.name
+    Aliases: db.operation.name, cloudflare.d1.query_type
     DEPRECATED: Use db.operation.name instead
     Example: "SELECT"
     """
@@ -2300,7 +2303,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: db.operation
+    Aliases: db.operation, cloudflare.d1.query_type
     Example: "SELECT"
     """
 
@@ -10156,6 +10159,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="run",
+        deprecation=DeprecationInfo(
+            replacement="db.operation.name", status=DeprecationStatus.BACKFILL
+        ),
+        aliases=["db.operation.name", "db.operation"],
         changelog=[
             ChangelogEntry(
                 version="0.11.0",
@@ -10643,7 +10650,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="db.operation.name", status=DeprecationStatus.NORMALIZE
         ),
-        aliases=["db.operation.name"],
+        aliases=["db.operation.name", "cloudflare.d1.query_type"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[199]),
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
@@ -10672,7 +10679,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="SELECT",
-        aliases=["db.operation"],
+        aliases=["db.operation", "cloudflare.d1.query_type"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),


### PR DESCRIPTION
## Description

I went over the Cloudflare D1 instrumentation and saw `cloudflare.d1.query_type`. Since the query type is the same as the `db.operation.name` it would be better to use this one (it would also be aligned with [workerd](https://github.com/cloudflare/workerd/blame/dc12d7650b4f5d4f9ba6a47aa45fad769cdf8db4/src/cloudflare/internal/d1-api.ts#L528) itself)

A PR will follow in the SDK to update the field

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
