### PR TITLE
feat(attributes): Add `host.id` attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -6540,7 +6540,7 @@ export type HARDWARECONCURRENCY_TYPE = string;
 // Path: model/attributes/host/host__id.json
 
 /**
- * Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. `host.id`
+ * Unique host ID. In cloud environments, this must be the instance ID assigned by the cloud provider. `host.id`
  *
  * Attribute Value Type: `string` {@link HOST_ID_TYPE}
  *
@@ -19486,8 +19486,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     ],
   },
   [HOST_ID]: {
-    brief:
-      'Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`.',
+    brief: 'Unique host ID. In cloud environments, this must be the instance ID assigned by the cloud provider.',
     type: 'string',
     pii: {
       isPii: 'maybe',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -6540,7 +6540,7 @@ export type HARDWARECONCURRENCY_TYPE = string;
 // Path: model/attributes/host/host__id.json
 
 /**
- * Unique host ID. In cloud environments, this must be the instance ID assigned by the cloud provider. `host.id`
+ * Unique host ID. In cloud environments, this must be the ID of the compute instance assigned by the provider. `host.id`
  *
  * Attribute Value Type: `string` {@link HOST_ID_TYPE}
  *
@@ -19486,7 +19486,8 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     ],
   },
   [HOST_ID]: {
-    brief: 'Unique host ID. In cloud environments, this must be the instance ID assigned by the cloud provider.',
+    brief:
+      'Unique host ID. In cloud environments, this must be the ID of the compute instance assigned by the provider.',
     type: 'string',
     pii: {
       isPii: 'maybe',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -6537,6 +6537,27 @@ export const HARDWARECONCURRENCY = 'hardwareConcurrency';
  */
 export type HARDWARECONCURRENCY_TYPE = string;
 
