### PR TITLE
docs: Remove semicolon in db.query.summary example

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3636,7 +3636,7 @@ export type DB_QUERY_PARAMETER_KEY_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * @example "SELECT users;"
+ * @example "SELECT users"
  */
 export const DB_QUERY_SUMMARY = 'db.query.summary';
 
@@ -18088,7 +18088,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: true,
     visibility: 'public',
-    example: 'SELECT users;',
+    example: 'SELECT users',
     changelog: [{ version: '0.4.0', prs: [208] }, { version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   [DB_QUERY_TEXT]: {

--- a/model/attributes/db/db__query__summary.json
+++ b/model/attributes/db/db__query__summary.json
@@ -6,7 +6,7 @@
     "key": "manual"
   },
   "is_in_otel": true,
-  "example": "SELECT users;",
+  "example": "SELECT users",
   "visibility": "public",
   "changelog": [
     {

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2336,7 +2336,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Example: "SELECT users;"
+    Example: "SELECT users"
     """
 
     # Path: model/attributes/db/db__query__text.json
@@ -10764,7 +10764,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
-        example="SELECT users;",
+        example="SELECT users",
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[208]),
             ChangelogEntry(version="0.1.0", prs=[127]),


### PR DESCRIPTION
## Description

I was going over the `db.query.*` examples and saw that the `;` should not be there in `db.query.summary` this also reflects the conventions: https://opentelemetry.io/docs/specs/semconv/db/sql/ (it is just a little tough to see, as there is a `;`, but it is not part of the example)

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
