### PR TITLE
feat(attributes): Add `span.initial_name` attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -12695,6 +12695,27 @@ export const SESSION_ID = 'session.id';
  */
 export type SESSION_ID_TYPE = string;
 
+// Path: model/attributes/span/span__initial_name.json
+
+/**
+ * Stores the initial name of the span (prior to any potential name update) that can for example be used SDK-side to filter spans `span.initial_name`
+ *
+ * Attribute Value Type: `string` {@link SPAN_INITIAL_NAME_TYPE}
+ *
+ * Apply Scrubbing: auto
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "GET /users/123"
+ */
+export const SPAN_INITIAL_NAME = 'span.initial_name';
+
+/**
+ * Type for {@link SPAN_INITIAL_NAME} span.initial_name
+ */
+export type SPAN_INITIAL_NAME_TYPE = string;
+
 // Path: model/attributes/stall_percentage.json
 
 /**
@@ -15140,6 +15161,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SERVICE_NAME]: 'string',
   [SERVICE_VERSION]: 'string',
   [SESSION_ID]: 'string',
+  [SPAN_INITIAL_NAME]: 'string',
   [STALL_PERCENTAGE]: 'double',
   [STALL_TOTAL_TIME]: 'double',
   [STATE_TYPE]: 'string',
@@ -15802,6 +15824,7 @@ export type AttributeName =
   | typeof SERVICE_NAME
   | typeof SERVICE_VERSION
   | typeof SESSION_ID
+  | typeof SPAN_INITIAL_NAME
   | typeof STALL_PERCENTAGE
   | typeof STALL_TOTAL_TIME
   | typeof STATE_TYPE
@@ -23614,6 +23637,21 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '00112233-4455-6677-8899-aabbccddeeff',
     changelog: [{ version: '0.11.0', prs: [412], description: 'Added session.id attribute' }],
   },
+  [SPAN_INITIAL_NAME]: {
+    brief:
+      'Stores the initial name of the span (prior to any potential name update) that can for example be used SDK-side to filter spans',
+    type: 'string',
+    applyScrubbing: {
+      key: 'auto',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'GET /users/123',
+    changelog: [{ version: 'next', prs: [443], description: 'Added span.initial_name attribute' }],
+    additionalContext: [
+      'This attribute must be set to the value that the SDK applies to `ignoreSpans` or `tracesSampler`. Only relevant for streamed spans.',
+    ],
+  },
   [STALL_PERCENTAGE]: {
     brief: 'The fraction of time the app was stalled. Only applies to React Native. This is computed by Relay.',
     type: 'double',
@@ -25193,6 +25231,7 @@ export type Attributes = {
   [SERVICE_NAME]?: SERVICE_NAME_TYPE;
   [SERVICE_VERSION]?: SERVICE_VERSION_TYPE;
   [SESSION_ID]?: SESSION_ID_TYPE;
+  [SPAN_INITIAL_NAME]?: SPAN_INITIAL_NAME_TYPE;
   [STALL_PERCENTAGE]?: STALL_PERCENTAGE_TYPE;
   [STALL_TOTAL_TIME]?: STALL_TOTAL_TIME_TYPE;
   [STATE_TYPE]?: STATE_TYPE_TYPE;

--- a/model/attributes/span/span__initial_name.json
+++ b/model/attributes/span/span__initial_name.json
@@ -1,0 +1,21 @@
+{
+  "key": "span.initial_name",
+  "brief": "Stores the initial name of the span (prior to any potential name update) that can for example be used SDK-side to filter spans",
+  "additional_context": [
+    "This attribute must be set to the value that the SDK applies to `ignoreSpans` or `tracesSampler`. Only relevant for streamed spans."
+  ],
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "auto"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "example": "GET /users/123",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [443],
+      "description": "Added span.initial_name attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -7382,6 +7382,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "00112233-4455-6677-8899-aabbccddeeff"
     """
 
+    # Path: model/attributes/span/span__initial_name.json
+    SPAN_INITIAL_NAME: Literal["span.initial_name"] = "span.initial_name"
+    """Stores the initial name of the span (prior to any potential name update) that can for example be used SDK-side to filter spans
+
+    Type: str
+    Apply Scrubbing: auto
+    Defined in OTEL: No
+    Visibility: public
+    Example: "GET /users/123"
+    """
+
     # Path: model/attributes/stall_percentage.json
     STALL_PERCENTAGE: Literal["stall_percentage"] = "stall_percentage"
     """The fraction of time the app was stalled. Only applies to React Native. This is computed by Relay.
@@ -16586,6 +16597,24 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "span.initial_name": AttributeMetadata(
+        brief="Stores the initial name of the span (prior to any potential name update) that can for example be used SDK-side to filter spans",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="GET /users/123",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[443],
+                description="Added span.initial_name attribute",
+            ),
+        ],
+        additional_context=[
+            "This attribute must be set to the value that the SDK applies to `ignoreSpans` or `tracesSampler`. Only relevant for streamed spans."
+        ],
+    ),
     "stall_percentage": AttributeMetadata(
         brief="The fraction of time the app was stalled. Only applies to React Native. This is computed by Relay.",
         type=AttributeType.DOUBLE,
@@ -18219,6 +18248,7 @@ Attributes = TypedDict(
         "service.name": str,
         "service.version": str,
         "session.id": str,
+        "span.initial_name": str,
         "stall_percentage": float,
         "stall_total_time": float,
         "state.type": str,


### PR DESCRIPTION
## Description

This PR proposes adding a new attribute set on every span that carries the initial span name. We can surface this attribute in the product to make it easier for users to see what they have to put into `ignoreSpans` to filter out spans they don't want. In contrast to the span name, this attribute will always hold the original name and not get updated later on by auto instrumentation or users. 

cc @ArthurKnaus 

## PR Checklist
<!-- Check these to make sure the PR is ready for review -->
- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:
- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:
- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
