### PR TITLE
feat(mcp): align MCP attributes with OTel semantic conventions

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -7905,7 +7905,7 @@ export type INP_TYPE = number;
  *
  * Attribute Value Type: `string` {@link JSONRPC_PROTOCOL_VERSION_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: Yes
  * Visibility: public
@@ -7926,7 +7926,7 @@ export type JSONRPC_PROTOCOL_VERSION_TYPE = string;
  *
  * Attribute Value Type: `string` {@link JSONRPC_REQUEST_ID_TYPE}
  *
- * Contains PII: false
+ * Contains PII: maybe
  *
  * Attribute defined in OTEL: Yes
  * Visibility: public
@@ -20768,7 +20768,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The version of the JSON-RPC protocol used.',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: true,
     visibility: 'public',
@@ -20779,7 +20779,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The JSON-RPC request identifier. Unique within the session.',
     type: 'string',
     pii: {
-      isPii: 'false',
+      isPii: 'maybe',
     },
     isInOtel: true,
     visibility: 'public',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -128,7 +128,7 @@ export type AI_FREQUENCY_PENALTY_TYPE = number;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link GEN_AI_TOOL_NAME} `gen_ai.tool.name`
+ * Aliases: {@link GEN_AI_TOOL_NAME} `gen_ai.tool.name`, {@link MCP_TOOL_NAME} `mcp.tool.name`
  *
  * @deprecated Use {@link GEN_AI_TOOL_NAME} (gen_ai.tool.name) instead
  * @example "function_name"
@@ -6534,7 +6534,7 @@ export type GEN_AI_TOOL_INPUT_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link GEN_AI_TOOL_CALL_RESULT} `gen_ai.tool.call.result`, {@link GEN_AI_TOOL_OUTPUT} `gen_ai.tool.output`
+ * Aliases: {@link GEN_AI_TOOL_CALL_RESULT} `gen_ai.tool.call.result`, {@link GEN_AI_TOOL_OUTPUT} `gen_ai.tool.output`, {@link MCP_TOOL_RESULT_CONTENT} `mcp.tool.result.content`
  *
  * @deprecated Use {@link GEN_AI_TOOL_CALL_RESULT} (gen_ai.tool.call.result) instead
  * @example "rainy, 57°F"
@@ -6581,7 +6581,7 @@ export type GEN_AI_TOOL_NAME_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link GEN_AI_TOOL_CALL_RESULT} `gen_ai.tool.call.result`, {@link GEN_AI_TOOL_MESSAGE} `gen_ai.tool.message`
+ * Aliases: {@link GEN_AI_TOOL_CALL_RESULT} `gen_ai.tool.call.result`, {@link GEN_AI_TOOL_MESSAGE} `gen_ai.tool.message`, {@link MCP_TOOL_RESULT_CONTENT} `mcp.tool.result.content`
  *
  * @deprecated Use {@link GEN_AI_TOOL_CALL_RESULT} (gen_ai.tool.call.result) instead
  * @example "rainy, 57°F"
@@ -8973,6 +8973,8 @@ export type MCP_SESSION_ID_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link GEN_AI_TOOL_NAME} `gen_ai.tool.name`, {@link AI_FUNCTION_CALL} `ai.function_call`
+ *
  * @deprecated Use {@link GEN_AI_TOOL_NAME} (gen_ai.tool.name) instead - OTel uses gen_ai.tool.name for MCP tool names
  * @example "calculator"
  */
@@ -8994,6 +8996,8 @@ export type MCP_TOOL_NAME_TYPE = string;
  *
  * Attribute defined in OTEL: No
  * Visibility: public
+ *
+ * Aliases: {@link GEN_AI_TOOL_CALL_RESULT} `gen_ai.tool.call.result`, {@link GEN_AI_TOOL_MESSAGE} `gen_ai.tool.message`, {@link GEN_AI_TOOL_OUTPUT} `gen_ai.tool.output`
  *
  * @deprecated Use {@link GEN_AI_TOOL_CALL_RESULT} (gen_ai.tool.call.result) instead - OTel uses gen_ai.tool.call.result for MCP tool results
  * @example "{\"output\": \"rainy\", \"toolCallId\": \"1\"}"
@@ -15976,7 +15980,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'gen_ai.tool.name',
     },
-    aliases: [GEN_AI_TOOL_NAME],
+    aliases: [GEN_AI_TOOL_NAME, MCP_TOOL_NAME],
     changelog: [{ version: '0.1.0', prs: [55, 57, 61, 108] }],
   },
   [AI_GENERATION_ID]: {
@@ -19840,7 +19844,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'gen_ai.tool.call.result',
     },
-    aliases: [GEN_AI_TOOL_CALL_RESULT, GEN_AI_TOOL_OUTPUT],
+    aliases: [GEN_AI_TOOL_CALL_RESULT, GEN_AI_TOOL_OUTPUT, MCP_TOOL_RESULT_CONTENT],
     changelog: [
       { version: '0.5.0', prs: [265] },
       { version: '0.1.0', prs: [62] },
@@ -19870,7 +19874,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'gen_ai.tool.call.result',
     },
-    aliases: [GEN_AI_TOOL_CALL_RESULT, GEN_AI_TOOL_MESSAGE],
+    aliases: [GEN_AI_TOOL_CALL_RESULT, GEN_AI_TOOL_MESSAGE, MCP_TOOL_RESULT_CONTENT],
     changelog: [
       { version: '0.5.0', prs: [265] },
       { version: '0.1.0', prs: [63, 74] },
@@ -21418,6 +21422,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.tool.name',
       reason: 'OTel uses gen_ai.tool.name for MCP tool names',
     },
+    aliases: [GEN_AI_TOOL_NAME, AI_FUNCTION_CALL],
     changelog: [
       { version: 'next', description: 'Deprecated in favor of gen_ai.tool.name' },
       { version: '0.3.0', prs: [171] },
@@ -21437,6 +21442,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.tool.call.result',
       reason: 'OTel uses gen_ai.tool.call.result for MCP tool results',
     },
