### PR TITLE
feat(description): Add span description conventions

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -65,6 +65,26 @@ const names = defineCollection({
   schema: nameSchema,
 });
 
+// Schema matching schemas/description.schema.json
+const descriptionOperationSchema = z.object({
+  name: z.string().optional(),
+  brief: z.string(),
+  ops: z.array(z.string()),
+  templates: z.array(z.string()),
+  examples: z.array(z.string()).optional(),
+});
+
+const descriptionSchema = z.object({
+  brief: z.string(),
+  operations: z.array(descriptionOperationSchema),
+});
+
+// Define the descriptions collection - loads all JSON files from model/description
+const descriptions = defineCollection({
+  loader: glob({ pattern: '*.json', base: '../model/description' }),
+  schema: descriptionSchema,
+});
+
 // Schema matching schemas/measurements.schema.json
 const measurementSchema = z.object({
   key: z.string(),
@@ -81,10 +101,12 @@ const measurements = defineCollection({
   schema: measurementSchema,
 });
 
-export const collections = { attributes, names, measurements };
+export const collections = { attributes, names, descriptions, measurements };
 
 // Export types for use in pages
 export type Attribute = z.infer<typeof attributeSchema>;
 export type SpanName = z.infer<typeof nameSchema>;
 export type SpanOperation = z.infer<typeof spanOperationSchema>;
+export type SpanDescription = z.infer<typeof descriptionSchema>;
+export type DescriptionOperation = z.infer<typeof descriptionOperationSchema>;
 export type Measurement = z.infer<typeof measurementSchema>;

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -80,6 +80,17 @@ const currentPath = Astro.url.pathname;
               Span Names
             </a>
             <a
+              href={`${import.meta.env.BASE_URL}descriptions/`}
+              class:list={[
+                "nav-link",
+                currentPath.includes('/descriptions')
+                  ? "text-accent bg-accent-soft"
+                  : "text-text-secondary hover:text-text-primary hover:bg-bg-hover"
+              ]}
+            >
+              Span Descriptions
+            </a>
+            <a
               href="https://github.com/getsentry/sentry-conventions"
               class="nav-link text-text-secondary hover:text-text-primary hover:bg-bg-hover"
               target="_blank"

--- a/docs/src/pages/descriptions/index.astro
+++ b/docs/src/pages/descriptions/index.astro
@@ -1,0 +1,114 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import CategoryChip from '../../components/CategoryChip.astro';
+import LinkedTemplate from '../../components/LinkedTemplate.astro';
+import { getCollection } from 'astro:content';
+
+// Get all description definitions
+const allDescriptions = await getCollection('descriptions');
+
+// Sort by brief (category name)
+allDescriptions.sort((a, b) => a.data.brief.localeCompare(b.data.brief));
+
+// Count total operations
+const totalOperations = allDescriptions.reduce((acc, desc) => acc + desc.data.operations.length, 0);
+---
+
+<BaseLayout
+  title="Span Descriptions"
+  description="Learn how to construct span descriptions using templates and attributes"
+>
+  <div class="mb-8">
+    <h1>Span Description Documentation</h1>
+    <p class="text-lg text-text-secondary max-w-3xl">
+      This page contains documentation for known span descriptions. You can use this documentation to understand
+      how to create the <code class="text-accent">sentry.description</code> attribute for a span, when you have the span's other attributes.
+    </p>
+  </div>
+
+  <section class="bg-bg-secondary border border-border rounded-lg p-6 mb-8">
+    <h2 class="text-xl mb-4">Generating Descriptions</h2>
+    <p class="text-sm max-w-2xl">
+      Span descriptions are generated via string template. Each span category of work has a set of templates
+      for the span description. Curly brackets in the template indicate that the contents inside the curly
+      brackets should be replaced with the contents of the span attribute of the name within the brackets.
+    </p>
+    <p class="text-sm max-w-2xl">
+      The templates should be evaluated <strong>in order of appearance</strong>. Every template references
+      at least one attribute.
+    </p>
+
+    <div class="mt-6 p-4 bg-bg-elevated rounded-md border-l-[3px] border-accent">
+      <h4 class="text-sm text-accent mb-3">Example</h4>
+      <p class="text-sm mb-2">Given template:</p>
+      <ol class="ml-4 mb-3 text-sm">
+        <li class="mb-1"><code>{"{{db.query.text}}"}</code></li>
+      </ol>
+      <p class="text-sm mb-2">And attribute <code>db.query.text = "SELECT * FROM users WHERE id = ?"</code>:</p>
+      <p class="text-sm m-0">Result: <code>"SELECT * FROM users WHERE id = ?"</code></p>
+    </div>
+  </section>
+
+  <nav class="flex items-start gap-4 p-4 bg-bg-secondary border border-border rounded-lg mb-8 flex-col md:flex-row">
+    <span class="text-sm text-text-muted whitespace-nowrap pt-1">Categories ({allDescriptions.length}):</span>
+    <div class="flex flex-wrap gap-2">
+      {allDescriptions.map(desc => (
+        <CategoryChip
+          name={desc.data.brief}
+          count={desc.data.operations.length}
+          href={`#${desc.id}`}
+        />
+      ))}
+    </div>
+  </nav>
+
+  <div class="flex flex-col gap-12">
+    {allDescriptions.map(desc => (
+      <section class="scroll-mt-20" id={desc.id}>
+        <h2 class="mb-6 pb-3 border-b border-border">{desc.data.brief}</h2>
+
+        <div class="flex flex-col gap-6">
+          {desc.data.operations.map(op => (
+            <article class="card">
+              <h3 class="text-xl mb-2">{op.name || op.brief}</h3>
+              <p class="text-sm text-text-secondary mb-4">{op.brief}</p>
+
+              <div class="flex flex-col gap-5">
+                <div>
+                  <h4 class="text-sm font-semibold text-text-muted mb-2">Affected <code class="text-accent">op</code>s</h4>
+                  <div class="flex flex-wrap gap-2">
+                    {op.ops.map(opValue => (
+                      <code class="px-2 py-1 bg-bg-elevated border border-border rounded-sm text-xs text-text-secondary">{opValue}</code>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <h4 class="text-sm font-semibold text-text-muted mb-2">Templates</h4>
+                  <ol class="m-0 pl-5 list-inside">
+                    {op.templates.map(tmpl => (
+                      <li class="flex items-center gap-2 mb-2 text-sm">
+                        <code class="px-2 py-1 bg-bg-elevated text-xs"><LinkedTemplate template={tmpl} /></code>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+
+                {op.examples && op.examples.length > 0 && (
+                  <div>
+                    <h4 class="text-sm font-semibold text-text-muted mb-2">Examples</h4>
+                    <div class="flex flex-wrap gap-2">
+                      {op.examples.map(example => (
+                        <code class="px-3 py-1 bg-accent-soft border border-transparent rounded-sm text-xs text-accent">{example}</code>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    ))}
+  </div>
+</BaseLayout>

--- a/model/description/db.json
+++ b/model/description/db.json
@@ -1,0 +1,23 @@
+{
+  "brief": "Database",
+  "operations": [
+    {
+      "name": "Queries",
+      "brief": "Operations that act on the data in a database. Includes operations like fetching, updating, and deleting records. Does not include operations like connecting to the database server.",
+      "ops": [
+        "db",
+        "db.query",
+        "db.sql.query",
+        "db.sql.prisma",
+        "db.sql.active_record",
+        "db.sql.execute",
+        "db.sql.room",
+        "db.sql.transaction",
+        "db.redis",
+        "redis"
+      ],
+      "templates": ["{{db.query.text}}"],
+      "examples": ["SELECT * FROM users WHERE id = ?"]
+    }
+  ]
+}

--- a/model/description/http.json
+++ b/model/description/http.json
@@ -1,0 +1,19 @@
+{
+  "brief": "HTTP",
+  "operations": [
+    {
+      "name": "Client",
+      "brief": "Operations that represent outgoing HTTP requests.",
+      "ops": ["http.client"],
+      "templates": ["{{http.request.method}} {{url.full}}"],
+      "examples": ["GET /users/123"]
+    },
+    {
+      "name": "Server",
+      "brief": "Operations that represent processing incoming HTTP requests in a web server.",
+      "ops": ["http.server"],
+      "templates": ["{{http.request.method}} {{url.path}}", "{{http.request.method}} {{url.full}}"],
+      "examples": ["GET /users/123", "GET http://example.com/users/123"]
+    }
+  ]
+}

--- a/schemas/description.schema.json
+++ b/schemas/description.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/SpanDescription",
+  "definitions": {
+    "SpanDescription": {
+      "title": "SpanDescription",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "brief": {
+          "type": "string"
+        },
+        "operations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/SpanOperation"
+          }
+        }
+      },
+      "required": ["brief", "operations"]
+    },
+    "SpanOperation": {
+      "title": "SpanOperation",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "brief": {
+          "type": "string"
+        },
+        "ops": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "templates": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["brief", "ops", "templates"]
+    }
+  }
+}

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -32,3 +32,14 @@ export interface NameJson {
     examples?: string[];
   }[];
 }
+
+export interface DescriptionJson {
+  brief: string;
+  operations: {
+    name?: string;
+    brief: string;
+    ops: string[];
+    templates: string[];
+    examples?: string[];
+  }[];
+}

--- a/test/description.test.ts
+++ b/test/description.test.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import Ajv from 'ajv';
+import { describe, expect, it } from 'vitest';
+
+import schema from '../schemas/description.schema.json';
+import type { AttributeJson, DescriptionJson } from '../scripts/types';
+import { attributeKeyToFileName } from '../scripts/utils';
+
+const descriptionsFolder = path.resolve(__dirname, '../model/description');
+const attributesFolder = path.resolve(__dirname, '../model/attributes');
+
+describe('Description JSON', async () => {
+  const filesIterator = fs.promises.glob(`${descriptionsFolder}/*.json`);
+  const files = await Array.fromAsync(filesIterator);
+  const ajv = new Ajv();
+
+  for (const file of files) {
+    const name = path.basename(file);
+
+    describe(name, async () => {
+      const content: DescriptionJson = JSON.parse(await fs.promises.readFile(file, 'utf-8'));
+
+      it('should follow the description json schema', () => {
+        ajv.validate(schema, content);
+        expect(ajv.errors).toBe(null);
+      });
+
+      it('should not have duplicate ops', () => {
+        for (const operation of content.operations) {
+          expect(new Set(operation.ops).size).toBe(operation.ops.length);
+        }
+      });
+
+      it('should have attributes in every template', () => {
+        for (const operation of content.operations) {
+          for (const tmpl of operation.templates) {
+            expect(tmpl, `template "${tmpl}" should reference an attribute`).toContain('{{');
+          }
+        }
+      });
+
+      it('only references existing, non-replaced attributes', async () => {
+        const placeholder = /\{\{([^}]+)\}\}/g;
+        const missing: string[] = [];
+        const deprecated: string[] = [];
+
+        for (const operation of content.operations) {
+          for (const tmpl of operation.templates) {
+            for (const match of tmpl.matchAll(placeholder)) {
+              const key = match[1] as string;
+              const fileName = attributeKeyToFileName(key);
+              const namespace = key.includes('.') ? (key.split('.')[0] as string) : undefined;
+              const filePath = namespace
+                ? path.join(attributesFolder, namespace, fileName)
+                : path.join(attributesFolder, fileName);
+
+              const exists = await fs.promises
+                .access(filePath, fs.constants.F_OK)
+                .then(() => true)
+                .catch(() => false);
+
+              if (!exists) {
+                missing.push(key);
+                continue;
+              }
+
+              const attr: AttributeJson = JSON.parse(await fs.promises.readFile(filePath, 'utf-8'));
+              if (attr.deprecation?.replacement) {
+                deprecated.push(key);
+              }
+            }
+          }
+        }
+
+        expect(missing, `template attributes without definitions: ${missing.join(', ')}`).toEqual([]);
+        expect(
+          deprecated,
+          `template references deprecated attributes with replacements: ${deprecated.join(', ')}`,
+        ).toEqual([]);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Description

Define our conventions for span descriptions (the `sentry.description` attribute) here, so clients like Relay can generate them.

The methodology is very similar to our span name conventions. The only difference in the model JSON schema is the lack of `is_in_otel` and `otel_notes` fields, as span descriptions don't exist in OTel.

Unlike names, we don't fallback to a static string - it's better to be null and just rely on the sent `name` in this case.

Also note that a test makes sure we only use the latest version of attribute names in templates - this keeps our templates short and up to date. In every case we want to coalesce the referenced attributes with their deprecated aliases - we can do that programmatically in Relay.

This PR only includes the descriptions Relay currently generates, as a starting point. If we're cool with this approach I'll start filling in the rest.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

---

🤖: Used an LLM for the docs website changes. Looked fine to me.