### PR TITLE
feat(attributes): Add Cloudflare R2 attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2720,6 +2720,132 @@ export const CLOUDFLARE_D1_ROWS_WRITTEN = 'cloudflare.d1.rows_written';
  */
 export type CLOUDFLARE_D1_ROWS_WRITTEN_TYPE = number;
 
+// Path: model/attributes/cloudflare/cloudflare__r2__bucket.json
+
+/**
+ * The name of the Cloudflare R2 bucket binding `cloudflare.r2.bucket`
+ *
+ * Attribute Value Type: `string` {@link CLOUDFLARE_R2_BUCKET_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "MY_BUCKET"
+ */
+export const CLOUDFLARE_R2_BUCKET = 'cloudflare.r2.bucket';
+
+/**
+ * Type for {@link CLOUDFLARE_R2_BUCKET} cloudflare.r2.bucket
+ */
+export type CLOUDFLARE_R2_BUCKET_TYPE = string;
+
+// Path: model/attributes/cloudflare/cloudflare__r2__operation.json
+
+/**
+ * The R2 API operation being performed `cloudflare.r2.operation`
+ *
+ * Attribute Value Type: `string` {@link CLOUDFLARE_R2_OPERATION_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "GetObject"
+ */
+export const CLOUDFLARE_R2_OPERATION = 'cloudflare.r2.operation';
+
+/**
+ * Type for {@link CLOUDFLARE_R2_OPERATION} cloudflare.r2.operation
+ */
+export type CLOUDFLARE_R2_OPERATION_TYPE = string;
+
+// Path: model/attributes/cloudflare/cloudflare__r2__request__delimiter.json
+
+/**
+ * The delimiter used to group objects in an R2 list operation `cloudflare.r2.request.delimiter`
+ *
+ * Attribute Value Type: `string` {@link CLOUDFLARE_R2_REQUEST_DELIMITER_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "/"
+ */
+export const CLOUDFLARE_R2_REQUEST_DELIMITER = 'cloudflare.r2.request.delimiter';
+
+/**
+ * Type for {@link CLOUDFLARE_R2_REQUEST_DELIMITER} cloudflare.r2.request.delimiter
+ */
+export type CLOUDFLARE_R2_REQUEST_DELIMITER_TYPE = string;
+
+// Path: model/attributes/cloudflare/cloudflare__r2__request__key.json
+
+/**
+ * The object key used in the R2 operation `cloudflare.r2.request.key`
+ *
+ * Attribute Value Type: `string` {@link CLOUDFLARE_R2_REQUEST_KEY_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "my-file.txt"
+ */
+export const CLOUDFLARE_R2_REQUEST_KEY = 'cloudflare.r2.request.key';
+
+/**
+ * Type for {@link CLOUDFLARE_R2_REQUEST_KEY} cloudflare.r2.request.key
+ */
+export type CLOUDFLARE_R2_REQUEST_KEY_TYPE = string;
+
+// Path: model/attributes/cloudflare/cloudflare__r2__request__part_number.json
+
+/**
+ * The part number in a multipart upload operation `cloudflare.r2.request.part_number`
+ *
+ * Attribute Value Type: `number` {@link CLOUDFLARE_R2_REQUEST_PART_NUMBER_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example 1
+ */
+export const CLOUDFLARE_R2_REQUEST_PART_NUMBER = 'cloudflare.r2.request.part_number';
+
+/**
+ * Type for {@link CLOUDFLARE_R2_REQUEST_PART_NUMBER} cloudflare.r2.request.part_number
+ */
+export type CLOUDFLARE_R2_REQUEST_PART_NUMBER_TYPE = number;
+
+// Path: model/attributes/cloudflare/cloudflare__r2__request__prefix.json
+
+/**
+ * The prefix used to filter objects in an R2 list operation `cloudflare.r2.request.prefix`
+ *
+ * Attribute Value Type: `string` {@link CLOUDFLARE_R2_REQUEST_PREFIX_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "images/"
+ */
+export const CLOUDFLARE_R2_REQUEST_PREFIX = 'cloudflare.r2.request.prefix';
+
+/**
+ * Type for {@link CLOUDFLARE_R2_REQUEST_PREFIX} cloudflare.r2.request.prefix
+ */
+export type CLOUDFLARE_R2_REQUEST_PREFIX_TYPE = string;
+
 // Path: model/attributes/cloudflare/cloudflare__workflow__attempt.json
 
 /**
@@ -14471,6 +14597,12 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [CLOUDFLARE_D1_QUERY_TYPE]: 'string',
   [CLOUDFLARE_D1_ROWS_READ]: 'integer',
   [CLOUDFLARE_D1_ROWS_WRITTEN]: 'integer',
+  [CLOUDFLARE_R2_BUCKET]: 'string',
+  [CLOUDFLARE_R2_OPERATION]: 'string',
+  [CLOUDFLARE_R2_REQUEST_DELIMITER]: 'string',
+  [CLOUDFLARE_R2_REQUEST_KEY]: 'string',
+  [CLOUDFLARE_R2_REQUEST_PART_NUMBER]: 'integer',
+  [CLOUDFLARE_R2_REQUEST_PREFIX]: 'string',
   [CLOUDFLARE_WORKFLOW_ATTEMPT]: 'integer',
   [CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF]: 'string',
   [CLOUDFLARE_WORKFLOW_RETRIES_DELAY]: 'string',
@@ -15124,6 +15256,12 @@ export type AttributeName =
   | typeof CLOUDFLARE_D1_QUERY_TYPE
   | typeof CLOUDFLARE_D1_ROWS_READ
   | typeof CLOUDFLARE_D1_ROWS_WRITTEN
+  | typeof CLOUDFLARE_R2_BUCKET
+  | typeof CLOUDFLARE_R2_OPERATION
+  | typeof CLOUDFLARE_R2_REQUEST_DELIMITER
+  | typeof CLOUDFLARE_R2_REQUEST_KEY
+  | typeof CLOUDFLARE_R2_REQUEST_PART_NUMBER
+  | typeof CLOUDFLARE_R2_REQUEST_PREFIX
   | typeof CLOUDFLARE_WORKFLOW_ATTEMPT
   | typeof CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF
   | typeof CLOUDFLARE_WORKFLOW_RETRIES_DELAY
@@ -17305,6 +17443,72 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 12,
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+  },
+  [CLOUDFLARE_R2_BUCKET]: {
+    brief: 'The name of the Cloudflare R2 bucket binding',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'MY_BUCKET',
+    changelog: [{ version: 'next', prs: [413], description: 'Added cloudflare.r2.bucket attribute' }],
+  },
+  [CLOUDFLARE_R2_OPERATION]: {
+    brief: 'The R2 API operation being performed',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'GetObject',
+    changelog: [{ version: 'next', prs: [413], description: 'Added cloudflare.r2.operation attribute' }],
+  },
+  [CLOUDFLARE_R2_REQUEST_DELIMITER]: {
+    brief: 'The delimiter used to group objects in an R2 list operation',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '/',
+    changelog: [{ version: 'next', prs: [413], description: 'Added cloudflare.r2.request.delimiter attribute' }],
+  },
+  [CLOUDFLARE_R2_REQUEST_KEY]: {
+    brief: 'The object key used in the R2 operation',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'my-file.txt',
+    changelog: [{ version: 'next', prs: [413], description: 'Added cloudflare.r2.request.key attribute' }],
+  },
+  [CLOUDFLARE_R2_REQUEST_PART_NUMBER]: {
+    brief: 'The part number in a multipart upload operation',
+    type: 'integer',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 1,
+    changelog: [{ version: 'next', prs: [413], description: 'Added cloudflare.r2.request.part_number attribute' }],
+  },
+  [CLOUDFLARE_R2_REQUEST_PREFIX]: {
+    brief: 'The prefix used to filter objects in an R2 list operation',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'images/',
+    changelog: [{ version: 'next', prs: [413], description: 'Added cloudflare.r2.request.prefix attribute' }],
   },
   [CLOUDFLARE_WORKFLOW_ATTEMPT]: {
     brief: 'The current attempt number for a Cloudflare Workflow step',
@@ -24322,6 +24526,12 @@ export type Attributes = {
   [CLOUDFLARE_D1_QUERY_TYPE]?: CLOUDFLARE_D1_QUERY_TYPE_TYPE;
   [CLOUDFLARE_D1_ROWS_READ]?: CLOUDFLARE_D1_ROWS_READ_TYPE;
   [CLOUDFLARE_D1_ROWS_WRITTEN]?: CLOUDFLARE_D1_ROWS_WRITTEN_TYPE;
+  [CLOUDFLARE_R2_BUCKET]?: CLOUDFLARE_R2_BUCKET_TYPE;
+  [CLOUDFLARE_R2_OPERATION]?: CLOUDFLARE_R2_OPERATION_TYPE;
+  [CLOUDFLARE_R2_REQUEST_DELIMITER]?: CLOUDFLARE_R2_REQUEST_DELIMITER_TYPE;
+  [CLOUDFLARE_R2_REQUEST_KEY]?: CLOUDFLARE_R2_REQUEST_KEY_TYPE;
+  [CLOUDFLARE_R2_REQUEST_PART_NUMBER]?: CLOUDFLARE_R2_REQUEST_PART_NUMBER_TYPE;
+  [CLOUDFLARE_R2_REQUEST_PREFIX]?: CLOUDFLARE_R2_REQUEST_PREFIX_TYPE;
   [CLOUDFLARE_WORKFLOW_ATTEMPT]?: CLOUDFLARE_WORKFLOW_ATTEMPT_TYPE;
   [CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF]?: CLOUDFLARE_WORKFLOW_RETRIES_BACKOFF_TYPE;
   [CLOUDFLARE_WORKFLOW_RETRIES_DELAY]?: CLOUDFLARE_WORKFLOW_RETRIES_DELAY_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2727,7 +2727,7 @@ export type CLOUDFLARE_D1_ROWS_WRITTEN_TYPE = number;
  *
  * Attribute Value Type: `string` {@link CLOUDFLARE_R2_BUCKET_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  * Visibility: public
@@ -2748,7 +2748,7 @@ export type CLOUDFLARE_R2_BUCKET_TYPE = string;
  *
  * Attribute Value Type: `string` {@link CLOUDFLARE_R2_OPERATION_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  * Visibility: public
@@ -2769,7 +2769,7 @@ export type CLOUDFLARE_R2_OPERATION_TYPE = string;
  *
  * Attribute Value Type: `string` {@link CLOUDFLARE_R2_REQUEST_DELIMITER_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  * Visibility: public
@@ -2811,7 +2811,7 @@ export type CLOUDFLARE_R2_REQUEST_KEY_TYPE = string;
  *
  * Attribute Value Type: `number` {@link CLOUDFLARE_R2_REQUEST_PART_NUMBER_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  * Visibility: public
@@ -17448,7 +17448,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The name of the Cloudflare R2 bucket binding',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     visibility: 'public',
@@ -17459,7 +17459,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The R2 API operation being performed',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     visibility: 'public',
@@ -17470,7 +17470,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The delimiter used to group objects in an R2 list operation',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     visibility: 'public',
@@ -17492,7 +17492,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The part number in a multipart upload operation',
     type: 'integer',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     visibility: 'public',

--- a/model/attributes/cloudflare/cloudflare__r2__bucket.json
+++ b/model/attributes/cloudflare/cloudflare__r2__bucket.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.r2.bucket",
+  "brief": "The name of the Cloudflare R2 bucket binding",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "example": "MY_BUCKET",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [413],
+      "description": "Added cloudflare.r2.bucket attribute"
+    }
+  ]
+}

--- a/model/attributes/cloudflare/cloudflare__r2__bucket.json
+++ b/model/attributes/cloudflare/cloudflare__r2__bucket.json
@@ -3,7 +3,7 @@
   "brief": "The name of the Cloudflare R2 bucket binding",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "visibility": "public",

--- a/model/attributes/cloudflare/cloudflare__r2__operation.json
+++ b/model/attributes/cloudflare/cloudflare__r2__operation.json
@@ -3,7 +3,7 @@
   "brief": "The R2 API operation being performed",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "visibility": "public",

--- a/model/attributes/cloudflare/cloudflare__r2__operation.json
+++ b/model/attributes/cloudflare/cloudflare__r2__operation.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.r2.operation",
+  "brief": "The R2 API operation being performed",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "example": "GetObject",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [413],
+      "description": "Added cloudflare.r2.operation attribute"
+    }
+  ]
+}

--- a/model/attributes/cloudflare/cloudflare__r2__request__delimiter.json
+++ b/model/attributes/cloudflare/cloudflare__r2__request__delimiter.json
@@ -3,7 +3,7 @@
   "brief": "The delimiter used to group objects in an R2 list operation",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "visibility": "public",

--- a/model/attributes/cloudflare/cloudflare__r2__request__delimiter.json
+++ b/model/attributes/cloudflare/cloudflare__r2__request__delimiter.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.r2.request.delimiter",
+  "brief": "The delimiter used to group objects in an R2 list operation",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "example": "/",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [413],
+      "description": "Added cloudflare.r2.request.delimiter attribute"
+    }
+  ]
+}

--- a/model/attributes/cloudflare/cloudflare__r2__request__key.json
+++ b/model/attributes/cloudflare/cloudflare__r2__request__key.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.r2.request.key",
+  "brief": "The object key used in the R2 operation",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "example": "my-file.txt",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [413],
+      "description": "Added cloudflare.r2.request.key attribute"
+    }
+  ]
+}

--- a/model/attributes/cloudflare/cloudflare__r2__request__part_number.json
+++ b/model/attributes/cloudflare/cloudflare__r2__request__part_number.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.r2.request.part_number",
+  "brief": "The part number in a multipart upload operation",
+  "type": "integer",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "example": 1,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [413],
+      "description": "Added cloudflare.r2.request.part_number attribute"
+    }
+  ]
+}

--- a/model/attributes/cloudflare/cloudflare__r2__request__part_number.json
+++ b/model/attributes/cloudflare/cloudflare__r2__request__part_number.json
@@ -3,7 +3,7 @@
   "brief": "The part number in a multipart upload operation",
   "type": "integer",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "visibility": "public",

--- a/model/attributes/cloudflare/cloudflare__r2__request__prefix.json
+++ b/model/attributes/cloudflare/cloudflare__r2__request__prefix.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.r2.request.prefix",
+  "brief": "The prefix used to filter objects in an R2 list operation",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "example": "images/",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [413],
+      "description": "Added cloudflare.r2.request.prefix attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1883,6 +1883,82 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 12
     """
 
+    # Path: model/attributes/cloudflare/cloudflare__r2__bucket.json
+    CLOUDFLARE_R2_BUCKET: Literal["cloudflare.r2.bucket"] = "cloudflare.r2.bucket"
+    """The name of the Cloudflare R2 bucket binding
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Visibility: public
+    Example: "MY_BUCKET"
+    """
+
+    # Path: model/attributes/cloudflare/cloudflare__r2__operation.json
+    CLOUDFLARE_R2_OPERATION: Literal["cloudflare.r2.operation"] = (
+        "cloudflare.r2.operation"
+    )
+    """The R2 API operation being performed
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Visibility: public
+    Example: "GetObject"
+    """
+
+    # Path: model/attributes/cloudflare/cloudflare__r2__request__delimiter.json
+    CLOUDFLARE_R2_REQUEST_DELIMITER: Literal["cloudflare.r2.request.delimiter"] = (
+        "cloudflare.r2.request.delimiter"
+    )
+    """The delimiter used to group objects in an R2 list operation
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: No
+    Visibility: public
+    Example: "/"
+    """
+
+    # Path: model/attributes/cloudflare/cloudflare__r2__request__key.json
+    CLOUDFLARE_R2_REQUEST_KEY: Literal["cloudflare.r2.request.key"] = (
+        "cloudflare.r2.request.key"
+    )
+    """The object key used in the R2 operation
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Visibility: public
+    Example: "my-file.txt"
+    """
+
+    # Path: model/attributes/cloudflare/cloudflare__r2__request__part_number.json
+    CLOUDFLARE_R2_REQUEST_PART_NUMBER: Literal["cloudflare.r2.request.part_number"] = (
+        "cloudflare.r2.request.part_number"
+    )
+    """The part number in a multipart upload operation
+
+    Type: int
+    Contains PII: false
+    Defined in OTEL: No
+    Visibility: public
+    Example: 1
+    """
+
+    # Path: model/attributes/cloudflare/cloudflare__r2__request__prefix.json
+    CLOUDFLARE_R2_REQUEST_PREFIX: Literal["cloudflare.r2.request.prefix"] = (
+        "cloudflare.r2.request.prefix"
+    )
+    """The prefix used to filter objects in an R2 list operation
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Visibility: public
+    Example: "images/"
+    """
+
     # Path: model/attributes/cloudflare/cloudflare__workflow__attempt.json
     CLOUDFLARE_WORKFLOW_ATTEMPT: Literal["cloudflare.workflow.attempt"] = (
         "cloudflare.workflow.attempt"
@@ -10112,6 +10188,96 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "cloudflare.r2.bucket": AttributeMetadata(
+        brief="The name of the Cloudflare R2 bucket binding",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="MY_BUCKET",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[413],
+                description="Added cloudflare.r2.bucket attribute",
+            ),
+        ],
+    ),
+    "cloudflare.r2.operation": AttributeMetadata(
+        brief="The R2 API operation being performed",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="GetObject",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[413],
+                description="Added cloudflare.r2.operation attribute",
+            ),
+        ],
+    ),
+    "cloudflare.r2.request.delimiter": AttributeMetadata(
+        brief="The delimiter used to group objects in an R2 list operation",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="/",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[413],
+                description="Added cloudflare.r2.request.delimiter attribute",
+            ),
+        ],
+    ),
+    "cloudflare.r2.request.key": AttributeMetadata(
+        brief="The object key used in the R2 operation",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="my-file.txt",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[413],
+                description="Added cloudflare.r2.request.key attribute",
+            ),
+        ],
+    ),
+    "cloudflare.r2.request.part_number": AttributeMetadata(
+        brief="The part number in a multipart upload operation",
+        type=AttributeType.INTEGER,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=1,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[413],
+                description="Added cloudflare.r2.request.part_number attribute",
+            ),
+        ],
+    ),
+    "cloudflare.r2.request.prefix": AttributeMetadata(
+        brief="The prefix used to filter objects in an R2 list operation",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="images/",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[413],
+                description="Added cloudflare.r2.request.prefix attribute",
+            ),
+        ],
+    ),
     "cloudflare.workflow.attempt": AttributeMetadata(
         brief="The current attempt number for a Cloudflare Workflow step",
         type=AttributeType.INTEGER,
@@ -17364,6 +17530,12 @@ Attributes = TypedDict(
         "cloudflare.d1.query_type": str,
         "cloudflare.d1.rows_read": int,
         "cloudflare.d1.rows_written": int,
+        "cloudflare.r2.bucket": str,
+        "cloudflare.r2.operation": str,
+        "cloudflare.r2.request.delimiter": str,
+        "cloudflare.r2.request.key": str,
+        "cloudflare.r2.request.part_number": int,
+        "cloudflare.r2.request.prefix": str,
         "cloudflare.workflow.attempt": int,
         "cloudflare.workflow.retries.backoff": str,
         "cloudflare.workflow.retries.delay": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1888,7 +1888,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The name of the Cloudflare R2 bucket binding
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
     Example: "MY_BUCKET"
@@ -1901,7 +1901,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The R2 API operation being performed
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
     Example: "GetObject"
@@ -1914,7 +1914,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The delimiter used to group objects in an R2 list operation
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
     Example: "/"
@@ -1940,7 +1940,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The part number in a multipart upload operation
 
     Type: int
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
     Example: 1
@@ -10191,7 +10191,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "cloudflare.r2.bucket": AttributeMetadata(
         brief="The name of the Cloudflare R2 bucket binding",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="MY_BUCKET",
@@ -10206,7 +10206,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "cloudflare.r2.operation": AttributeMetadata(
         brief="The R2 API operation being performed",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="GetObject",
@@ -10221,7 +10221,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "cloudflare.r2.request.delimiter": AttributeMetadata(
         brief="The delimiter used to group objects in an R2 list operation",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="/",
@@ -10251,7 +10251,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "cloudflare.r2.request.part_number": AttributeMetadata(
         brief="The part number in a multipart upload operation",
         type=AttributeType.INTEGER,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=1,


### PR DESCRIPTION
## Description

This adds Cloudflare R2 attributes. These attributes were taken from Cloudflare's traces directly.

Only `cloudflare.r2.bucket` is not part of Cloudflare itself, and was inspired by [AWS S3](https://opentelemetry.io/docs/specs/semconv/object-stores/s3/) attributes.

For the PII I wasn't sure if that is correct, maybe one could have a special eye on these values.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