+    aliases: [GEN_AI_TOOL_CALL_RESULT, GEN_AI_TOOL_MESSAGE, GEN_AI_TOOL_OUTPUT],
     changelog: [
       { version: 'next', description: 'Deprecated in favor of gen_ai.tool.call.result' },
       { version: '0.3.0', prs: [171] },

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -5590,6 +5590,29 @@ export const GEN_AI_PROMPT = 'gen_ai.prompt';
  */
 export type GEN_AI_PROMPT_TYPE = string;
 
+// Path: model/attributes/gen_ai/gen_ai__prompt__name.json
+
+/**
+ * The name of the prompt that uniquely identifies it. `gen_ai.prompt.name`
+ *
+ * Attribute Value Type: `string` {@link GEN_AI_PROMPT_NAME_TYPE}
+ *
+ * Contains PII: maybe - Prompt names may reveal user behavior patterns or sensitive operations
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * Aliases: {@link MCP_PROMPT_NAME} `mcp.prompt.name`
+ *
+ * @example "summarize_text"
+ */
+export const GEN_AI_PROMPT_NAME = 'gen_ai.prompt.name';
+
+/**
+ * Type for {@link GEN_AI_PROMPT_NAME} gen_ai.prompt.name
+ */
+export type GEN_AI_PROMPT_NAME_TYPE = string;
+
 // Path: model/attributes/gen_ai/gen_ai__provider__name.json
 
 /**
@@ -7496,6 +7519,50 @@ export const INP = 'inp';
  */
 export type INP_TYPE = number;
 
+// Path: model/attributes/jsonrpc/jsonrpc__protocol__version.json
+
+/**
+ * The version of the JSON-RPC protocol used. `jsonrpc.protocol.version`
+ *
+ * Attribute Value Type: `string` {@link JSONRPC_PROTOCOL_VERSION_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "2.0"
+ */
+export const JSONRPC_PROTOCOL_VERSION = 'jsonrpc.protocol.version';
+
+/**
+ * Type for {@link JSONRPC_PROTOCOL_VERSION} jsonrpc.protocol.version
+ */
+export type JSONRPC_PROTOCOL_VERSION_TYPE = string;
+
+// Path: model/attributes/jsonrpc/jsonrpc__request__id.json
+
+/**
+ * The JSON-RPC request identifier. Unique within the session. `jsonrpc.request.id`
+ *
+ * Attribute Value Type: `string` {@link JSONRPC_REQUEST_ID_TYPE}
+ *
+ * Contains PII: false
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * Aliases: {@link MCP_REQUEST_ID} `mcp.request.id`
+ *
+ * @example "1"
+ */
+export const JSONRPC_REQUEST_ID = 'jsonrpc.request.id';
+
+/**
+ * Type for {@link JSONRPC_REQUEST_ID} jsonrpc.request.id
+ */
+export type JSONRPC_REQUEST_ID_TYPE = string;
+
 // Path: model/attributes/jvm/jvm__gc__action.json
 
 /**
@@ -8030,7 +8097,7 @@ export type MCP_LOGGING_MESSAGE_TYPE = string;
  *
  * Contains PII: false
  *
- * Attribute defined in OTEL: No
+ * Attribute defined in OTEL: Yes
  * Visibility: public
  *
  * @example "tools/call"
@@ -8159,6 +8226,9 @@ export type MCP_PROGRESS_TOTAL_TYPE = number;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link GEN_AI_PROMPT_NAME} `gen_ai.prompt.name`
+ *
+ * @deprecated Use {@link GEN_AI_PROMPT_NAME} (gen_ai.prompt.name) instead - OTel uses gen_ai.prompt.name for MCP prompt names
  * @example "summarize"
  */
 export const MCP_PROMPT_NAME = 'mcp.prompt.name';
@@ -8282,7 +8352,7 @@ export type MCP_PROTOCOL_READY_TYPE = number;
  *
  * Contains PII: false
  *
- * Attribute defined in OTEL: No
+ * Attribute defined in OTEL: Yes
  * Visibility: public
  *
  * @example "2024-11-05"
@@ -8371,6 +8441,9 @@ export type MCP_REQUEST_ARGUMENT_URI_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link JSONRPC_REQUEST_ID} `jsonrpc.request.id`
+ *
+ * @deprecated Use {@link JSONRPC_REQUEST_ID} (jsonrpc.request.id) instead - OTel models MCP as JSON-RPC, uses jsonrpc.request.id
  * @example "1"
  */
 export const MCP_REQUEST_ID = 'mcp.request.id';
@@ -8392,6 +8465,9 @@ export type MCP_REQUEST_ID_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link NETWORK_PROTOCOL_NAME} `network.protocol.name`, {@link NET_PROTOCOL_NAME} `net.protocol.name`
+ *
+ * @deprecated Use {@link NETWORK_PROTOCOL_NAME} (network.protocol.name) instead - OTel uses the generic network.protocol.name attribute
  * @example "file"
  */
 export const MCP_RESOURCE_PROTOCOL = 'mcp.resource.protocol';
@@ -8410,7 +8486,7 @@ export type MCP_RESOURCE_PROTOCOL_TYPE = string;
  *
  * Contains PII: true - URIs can contain sensitive file paths
  *
- * Attribute defined in OTEL: No
+ * Attribute defined in OTEL: Yes
  * Visibility: public
  *
  * @example "file:///path/to/file.txt"
@@ -8494,7 +8570,7 @@ export type MCP_SERVER_VERSION_TYPE = string;
  *
  * Contains PII: false
  *
- * Attribute defined in OTEL: No
+ * Attribute defined in OTEL: Yes
  * Visibility: public
  *
  * @example "550e8400-e29b-41d4-a716-446655440000"
@@ -8518,6 +8594,7 @@ export type MCP_SESSION_ID_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * @deprecated Use {@link GEN_AI_TOOL_NAME} (gen_ai.tool.name) instead - OTel uses gen_ai.tool.name for MCP tool names
  * @example "calculator"
  */
 export const MCP_TOOL_NAME = 'mcp.tool.name';
@@ -8539,6 +8616,7 @@ export type MCP_TOOL_NAME_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * @deprecated Use {@link GEN_AI_TOOL_CALL_RESULT} (gen_ai.tool.call.result) instead - OTel uses gen_ai.tool.call.result for MCP tool results
  * @example "{\"output\": \"rainy\", \"toolCallId\": \"1\"}"
  */
 export const MCP_TOOL_RESULT_CONTENT = 'mcp.tool.result.content';
@@ -8581,6 +8659,7 @@ export type MCP_TOOL_RESULT_CONTENT_COUNT_TYPE = number;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * @deprecated Use {@link ERROR_TYPE} (error.type) instead - OTel uses error.type set to 'tool_error' when isError is true. Cannot be automatically backfilled due to type mismatch (boolean vs string).
  * @example false
  */
 export const MCP_TOOL_RESULT_IS_ERROR = 'mcp.tool.result.is_error';
@@ -8602,6 +8681,9 @@ export type MCP_TOOL_RESULT_IS_ERROR_TYPE = boolean;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link NETWORK_TRANSPORT} `network.transport`, {@link NET_TRANSPORT} `net.transport`
+ *
+ * @deprecated Use {@link NETWORK_TRANSPORT} (network.transport) instead - OTel uses the generic network.transport attribute
  * @example "stdio"
  */
 export const MCP_TRANSPORT = 'mcp.transport';
@@ -9207,7 +9289,7 @@ export type NETWORK_PEER_PORT_TYPE = number;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link NET_PROTOCOL_NAME} `net.protocol.name`
+ * Aliases: {@link NET_PROTOCOL_NAME} `net.protocol.name`, {@link MCP_RESOURCE_PROTOCOL} `mcp.resource.protocol`
  *
  * @example "http"
  */
@@ -9253,7 +9335,7 @@ export type NETWORK_PROTOCOL_VERSION_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link NET_TRANSPORT} `net.transport`
+ * Aliases: {@link NET_TRANSPORT} `net.transport`, {@link MCP_TRANSPORT} `mcp.transport`
  *
  * @example "tcp"
  */
@@ -9437,7 +9519,7 @@ export type NET_PEER_PORT_TYPE = number;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link NETWORK_PROTOCOL_NAME} `network.protocol.name`
+ * Aliases: {@link NETWORK_PROTOCOL_NAME} `network.protocol.name`, {@link MCP_RESOURCE_PROTOCOL} `mcp.resource.protocol`
  *
  * @deprecated Use {@link NETWORK_PROTOCOL_NAME} (network.protocol.name) instead
  * @example "http"
@@ -9623,7 +9705,7 @@ export type NET_SOCK_PEER_PORT_TYPE = number;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link NETWORK_TRANSPORT} `network.transport`
+ * Aliases: {@link NETWORK_TRANSPORT} `network.transport`, {@link MCP_TRANSPORT} `mcp.transport`
  *
  * @deprecated Use {@link NETWORK_TRANSPORT} (network.transport) instead
  * @example "tcp"
@@ -14335,6 +14417,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [GEN_AI_OUTPUT_MESSAGES]: 'string',
   [GEN_AI_PIPELINE_NAME]: 'string',
   [GEN_AI_PROMPT]: 'string',
+  [GEN_AI_PROMPT_NAME]: 'string',
   [GEN_AI_PROVIDER_NAME]: 'string',
   [GEN_AI_REQUEST_AVAILABLE_TOOLS]: 'string',
   [GEN_AI_REQUEST_FREQUENCY_PENALTY]: 'double',
