### PR TITLE
feat(attributes): Add Cloudflare DO sql attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2723,6 +2723,69 @@ export const CLOUDFLARE_D1_ROWS_WRITTEN = 'cloudflare.d1.rows_written';
  */
 export type CLOUDFLARE_D1_ROWS_WRITTEN_TYPE = number;
 
+// Path: model/attributes/cloudflare/cloudflare__durable_object__query__bindings.json
+
+/**
+ * The number of bound parameters passed to the SQL exec call. `cloudflare.durable_object.query.bindings`
+ *
+ * Attribute Value Type: `number` {@link CLOUDFLARE_DURABLE_OBJECT_QUERY_BINDINGS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example 2
+ */
+export const CLOUDFLARE_DURABLE_OBJECT_QUERY_BINDINGS = 'cloudflare.durable_object.query.bindings';
+
+/**
+ * Type for {@link CLOUDFLARE_DURABLE_OBJECT_QUERY_BINDINGS} cloudflare.durable_object.query.bindings
+ */
+export type CLOUDFLARE_DURABLE_OBJECT_QUERY_BINDINGS_TYPE = number;
+
+// Path: model/attributes/cloudflare/cloudflare__durable_object__response__rows_read.json
+
+/**
+ * The number of rows read by a Cloudflare Durable Object SQL operation. `cloudflare.durable_object.response.rows_read`
+ *
+ * Attribute Value Type: `number` {@link CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_READ_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example 12
+ */
+export const CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_READ = 'cloudflare.durable_object.response.rows_read';
+
+/**
+ * Type for {@link CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_READ} cloudflare.durable_object.response.rows_read
+ */
+export type CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_READ_TYPE = number;
+
+// Path: model/attributes/cloudflare/cloudflare__durable_object__response__rows_written.json
+
+/**
+ * The number of rows written by a Cloudflare Durable Object SQL operation. `cloudflare.durable_object.response.rows_written`
+ *
+ * Attribute Value Type: `number` {@link CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_WRITTEN_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example 1
+ */
+export const CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_WRITTEN = 'cloudflare.durable_object.response.rows_written';
+
+/**
+ * Type for {@link CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_WRITTEN} cloudflare.durable_object.response.rows_written
+ */
+export type CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_WRITTEN_TYPE = number;
+
 // Path: model/attributes/cloudflare/cloudflare__r2__bucket.json
 
 /**
@@ -14755,6 +14818,9 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [CLOUDFLARE_D1_QUERY_TYPE]: 'string',
   [CLOUDFLARE_D1_ROWS_READ]: 'integer',
   [CLOUDFLARE_D1_ROWS_WRITTEN]: 'integer',
+  [CLOUDFLARE_DURABLE_OBJECT_QUERY_BINDINGS]: 'integer',
+  [CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_READ]: 'integer',
+  [CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_WRITTEN]: 'integer',
   [CLOUDFLARE_R2_BUCKET]: 'string',
   [CLOUDFLARE_R2_OPERATION]: 'string',
   [CLOUDFLARE_R2_REQUEST_DELIMITER]: 'string',
@@ -15420,6 +15486,9 @@ export type AttributeName =
   | typeof CLOUDFLARE_D1_QUERY_TYPE
   | typeof CLOUDFLARE_D1_ROWS_READ
   | typeof CLOUDFLARE_D1_ROWS_WRITTEN
+  | typeof CLOUDFLARE_DURABLE_OBJECT_QUERY_BINDINGS
+  | typeof CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_READ
+  | typeof CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_WRITTEN
   | typeof CLOUDFLARE_R2_BUCKET
   | typeof CLOUDFLARE_R2_OPERATION
   | typeof CLOUDFLARE_R2_REQUEST_DELIMITER
@@ -17629,6 +17698,45 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 12,
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+  },
+  [CLOUDFLARE_DURABLE_OBJECT_QUERY_BINDINGS]: {
+    brief: 'The number of bound parameters passed to the SQL exec call.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 2,
+    changelog: [
+      { version: 'next', prs: [435], description: 'Added cloudflare.durable_object.query.bindings attribute' },
+    ],
+  },
+  [CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_READ]: {
+    brief: 'The number of rows read by a Cloudflare Durable Object SQL operation.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 12,
+    changelog: [
+      { version: 'next', prs: [435], description: 'Added cloudflare.durable_object.response.rows_read attribute' },
+    ],
+  },
+  [CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_WRITTEN]: {
+    brief: 'The number of rows written by a Cloudflare Durable Object SQL operation.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 1,
+    changelog: [
+      { version: 'next', prs: [435], description: 'Added cloudflare.durable_object.response.rows_written attribute' },
+    ],
   },
   [CLOUDFLARE_R2_BUCKET]: {
     brief: 'The name of the Cloudflare R2 bucket binding',
@@ -24858,6 +24966,9 @@ export type Attributes = {
   [CLOUDFLARE_D1_QUERY_TYPE]?: CLOUDFLARE_D1_QUERY_TYPE_TYPE;
   [CLOUDFLARE_D1_ROWS_READ]?: CLOUDFLARE_D1_ROWS_READ_TYPE;
   [CLOUDFLARE_D1_ROWS_WRITTEN]?: CLOUDFLARE_D1_ROWS_WRITTEN_TYPE;
+  [CLOUDFLARE_DURABLE_OBJECT_QUERY_BINDINGS]?: CLOUDFLARE_DURABLE_OBJECT_QUERY_BINDINGS_TYPE;
+  [CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_READ]?: CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_READ_TYPE;
+  [CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_WRITTEN]?: CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_WRITTEN_TYPE;
   [CLOUDFLARE_R2_BUCKET]?: CLOUDFLARE_R2_BUCKET_TYPE;
   [CLOUDFLARE_R2_OPERATION]?: CLOUDFLARE_R2_OPERATION_TYPE;
   [CLOUDFLARE_R2_REQUEST_DELIMITER]?: CLOUDFLARE_R2_REQUEST_DELIMITER_TYPE;

--- a/model/attributes/cloudflare/cloudflare__durable_object__query__bindings.json
+++ b/model/attributes/cloudflare/cloudflare__durable_object__query__bindings.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.durable_object.query.bindings",
+  "brief": "The number of bound parameters passed to the SQL exec call.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "example": 2,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [435],
+      "description": "Added cloudflare.durable_object.query.bindings attribute"
+    }
+  ]
+}

--- a/model/attributes/cloudflare/cloudflare__durable_object__response__rows_read.json
+++ b/model/attributes/cloudflare/cloudflare__durable_object__response__rows_read.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.durable_object.response.rows_read",
+  "brief": "The number of rows read by a Cloudflare Durable Object SQL operation.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "example": 12,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [435],
+      "description": "Added cloudflare.durable_object.response.rows_read attribute"
+    }
+  ]
+}

--- a/model/attributes/cloudflare/cloudflare__durable_object__response__rows_written.json
+++ b/model/attributes/cloudflare/cloudflare__durable_object__response__rows_written.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.durable_object.response.rows_written",
+  "brief": "The number of rows written by a Cloudflare Durable Object SQL operation.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "example": 1,
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [435],
+      "description": "Added cloudflare.durable_object.response.rows_written attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1895,6 +1895,45 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 12
     """
 
+    # Path: model/attributes/cloudflare/cloudflare__durable_object__query__bindings.json
+    CLOUDFLARE_DURABLE_OBJECT_QUERY_BINDINGS: Literal[
+        "cloudflare.durable_object.query.bindings"
+    ] = "cloudflare.durable_object.query.bindings"
+    """The number of bound parameters passed to the SQL exec call.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: 2
+    """
+
+    # Path: model/attributes/cloudflare/cloudflare__durable_object__response__rows_read.json
+    CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_READ: Literal[
+        "cloudflare.durable_object.response.rows_read"
+    ] = "cloudflare.durable_object.response.rows_read"
+    """The number of rows read by a Cloudflare Durable Object SQL operation.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: 12
+    """
+
+    # Path: model/attributes/cloudflare/cloudflare__durable_object__response__rows_written.json
+    CLOUDFLARE_DURABLE_OBJECT_RESPONSE_ROWS_WRITTEN: Literal[
+        "cloudflare.durable_object.response.rows_written"
+    ] = "cloudflare.durable_object.response.rows_written"
+    """The number of rows written by a Cloudflare Durable Object SQL operation.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: 1
+    """
+
     # Path: model/attributes/cloudflare/cloudflare__r2__bucket.json
     CLOUDFLARE_R2_BUCKET: Literal["cloudflare.r2.bucket"] = "cloudflare.r2.bucket"
     """The name of the Cloudflare R2 bucket binding
@@ -10297,6 +10336,51 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "cloudflare.durable_object.query.bindings": AttributeMetadata(
+        brief="The number of bound parameters passed to the SQL exec call.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=2,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[435],
+                description="Added cloudflare.durable_object.query.bindings attribute",
+            ),
+        ],
+    ),
+    "cloudflare.durable_object.response.rows_read": AttributeMetadata(
+        brief="The number of rows read by a Cloudflare Durable Object SQL operation.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=12,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[435],
+                description="Added cloudflare.durable_object.response.rows_read attribute",
+            ),
+        ],
+    ),
+    "cloudflare.durable_object.response.rows_written": AttributeMetadata(
+        brief="The number of rows written by a Cloudflare Durable Object SQL operation.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=1,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[435],
+                description="Added cloudflare.durable_object.response.rows_written attribute",
+            ),
+        ],
+    ),
     "cloudflare.r2.bucket": AttributeMetadata(
         brief="The name of the Cloudflare R2 bucket binding",
         type=AttributeType.STRING,
@@ -17863,6 +17947,9 @@ Attributes = TypedDict(
         "cloudflare.d1.query_type": str,
         "cloudflare.d1.rows_read": int,
         "cloudflare.d1.rows_written": int,
+        "cloudflare.durable_object.query.bindings": int,
+        "cloudflare.durable_object.response.rows_read": int,
+        "cloudflare.durable_object.response.rows_written": int,
         "cloudflare.r2.bucket": str,
         "cloudflare.r2.operation": str,
         "cloudflare.r2.request.delimiter": str,


### PR DESCRIPTION
## Description

This adds Cloudflare attributes for SQL in Durable Object (sqlite). These attributes were taken from Cloudflare's traces directly.

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
