### PR TITLE
fix(attributes): Set `pii: 'maybe'` on `faas` string attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4712,7 +4712,7 @@ export type FAAS_DURATION_IN_MS_TYPE = number;
  *
  * Attribute Value Type: `string` {@link FAAS_ENTRY_POINT_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: No
  * Visibility: public
@@ -18227,7 +18227,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: "The code that's run when the cloud provider invokes your function.",
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: false,
     visibility: 'public',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4754,7 +4754,7 @@ export type FAAS_IDENTITY_TYPE = string;
  *
  * Attribute Value Type: `string` {@link FAAS_NAME_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: Yes
  * Visibility: public
@@ -18251,12 +18251,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The name of the serverless function',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: true,
     visibility: 'public',
     example: 'my_function',
-    changelog: [{ version: 'next' }],
+    changelog: [{ version: 'next', prs: [403, 415] }],
   },
   [FAAS_TIME]: {
     brief: 'A string containing the function invocation time in the ISO 8601 format expressed in UTC.',

--- a/model/attributes/faas/faas__entry_point.json
+++ b/model/attributes/faas/faas__entry_point.json
@@ -3,7 +3,7 @@
   "brief": "The code that's run when the cloud provider invokes your function.",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": false,
   "example": "my_main_function",

--- a/model/attributes/faas/faas__name.json
+++ b/model/attributes/faas/faas__name.json
@@ -3,7 +3,7 @@
   "brief": "The name of the serverless function",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": true,
   "example": "my_function",

--- a/model/attributes/faas/faas__name.json
+++ b/model/attributes/faas/faas__name.json
@@ -10,7 +10,8 @@
   "visibility": "public",
   "changelog": [
     {
-      "version": "next"
+      "version": "next",
+      "prs": [403, 415]
     }
   ]
 }

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2893,7 +2893,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The code that's run when the cloud provider invokes your function.
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
     Example: "my_main_function"
@@ -11333,7 +11333,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "faas.entry_point": AttributeMetadata(
         brief="The code that's run when the cloud provider invokes your function.",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="my_main_function",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2915,7 +2915,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The name of the serverless function
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: Yes
     Visibility: public
     Example: "my_function"
@@ -11355,12 +11355,12 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "faas.name": AttributeMetadata(
         brief="The name of the serverless function",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="my_function",
         changelog=[
-            ChangelogEntry(version="next"),
+            ChangelogEntry(version="next", prs=[403, 415]),
         ],
     ),
     "faas.time": AttributeMetadata(

--- a/scripts/create_attribute.ts
+++ b/scripts/create_attribute.ts
@@ -273,10 +273,11 @@ async function askForAttributePii() {
     select({
       message: 'Does the attribute contain PII?',
       options: [
+        { value: 'maybe', label: 'Maybe' },
         { value: 'true', label: 'Yes' },
         { value: 'false', label: 'No' },
-        { value: 'maybe', label: 'Maybe' },
       ],
+      initialValue: 'maybe',
     }),
   );
 }


### PR DESCRIPTION
Just noticed that the `faas.name` and `faas.entry_point` string attributes was set to `pii: false` which IMHO should be changed to `'maybe'` (I missed this while reviewing the PR adding this attributes). Since it's a string attribute we usually set `'maybe'` so that users can optionally configure scrubbing on this field. 

This PR also adjusts our attribute creation CLI script to default to `maybe` since that's what we set on most attributes. 