@@ -14420,6 +14503,8 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [HTTP_USER_AGENT]: 'string',
   [ID]: 'string',
   [INP]: 'double',
+  [JSONRPC_PROTOCOL_VERSION]: 'string',
+  [JSONRPC_REQUEST_ID]: 'string',
   [JVM_GC_ACTION]: 'string',
   [JVM_GC_NAME]: 'string',
   [JVM_MEMORY_POOL_NAME]: 'string',
@@ -14977,6 +15062,7 @@ export type AttributeName =
   | typeof GEN_AI_OUTPUT_MESSAGES
   | typeof GEN_AI_PIPELINE_NAME
   | typeof GEN_AI_PROMPT
+  | typeof GEN_AI_PROMPT_NAME
   | typeof GEN_AI_PROVIDER_NAME
   | typeof GEN_AI_REQUEST_AVAILABLE_TOOLS
   | typeof GEN_AI_REQUEST_FREQUENCY_PENALTY
@@ -15062,6 +15148,8 @@ export type AttributeName =
   | typeof HTTP_USER_AGENT
   | typeof ID
   | typeof INP
+  | typeof JSONRPC_PROTOCOL_VERSION
+  | typeof JSONRPC_REQUEST_ID
   | typeof JVM_GC_ACTION
   | typeof JVM_GC_NAME
   | typeof JVM_MEMORY_POOL_NAME
@@ -18811,6 +18899,19 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     changelog: [{ version: '0.1.0', prs: [74, 108, 119] }, { version: '0.0.0' }],
   },
+  [GEN_AI_PROMPT_NAME]: {
+    brief: 'The name of the prompt that uniquely identifies it.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+      reason: 'Prompt names may reveal user behavior patterns or sensitive operations',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'summarize_text',
+    aliases: [MCP_PROMPT_NAME],
+    changelog: [{ version: 'next', description: 'Added gen_ai.prompt.name attribute' }],
+  },
   [GEN_AI_PROVIDER_NAME]: {
     brief: 'The Generative AI provider as identified by the client or server instrumentation.',
     type: 'string',
@@ -20084,6 +20185,29 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       },
     ],
   },
