### PR TITLE
feat(attributes): Add FaaS/AWS conventions and deprecate Lambda-specific attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -17340,6 +17340,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function',
     changelog: [{ version: 'next' }],
+    additionalContext: [
+      'This can be an identifier for a resource in AWS, GCP, or Azure. There may be some overlap in values found here with other attributes. For instance, an AWS lambda ARN may be found here as well as in `aws.lambda.invoked_arn`. OTEL recommends setting them alongside each other.',
+    ],
   },
   [CLS]: {
     brief: 'The value of the recorded Cumulative Layout Shift (CLS) web vital',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1691,6 +1691,7 @@ export type AWS_CLOUDWATCH_LOGS_URL_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * @deprecated Use {@link FAAS_INVOCATION_ID} (faas.invocation_id) instead - This attribute is being deprecated in favor of faas.invocation_id
  * @example "8476a536-e9f4-11e8-9739-2dfe598c3fcd"
  */
 export const AWS_LAMBDA_AWS_REQUEST_ID = 'aws.lambda.aws_request_id';
@@ -1733,6 +1734,7 @@ export type AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS_TYPE = number;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * @deprecated Use {@link FAAS_NAME} (faas.name) instead - Use the OTel-aligned faas.name attribute instead
  * @example "my-function"
  */
 export const AWS_LAMBDA_FUNCTION_NAME = 'aws.lambda.function_name';
@@ -1754,6 +1756,7 @@ export type AWS_LAMBDA_FUNCTION_NAME_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * @deprecated Use {@link FAAS_VERSION} (faas.version) instead - Use the OTel-aligned faas.version attribute instead
  * @example "$LATEST"
  */
 export const AWS_LAMBDA_FUNCTION_VERSION = 'aws.lambda.function_version';
@@ -1762,6 +1765,27 @@ export const AWS_LAMBDA_FUNCTION_VERSION = 'aws.lambda.function_version';
  * Type for {@link AWS_LAMBDA_FUNCTION_VERSION} aws.lambda.function_version
  */
 export type AWS_LAMBDA_FUNCTION_VERSION_TYPE = string;
+
+// Path: model/attributes/aws/aws__lambda__invoked_arn.json
+
+/**
+ * The full ARN of the Lambda function that was invoked `aws.lambda.invoked_arn`
+ *
+ * Attribute Value Type: `string` {@link AWS_LAMBDA_INVOKED_ARN_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "arn:aws:lambda:us-east-1:123456789012:function:my-function"
+ */
+export const AWS_LAMBDA_INVOKED_ARN = 'aws.lambda.invoked_arn';
+
+/**
+ * Type for {@link AWS_LAMBDA_INVOKED_ARN} aws.lambda.invoked_arn
+ */
+export type AWS_LAMBDA_INVOKED_ARN_TYPE = string;
 
 // Path: model/attributes/aws/aws__lambda__invoked_function_arn.json
 
@@ -1775,6 +1799,7 @@ export type AWS_LAMBDA_FUNCTION_VERSION_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * @deprecated Use {@link AWS_LAMBDA_INVOKED_ARN} (aws.lambda.invoked_arn) instead - This attribute is being deprecated in favor of aws.lambda.invoked_arn
  * @example "arn:aws:lambda:us-east-1:123456789012:function:my-function"
  */
 export const AWS_LAMBDA_INVOKED_FUNCTION_ARN = 'aws.lambda.invoked_function_arn';
@@ -1804,6 +1829,48 @@ export const AWS_LAMBDA_REMAINING_TIME_IN_MILLIS = 'aws.lambda.remaining_time_in
  * Type for {@link AWS_LAMBDA_REMAINING_TIME_IN_MILLIS} aws.lambda.remaining_time_in_millis
  */
 export type AWS_LAMBDA_REMAINING_TIME_IN_MILLIS_TYPE = number;
+
+// Path: model/attributes/aws/aws__log__group__names.json
+
+/**
+ * The name(s) of the AWS log group(s) an application is writing to. `aws.log.group.names`
+ *
+ * Attribute Value Type: `Array<string>` {@link AWS_LOG_GROUP_NAMES_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["/aws/lambda/my-function","opentelemetry-service"]
+ */
+export const AWS_LOG_GROUP_NAMES = 'aws.log.group.names';
+
+/**
+ * Type for {@link AWS_LOG_GROUP_NAMES} aws.log.group.names
+ */
+export type AWS_LOG_GROUP_NAMES_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__log__stream__names.json
+
+/**
+ * The name(s) of the AWS log stream(s) an application is writing to. `aws.log.stream.names`
+ *
+ * Attribute Value Type: `Array<string>` {@link AWS_LOG_STREAM_NAMES_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["logs/main/10838bed-421f-43ef-870a-f43feacbbb5b"]
+ */
+export const AWS_LOG_STREAM_NAMES = 'aws.log.stream.names';
+
+/**
+ * Type for {@link AWS_LOG_STREAM_NAMES} aws.log.stream.names
+ */
+export type AWS_LOG_STREAM_NAMES_TYPE = Array<string>;
 
 // Path: model/attributes/blocked_main_thread.json
 
@@ -2852,6 +2919,27 @@ export const CLOUD_REGION = 'cloud.region';
  * Type for {@link CLOUD_REGION} cloud.region
  */
 export type CLOUD_REGION_TYPE = string;
+
+// Path: model/attributes/cloud/cloud__resource_id.json
+
+/**
+ * Cloud provider-specific native identifier of the monitored cloud resource `cloud.resource_id`
+ *
+ * Attribute Value Type: `string` {@link CLOUD_RESOURCE_ID_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function"
+ */
+export const CLOUD_RESOURCE_ID = 'cloud.resource_id';
+
+/**
+ * Type for {@link CLOUD_RESOURCE_ID} cloud.resource_id
+ */
+export type CLOUD_RESOURCE_ID_TYPE = string;
 
 // Path: model/attributes/cls.json
 
@@ -4747,6 +4835,27 @@ export const FAAS_IDENTITY = 'faas.identity';
  */
 export type FAAS_IDENTITY_TYPE = string;
 
+// Path: model/attributes/faas/faas__invocation_id.json
+
+/**
+ * The invocation ID of the current function invocation. `faas.invocation_id`
+ *
+ * Attribute Value Type: `string` {@link FAAS_INVOCATION_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
+ */
+export const FAAS_INVOCATION_ID = 'faas.invocation_id';
+
+/**
+ * Type for {@link FAAS_INVOCATION_ID} faas.invocation_id
+ */
+export type FAAS_INVOCATION_ID_TYPE = string;
+
 // Path: model/attributes/faas/faas__name.json
 
 /**
@@ -4809,6 +4918,27 @@ export const FAAS_TRIGGER = 'faas.trigger';
  * Type for {@link FAAS_TRIGGER} faas.trigger
  */
 export type FAAS_TRIGGER_TYPE = string;
+
+// Path: model/attributes/faas/faas__version.json
+
+/**
+ * The version of the function that was invoked `faas.version`
+ *
+ * Attribute Value Type: `string` {@link FAAS_VERSION_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 1
+ */
+export const FAAS_VERSION = 'faas.version';
+
+/**
+ * Type for {@link FAAS_VERSION} faas.version
+ */
+export type FAAS_VERSION_TYPE = string;
 
 // Path: model/attributes/fcp.json
 
@@ -14138,8 +14268,11 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS]: 'double',
   [AWS_LAMBDA_FUNCTION_NAME]: 'string',
   [AWS_LAMBDA_FUNCTION_VERSION]: 'string',