+// Path: model/attributes/host/host__id.json
+
+/**
+ * Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. `host.id`
+ *
+ * Attribute Value Type: `string` {@link HOST_ID_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "fdbf79e8af94cb7f9e8df36789187052"
+ */
+export const HOST_ID = 'host.id';
+
+/**
+ * Type for {@link HOST_ID} host.id
+ */
+export type HOST_ID_TYPE = string;
+
 // Path: model/attributes/http/http__client_ip.json
 
 /**
@@ -14356,6 +14377,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [GRAPHQL_OPERATION_NAME]: 'string',
   [GRAPHQL_OPERATION_TYPE]: 'string',
   [HARDWARECONCURRENCY]: 'string',
+  [HOST_ID]: 'string',
   [HTTP_CLIENT_IP]: 'string',
   [HTTP_DECODED_RESPONSE_CONTENT_LENGTH]: 'integer',
   [HTTP_FLAVOR]: 'string',
@@ -14997,6 +15019,7 @@ export type AttributeName =
   | typeof GRAPHQL_OPERATION_NAME
   | typeof GRAPHQL_OPERATION_TYPE
   | typeof HARDWARECONCURRENCY
+  | typeof HOST_ID
   | typeof HTTP_CLIENT_IP
   | typeof HTTP_DECODED_RESPONSE_CONTENT_LENGTH
   | typeof HTTP_FLAVOR
@@ -19461,6 +19484,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
         description: "Added and deprecated attribute to document JS SDK's current behaviour",
       },
     ],
+  },
+  [HOST_ID]: {
+    brief:
+      'Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'fdbf79e8af94cb7f9e8df36789187052',
+    changelog: [{ version: 'next', prs: [416], description: 'Added host.id attribute' }],
   },
   [HTTP_CLIENT_IP]: {
     brief:
@@ -24131,6 +24166,7 @@ export type Attributes = {
   [GRAPHQL_OPERATION_NAME]?: GRAPHQL_OPERATION_NAME_TYPE;
   [GRAPHQL_OPERATION_TYPE]?: GRAPHQL_OPERATION_TYPE_TYPE;
   [HARDWARECONCURRENCY]?: HARDWARECONCURRENCY_TYPE;
+  [HOST_ID]?: HOST_ID_TYPE;
   [HTTP_CLIENT_IP]?: HTTP_CLIENT_IP_TYPE;
   [HTTP_DECODED_RESPONSE_CONTENT_LENGTH]?: HTTP_DECODED_RESPONSE_CONTENT_LENGTH_TYPE;
   [HTTP_FLAVOR]?: HTTP_FLAVOR_TYPE;

--- a/model/attributes/host/host__id.json
+++ b/model/attributes/host/host__id.json
@@ -1,0 +1,18 @@
+{
+  "key": "host.id",
+  "brief": "Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`.",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": true,
+  "visibility": "public",
+  "example": "fdbf79e8af94cb7f9e8df36789187052",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [416],
+      "description": "Added host.id attribute"
+    }
+  ]
+}

--- a/model/attributes/host/host__id.json
+++ b/model/attributes/host/host__id.json
@@ -1,6 +1,6 @@
 {
   "key": "host.id",
-  "brief": "Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`.",
+  "brief": "Unique host ID. In cloud environments, this must be the instance ID assigned by the cloud provider.",
   "type": "string",
   "pii": {
     "key": "maybe"

--- a/model/attributes/host/host__id.json
+++ b/model/attributes/host/host__id.json
@@ -1,6 +1,6 @@
 {
   "key": "host.id",
-  "brief": "Unique host ID. In cloud environments, this must be the instance ID assigned by the cloud provider.",
+  "brief": "Unique host ID. In cloud environments, this must be the ID of the compute instance assigned by the provider.",
   "type": "string",
   "pii": {
     "key": "maybe"

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3936,7 +3936,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/host/host__id.json
     HOST_ID: Literal["host.id"] = "host.id"
-    """Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`.
+    """Unique host ID. In cloud environments, this must be the instance ID assigned by the cloud provider.
 
     Type: str
     Contains PII: maybe
@@ -12583,7 +12583,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "host.id": AttributeMetadata(
-        brief="Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`.",
+        brief="Unique host ID. In cloud environments, this must be the instance ID assigned by the cloud provider.",
         type=AttributeType.STRING,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3936,7 +3936,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/host/host__id.json
     HOST_ID: Literal["host.id"] = "host.id"
-    """Unique host ID. In cloud environments, this must be the instance ID assigned by the cloud provider.
+    """Unique host ID. In cloud environments, this must be the ID of the compute instance assigned by the provider.
 
     Type: str
     Contains PII: maybe
@@ -12583,7 +12583,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "host.id": AttributeMetadata(
-        brief="Unique host ID. In cloud environments, this must be the instance ID assigned by the cloud provider.",
+        brief="Unique host ID. In cloud environments, this must be the ID of the compute instance assigned by the provider.",
         type=AttributeType.STRING,
         pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3934,6 +3934,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "14"
     """
 
+    # Path: model/attributes/host/host__id.json
+    HOST_ID: Literal["host.id"] = "host.id"
+    """Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`.
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "fdbf79e8af94cb7f9e8df36789187052"
+    """
+
     # Path: model/attributes/http/http__client_ip.json
     HTTP_CLIENT_IP: Literal["http.client_ip"] = "http.client_ip"
     """Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
@@ -12571,6 +12582,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "host.id": AttributeMetadata(
+        brief="Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="fdbf79e8af94cb7f9e8df36789187052",
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[416], description="Added host.id attribute"
+            ),
+        ],
+    ),
     "http.client_ip": AttributeMetadata(
         brief="Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
         type=AttributeType.STRING,
@@ -17381,6 +17405,7 @@ Attributes = TypedDict(
         "graphql.operation.name": str,
         "graphql.operation.type": str,
         "hardwareConcurrency": str,
+        "host.id": str,
         "http.client_ip": str,
         "http.decoded_response_content_length": int,
         "http.flavor": str,


### PR DESCRIPTION
## Description
<!-- Describe your changes -->

Document the field currently set as context by `sentry-python`:

https://github.com/getsentry/sentry-python/blob/7d38a49af058d46299e1e01ec0086ff05f585866/sentry_sdk/integrations/cloud_resource_context.py#L130

The host ID would be set as an attribute with the streaming trace lifecycle.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [ ] I have run `yarn test` and verified that the tests pass.
- [ ] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