+  [JSONRPC_PROTOCOL_VERSION]: {
+    brief: 'The version of the JSON-RPC protocol used.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: '2.0',
+    changelog: [{ version: 'next', description: 'Added jsonrpc.protocol.version attribute' }],
+  },
+  [JSONRPC_REQUEST_ID]: {
+    brief: 'The JSON-RPC request identifier. Unique within the session.',
+    type: 'string',
+    pii: {
+      isPii: 'false',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: '1',
+    aliases: [MCP_REQUEST_ID],
+    changelog: [{ version: 'next', description: 'Added jsonrpc.request.id attribute' }],
+  },
   [JVM_GC_ACTION]: {
     brief: 'Name of the garbage collector action.',
     type: 'string',
@@ -20402,10 +20526,13 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     pii: {
       isPii: 'false',
     },
-    isInOtel: false,
+    isInOtel: true,
     visibility: 'public',
     example: 'tools/call',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    changelog: [
+      { version: 'next', description: 'Set is_in_otel=true, attribute exists in OTel MCP registry' },
+      { version: '0.3.0', prs: [171] },
+    ],
   },
   [MCP_PROGRESS_CURRENT]: {
     brief: 'Current progress value of an MCP operation.',
@@ -20482,7 +20609,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'summarize',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    deprecation: {
+      replacement: 'gen_ai.prompt.name',
+      reason: 'OTel uses gen_ai.prompt.name for MCP prompt names',
+    },
+    aliases: [GEN_AI_PROMPT_NAME],
+    changelog: [
+      { version: 'next', description: 'Deprecated in favor of gen_ai.prompt.name' },
+      { version: '0.3.0', prs: [171] },
+    ],
   },
   [MCP_PROMPT_RESULT_DESCRIPTION]: {
     brief: 'Description of the prompt result.',
@@ -20551,10 +20686,13 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     pii: {
       isPii: 'false',
     },
-    isInOtel: false,
+    isInOtel: true,
     visibility: 'public',
     example: '2024-11-05',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    changelog: [
+      { version: 'next', description: 'Set is_in_otel=true, attribute exists in OTel MCP registry' },
+      { version: '0.3.0', prs: [171] },
+    ],
   },
   [MCP_REQUEST_ARGUMENT_KEY]: {
     brief:
@@ -20603,7 +20741,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: '1',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    deprecation: {
+      replacement: 'jsonrpc.request.id',
+      reason: 'OTel models MCP as JSON-RPC, uses jsonrpc.request.id',
+    },
+    aliases: [JSONRPC_REQUEST_ID],
+    changelog: [
+      { version: 'next', description: 'Deprecated in favor of jsonrpc.request.id' },
+      { version: '0.3.0', prs: [171] },
+    ],
   },
   [MCP_RESOURCE_PROTOCOL]: {
     brief: 'Protocol of the resource URI being accessed, extracted from the URI.',
@@ -20614,7 +20760,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'file',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    deprecation: {
+      replacement: 'network.protocol.name',
+      reason: 'OTel uses the generic network.protocol.name attribute',
+    },
+    aliases: [NETWORK_PROTOCOL_NAME, NET_PROTOCOL_NAME],
+    changelog: [
+      { version: 'next', description: 'Deprecated in favor of network.protocol.name' },
+      { version: '0.3.0', prs: [171] },
+    ],
   },
   [MCP_RESOURCE_URI]: {
     brief: 'The resource URI being accessed in an MCP operation.',
@@ -20623,10 +20777,13 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       isPii: 'true',
       reason: 'URIs can contain sensitive file paths',
     },
-    isInOtel: false,
+    isInOtel: true,
     visibility: 'public',
     example: 'file:///path/to/file.txt',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    changelog: [
+      { version: 'next', description: 'Set is_in_otel=true, attribute exists in OTel MCP registry' },
+      { version: '0.3.0', prs: [171] },
+    ],
   },
   [MCP_SERVER_NAME]: {
     brief: 'Name of the MCP server application.',
@@ -20668,10 +20825,13 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     pii: {
       isPii: 'false',
     },
-    isInOtel: false,
+    isInOtel: true,
     visibility: 'public',
     example: '550e8400-e29b-41d4-a716-446655440000',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    changelog: [
+      { version: 'next', description: 'Set is_in_otel=true, attribute exists in OTel MCP registry' },
+      { version: '0.3.0', prs: [171] },
+    ],
   },
   [MCP_TOOL_NAME]: {
     brief: 'Name of the MCP tool being called.',
@@ -20682,7 +20842,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'calculator',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    deprecation: {
+      replacement: 'gen_ai.tool.name',
+      reason: 'OTel uses gen_ai.tool.name for MCP tool names',
+    },
+    changelog: [
+      { version: 'next', description: 'Deprecated in favor of gen_ai.tool.name' },
+      { version: '0.3.0', prs: [171] },
+    ],
   },
   [MCP_TOOL_RESULT_CONTENT]: {
     brief: 'The content of the tool result.',
@@ -20694,7 +20861,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: '{"output": "rainy", "toolCallId": "1"}',
+    deprecation: {
+      replacement: 'gen_ai.tool.call.result',
+      reason: 'OTel uses gen_ai.tool.call.result for MCP tool results',
+    },
     changelog: [
+      { version: 'next', description: 'Deprecated in favor of gen_ai.tool.call.result' },
       { version: '0.3.0', prs: [171] },
       { version: '0.2.0', prs: [164] },
     ],
@@ -20722,7 +20894,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: false,
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    deprecation: {
+      replacement: 'error.type',
+      reason:
+        "OTel uses error.type set to 'tool_error' when isError is true. Cannot be automatically backfilled due to type mismatch (boolean vs string).",
+    },
+    changelog: [
+      { version: 'next', description: 'Deprecated in favor of error.type' },
+      { version: '0.3.0', prs: [171] },
+    ],
   },
   [MCP_TRANSPORT]: {
     brief: 'Transport method used for MCP communication.',
@@ -20733,7 +20913,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'stdio',
-    changelog: [{ version: '0.3.0', prs: [171] }],
+    deprecation: {
+      replacement: 'network.transport',
+      reason: 'OTel uses the generic network.transport attribute',
+    },
+    aliases: [NETWORK_TRANSPORT, NET_TRANSPORT],
+    changelog: [
+      { version: 'next', description: 'Deprecated in favor of network.transport' },
+      { version: '0.3.0', prs: [171] },
+    ],
   },
   [MDC_KEY]: {
     brief:
@@ -21094,7 +21282,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'http',
-    aliases: [NET_PROTOCOL_NAME],
+    aliases: [NET_PROTOCOL_NAME, MCP_RESOURCE_PROTOCOL],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [NETWORK_PROTOCOL_VERSION]: {
@@ -21118,7 +21306,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'tcp',
-    aliases: [NET_TRANSPORT],
+    aliases: [NET_TRANSPORT, MCP_TRANSPORT],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [NETWORK_TYPE]: {
@@ -21236,7 +21424,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'network.protocol.name',
     },
-    aliases: [NETWORK_PROTOCOL_NAME],
+    aliases: [NETWORK_PROTOCOL_NAME, MCP_RESOURCE_PROTOCOL],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [NET_PROTOCOL_VERSION]: {
@@ -21354,7 +21542,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'network.transport',
     },
-    aliases: [NETWORK_TRANSPORT],
+    aliases: [NETWORK_TRANSPORT, MCP_TRANSPORT],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   [OS_BUILD]: {
@@ -24125,6 +24313,7 @@ export type Attributes = {
   [GEN_AI_OUTPUT_MESSAGES]?: GEN_AI_OUTPUT_MESSAGES_TYPE;
   [GEN_AI_PIPELINE_NAME]?: GEN_AI_PIPELINE_NAME_TYPE;
   [GEN_AI_PROMPT]?: GEN_AI_PROMPT_TYPE;
+  [GEN_AI_PROMPT_NAME]?: GEN_AI_PROMPT_NAME_TYPE;
   [GEN_AI_PROVIDER_NAME]?: GEN_AI_PROVIDER_NAME_TYPE;
   [GEN_AI_REQUEST_AVAILABLE_TOOLS]?: GEN_AI_REQUEST_AVAILABLE_TOOLS_TYPE;
   [GEN_AI_REQUEST_FREQUENCY_PENALTY]?: GEN_AI_REQUEST_FREQUENCY_PENALTY_TYPE;
@@ -24210,6 +24399,8 @@ export type Attributes = {
   [HTTP_USER_AGENT]?: HTTP_USER_AGENT_TYPE;
   [ID]?: ID_TYPE;
   [INP]?: INP_TYPE;
+  [JSONRPC_PROTOCOL_VERSION]?: JSONRPC_PROTOCOL_VERSION_TYPE;
+  [JSONRPC_REQUEST_ID]?: JSONRPC_REQUEST_ID_TYPE;
   [JVM_GC_ACTION]?: JVM_GC_ACTION_TYPE;
   [JVM_GC_NAME]?: JVM_GC_NAME_TYPE;
   [JVM_MEMORY_POOL_NAME]?: JVM_MEMORY_POOL_NAME_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -6144,7 +6144,7 @@ export type GEN_AI_TOOL_CALL_ARGUMENTS_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link GEN_AI_TOOL_OUTPUT} `gen_ai.tool.output`, {@link GEN_AI_TOOL_MESSAGE} `gen_ai.tool.message`
+ * Aliases: {@link GEN_AI_TOOL_OUTPUT} `gen_ai.tool.output`, {@link GEN_AI_TOOL_MESSAGE} `gen_ai.tool.message`, {@link MCP_TOOL_RESULT_CONTENT} `mcp.tool.result.content`
  *
  * @example "rainy, 57°F"
  */
@@ -6257,7 +6257,7 @@ export type GEN_AI_TOOL_MESSAGE_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link AI_FUNCTION_CALL} `ai.function_call`
+ * Aliases: {@link AI_FUNCTION_CALL} `ai.function_call`, {@link MCP_TOOL_NAME} `mcp.tool.name`
  *
  * @example "Flights"
  */
@@ -19262,7 +19262,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'rainy, 57°F',
-    aliases: [GEN_AI_TOOL_OUTPUT, GEN_AI_TOOL_MESSAGE],
+    aliases: [GEN_AI_TOOL_OUTPUT, GEN_AI_TOOL_MESSAGE, MCP_TOOL_RESULT_CONTENT],
     changelog: [
       { version: '0.5.0', prs: [265] },
       { version: '0.4.0', prs: [221] },
@@ -19336,7 +19336,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'Flights',
-    aliases: [AI_FUNCTION_CALL],
+    aliases: [AI_FUNCTION_CALL, MCP_TOOL_NAME],
     changelog: [{ version: '0.1.0', prs: [57, 127] }],
   },
   [GEN_AI_TOOL_OUTPUT]: {

--- a/model/attributes/ai/ai__function_call.json
+++ b/model/attributes/ai/ai__function_call.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": false,
   "example": "function_name",
-  "alias": ["gen_ai.tool.name"],
+  "alias": ["gen_ai.tool.name", "mcp.tool.name"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.tool.name"

--- a/model/attributes/gen_ai/gen_ai__prompt__name.json
+++ b/model/attributes/gen_ai/gen_ai__prompt__name.json
@@ -1,0 +1,19 @@
+{
+  "key": "gen_ai.prompt.name",
+  "brief": "The name of the prompt that uniquely identifies it.",
+  "type": "string",
+  "pii": {
+    "key": "maybe",
+    "reason": "Prompt names may reveal user behavior patterns or sensitive operations"
+  },
+  "is_in_otel": true,
+  "visibility": "public",
+  "example": "summarize_text",
+  "alias": ["mcp.prompt.name"],
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added gen_ai.prompt.name attribute"
+    }
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__tool__call__result.json
+++ b/model/attributes/gen_ai/gen_ai__tool__call__result.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "rainy, 57°F",
-  "alias": ["gen_ai.tool.output", "gen_ai.tool.message"],
+  "alias": ["gen_ai.tool.output", "gen_ai.tool.message", "mcp.tool.result.content"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/gen_ai/gen_ai__tool__message.json
+++ b/model/attributes/gen_ai/gen_ai__tool__message.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": false,
   "example": "rainy, 57°F",
-  "alias": ["gen_ai.tool.call.result", "gen_ai.tool.output"],
+  "alias": ["gen_ai.tool.call.result", "gen_ai.tool.output", "mcp.tool.result.content"],
   "deprecation": {
     "_status": "normalize",
     "replacement": "gen_ai.tool.call.result"

--- a/model/attributes/gen_ai/gen_ai__tool__name.json
+++ b/model/attributes/gen_ai/gen_ai__tool__name.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "Flights",
-  "alias": ["ai.function_call"],
+  "alias": ["ai.function_call", "mcp.tool.name"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/gen_ai/gen_ai__tool__output.json
+++ b/model/attributes/gen_ai/gen_ai__tool__output.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": false,
   "example": "rainy, 57°F",
-  "alias": ["gen_ai.tool.call.result", "gen_ai.tool.message"],
+  "alias": ["gen_ai.tool.call.result", "gen_ai.tool.message", "mcp.tool.result.content"],
   "deprecation": {
     "_status": "normalize",
     "replacement": "gen_ai.tool.call.result"

--- a/model/attributes/jsonrpc/jsonrpc__protocol__version.json
+++ b/model/attributes/jsonrpc/jsonrpc__protocol__version.json
@@ -1,0 +1,17 @@
+{
+  "key": "jsonrpc.protocol.version",
+  "brief": "The version of the JSON-RPC protocol used.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "visibility": "public",
+  "example": "2.0",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added jsonrpc.protocol.version attribute"
+    }
+  ]
+}

--- a/model/attributes/jsonrpc/jsonrpc__protocol__version.json
+++ b/model/attributes/jsonrpc/jsonrpc__protocol__version.json
@@ -3,7 +3,7 @@
   "brief": "The version of the JSON-RPC protocol used.",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": true,
   "visibility": "public",

--- a/model/attributes/jsonrpc/jsonrpc__request__id.json
+++ b/model/attributes/jsonrpc/jsonrpc__request__id.json
@@ -3,7 +3,7 @@
   "brief": "The JSON-RPC request identifier. Unique within the session.",
   "type": "string",
   "pii": {
-    "key": "false"
+    "key": "maybe"
   },
   "is_in_otel": true,
   "visibility": "public",

--- a/model/attributes/jsonrpc/jsonrpc__request__id.json
+++ b/model/attributes/jsonrpc/jsonrpc__request__id.json
@@ -1,0 +1,18 @@
+{
+  "key": "jsonrpc.request.id",
+  "brief": "The JSON-RPC request identifier. Unique within the session.",
+  "type": "string",
+  "pii": {
+    "key": "false"
+  },
+  "is_in_otel": true,
+  "visibility": "public",
+  "example": "1",
+  "alias": ["mcp.request.id"],
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added jsonrpc.request.id attribute"
+    }
+  ]
+}

--- a/model/attributes/mcp/mcp__method__name.json
+++ b/model/attributes/mcp/mcp__method__name.json
@@ -5,10 +5,14 @@
   "pii": {
     "key": "false"
   },
-  "is_in_otel": false,
+  "is_in_otel": true,
   "example": "tools/call",
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Set is_in_otel=true, attribute exists in OTel MCP registry"
+    },
     {
       "version": "0.3.0",
       "prs": [171]

--- a/model/attributes/mcp/mcp__prompt__name.json
+++ b/model/attributes/mcp/mcp__prompt__name.json
@@ -11,8 +11,18 @@
   "visibility": "public",
   "changelog": [
     {
+      "version": "next",
+      "description": "Deprecated in favor of gen_ai.prompt.name"
+    },
+    {
       "version": "0.3.0",
       "prs": [171]
     }
-  ]
+  ],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "gen_ai.prompt.name",
+    "reason": "OTel uses gen_ai.prompt.name for MCP prompt names"
+  },
+  "alias": ["gen_ai.prompt.name"]
 }

--- a/model/attributes/mcp/mcp__protocol__version.json
+++ b/model/attributes/mcp/mcp__protocol__version.json
@@ -5,10 +5,14 @@
   "pii": {
     "key": "false"
   },
-  "is_in_otel": false,
+  "is_in_otel": true,
   "example": "2024-11-05",
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Set is_in_otel=true, attribute exists in OTel MCP registry"
+    },
     {
       "version": "0.3.0",
       "prs": [171]

--- a/model/attributes/mcp/mcp__request__id.json
+++ b/model/attributes/mcp/mcp__request__id.json
@@ -10,8 +10,18 @@
   "visibility": "public",
   "changelog": [
     {
+      "version": "next",
+      "description": "Deprecated in favor of jsonrpc.request.id"
+    },
+    {
       "version": "0.3.0",
       "prs": [171]
     }
-  ]
+  ],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "jsonrpc.request.id",
+    "reason": "OTel models MCP as JSON-RPC, uses jsonrpc.request.id"
+  },
+  "alias": ["jsonrpc.request.id"]
 }