+  [AWS_LAMBDA_INVOKED_ARN]: 'string',
   [AWS_LAMBDA_INVOKED_FUNCTION_ARN]: 'string',
   [AWS_LAMBDA_REMAINING_TIME_IN_MILLIS]: 'double',
+  [AWS_LOG_GROUP_NAMES]: 'string[]',
+  [AWS_LOG_STREAM_NAMES]: 'string[]',
   [BLOCKED_MAIN_THREAD]: 'boolean',
   [BROWSER_NAME]: 'string',
   [BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START]: 'double',
@@ -14188,6 +14321,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [CLOUD_PLATFORM]: 'string',
   [CLOUD_PROVIDER]: 'string',
   [CLOUD_REGION]: 'string',
+  [CLOUD_RESOURCE_ID]: 'string',
   [CLS]: 'double',
   [CLS_SOURCE_KEY]: 'string',
   [CODE_FILEPATH]: 'string',
@@ -14275,9 +14409,11 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [FAAS_DURATION_IN_MS]: 'integer',
   [FAAS_ENTRY_POINT]: 'string',
   [FAAS_IDENTITY]: 'string',
+  [FAAS_INVOCATION_ID]: 'string',
   [FAAS_NAME]: 'string',
   [FAAS_TIME]: 'string',
   [FAAS_TRIGGER]: 'string',
+  [FAAS_VERSION]: 'string',
   [FCP]: 'double',
   [FLAG_EVALUATION_KEY]: 'boolean',
   [FP]: 'double',
@@ -14779,8 +14915,11 @@ export type AttributeName =
   | typeof AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS
   | typeof AWS_LAMBDA_FUNCTION_NAME
   | typeof AWS_LAMBDA_FUNCTION_VERSION
+  | typeof AWS_LAMBDA_INVOKED_ARN
   | typeof AWS_LAMBDA_INVOKED_FUNCTION_ARN
   | typeof AWS_LAMBDA_REMAINING_TIME_IN_MILLIS
+  | typeof AWS_LOG_GROUP_NAMES
+  | typeof AWS_LOG_STREAM_NAMES
   | typeof BLOCKED_MAIN_THREAD
   | typeof BROWSER_NAME
   | typeof BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START
@@ -14829,6 +14968,7 @@ export type AttributeName =
   | typeof CLOUD_PLATFORM
   | typeof CLOUD_PROVIDER
   | typeof CLOUD_REGION
+  | typeof CLOUD_RESOURCE_ID
   | typeof CLS
   | typeof CLS_SOURCE_KEY
   | typeof CODE_FILEPATH
@@ -14916,9 +15056,11 @@ export type AttributeName =
   | typeof FAAS_DURATION_IN_MS
   | typeof FAAS_ENTRY_POINT
   | typeof FAAS_IDENTITY
+  | typeof FAAS_INVOCATION_ID
   | typeof FAAS_NAME
   | typeof FAAS_TIME
   | typeof FAAS_TRIGGER
+  | typeof FAAS_VERSION
   | typeof FCP
   | typeof FLAG_EVALUATION_KEY
   | typeof FP
@@ -16478,7 +16620,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: '8476a536-e9f4-11e8-9739-2dfe598c3fcd',
-    changelog: [{ version: '0.7.0', prs: [369], description: 'Added aws.lambda.aws_request_id attribute' }],
+    deprecation: {
+      replacement: 'faas.invocation_id',
+      reason: 'This attribute is being deprecated in favor of faas.invocation_id',
+    },
+    changelog: [
+      { version: 'next', description: 'Deprecated aws.lambda.aws_request_id in favor of faas.invocation_id' },
+      { version: '0.7.0', prs: [369], description: 'Added aws.lambda.aws_request_id attribute' },
+    ],
   },
   [AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS]: {
     brief: 'The execution duration of the Lambda function invocation in milliseconds',
@@ -16502,7 +16651,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'my-function',
-    changelog: [{ version: '0.7.0', prs: [369], description: 'Added aws.lambda.function_name attribute' }],
+    deprecation: {
+      replacement: 'faas.name',
+      reason: 'Use the OTel-aligned faas.name attribute instead',
+    },
+    changelog: [
+      { version: '0.7.0', prs: [369], description: 'Added aws.lambda.function_name attribute' },
+      { version: 'next', description: 'Deprecated aws.lambda.function_name in favor of faas.name' },
+    ],
   },
   [AWS_LAMBDA_FUNCTION_VERSION]: {
     brief: 'The version of the Lambda function',
@@ -16513,7 +16669,25 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: '$LATEST',
-    changelog: [{ version: '0.7.0', prs: [369], description: 'Added aws.lambda.function_version attribute' }],
+    deprecation: {
+      replacement: 'faas.version',
+      reason: 'Use the OTel-aligned faas.version attribute instead',
+    },
+    changelog: [
+      { version: '0.7.0', prs: [369], description: 'Added aws.lambda.function_version attribute' },
+      { version: 'next', description: 'Deprecated aws.lambda.function_version in favor of faas.version' },
+    ],
+  },
+  [AWS_LAMBDA_INVOKED_ARN]: {
+    brief: 'The full ARN of the Lambda function that was invoked',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'arn:aws:lambda:us-east-1:123456789012:function:my-function',
+    changelog: [{ version: 'next' }],
   },
   [AWS_LAMBDA_INVOKED_FUNCTION_ARN]: {
     brief: 'The full ARN of the Lambda function that was invoked',
@@ -16524,7 +16698,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'arn:aws:lambda:us-east-1:123456789012:function:my-function',
-    changelog: [{ version: '0.7.0', prs: [369], description: 'Added aws.lambda.invoked_function_arn attribute' }],
+    deprecation: {
+      replacement: 'aws.lambda.invoked_arn',
+      reason: 'This attribute is being deprecated in favor of aws.lambda.invoked_arn',
+    },
+    changelog: [
+      { version: 'next', description: 'Deprecated aws.lambda.invoked_function_arn in favor of aws.lambda.invoked_arn' },
+      { version: '0.7.0', prs: [369], description: 'Added aws.lambda.invoked_function_arn attribute' },
+    ],
   },
   [AWS_LAMBDA_REMAINING_TIME_IN_MILLIS]: {
     brief: 'The remaining time in milliseconds before the Lambda function times out',
@@ -16536,6 +16717,28 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 5000,
     changelog: [{ version: '0.7.0', prs: [369], description: 'Added aws.lambda.remaining_time_in_millis attribute' }],
+  },
+  [AWS_LOG_GROUP_NAMES]: {
+    brief: 'The name(s) of the AWS log group(s) an application is writing to.',
+    type: 'string[]',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: ['/aws/lambda/my-function', 'opentelemetry-service'],
+    changelog: [{ version: 'next' }],
+  },
+  [AWS_LOG_STREAM_NAMES]: {
+    brief: 'The name(s) of the AWS log stream(s) an application is writing to.',
+    type: 'string[]',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: ['logs/main/10838bed-421f-43ef-870a-f43feacbbb5b'],
+    changelog: [{ version: 'next' }],
   },
   [BLOCKED_MAIN_THREAD]: {
     brief: 'Whether the main thread was blocked by the span.',
@@ -17126,6 +17329,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'us-east-1',
     changelog: [{ version: '0.7.0', prs: [364], description: 'Added cloud.region attribute' }],
+  },
+  [CLOUD_RESOURCE_ID]: {
+    brief: 'Cloud provider-specific native identifier of the monitored cloud resource',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function',
+    changelog: [{ version: 'next' }],
   },
   [CLS]: {
     brief: 'The value of the recorded Cumulative Layout Shift (CLS) web vital',
@@ -18247,6 +18461,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       'name@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)',
     changelog: [{ version: 'next' }],
   },
