### PR TITLE
feat(attributes): Add `process.runtime.build` attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -10195,6 +10195,29 @@ export const PROCESS_PID = 'process.pid';
  */
 export type PROCESS_PID_TYPE = number;
 
+// Path: model/attributes/process/process__runtime__build.json
+
+/**
+ * The application build string. Equivalent to `build` in the Sentry runtime context. `process.runtime.build`
+ *
+ * Attribute Value Type: `string` {@link PROCESS_RUNTIME_BUILD_TYPE}
+ *
+ * Contains PII: maybe
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link RUNTIME_BUILD} `runtime.build`
+ *
+ * @example "stable"
+ */
+export const PROCESS_RUNTIME_BUILD = 'process.runtime.build';
+
+/**
+ * Type for {@link PROCESS_RUNTIME_BUILD} process.runtime.build
+ */
+export type PROCESS_RUNTIME_BUILD_TYPE = string;
+
 // Path: model/attributes/process/process__runtime__description.json
 
 /**
@@ -10606,6 +10629,8 @@ export type RPC_SERVICE_TYPE = string;
  *
  * Attribute defined in OTEL: No
  * Visibility: public
+ *
+ * Aliases: {@link PROCESS_RUNTIME_BUILD} `process.runtime.build`
  *
  * @deprecated  - The runtime.* namespace is deprecated in favor of process.runtime.*. No direct OTel equivalent exists for this attribute.
  * @example "stable"
@@ -14668,6 +14693,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [PROCESS_COMMAND_ARGS]: 'string[]',
   [PROCESS_EXECUTABLE_NAME]: 'string',
   [PROCESS_PID]: 'integer',
+  [PROCESS_RUNTIME_BUILD]: 'string',
   [PROCESS_RUNTIME_DESCRIPTION]: 'string',
   [PROCESS_RUNTIME_ENGINE_NAME]: 'string',
   [PROCESS_RUNTIME_ENGINE_VERSION]: 'string',
@@ -15315,6 +15341,7 @@ export type AttributeName =
   | typeof PROCESS_COMMAND_ARGS
   | typeof PROCESS_EXECUTABLE_NAME
   | typeof PROCESS_PID
+  | typeof PROCESS_RUNTIME_BUILD
   | typeof PROCESS_RUNTIME_DESCRIPTION
   | typeof PROCESS_RUNTIME_ENGINE_NAME
   | typeof PROCESS_RUNTIME_ENGINE_VERSION
@@ -21836,6 +21863,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 12345,
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
+  [PROCESS_RUNTIME_BUILD]: {
+    brief: 'The application build string. Equivalent to `build` in the Sentry runtime context.',
+    type: 'string',
+    pii: {
+      isPii: 'maybe',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'stable',
+    aliases: [RUNTIME_BUILD],
+    changelog: [{ version: 'next', prs: [421], description: 'Added process.runtime.build attribute' }],
+  },
   [PROCESS_RUNTIME_DESCRIPTION]: {
     brief:
       'An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment. Equivalent to `raw_description` in the Sentry runtime context.',
@@ -22080,6 +22119,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason:
         'The runtime.* namespace is deprecated in favor of process.runtime.*. No direct OTel equivalent exists for this attribute.',
     },
+    aliases: [PROCESS_RUNTIME_BUILD],
     changelog: [{ version: 'next', prs: [383], description: 'Added and deprecated runtime.build attribute' }],
   },
   [RUNTIME_NAME]: {
@@ -24562,6 +24602,7 @@ export type Attributes = {
   [PROCESS_COMMAND_ARGS]?: PROCESS_COMMAND_ARGS_TYPE;
   [PROCESS_EXECUTABLE_NAME]?: PROCESS_EXECUTABLE_NAME_TYPE;
   [PROCESS_PID]?: PROCESS_PID_TYPE;
+  [PROCESS_RUNTIME_BUILD]?: PROCESS_RUNTIME_BUILD_TYPE;
   [PROCESS_RUNTIME_DESCRIPTION]?: PROCESS_RUNTIME_DESCRIPTION_TYPE;
   [PROCESS_RUNTIME_ENGINE_NAME]?: PROCESS_RUNTIME_ENGINE_NAME_TYPE;
   [PROCESS_RUNTIME_ENGINE_VERSION]?: PROCESS_RUNTIME_ENGINE_VERSION_TYPE;

--- a/model/attributes/process/process__runtime__build.json
+++ b/model/attributes/process/process__runtime__build.json
@@ -1,0 +1,19 @@
+{
+  "key": "process.runtime.build",
+  "brief": "The application build string. Equivalent to `build` in the Sentry runtime context.",
+  "type": "string",
+  "pii": {
+    "key": "maybe"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "example": "stable",
+  "alias": ["runtime.build"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [421],
+      "description": "Added process.runtime.build attribute"
+    }
+  ]
+}

--- a/model/attributes/runtime/runtime__build.json
+++ b/model/attributes/runtime/runtime__build.json
@@ -12,6 +12,7 @@
     "reason": "The runtime.* namespace is deprecated in favor of process.runtime.*. No direct OTel equivalent exists for this attribute.",
     "_status": null
   },
+  "alias": ["process.runtime.build"],
   "changelog": [
     {
       "version": "next",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5982,6 +5982,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 12345
     """
 
+    # Path: model/attributes/process/process__runtime__build.json
+    PROCESS_RUNTIME_BUILD: Literal["process.runtime.build"] = "process.runtime.build"
+    """The application build string. Equivalent to `build` in the Sentry runtime context.
+
+    Type: str
+    Contains PII: maybe
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: runtime.build
+    Example: "stable"
+    """
+
     # Path: model/attributes/process/process__runtime__description.json
     PROCESS_RUNTIME_DESCRIPTION: Literal["process.runtime.description"] = (
         "process.runtime.description"
@@ -6220,6 +6232,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Contains PII: maybe
     Defined in OTEL: No
     Visibility: public
+    Aliases: process.runtime.build
     DEPRECATED: No replacement at this time - The runtime.* namespace is deprecated in favor of process.runtime.*. No direct OTel equivalent exists for this attribute.
     Example: "stable"
     """
@@ -14991,6 +15004,22 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "process.runtime.build": AttributeMetadata(
+        brief="The application build string. Equivalent to `build` in the Sentry runtime context.",
+        type=AttributeType.STRING,
+        pii=PiiInfo(isPii=IsPii.MAYBE),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="stable",
+        aliases=["runtime.build"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[421],
+                description="Added process.runtime.build attribute",
+            ),
+        ],
+    ),
     "process.runtime.description": AttributeMetadata(
         brief="An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment. Equivalent to `raw_description` in the Sentry runtime context.",
         type=AttributeType.STRING,
@@ -15240,6 +15269,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             reason="The runtime.* namespace is deprecated in favor of process.runtime.*. No direct OTel equivalent exists for this attribute."
         ),
+        aliases=["process.runtime.build"],
         changelog=[
             ChangelogEntry(
                 version="next",
@@ -17788,6 +17818,7 @@ Attributes = TypedDict(
         "process.command_args": List[str],
         "process.executable.name": str,
         "process.pid": int,
+        "process.runtime.build": str,
         "process.runtime.description": str,
         "process.runtime.engine.name": str,
         "process.runtime.engine.version": str,


### PR DESCRIPTION
## Description
<!-- Describe your changes -->

Document the field currently set as context by sentry-python:

https://github.com/getsentry/sentry-python/blob/3bbd78d4fe3a2803839d8091ecc435136bd83363/sentry_sdk/integrations/stdlib.py#L39

The string would be set as an attribute with the streaming trace lifecycle.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [ ] I have run `yarn test` and verified that the tests pass.
- [ ] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `pii` (i.e. `maybe` or `true`. Use `false` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