--- a/model/attributes/mcp/mcp__resource__protocol.json
+++ b/model/attributes/mcp/mcp__resource__protocol.json
@@ -10,8 +10,18 @@
   "visibility": "public",
   "changelog": [
     {
+      "version": "next",
+      "description": "Deprecated in favor of network.protocol.name"
+    },
+    {
       "version": "0.3.0",
       "prs": [171]
     }
-  ]
+  ],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "network.protocol.name",
+    "reason": "OTel uses the generic network.protocol.name attribute"
+  },
+  "alias": ["network.protocol.name", "net.protocol.name"]
 }

--- a/model/attributes/mcp/mcp__resource__uri.json
+++ b/model/attributes/mcp/mcp__resource__uri.json
@@ -6,10 +6,14 @@
     "key": "true",
     "reason": "URIs can contain sensitive file paths"
   },
-  "is_in_otel": false,
+  "is_in_otel": true,
   "example": "file:///path/to/file.txt",
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Set is_in_otel=true, attribute exists in OTel MCP registry"
+    },
     {
       "version": "0.3.0",
       "prs": [171]

--- a/model/attributes/mcp/mcp__session__id.json
+++ b/model/attributes/mcp/mcp__session__id.json
@@ -5,10 +5,14 @@
   "pii": {
     "key": "false"
   },
-  "is_in_otel": false,
+  "is_in_otel": true,
   "example": "550e8400-e29b-41d4-a716-446655440000",
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Set is_in_otel=true, attribute exists in OTel MCP registry"
+    },
     {
       "version": "0.3.0",
       "prs": [171]

--- a/model/attributes/mcp/mcp__tool__name.json
+++ b/model/attributes/mcp/mcp__tool__name.json
@@ -7,6 +7,7 @@
   },
   "is_in_otel": false,
   "example": "calculator",
+  "alias": ["gen_ai.tool.name", "ai.function_call"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/mcp/mcp__tool__name.json
+++ b/model/attributes/mcp/mcp__tool__name.json
@@ -10,8 +10,17 @@
   "visibility": "public",
   "changelog": [
     {
+      "version": "next",
+      "description": "Deprecated in favor of gen_ai.tool.name"
+    },
+    {
       "version": "0.3.0",
       "prs": [171]
     }
-  ]
+  ],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "gen_ai.tool.name",
+    "reason": "OTel uses gen_ai.tool.name for MCP tool names"
+  }
 }

--- a/model/attributes/mcp/mcp__tool__result__content.json
+++ b/model/attributes/mcp/mcp__tool__result__content.json
@@ -12,6 +12,10 @@
   "visibility": "public",
   "changelog": [
     {
+      "version": "next",
+      "description": "Deprecated in favor of gen_ai.tool.call.result"
+    },
+    {
       "version": "0.3.0",
       "prs": [171]
     },
@@ -19,5 +23,10 @@
       "version": "0.2.0",
       "prs": [164]
     }
-  ]
+  ],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "gen_ai.tool.call.result",
+    "reason": "OTel uses gen_ai.tool.call.result for MCP tool results"
+  }
 }

--- a/model/attributes/mcp/mcp__tool__result__content.json
+++ b/model/attributes/mcp/mcp__tool__result__content.json
@@ -8,7 +8,7 @@
   },
   "is_in_otel": false,
   "example": "{\"output\": \"rainy\", \"toolCallId\": \"1\"}",
-  "alias": [],
+  "alias": ["gen_ai.tool.call.result", "gen_ai.tool.message", "gen_ai.tool.output"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/mcp/mcp__tool__result__is_error.json
+++ b/model/attributes/mcp/mcp__tool__result__is_error.json
@@ -10,8 +10,17 @@
   "visibility": "public",
   "changelog": [
     {
+      "version": "next",
+      "description": "Deprecated in favor of error.type"
+    },
+    {
       "version": "0.3.0",
       "prs": [171]
     }
-  ]
+  ],
+  "deprecation": {
+    "_status": null,
+    "replacement": "error.type",
+    "reason": "OTel uses error.type set to 'tool_error' when isError is true. Cannot be automatically backfilled due to type mismatch (boolean vs string)."
+  }
 }