+  [FAAS_INVOCATION_ID]: {
+    brief: 'The invocation ID of the current function invocation.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'af9d5aa4-a685-4c5f-a22b-444f80b3cc28',
+    changelog: [{ version: 'next' }],
+  },
   [FAAS_NAME]: {
     brief: 'The name of the serverless function',
     type: 'string',
@@ -18279,6 +18504,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'timer',
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+  },
+  [FAAS_VERSION]: {
+    brief: 'The version of the function that was invoked',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 1,
+    changelog: [{ version: 'next' }],
   },
   [FCP]: {
     brief: 'The time it takes for the browser to render the first piece of meaningful content on the screen',
@@ -23913,8 +24149,11 @@ export type Attributes = {
   [AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS]?: AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS_TYPE;
   [AWS_LAMBDA_FUNCTION_NAME]?: AWS_LAMBDA_FUNCTION_NAME_TYPE;
   [AWS_LAMBDA_FUNCTION_VERSION]?: AWS_LAMBDA_FUNCTION_VERSION_TYPE;
+  [AWS_LAMBDA_INVOKED_ARN]?: AWS_LAMBDA_INVOKED_ARN_TYPE;
   [AWS_LAMBDA_INVOKED_FUNCTION_ARN]?: AWS_LAMBDA_INVOKED_FUNCTION_ARN_TYPE;
   [AWS_LAMBDA_REMAINING_TIME_IN_MILLIS]?: AWS_LAMBDA_REMAINING_TIME_IN_MILLIS_TYPE;
+  [AWS_LOG_GROUP_NAMES]?: AWS_LOG_GROUP_NAMES_TYPE;
+  [AWS_LOG_STREAM_NAMES]?: AWS_LOG_STREAM_NAMES_TYPE;
   [BLOCKED_MAIN_THREAD]?: BLOCKED_MAIN_THREAD_TYPE;
   [BROWSER_NAME]?: BROWSER_NAME_TYPE;
   [BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START]?: BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START_TYPE;
@@ -23963,6 +24202,7 @@ export type Attributes = {
   [CLOUD_PLATFORM]?: CLOUD_PLATFORM_TYPE;
   [CLOUD_PROVIDER]?: CLOUD_PROVIDER_TYPE;
   [CLOUD_REGION]?: CLOUD_REGION_TYPE;
+  [CLOUD_RESOURCE_ID]?: CLOUD_RESOURCE_ID_TYPE;
   [CLS]?: CLS_TYPE;
   [CLS_SOURCE_KEY]?: CLS_SOURCE_KEY_TYPE;
   [CODE_FILEPATH]?: CODE_FILEPATH_TYPE;
@@ -24050,9 +24290,11 @@ export type Attributes = {
   [FAAS_DURATION_IN_MS]?: FAAS_DURATION_IN_MS_TYPE;
   [FAAS_ENTRY_POINT]?: FAAS_ENTRY_POINT_TYPE;
   [FAAS_IDENTITY]?: FAAS_IDENTITY_TYPE;
+  [FAAS_INVOCATION_ID]?: FAAS_INVOCATION_ID_TYPE;
   [FAAS_NAME]?: FAAS_NAME_TYPE;
   [FAAS_TIME]?: FAAS_TIME_TYPE;
   [FAAS_TRIGGER]?: FAAS_TRIGGER_TYPE;
+  [FAAS_VERSION]?: FAAS_VERSION_TYPE;
   [FCP]?: FCP_TYPE;
   [FLAG_EVALUATION_KEY]?: FLAG_EVALUATION_KEY_TYPE;
   [FP]?: FP_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1755,7 +1755,7 @@ export type AWS_LAMBDA_FUNCTION_NAME_TYPE = string;
  *
  * Attribute Value Type: `string` {@link AWS_LAMBDA_FUNCTION_VERSION_TYPE}
  *
- * Contains PII: maybe
+ * Contains PII: false
  *
  * Attribute defined in OTEL: No
  * Visibility: public
@@ -16783,7 +16783,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The version of the Lambda function',
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'false',
     },
     isInOtel: false,
     visibility: 'public',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1691,6 +1691,8 @@ export type AWS_CLOUDWATCH_LOGS_URL_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link FAAS_INVOCATION_ID} `faas.invocation_id`
+ *
  * @deprecated Use {@link FAAS_INVOCATION_ID} (faas.invocation_id) instead - This attribute is being deprecated in favor of faas.invocation_id
  * @example "8476a536-e9f4-11e8-9739-2dfe598c3fcd"
  */
@@ -1778,6 +1780,8 @@ export type AWS_LAMBDA_FUNCTION_VERSION_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
+ * Aliases: {@link AWS_LAMBDA_INVOKED_FUNCTION_ARN} `aws.lambda.invoked_function_arn`
+ *
  * @example "arn:aws:lambda:us-east-1:123456789012:function:my-function"
  */
 export const AWS_LAMBDA_INVOKED_ARN = 'aws.lambda.invoked_arn';
@@ -1798,6 +1802,8 @@ export type AWS_LAMBDA_INVOKED_ARN_TYPE = string;
  *
  * Attribute defined in OTEL: No
  * Visibility: public
+ *
+ * Aliases: {@link AWS_LAMBDA_INVOKED_ARN} `aws.lambda.invoked_arn`
  *
  * @deprecated Use {@link AWS_LAMBDA_INVOKED_ARN} (aws.lambda.invoked_arn) instead - This attribute is being deprecated in favor of aws.lambda.invoked_arn
  * @example "arn:aws:lambda:us-east-1:123456789012:function:my-function"
@@ -4867,6 +4873,8 @@ export type FAAS_IDENTITY_TYPE = string;
  *
  * Attribute defined in OTEL: Yes
  * Visibility: public
+ *
+ * Aliases: {@link AWS_LAMBDA_AWS_REQUEST_ID} `aws.lambda.aws_request_id`
  *
  * @example "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
  */
@@ -16725,6 +16733,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'faas.invocation_id',
       reason: 'This attribute is being deprecated in favor of faas.invocation_id',
     },
+    aliases: [FAAS_INVOCATION_ID],
     changelog: [
       { version: 'next', description: 'Deprecated aws.lambda.aws_request_id in favor of faas.invocation_id' },
       { version: '0.7.0', prs: [369], description: 'Added aws.lambda.aws_request_id attribute' },
@@ -16788,6 +16797,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'arn:aws:lambda:us-east-1:123456789012:function:my-function',
+    aliases: [AWS_LAMBDA_INVOKED_FUNCTION_ARN],
     changelog: [{ version: 'next' }],
   },
   [AWS_LAMBDA_INVOKED_FUNCTION_ARN]: {
@@ -16803,6 +16813,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'aws.lambda.invoked_arn',
       reason: 'This attribute is being deprecated in favor of aws.lambda.invoked_arn',
     },
+    aliases: [AWS_LAMBDA_INVOKED_ARN],
     changelog: [
       { version: 'next', description: 'Deprecated aws.lambda.invoked_function_arn in favor of aws.lambda.invoked_arn' },
       { version: '0.7.0', prs: [369], description: 'Added aws.lambda.invoked_function_arn attribute' },
@@ -18538,6 +18549,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'af9d5aa4-a685-4c5f-a22b-444f80b3cc28',
+    aliases: [AWS_LAMBDA_AWS_REQUEST_ID],
     changelog: [{ version: 'next' }],
   },
   [FAAS_NAME]: {

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -20958,7 +20958,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 10,
-    sdks: ['javascript-cloudflare'],
+    sdks: ['javascript-cloudflare', 'python'],
     changelog: [{ version: '0.6.0', prs: [341], description: 'Added messaging.batch.message_count attribute' }],
   },
   [MESSAGING_DESTINATION_CONNECTION]: {

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4926,12 +4926,12 @@ export type FAAS_TRIGGER_TYPE = string;
  *
  * Attribute Value Type: `string` {@link FAAS_VERSION_TYPE}
  *
- * Contains PII: maybe
+ * Contains PII: false
  *
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * @example 1
+ * @example "$LATEST"
  */
 export const FAAS_VERSION = 'faas.version';
 
@@ -16656,8 +16656,8 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'Use the OTel-aligned faas.name attribute instead',
     },
     changelog: [
-      { version: '0.7.0', prs: [369], description: 'Added aws.lambda.function_name attribute' },
       { version: 'next', description: 'Deprecated aws.lambda.function_name in favor of faas.name' },
+      { version: '0.7.0', prs: [369], description: 'Added aws.lambda.function_name attribute' },
     ],
   },
   [AWS_LAMBDA_FUNCTION_VERSION]: {
@@ -16674,8 +16674,8 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'Use the OTel-aligned faas.version attribute instead',
     },
     changelog: [
-      { version: '0.7.0', prs: [369], description: 'Added aws.lambda.function_version attribute' },
       { version: 'next', description: 'Deprecated aws.lambda.function_version in favor of faas.version' },
+      { version: '0.7.0', prs: [369], description: 'Added aws.lambda.function_version attribute' },
     ],
   },
   [AWS_LAMBDA_INVOKED_ARN]: {
@@ -18509,11 +18509,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The version of the function that was invoked',
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'false',
     },
     isInOtel: true,
     visibility: 'public',
