### PR TITLE
test(name): Disallow replaced attributes

### DIFF
--- a/test/name.test.ts
+++ b/test/name.test.ts
@@ -5,7 +5,7 @@ import Ajv from 'ajv';
 import { describe, expect, it } from 'vitest';
 
 import schema from '../schemas/name.schema.json';
-import type { NameJson } from '../scripts/types';
+import type { AttributeJson, NameJson } from '../scripts/types';
 import { attributeKeyToFileName } from '../scripts/utils';
 
 const namesFolder = path.resolve(__dirname, '../model/name');
@@ -45,9 +45,10 @@ describe('Name JSON', async () => {
         }
       });
 
-      it('only references existing attributes', async () => {
+      it('only references existing, non-replaced attributes', async () => {
         const placeholder = /\{\{([^}]+)\}\}/g;
         const missing: string[] = [];
+        const deprecated: string[] = [];
 
         for (const operation of content.operations) {
           for (const tmpl of operation.templates) {
@@ -66,12 +67,22 @@ describe('Name JSON', async () => {
 
               if (!exists) {
                 missing.push(key);
+                continue;
+              }
+
+              const attr: AttributeJson = JSON.parse(await fs.promises.readFile(filePath, 'utf-8'));
+              if (attr.deprecation?.replacement) {
+                deprecated.push(key);
               }
             }
           }
         }
 
         expect(missing, `template attributes without definitions: ${missing.join(', ')}`).toEqual([]);
+        expect(
+          deprecated,
+          `template references deprecated attributes with replacements: ${deprecated.join(', ')}`,
+        ).toEqual([]);
       });
     });
   }


### PR DESCRIPTION
## Description

Make the same change to `name` tests as https://github.com/getsentry/sentry-conventions/pull/422 does for `description` -  make sure we don't reference replaced attributes in our `name` conventions. Keeps the template list short (don't have to manually list deprecated names) and means we only have to coalesce in one direction in Relay.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.