--- a/model/attributes/mcp/mcp__transport.json
+++ b/model/attributes/mcp/mcp__transport.json
@@ -10,8 +10,18 @@
   "visibility": "public",
   "changelog": [
     {
+      "version": "next",
+      "description": "Deprecated in favor of network.transport"
+    },
+    {
       "version": "0.3.0",
       "prs": [171]
     }
-  ]
+  ],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "network.transport",
+    "reason": "OTel uses the generic network.transport attribute"
+  },
+  "alias": ["network.transport", "net.transport"]
 }

--- a/model/attributes/net/net__protocol__name.json
+++ b/model/attributes/net/net__protocol__name.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "http",
-  "alias": ["network.protocol.name"],
+  "alias": ["network.protocol.name", "mcp.resource.protocol"],
   "deprecation": {
     "_status": null,
     "replacement": "network.protocol.name"

--- a/model/attributes/net/net__transport.json
+++ b/model/attributes/net/net__transport.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "tcp",
-  "alias": ["network.transport"],
+  "alias": ["network.transport", "mcp.transport"],
   "deprecation": {
     "_status": null,
     "replacement": "network.transport"

--- a/model/attributes/network/network__protocol__name.json
+++ b/model/attributes/network/network__protocol__name.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "http",
-  "alias": ["net.protocol.name"],
+  "alias": ["net.protocol.name", "mcp.resource.protocol"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/network/network__transport.json
+++ b/model/attributes/network/network__transport.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "tcp",
-  "alias": ["net.transport"],
+  "alias": ["net.transport", "mcp.transport"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/name/mcp.json
+++ b/model/name/mcp.json
@@ -5,11 +5,11 @@
       "name": "Server",
       "brief": "MCP server-side operations. Processing of incoming MCP requests or notifications initiated by a client, such as tool calls, prompt requests, and resource reads.",
       "is_in_otel": true,
-      "otel_notes": "OpenTelemetry uses gen_ai.tool.name and gen_ai.prompt.name for the target in the span name. Sentry uses mcp.tool.name and mcp.prompt.name instead.",
+      "otel_notes": "OpenTelemetry uses gen_ai.tool.name and gen_ai.prompt.name for the target in the span name.",
       "ops": ["mcp.server"],
       "templates": [
-        "{{mcp.method.name}} {{mcp.tool.name}}",
-        "{{mcp.method.name}} {{mcp.prompt.name}}",
+        "{{mcp.method.name}} {{gen_ai.tool.name}}",
+        "{{mcp.method.name}} {{gen_ai.prompt.name}}",
         "{{mcp.method.name}}",
         "MCP server operation"
       ],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -365,7 +365,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: true
     Defined in OTEL: No
     Visibility: public
-    Aliases: gen_ai.tool.name
+    Aliases: gen_ai.tool.name, mcp.tool.name
     DEPRECATED: Use gen_ai.tool.name instead
     Example: "function_name"
     """
@@ -3945,7 +3945,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: true
     Defined in OTEL: No
     Visibility: public
-    Aliases: gen_ai.tool.call.result, gen_ai.tool.output
+    Aliases: gen_ai.tool.call.result, gen_ai.tool.output, mcp.tool.result.content
     DEPRECATED: Use gen_ai.tool.call.result instead
     Example: "rainy, 57°F"
     """
@@ -3970,7 +3970,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
-    Aliases: gen_ai.tool.call.result, gen_ai.tool.message
+    Aliases: gen_ai.tool.call.result, gen_ai.tool.message, mcp.tool.result.content
     DEPRECATED: Use gen_ai.tool.call.result instead
     Example: "rainy, 57°F"
     """
@@ -5324,6 +5324,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
+    Aliases: gen_ai.tool.name, ai.function_call
     DEPRECATED: Use gen_ai.tool.name instead - OTel uses gen_ai.tool.name for MCP tool names
     Example: "calculator"
     """
@@ -5338,6 +5339,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: true - Tool results can contain user data
     Defined in OTEL: No
     Visibility: public
+    Aliases: gen_ai.tool.call.result, gen_ai.tool.message, gen_ai.tool.output
     DEPRECATED: Use gen_ai.tool.call.result instead - OTel uses gen_ai.tool.call.result for MCP tool results
     Example: "{\"output\": \"rainy\", \"toolCallId\": \"1\"}"
     """
@@ -8438,7 +8440,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="gen_ai.tool.name", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["gen_ai.tool.name"],
+        aliases=["gen_ai.tool.name", "mcp.tool.name"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[55, 57, 61, 108]),
         ],
@@ -12657,7 +12659,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="gen_ai.tool.call.result", status=DeprecationStatus.NORMALIZE
         ),
-        aliases=["gen_ai.tool.call.result", "gen_ai.tool.output"],
+        aliases=[
+            "gen_ai.tool.call.result",
+            "gen_ai.tool.output",
+            "mcp.tool.result.content",
+        ],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[265]),
             ChangelogEntry(version="0.1.0", prs=[62]),
@@ -12685,7 +12691,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="gen_ai.tool.call.result", status=DeprecationStatus.NORMALIZE
         ),
-        aliases=["gen_ai.tool.call.result", "gen_ai.tool.message"],
+        aliases=[
+            "gen_ai.tool.call.result",
+            "gen_ai.tool.message",
+            "mcp.tool.result.content",
+        ],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[265]),
             ChangelogEntry(version="0.1.0", prs=[63, 74]),
@@ -14299,6 +14309,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             reason="OTel uses gen_ai.tool.name for MCP tool names",
             status=DeprecationStatus.BACKFILL,
         ),
+        aliases=["gen_ai.tool.name", "ai.function_call"],
         changelog=[
             ChangelogEntry(
                 version="next", description="Deprecated in favor of gen_ai.tool.name"
@@ -14318,6 +14329,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             reason="OTel uses gen_ai.tool.call.result for MCP tool results",
             status=DeprecationStatus.BACKFILL,
         ),
+        aliases=[
+            "gen_ai.tool.call.result",
+            "gen_ai.tool.message",
+            "gen_ai.tool.output",
+        ],
         changelog=[
             ChangelogEntry(
                 version="next",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3716,7 +3716,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: gen_ai.tool.output, gen_ai.tool.message
+    Aliases: gen_ai.tool.output, gen_ai.tool.message, mcp.tool.result.content
     Example: "rainy, 57°F"
     """
 
@@ -3780,7 +3780,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: ai.function_call
+    Aliases: ai.function_call, mcp.tool.name
     Example: "Flights"
     """
 
@@ -12347,7 +12347,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="rainy, 57°F",
-        aliases=["gen_ai.tool.output", "gen_ai.tool.message"],
+        aliases=[
+            "gen_ai.tool.output",
+            "gen_ai.tool.message",
+            "mcp.tool.result.content",
+        ],
         changelog=[
             ChangelogEntry(version="0.5.0", prs=[265]),
             ChangelogEntry(version="0.4.0", prs=[221]),
@@ -12414,7 +12418,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="Flights",
-        aliases=["ai.function_call"],
+        aliases=["ai.function_call", "mcp.tool.name"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[57, 127]),
         ],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -212,6 +212,13 @@ class _AttributeNamesMeta(type):
         "LCP_SIZE",
         "LCP_URL",
         "LCP",
+        "MCP_PROMPT_NAME",
+        "MCP_REQUEST_ID",
+        "MCP_RESOURCE_PROTOCOL",
+        "MCP_TOOL_NAME",
+        "MCP_TOOL_RESULT_CONTENT",
+        "MCP_TOOL_RESULT_IS_ERROR",
+        "MCP_TRANSPORT",
         "METHOD",
         "NET_HOST_IP",
         "NET_HOST_NAME",
@@ -3387,6 +3394,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "[{\"role\": \"user\", \"message\": \"hello\"}]"
     """
 
+    # Path: model/attributes/gen_ai/gen_ai__prompt__name.json
+    GEN_AI_PROMPT_NAME: Literal["gen_ai.prompt.name"] = "gen_ai.prompt.name"
+    """The name of the prompt that uniquely identifies it.
+
+    Type: str
+    Contains PII: maybe - Prompt names may reveal user behavior patterns or sensitive operations
+    Defined in OTEL: Yes
+    Visibility: public
+    Aliases: mcp.prompt.name
+    Example: "summarize_text"
+    """
+
     # Path: model/attributes/gen_ai/gen_ai__provider__name.json
     GEN_AI_PROVIDER_NAME: Literal["gen_ai.provider.name"] = "gen_ai.provider.name"
     """The Generative AI provider as identified by the client or server instrumentation.
@@ -4490,6 +4509,31 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 200
     """
 
+    # Path: model/attributes/jsonrpc/jsonrpc__protocol__version.json
+    JSONRPC_PROTOCOL_VERSION: Literal["jsonrpc.protocol.version"] = (
+        "jsonrpc.protocol.version"
+    )
+    """The version of the JSON-RPC protocol used.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "2.0"
+    """
+
+    # Path: model/attributes/jsonrpc/jsonrpc__request__id.json
+    JSONRPC_REQUEST_ID: Literal["jsonrpc.request.id"] = "jsonrpc.request.id"
+    """The JSON-RPC request identifier. Unique within the session.
+
+    Type: str
+    Contains PII: false
+    Defined in OTEL: Yes
+    Visibility: public
+    Aliases: mcp.request.id
+    Example: "1"
+    """
+
     # Path: model/attributes/jvm/jvm__gc__action.json
     JVM_GC_ACTION: Literal["jvm.gc.action"] = "jvm.gc.action"
     """Name of the garbage collector action.
@@ -4776,7 +4820,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     Type: str
     Contains PII: false
-    Defined in OTEL: No
+    Defined in OTEL: Yes
     Visibility: public
     Example: "tools/call"
     """
@@ -4846,6 +4890,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe - Prompt names may reveal user behavior patterns or sensitive operations
     Defined in OTEL: No
     Visibility: public
+    Aliases: gen_ai.prompt.name
+    DEPRECATED: Use gen_ai.prompt.name instead - OTel uses gen_ai.prompt.name for MCP prompt names
     Example: "summarize"
     """
 
@@ -4918,7 +4964,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     Type: str
     Contains PII: false
-    Defined in OTEL: No
+    Defined in OTEL: Yes
     Visibility: public
     Example: "2024-11-05"
     """
@@ -4971,6 +5017,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: false
     Defined in OTEL: No
     Visibility: public
+    Aliases: jsonrpc.request.id
+    DEPRECATED: Use jsonrpc.request.id instead - OTel models MCP as JSON-RPC, uses jsonrpc.request.id
     Example: "1"
     """
 
@@ -4982,6 +5030,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: false
     Defined in OTEL: No
     Visibility: public
+    Aliases: network.protocol.name, net.protocol.name
+    DEPRECATED: Use network.protocol.name instead - OTel uses the generic network.protocol.name attribute
     Example: "file"
     """
 
@@ -4991,7 +5041,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     Type: str
     Contains PII: true - URIs can contain sensitive file paths
-    Defined in OTEL: No
+    Defined in OTEL: Yes
     Visibility: public
     Example: "file:///path/to/file.txt"
     """
@@ -5035,7 +5085,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     Type: str
     Contains PII: false
-    Defined in OTEL: No
+    Defined in OTEL: Yes
     Visibility: public
     Example: "550e8400-e29b-41d4-a716-446655440000"
     """
@@ -5048,6 +5098,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: false
     Defined in OTEL: No
     Visibility: public
+    DEPRECATED: Use gen_ai.tool.name instead - OTel uses gen_ai.tool.name for MCP tool names
     Example: "calculator"
     """
 
@@ -5061,6 +5112,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: true - Tool results can contain user data
     Defined in OTEL: No
     Visibility: public
+    DEPRECATED: Use gen_ai.tool.call.result instead - OTel uses gen_ai.tool.call.result for MCP tool results
     Example: "{\"output\": \"rainy\", \"toolCallId\": \"1\"}"
     """
 
@@ -5087,6 +5139,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: false
     Defined in OTEL: No
     Visibility: public
+    DEPRECATED: Use error.type instead - OTel uses error.type set to 'tool_error' when isError is true. Cannot be automatically backfilled due to type mismatch (boolean vs string).
     Example: false
     """
 
@@ -5098,6 +5151,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: false
     Defined in OTEL: No
     Visibility: public
+    Aliases: network.transport, net.transport
+    DEPRECATED: Use network.transport instead - OTel uses the generic network.transport attribute
     Example: "stdio"
     """
 
@@ -5426,7 +5481,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: network.protocol.name
+    Aliases: network.protocol.name, mcp.resource.protocol
     DEPRECATED: Use network.protocol.name instead
     Example: "http"
     """
@@ -5527,7 +5582,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: network.transport
+    Aliases: network.transport, mcp.transport
     DEPRECATED: Use network.transport instead
     Example: "tcp"
     """
@@ -5627,7 +5682,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: net.protocol.name
+    Aliases: net.protocol.name, mcp.resource.protocol
     Example: "http"
     """
 
@@ -5653,7 +5708,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: net.transport
+    Aliases: net.transport, mcp.transport
     Example: "tcp"
     """
 
@@ -11966,6 +12021,23 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "gen_ai.prompt.name": AttributeMetadata(
+        brief="The name of the prompt that uniquely identifies it.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(
+            isPii=IsPii.MAYBE,
+            reason="Prompt names may reveal user behavior patterns or sensitive operations",
+        ),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="summarize_text",
+        aliases=["mcp.prompt.name"],
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added gen_ai.prompt.name attribute"
+            ),
+        ],
+    ),
     "gen_ai.provider.name": AttributeMetadata(
         brief="The Generative AI provider as identified by the client or server instrumentation.",
         type=AttributeType.STRING,
@@ -13206,6 +13278,33 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "jsonrpc.protocol.version": AttributeMetadata(
+        brief="The version of the JSON-RPC protocol used.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="2.0",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added jsonrpc.protocol.version attribute"
+            ),
+        ],
+    ),
+    "jsonrpc.request.id": AttributeMetadata(
+        brief="The JSON-RPC request identifier. Unique within the session.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.FALSE),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="1",
+        aliases=["mcp.request.id"],
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added jsonrpc.request.id attribute"
+            ),
+        ],
+    ),
     "jvm.gc.action": AttributeMetadata(
         brief="Name of the garbage collector action.",
         type=AttributeType.STRING,
@@ -13546,10 +13645,14 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="The name of the MCP request or notification method being called.",
         type=AttributeType.STRING,
         pii=PiiInfo(isPii=IsPii.FALSE),
-        is_in_otel=False,
+        is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="tools/call",
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Set is_in_otel=true, attribute exists in OTel MCP registry",
+            ),
             ChangelogEntry(version="0.3.0", prs=[171]),
         ],
     ),