-    example: 1,
+    example: '$LATEST',
     changelog: [{ version: 'next' }],
   },
   [FCP]: {

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1686,7 +1686,7 @@ export type AWS_CLOUDWATCH_LOGS_URL_TYPE = string;
  *
  * Attribute Value Type: `string` {@link AWS_LAMBDA_AWS_REQUEST_ID_TYPE}
  *
- * Contains PII: maybe
+ * Contains PII: false
  *
  * Attribute defined in OTEL: No
  * Visibility: public
@@ -1736,6 +1736,8 @@ export type AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS_TYPE = number;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link FAAS_NAME} `faas.name`
+ *
  * @deprecated Use {@link FAAS_NAME} (faas.name) instead - Use the OTel-aligned faas.name attribute instead
  * @example "my-function"
  */
@@ -1757,6 +1759,8 @@ export type AWS_LAMBDA_FUNCTION_NAME_TYPE = string;
  *
  * Attribute defined in OTEL: No
  * Visibility: public
+ *
+ * Aliases: {@link FAAS_VERSION} `faas.version`
  *
  * @deprecated Use {@link FAAS_VERSION} (faas.version) instead - Use the OTel-aligned faas.version attribute instead
  * @example "$LATEST"
@@ -4897,6 +4901,8 @@ export type FAAS_INVOCATION_ID_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
+ * Aliases: {@link AWS_LAMBDA_FUNCTION_NAME} `aws.lambda.function_name`
+ *
  * @example "my_function"
  */
 export const FAAS_NAME = 'faas.name';
@@ -4959,6 +4965,8 @@ export type FAAS_TRIGGER_TYPE = string;
  *
  * Attribute defined in OTEL: Yes
  * Visibility: public
+ *
+ * Aliases: {@link AWS_LAMBDA_FUNCTION_VERSION} `aws.lambda.function_version`
  *
  * @example "$LATEST"
  */
@@ -16724,7 +16732,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The AWS request ID as received by the Lambda function runtime',
     type: 'string',
     pii: {
-      isPii: 'maybe',
+      isPii: 'false',
     },
     isInOtel: false,
     visibility: 'public',
@@ -16765,6 +16773,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'faas.name',
       reason: 'Use the OTel-aligned faas.name attribute instead',
     },
+    aliases: [FAAS_NAME],
     changelog: [
       { version: 'next', description: 'Deprecated aws.lambda.function_name in favor of faas.name' },
       { version: '0.7.0', prs: [369], description: 'Added aws.lambda.function_name attribute' },
@@ -16783,6 +16792,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'faas.version',
       reason: 'Use the OTel-aligned faas.version attribute instead',
     },
+    aliases: [FAAS_VERSION],
     changelog: [
       { version: 'next', description: 'Deprecated aws.lambda.function_version in favor of faas.version' },
       { version: '0.7.0', prs: [369], description: 'Added aws.lambda.function_version attribute' },
@@ -18561,6 +18571,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'my_function',
+    aliases: [AWS_LAMBDA_FUNCTION_NAME],
     changelog: [{ version: '0.11.0', prs: [403, 415] }],
   },
   [FAAS_TIME]: {
@@ -18594,6 +18605,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: '$LATEST',
+    aliases: [AWS_LAMBDA_FUNCTION_VERSION],
     changelog: [{ version: 'next' }],
   },
   [FCP]: {

--- a/model/attributes/aws/aws__lambda__aws_request_id.json
+++ b/model/attributes/aws/aws__lambda__aws_request_id.json
@@ -3,7 +3,7 @@
   "brief": "The AWS request ID as received by the Lambda function runtime",
   "type": "string",
   "pii": {
-    "key": "maybe"
+    "key": "false"
   },
   "is_in_otel": false,
   "example": "8476a536-e9f4-11e8-9739-2dfe598c3fcd",

--- a/model/attributes/aws/aws__lambda__aws_request_id.json
+++ b/model/attributes/aws/aws__lambda__aws_request_id.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": "8476a536-e9f4-11e8-9739-2dfe598c3fcd",
   "deprecation": {
-    "_status": "null",
+    "_status": null,
     "replacement": "faas.invocation_id",
     "reason": "This attribute is being deprecated in favor of faas.invocation_id"
   },

--- a/model/attributes/aws/aws__lambda__aws_request_id.json
+++ b/model/attributes/aws/aws__lambda__aws_request_id.json
@@ -7,6 +7,7 @@
   },
   "is_in_otel": false,
   "example": "8476a536-e9f4-11e8-9739-2dfe598c3fcd",
+  "alias": ["faas.invocation_id"],
   "deprecation": {
     "_status": null,
     "replacement": "faas.invocation_id",

--- a/model/attributes/aws/aws__lambda__aws_request_id.json
+++ b/model/attributes/aws/aws__lambda__aws_request_id.json
@@ -7,8 +7,17 @@
   },
   "is_in_otel": false,
   "example": "8476a536-e9f4-11e8-9739-2dfe598c3fcd",
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "faas.invocation_id",
+    "reason": "This attribute is being deprecated in favor of faas.invocation_id"
+  },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Deprecated aws.lambda.aws_request_id in favor of faas.invocation_id"
+    },
     {
       "version": "0.7.0",
       "prs": [369],

--- a/model/attributes/aws/aws__lambda__aws_request_id.json
+++ b/model/attributes/aws/aws__lambda__aws_request_id.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "example": "8476a536-e9f4-11e8-9739-2dfe598c3fcd",
   "deprecation": {
-    "_status": "backfill",
+    "_status": "null",
     "replacement": "faas.invocation_id",
     "reason": "This attribute is being deprecated in favor of faas.invocation_id"
   },

--- a/model/attributes/aws/aws__lambda__aws_request_id.json
+++ b/model/attributes/aws/aws__lambda__aws_request_id.json
@@ -9,7 +9,7 @@
   "example": "8476a536-e9f4-11e8-9739-2dfe598c3fcd",
   "alias": ["faas.invocation_id"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "faas.invocation_id",
     "reason": "This attribute is being deprecated in favor of faas.invocation_id"
   },

--- a/model/attributes/aws/aws__lambda__function_name.json
+++ b/model/attributes/aws/aws__lambda__function_name.json
@@ -7,6 +7,7 @@
   },
   "is_in_otel": false,
   "example": "my-function",
+  "alias": ["faas.name"],
   "deprecation": {
     "_status": null,
     "replacement": "faas.name",

--- a/model/attributes/aws/aws__lambda__function_name.json
+++ b/model/attributes/aws/aws__lambda__function_name.json
@@ -8,19 +8,20 @@
   "is_in_otel": false,
   "example": "my-function",
   "deprecation": {
+    "_status": null,
     "replacement": "faas.name",
     "reason": "Use the OTel-aligned faas.name attribute instead"
   },
   "visibility": "public",
   "changelog": [
     {
+      "version": "next",
+      "description": "Deprecated aws.lambda.function_name in favor of faas.name"
+    },
+    {
       "version": "0.7.0",
       "prs": [369],
       "description": "Added aws.lambda.function_name attribute"
-    },
-    {
-      "version": "next",
-      "description": "Deprecated aws.lambda.function_name in favor of faas.name"
     }
   ]
 }

--- a/model/attributes/aws/aws__lambda__function_name.json
+++ b/model/attributes/aws/aws__lambda__function_name.json
@@ -7,12 +7,20 @@
   },
   "is_in_otel": false,
   "example": "my-function",
+  "deprecation": {
+    "replacement": "faas.name",
+    "reason": "Use the OTel-aligned faas.name attribute instead"
+  },
   "visibility": "public",
   "changelog": [
     {
       "version": "0.7.0",
       "prs": [369],
       "description": "Added aws.lambda.function_name attribute"
+    },
+    {
+      "version": "next",
+      "description": "Deprecated aws.lambda.function_name in favor of faas.name"
     }
   ]
 }

--- a/model/attributes/aws/aws__lambda__function_name.json
+++ b/model/attributes/aws/aws__lambda__function_name.json
@@ -9,7 +9,7 @@
   "example": "my-function",
   "alias": ["faas.name"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "faas.name",
     "reason": "Use the OTel-aligned faas.name attribute instead"
   },

--- a/model/attributes/aws/aws__lambda__function_version.json
+++ b/model/attributes/aws/aws__lambda__function_version.json
@@ -7,6 +7,7 @@
   },
   "is_in_otel": false,
   "example": "$LATEST",
+  "alias": ["faas.version"],
   "deprecation": {
     "_status": null,
     "replacement": "faas.version",

--- a/model/attributes/aws/aws__lambda__function_version.json
+++ b/model/attributes/aws/aws__lambda__function_version.json
@@ -8,19 +8,20 @@
   "is_in_otel": false,
   "example": "$LATEST",
   "deprecation": {
+    "_status": null,
     "replacement": "faas.version",
     "reason": "Use the OTel-aligned faas.version attribute instead"
   },
   "visibility": "public",
   "changelog": [
     {
+      "version": "next",
+      "description": "Deprecated aws.lambda.function_version in favor of faas.version"
+    },
+    {
       "version": "0.7.0",
       "prs": [369],
       "description": "Added aws.lambda.function_version attribute"
-    },
-    {
-      "version": "next",
-      "description": "Deprecated aws.lambda.function_version in favor of faas.version"
     }
   ]
 }

--- a/model/attributes/aws/aws__lambda__function_version.json
+++ b/model/attributes/aws/aws__lambda__function_version.json
@@ -3,13 +3,13 @@
   "brief": "The version of the Lambda function",
   "type": "string",
   "pii": {
-    "key": "maybe"
+    "key": "false"
   },
   "is_in_otel": false,
   "example": "$LATEST",
   "alias": ["faas.version"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "faas.version",
     "reason": "Use the OTel-aligned faas.version attribute instead"
   },

--- a/model/attributes/aws/aws__lambda__function_version.json
+++ b/model/attributes/aws/aws__lambda__function_version.json
@@ -7,12 +7,20 @@
   },
   "is_in_otel": false,
   "example": "$LATEST",
+  "deprecation": {
+    "replacement": "faas.version",
+    "reason": "Use the OTel-aligned faas.version attribute instead"
+  },
   "visibility": "public",
   "changelog": [
     {
       "version": "0.7.0",
       "prs": [369],
       "description": "Added aws.lambda.function_version attribute"
+    },
+    {
+      "version": "next",
+      "description": "Deprecated aws.lambda.function_version in favor of faas.version"
     }
   ]
 }

--- a/model/attributes/aws/aws__lambda__invoked_arn.json
+++ b/model/attributes/aws/aws__lambda__invoked_arn.json
@@ -7,6 +7,7 @@
   },
   "is_in_otel": true,
   "example": "arn:aws:lambda:us-east-1:123456789012:function:my-function",