@@ -13624,7 +13727,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="summarize",
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.prompt.name",
+            reason="OTel uses gen_ai.prompt.name for MCP prompt names",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["gen_ai.prompt.name"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Deprecated in favor of gen_ai.prompt.name"
+            ),
             ChangelogEntry(version="0.3.0", prs=[171]),
         ],
     ),
@@ -13689,10 +13801,14 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="MCP protocol version used in the session.",
         type=AttributeType.STRING,
         pii=PiiInfo(isPii=IsPii.FALSE),
-        is_in_otel=False,
+        is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="2024-11-05",
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Set is_in_otel=true, attribute exists in OTel MCP registry",
+            ),
             ChangelogEntry(version="0.3.0", prs=[171]),
         ],
     ),
@@ -13737,7 +13853,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="1",
+        deprecation=DeprecationInfo(
+            replacement="jsonrpc.request.id",
+            reason="OTel models MCP as JSON-RPC, uses jsonrpc.request.id",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["jsonrpc.request.id"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Deprecated in favor of jsonrpc.request.id"
+            ),
             ChangelogEntry(version="0.3.0", prs=[171]),
         ],
     ),
@@ -13748,7 +13873,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="file",
+        deprecation=DeprecationInfo(
+            replacement="network.protocol.name",
+            reason="OTel uses the generic network.protocol.name attribute",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["network.protocol.name", "net.protocol.name"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Deprecated in favor of network.protocol.name",
+            ),
             ChangelogEntry(version="0.3.0", prs=[171]),
         ],
     ),