+  "alias": ["aws.lambda.invoked_function_arn"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/aws/aws__lambda__invoked_arn.json
+++ b/model/attributes/aws/aws__lambda__invoked_arn.json
@@ -1,0 +1,16 @@
+{
+  "key": "aws.lambda.invoked_arn",
+  "brief": "The full ARN of the Lambda function that was invoked",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": true,
+  "example": "arn:aws:lambda:us-east-1:123456789012:function:my-function",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__lambda__invoked_function_arn.json
+++ b/model/attributes/aws/aws__lambda__invoked_function_arn.json
@@ -9,7 +9,7 @@
   "example": "arn:aws:lambda:us-east-1:123456789012:function:my-function",
   "visibility": "public",
   "deprecation": {
-    "_status": "backfill",
+    "_status": null,
     "replacement": "aws.lambda.invoked_arn",
     "reason": "This attribute is being deprecated in favor of aws.lambda.invoked_arn"
   },

--- a/model/attributes/aws/aws__lambda__invoked_function_arn.json
+++ b/model/attributes/aws/aws__lambda__invoked_function_arn.json
@@ -8,7 +8,16 @@
   "is_in_otel": false,
   "example": "arn:aws:lambda:us-east-1:123456789012:function:my-function",
   "visibility": "public",
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "aws.lambda.invoked_arn",
+    "reason": "This attribute is being deprecated in favor of aws.lambda.invoked_arn"
+  },
   "changelog": [
+    {
+      "version": "next",
+      "description": "Deprecated aws.lambda.invoked_function_arn in favor of aws.lambda.invoked_arn"
+    },
     {
       "version": "0.7.0",
       "prs": [369],

--- a/model/attributes/aws/aws__lambda__invoked_function_arn.json
+++ b/model/attributes/aws/aws__lambda__invoked_function_arn.json
@@ -8,6 +8,7 @@
   "is_in_otel": false,
   "example": "arn:aws:lambda:us-east-1:123456789012:function:my-function",
   "visibility": "public",
+  "alias": ["aws.lambda.invoked_arn"],
   "deprecation": {
     "_status": null,
     "replacement": "aws.lambda.invoked_arn",

--- a/model/attributes/aws/aws__lambda__invoked_function_arn.json
+++ b/model/attributes/aws/aws__lambda__invoked_function_arn.json
@@ -10,7 +10,7 @@
   "visibility": "public",
   "alias": ["aws.lambda.invoked_arn"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "aws.lambda.invoked_arn",
     "reason": "This attribute is being deprecated in favor of aws.lambda.invoked_arn"
   },

--- a/model/attributes/aws/aws__log__group__names.json
+++ b/model/attributes/aws/aws__log__group__names.json
@@ -1,0 +1,16 @@
+{
+  "key": "aws.log.group.names",
+  "brief": "The name(s) of the AWS log group(s) an application is writing to.",
+  "type": "string[]",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": true,
+  "example": ["/aws/lambda/my-function", "opentelemetry-service"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__log__stream__names.json
+++ b/model/attributes/aws/aws__log__stream__names.json
@@ -1,0 +1,16 @@
+{
+  "key": "aws.log.stream.names",
+  "brief": "The name(s) of the AWS log stream(s) an application is writing to.",
+  "type": "string[]",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": true,
+  "example": ["logs/main/10838bed-421f-43ef-870a-f43feacbbb5b"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/cloud/cloud__resource_id.json
+++ b/model/attributes/cloud/cloud__resource_id.json
@@ -7,6 +7,9 @@
   },
   "is_in_otel": true,
   "example": "arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function",
+  "additional_context": [
+    "This can be an identifier for a resource in AWS, GCP, or Azure. There may be some overlap in values found here with other attributes. For instance, an AWS lambda ARN may be found here as well as in `aws.lambda.invoked_arn`. OTEL recommends setting them alongside each other."
+  ],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/cloud/cloud__resource_id.json
+++ b/model/attributes/cloud/cloud__resource_id.json
@@ -1,0 +1,16 @@
+{
+  "key": "cloud.resource_id",
+  "brief": "Cloud provider-specific native identifier of the monitored cloud resource",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": true,
+  "example": "arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/faas/faas__invocation_id.json
+++ b/model/attributes/faas/faas__invocation_id.json
@@ -1,0 +1,16 @@
+{
+  "key": "faas.invocation_id",
+  "brief": "The invocation ID of the current function invocation.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "example": "af9d5aa4-a685-4c5f-a22b-444f80b3cc28",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/faas/faas__invocation_id.json
+++ b/model/attributes/faas/faas__invocation_id.json
@@ -7,6 +7,7 @@
   },
   "is_in_otel": true,
   "example": "af9d5aa4-a685-4c5f-a22b-444f80b3cc28",
+  "alias": ["aws.lambda.aws_request_id"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/faas/faas__name.json
+++ b/model/attributes/faas/faas__name.json
@@ -7,6 +7,7 @@
   },
   "is_in_otel": true,
   "example": "my_function",
+  "alias": ["aws.lambda.function_name"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/faas/faas__version.json
+++ b/model/attributes/faas/faas__version.json
@@ -7,6 +7,7 @@
   },
   "is_in_otel": true,
   "example": "$LATEST",
+  "alias": ["aws.lambda.function_version"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/faas/faas__version.json
+++ b/model/attributes/faas/faas__version.json
@@ -3,10 +3,10 @@
   "brief": "The version of the function that was invoked",
   "type": "string",
   "pii": {
-    "key": "$LATEST"
+    "key": "false"
   },
   "is_in_otel": true,
-  "example": 1.0,
+  "example": "$LATEST",
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/faas/faas__version.json
+++ b/model/attributes/faas/faas__version.json
@@ -1,0 +1,16 @@
+{
+  "key": "faas.version",
+  "brief": "The version of the function that was invoked",
+  "type": "string",
+  "pii": {
+    "key": "$LATEST"
+  },
+  "is_in_otel": true,
+  "example": 1.0,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/messaging/messaging__batch__message_count.json
+++ b/model/attributes/messaging/messaging__batch__message_count.json
@@ -7,7 +7,6 @@
   },
   "is_in_otel": true,
   "example": 10,
-  "sdks": ["javascript-cloudflare", "python"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/messaging/messaging__batch__message_count.json
+++ b/model/attributes/messaging/messaging__batch__message_count.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": 10,
-  "sdks": ["javascript-cloudflare"],
+  "sdks": ["javascript-cloudflare", "python"],
   "visibility": "public",
   "changelog": [
     {

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3011,10 +3011,10 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The version of the function that was invoked
 
     Type: str
-    Contains PII: $LATEST
+    Contains PII: false
     Defined in OTEL: Yes
     Visibility: public
-    Example: 1
+    Example: "$LATEST"
     """
 
     # Path: model/attributes/fcp.json
@@ -9498,13 +9498,13 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ),
         changelog=[
             ChangelogEntry(
+                version="next",
+                description="Deprecated aws.lambda.function_name in favor of faas.name",
+            ),
+            ChangelogEntry(
                 version="0.7.0",
                 prs=[369],
                 description="Added aws.lambda.function_name attribute",
-            ),
-            ChangelogEntry(
-                version="next",
-                description="Deprecated aws.lambda.function_name in favor of faas.name",
             ),
         ],
     ),
@@ -9521,13 +9521,13 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ),
         changelog=[
             ChangelogEntry(
+                version="next",
+                description="Deprecated aws.lambda.function_version in favor of faas.version",
+            ),
+            ChangelogEntry(
                 version="0.7.0",
                 prs=[369],
                 description="Added aws.lambda.function_version attribute",
-            ),
-            ChangelogEntry(
-                version="next",
-                description="Deprecated aws.lambda.function_version in favor of faas.version",
             ),
         ],
     ),
@@ -11553,10 +11553,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "faas.version": AttributeMetadata(
         brief="The version of the function that was invoked",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.MAYBE),
+        pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
-        example=1,
+        example="$LATEST",
         changelog=[
             ChangelogEntry(version="next"),
         ],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -10139,6 +10139,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(version="next"),
         ],
+        additional_context=[
+            "This can be an identifier for a resource in AWS, GCP, or Azure. There may be some overlap in values found here with other attributes. For instance, an AWS lambda ARN may be found here as well as in `aws.lambda.invoked_arn`. OTEL recommends setting them alongside each other."
+        ],
     ),
     "cloudflare.d1.duration": AttributeMetadata(
         brief="The duration of a Cloudflare D1 operation.",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -9456,7 +9456,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="faas.invocation_id",
             reason="This attribute is being deprecated in favor of faas.invocation_id",
-            status=DeprecationStatus.NORMALIZE,
         ),
         changelog=[
             ChangelogEntry(

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -155,6 +155,10 @@ class _AttributeNamesMeta(type):
         "APP_START_COLD",
         "APP_START_TYPE",
         "APP_START_WARM",
+        "AWS_LAMBDA_AWS_REQUEST_ID",
+        "AWS_LAMBDA_FUNCTION_NAME",
+        "AWS_LAMBDA_FUNCTION_VERSION",
+        "AWS_LAMBDA_INVOKED_FUNCTION_ARN",
         "CLS_SOURCE_KEY",
         "CLS",
         "CODE_FILEPATH",
@@ -1216,6 +1220,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
+    DEPRECATED: Use faas.invocation_id instead - This attribute is being deprecated in favor of faas.invocation_id
     Example: "8476a536-e9f4-11e8-9739-2dfe598c3fcd"
     """
 
@@ -1242,6 +1247,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
+    DEPRECATED: Use faas.name instead - Use the OTel-aligned faas.name attribute instead
     Example: "my-function"
     """
 
@@ -1255,7 +1261,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
+    DEPRECATED: Use faas.version instead - Use the OTel-aligned faas.version attribute instead
     Example: "$LATEST"
+    """
+
+    # Path: model/attributes/aws/aws__lambda__invoked_arn.json
+    AWS_LAMBDA_INVOKED_ARN: Literal["aws.lambda.invoked_arn"] = "aws.lambda.invoked_arn"
+    """The full ARN of the Lambda function that was invoked
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "arn:aws:lambda:us-east-1:123456789012:function:my-function"
     """
 
     # Path: model/attributes/aws/aws__lambda__invoked_function_arn.json
@@ -1268,6 +1286,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
+    DEPRECATED: Use aws.lambda.invoked_arn instead - This attribute is being deprecated in favor of aws.lambda.invoked_arn
     Example: "arn:aws:lambda:us-east-1:123456789012:function:my-function"
     """
 
@@ -1282,6 +1301,28 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Visibility: public
     Example: 5000
+    """
+
+    # Path: model/attributes/aws/aws__log__group__names.json
+    AWS_LOG_GROUP_NAMES: Literal["aws.log.group.names"] = "aws.log.group.names"
+    """The name(s) of the AWS log group(s) an application is writing to.
+
+    Type: List[str]
+    Contains PII: maybe
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["/aws/lambda/my-function","opentelemetry-service"]
+    """
+
+    # Path: model/attributes/aws/aws__log__stream__names.json
+    AWS_LOG_STREAM_NAMES: Literal["aws.log.stream.names"] = "aws.log.stream.names"
+    """The name(s) of the AWS log stream(s) an application is writing to.
+
+    Type: List[str]
+    Contains PII: maybe
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["logs/main/10838bed-421f-43ef-870a-f43feacbbb5b"]
     """
 
     # Path: model/attributes/blocked_main_thread.json
@@ -1773,6 +1814,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Example: "us-east-1"
+    """
+
+    # Path: model/attributes/cloud/cloud__resource_id.json
+    CLOUD_RESOURCE_ID: Literal["cloud.resource_id"] = "cloud.resource_id"
+    """Cloud provider-specific native identifier of the monitored cloud resource
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function"
     """
 
     # Path: model/attributes/cloudflare/cloudflare__d1__duration.json
@@ -2910,6 +2962,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "name@project.iam.gserviceaccount.com (GCP), arn:aws:iam::123456789012:role/role-name (AWS), 00000000-0000-0000-0000-000000000000 (Azure)"
     """
 
+    # Path: model/attributes/faas/faas__invocation_id.json
+    FAAS_INVOCATION_ID: Literal["faas.invocation_id"] = "faas.invocation_id"
+    """The invocation ID of the current function invocation.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
+    """
+
     # Path: model/attributes/faas/faas__name.json
     FAAS_NAME: Literal["faas.name"] = "faas.name"
     """The name of the serverless function
@@ -2941,6 +3004,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Example: "timer"
+    """
+
+    # Path: model/attributes/faas/faas__version.json
+    FAAS_VERSION: Literal["faas.version"] = "faas.version"
+    """The version of the function that was invoked
+
+    Type: str
+    Contains PII: $LATEST
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 1
     """
 
     # Path: model/attributes/fcp.json
@@ -9379,7 +9453,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="8476a536-e9f4-11e8-9739-2dfe598c3fcd",
+        deprecation=DeprecationInfo(
+            replacement="faas.invocation_id",
+            reason="This attribute is being deprecated in favor of faas.invocation_id",
+            status=DeprecationStatus.BACKFILL,
+        ),
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Deprecated aws.lambda.aws_request_id in favor of faas.invocation_id",
+            ),
             ChangelogEntry(
                 version="0.7.0",
                 prs=[369],
@@ -9409,11 +9492,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="my-function",
+        deprecation=DeprecationInfo(
+            replacement="faas.name",
+            reason="Use the OTel-aligned faas.name attribute instead",
+        ),
         changelog=[
             ChangelogEntry(
                 version="0.7.0",
                 prs=[369],
                 description="Added aws.lambda.function_name attribute",
+            ),
+            ChangelogEntry(
+                version="next",
+                description="Deprecated aws.lambda.function_name in favor of faas.name",
             ),
         ],
     ),
@@ -9424,12 +9515,31 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="$LATEST",
+        deprecation=DeprecationInfo(
+            replacement="faas.version",
+            reason="Use the OTel-aligned faas.version attribute instead",
+        ),
         changelog=[
             ChangelogEntry(
                 version="0.7.0",
                 prs=[369],
                 description="Added aws.lambda.function_version attribute",
             ),
+            ChangelogEntry(
+                version="next",
+                description="Deprecated aws.lambda.function_version in favor of faas.version",
+            ),
+        ],
+    ),
+    "aws.lambda.invoked_arn": AttributeMetadata(
+        brief="The full ARN of the Lambda function that was invoked",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="arn:aws:lambda:us-east-1:123456789012:function:my-function",
+        changelog=[
+            ChangelogEntry(version="next"),
         ],
     ),
     "aws.lambda.invoked_function_arn": AttributeMetadata(
@@ -9439,7 +9549,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="arn:aws:lambda:us-east-1:123456789012:function:my-function",
+        deprecation=DeprecationInfo(
+            replacement="aws.lambda.invoked_arn",
+            reason="This attribute is being deprecated in favor of aws.lambda.invoked_arn",
+            status=DeprecationStatus.BACKFILL,
+        ),
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Deprecated aws.lambda.invoked_function_arn in favor of aws.lambda.invoked_arn",
+            ),
             ChangelogEntry(
                 version="0.7.0",
                 prs=[369],
@@ -9460,6 +9579,28 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
                 prs=[369],
                 description="Added aws.lambda.remaining_time_in_millis attribute",
             ),
+        ],
+    ),
+    "aws.log.group.names": AttributeMetadata(
+        brief="The name(s) of the AWS log group(s) an application is writing to.",
+        type=AttributeType.STRING_ARRAY,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=["/aws/lambda/my-function", "opentelemetry-service"],
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
+    "aws.log.stream.names": AttributeMetadata(
+        brief="The name(s) of the AWS log stream(s) an application is writing to.",
+        type=AttributeType.STRING_ARRAY,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=["logs/main/10838bed-421f-43ef-870a-f43feacbbb5b"],
+        changelog=[
+            ChangelogEntry(version="next"),
         ],
     ),
     "blocked_main_thread": AttributeMetadata(
@@ -9988,6 +10129,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(
                 version="0.7.0", prs=[364], description="Added cloud.region attribute"
             ),
+        ],
+    ),
+    "cloud.resource_id": AttributeMetadata(
+        brief="Cloud provider-specific native identifier of the monitored cloud resource",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function",
+        changelog=[
+            ChangelogEntry(version="next"),
         ],
     ),
     "cloudflare.d1.duration": AttributeMetadata(
@@ -11352,6 +11504,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="next"),
         ],
     ),
+    "faas.invocation_id": AttributeMetadata(
+        brief="The invocation ID of the current function invocation.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="af9d5aa4-a685-4c5f-a22b-444f80b3cc28",
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
     "faas.name": AttributeMetadata(
         brief="The name of the serverless function",
         type=AttributeType.STRING,
@@ -11385,6 +11548,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "faas.version": AttributeMetadata(
+        brief="The version of the function that was invoked",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=1,
+        changelog=[
+            ChangelogEntry(version="next"),
         ],
     ),
     "fcp": AttributeMetadata(
@@ -17163,8 +17337,11 @@ Attributes = TypedDict(
         "aws.lambda.execution_duration_in_millis": float,
         "aws.lambda.function_name": str,
         "aws.lambda.function_version": str,
+        "aws.lambda.invoked_arn": str,
         "aws.lambda.invoked_function_arn": str,
         "aws.lambda.remaining_time_in_millis": float,
+        "aws.log.group.names": List[str],
+        "aws.log.stream.names": List[str],
         "blocked_main_thread": bool,
         "browser.name": str,
         "browser.performance.navigation.activation_start": float,
@@ -17204,6 +17381,7 @@ Attributes = TypedDict(
         "cloud.platform": str,
         "cloud.provider": str,
         "cloud.region": str,
+        "cloud.resource_id": str,
         "cloudflare.d1.duration": int,
         "cloudflare.d1.query_type": str,
         "cloudflare.d1.rows_read": int,
@@ -17300,9 +17478,11 @@ Attributes = TypedDict(
         "faas.duration_in_ms": int,
         "faas.entry_point": str,
         "faas.identity": str,
+        "faas.invocation_id": str,
         "faas.name": str,
         "faas.time": str,
         "faas.trigger": str,
+        "faas.version": str,
         "fcp": float,
         "flag.evaluation.<key>": bool,
         "fp": float,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1261,7 +1261,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The version of the Lambda function
 
     Type: str
-    Contains PII: maybe
+    Contains PII: false
     Defined in OTEL: No
     Visibility: public
     Aliases: faas.version
@@ -9392,6 +9392,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="faas.invocation_id",
             reason="This attribute is being deprecated in favor of faas.invocation_id",
+            status=DeprecationStatus.BACKFILL,
         ),
         aliases=["faas.invocation_id"],
         changelog=[
@@ -9431,6 +9432,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="faas.name",
             reason="Use the OTel-aligned faas.name attribute instead",
+            status=DeprecationStatus.BACKFILL,
         ),
         aliases=["faas.name"],
         changelog=[
@@ -9448,13 +9450,14 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "aws.lambda.function_version": AttributeMetadata(
         brief="The version of the Lambda function",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.MAYBE),
+        pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="$LATEST",
         deprecation=DeprecationInfo(
             replacement="faas.version",
             reason="Use the OTel-aligned faas.version attribute instead",
+            status=DeprecationStatus.BACKFILL,
         ),
         aliases=["faas.version"],
         changelog=[
@@ -9491,6 +9494,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="aws.lambda.invoked_arn",
             reason="This attribute is being deprecated in favor of aws.lambda.invoked_arn",
+            status=DeprecationStatus.BACKFILL,
         ),
         aliases=["aws.lambda.invoked_arn"],
         changelog=[

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1221,6 +1221,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
+    Aliases: faas.invocation_id
     DEPRECATED: Use faas.invocation_id instead - This attribute is being deprecated in favor of faas.invocation_id
     Example: "8476a536-e9f4-11e8-9739-2dfe598c3fcd"
     """
@@ -1274,6 +1275,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: aws.lambda.invoked_function_arn
     Example: "arn:aws:lambda:us-east-1:123456789012:function:my-function"
     """
 
@@ -1287,6 +1289,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
+    Aliases: aws.lambda.invoked_arn
     DEPRECATED: Use aws.lambda.invoked_arn instead - This attribute is being deprecated in favor of aws.lambda.invoked_arn
     Example: "arn:aws:lambda:us-east-1:123456789012:function:my-function"
     """
@@ -2984,6 +2987,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: false
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: aws.lambda.aws_request_id
     Example: "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
     """
 
@@ -9385,6 +9389,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             replacement="faas.invocation_id",
             reason="This attribute is being deprecated in favor of faas.invocation_id",
         ),
+        aliases=["faas.invocation_id"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -9465,6 +9470,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="arn:aws:lambda:us-east-1:123456789012:function:my-function",
+        aliases=["aws.lambda.invoked_function_arn"],
         changelog=[
             ChangelogEntry(version="next"),
         ],
@@ -9480,6 +9486,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             replacement="aws.lambda.invoked_arn",
             reason="This attribute is being deprecated in favor of aws.lambda.invoked_arn",
         ),
+        aliases=["aws.lambda.invoked_arn"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -11407,6 +11414,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="af9d5aa4-a685-4c5f-a22b-444f80b3cc28",
+        aliases=["aws.lambda.aws_request_id"],
         changelog=[
             ChangelogEntry(version="next"),
         ],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -9456,7 +9456,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="faas.invocation_id",
             reason="This attribute is being deprecated in favor of faas.invocation_id",
-            status=DeprecationStatus.BACKFILL,
+            status=DeprecationStatus.NORMALIZE,
         ),
         changelog=[
             ChangelogEntry(
@@ -9552,7 +9552,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="aws.lambda.invoked_arn",
             reason="This attribute is being deprecated in favor of aws.lambda.invoked_arn",
-            status=DeprecationStatus.BACKFILL,
         ),
         changelog=[
             ChangelogEntry(

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1218,7 +1218,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The AWS request ID as received by the Lambda function runtime
 
     Type: str
-    Contains PII: maybe
+    Contains PII: false
     Defined in OTEL: No
     Visibility: public
     Aliases: faas.invocation_id
@@ -1249,6 +1249,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
+    Aliases: faas.name
     DEPRECATED: Use faas.name instead - Use the OTel-aligned faas.name attribute instead
     Example: "my-function"
     """
@@ -1263,6 +1264,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
+    Aliases: faas.version
     DEPRECATED: Use faas.version instead - Use the OTel-aligned faas.version attribute instead
     Example: "$LATEST"
     """
@@ -2999,6 +3001,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: aws.lambda.function_name
     Example: "my_function"
     """
 
@@ -3032,6 +3035,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: false
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: aws.lambda.function_version
     Example: "$LATEST"
     """
 
@@ -9381,7 +9385,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "aws.lambda.aws_request_id": AttributeMetadata(
         brief="The AWS request ID as received by the Lambda function runtime",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.MAYBE),
+        pii=PiiInfo(isPii=IsPii.FALSE),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="8476a536-e9f4-11e8-9739-2dfe598c3fcd",
@@ -9428,6 +9432,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             replacement="faas.name",
             reason="Use the OTel-aligned faas.name attribute instead",
         ),
+        aliases=["faas.name"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -9451,6 +9456,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             replacement="faas.version",
             reason="Use the OTel-aligned faas.version attribute instead",
         ),
+        aliases=["faas.version"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -11426,6 +11432,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="my_function",
+        aliases=["aws.lambda.function_name"],
         changelog=[
             ChangelogEntry(version="0.11.0", prs=[403, 415]),
         ],
@@ -11461,6 +11468,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="$LATEST",
+        aliases=["aws.lambda.function_version"],
         changelog=[
             ChangelogEntry(version="next"),
         ],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -14025,7 +14025,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example=10,
-        sdks=["javascript-cloudflare"],
+        sdks=["javascript-cloudflare", "python"],
         changelog=[
             ChangelogEntry(
                 version="0.6.0",


### PR DESCRIPTION
Add OTel-aligned attributes for FaaS and AWS Lambda context:
- faas.invocation_id, faas.version, aws.lambda.invoked_arn
- aws.log.group.names, aws.log.stream.names, cloud.resource_id

Deprecate corresponding AWS Lambda-specific attributes in favor of the OTel-aligned equivalents.

Refs PY-2307