@@ -13756,10 +13891,14 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="The resource URI being accessed in an MCP operation.",
         type=AttributeType.STRING,
         pii=PiiInfo(isPii=IsPii.TRUE, reason="URIs can contain sensitive file paths"),
-        is_in_otel=False,
+        is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="file:///path/to/file.txt",
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Set is_in_otel=true, attribute exists in OTel MCP registry",
+            ),
             ChangelogEntry(version="0.3.0", prs=[171]),
         ],
     ),
@@ -13803,10 +13942,14 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="Identifier for the MCP session.",
         type=AttributeType.STRING,
         pii=PiiInfo(isPii=IsPii.FALSE),
-        is_in_otel=False,
+        is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="550e8400-e29b-41d4-a716-446655440000",
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Set is_in_otel=true, attribute exists in OTel MCP registry",
+            ),
             ChangelogEntry(version="0.3.0", prs=[171]),
         ],
     ),
@@ -13817,7 +13960,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="calculator",
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.tool.name",
+            reason="OTel uses gen_ai.tool.name for MCP tool names",
+            status=DeprecationStatus.BACKFILL,
+        ),
         changelog=[
+            ChangelogEntry(
+                version="next", description="Deprecated in favor of gen_ai.tool.name"
+            ),
             ChangelogEntry(version="0.3.0", prs=[171]),
         ],
     ),
@@ -13828,7 +13979,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example='{"output": "rainy", "toolCallId": "1"}',
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.tool.call.result",
+            reason="OTel uses gen_ai.tool.call.result for MCP tool results",
+            status=DeprecationStatus.BACKFILL,
+        ),
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Deprecated in favor of gen_ai.tool.call.result",
+            ),
             ChangelogEntry(version="0.3.0", prs=[171]),
             ChangelogEntry(version="0.2.0", prs=[164]),
         ],
@@ -13852,7 +14012,14 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=False,
+        deprecation=DeprecationInfo(
+            replacement="error.type",
+            reason="OTel uses error.type set to 'tool_error' when isError is true. Cannot be automatically backfilled due to type mismatch (boolean vs string).",
+        ),
         changelog=[
+            ChangelogEntry(
+                version="next", description="Deprecated in favor of error.type"
+            ),
             ChangelogEntry(version="0.3.0", prs=[171]),
         ],
     ),
@@ -13863,7 +14030,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="stdio",
+        deprecation=DeprecationInfo(
+            replacement="network.transport",
+            reason="OTel uses the generic network.transport attribute",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["network.transport", "net.transport"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Deprecated in favor of network.transport"
+            ),
             ChangelogEntry(version="0.3.0", prs=[171]),
         ],
     ),
@@ -14225,7 +14401,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="http",
         deprecation=DeprecationInfo(replacement="network.protocol.name"),
-        aliases=["network.protocol.name"],
+        aliases=["network.protocol.name", "mcp.resource.protocol"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
             ChangelogEntry(version="0.0.0"),
@@ -14341,7 +14517,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="tcp",
         deprecation=DeprecationInfo(replacement="network.transport"),
-        aliases=["network.transport"],
+        aliases=["network.transport", "mcp.transport"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
             ChangelogEntry(version="0.0.0"),
@@ -14456,7 +14632,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="http",
-        aliases=["net.protocol.name"],
+        aliases=["net.protocol.name", "mcp.resource.protocol"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -14482,7 +14658,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="tcp",
-        aliases=["net.transport"],
+        aliases=["net.transport", "mcp.transport"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -17373,6 +17549,7 @@ Attributes = TypedDict(
         "gen_ai.output.messages": str,
         "gen_ai.pipeline.name": str,
         "gen_ai.prompt": str,
+        "gen_ai.prompt.name": str,
         "gen_ai.provider.name": str,
         "gen_ai.request.available_tools": str,
         "gen_ai.request.frequency_penalty": float,
@@ -17458,6 +17635,8 @@ Attributes = TypedDict(
         "http.user_agent": str,
         "id": str,
         "inp": float,
+        "jsonrpc.protocol.version": str,
+        "jsonrpc.request.id": str,
         "jvm.gc.action": str,
         "jvm.gc.name": str,
         "jvm.memory.pool.name": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -4742,7 +4742,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The version of the JSON-RPC protocol used.
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: Yes
     Visibility: public
     Example: "2.0"
@@ -4753,7 +4753,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The JSON-RPC request identifier. Unique within the session.
 
     Type: str
-    Contains PII: false
+    Contains PII: maybe
     Defined in OTEL: Yes
     Visibility: public
     Aliases: mcp.request.id
@@ -13628,7 +13628,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "jsonrpc.protocol.version": AttributeMetadata(
         brief="The version of the JSON-RPC protocol used.",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="2.0",
@@ -13641,7 +13641,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "jsonrpc.request.id": AttributeMetadata(
         brief="The JSON-RPC request identifier. Unique within the session.",
         type=AttributeType.STRING,
-        pii=PiiInfo(isPii=IsPii.FALSE),
+        pii=PiiInfo(isPii=IsPii.MAYBE),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="1",


### PR DESCRIPTION
## Description

Align Sentry MCP attributes with the OTel MCP semantic conventions that merged in open-telemetry/semantic-conventions#2083 (Jan 2026).

OTel's MCP convention is deliberately minimal: only 4 mcp.* registry attributes, reusing existing gen_ai.*, network.*, jsonrpc.*, and error.* namespaces for everything else. This commit brings Sentry conventions in line with that approach.

Changes:

Set is_in_otel=true on 4 direct matches:
- mcp.method.name
- mcp.protocol.version
- mcp.resource.uri
- mcp.session.id

Deprecated 7 attributes with backfill to OTel equivalents:
- mcp.tool.name → gen_ai.tool.name
- mcp.prompt.name → gen_ai.prompt.name
- mcp.tool.result.content → gen_ai.tool.call.result
- mcp.tool.result.is_error → error.type
- mcp.request.id → jsonrpc.request.id
- mcp.transport → network.transport
- mcp.resource.protocol → network.protocol.name

Created 3 new attributes:
- gen_ai.prompt.name (OTel gen_ai registry, aliased from mcp.prompt.name)
- jsonrpc.request.id (OTel MCP common refs, aliased from mcp.request.id)
- jsonrpc.protocol.version (OTel MCP common refs)


Closes https://linear.app/getsentry/issue/TET-2436/update-conventions-for-mcp-spans

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
