### PR TITLE
fix(attributes): Add deprecated `sentry.thread.id`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -12380,6 +12380,28 @@ export const SENTRY_STATUS_MESSAGE = 'sentry.status.message';
  */
 export type SENTRY_STATUS_MESSAGE_TYPE = string;
 
+// Path: model/attributes/sentry/sentry__thread__id.json
+
+/**
+ * Current “managed” thread ID. `sentry.thread.id`
+ *
+ * Attribute Value Type: `number` {@link SENTRY_THREAD_ID_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @deprecated Use {@link THREAD_ID} (thread.id) instead - This attribute is being deprecated in favor of the OTel-standard thread.id
+ * @example 56
+ */
+export const SENTRY_THREAD_ID = 'sentry.thread.id';
+
+/**
+ * Type for {@link SENTRY_THREAD_ID} sentry.thread.id
+ */
+export type SENTRY_THREAD_ID_TYPE = number;
+
 // Path: model/attributes/sentry/sentry__timestamp__sequence.json
 
 /**
@@ -15173,6 +15195,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SENTRY_SPAN_SOURCE]: 'string',
   [SENTRY_STATUS_CODE]: 'integer',
   [SENTRY_STATUS_MESSAGE]: 'string',
+  [SENTRY_THREAD_ID]: 'integer',
   [SENTRY_TIMESTAMP_SEQUENCE]: 'integer',
   [SENTRY_TRACE_PARENT_SPAN_ID]: 'string',
   [SENTRY_TRANSACTION]: 'string',
@@ -15837,6 +15860,7 @@ export type AttributeName =
   | typeof SENTRY_SPAN_SOURCE
   | typeof SENTRY_STATUS_CODE
   | typeof SENTRY_STATUS_MESSAGE
+  | typeof SENTRY_THREAD_ID
   | typeof SENTRY_TIMESTAMP_SEQUENCE
   | typeof SENTRY_TRACE_PARENT_SPAN_ID
   | typeof SENTRY_TRANSACTION
@@ -23476,6 +23500,21 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'foobar',
     changelog: [{ version: '0.3.1', prs: [190] }],
   },
+  [SENTRY_THREAD_ID]: {
+    brief: 'Current “managed” thread ID.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 56,
+    deprecation: {
+      replacement: 'thread.id',
+      reason: 'This attribute is being deprecated in favor of the OTel-standard thread.id',
+    },
+    changelog: [{ version: 'next' }],
+  },
   [SENTRY_TIMESTAMP_SEQUENCE]: {
     brief:
       'A sequencing counter for deterministic ordering of logs or metrics when timestamps share the same integer millisecond. Starts at 0 on SDK initialization, increments by 1 for each captured item, and resets to 0 when the integer millisecond of the current item differs from the previous one.',
@@ -25259,6 +25298,7 @@ export type Attributes = {
   [SENTRY_SPAN_SOURCE]?: SENTRY_SPAN_SOURCE_TYPE;
   [SENTRY_STATUS_CODE]?: SENTRY_STATUS_CODE_TYPE;
   [SENTRY_STATUS_MESSAGE]?: SENTRY_STATUS_MESSAGE_TYPE;
+  [SENTRY_THREAD_ID]?: SENTRY_THREAD_ID_TYPE;
   [SENTRY_TIMESTAMP_SEQUENCE]?: SENTRY_TIMESTAMP_SEQUENCE_TYPE;
   [SENTRY_TRACE_PARENT_SPAN_ID]?: SENTRY_TRACE_PARENT_SPAN_ID_TYPE;
   [SENTRY_TRANSACTION]?: SENTRY_TRANSACTION_TYPE;

--- a/model/attributes/sentry/sentry__thread__id.json
+++ b/model/attributes/sentry/sentry__thread__id.json
@@ -1,0 +1,21 @@
+{
+  "key": "sentry.thread.id",
+  "brief": "Current “managed” thread ID.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 56,
+  "visibility": "public",
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "thread.id",
+    "reason": "This attribute is being deprecated in favor of the OTel-standard thread.id"
+  },
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -260,6 +260,7 @@ class _AttributeNamesMeta(type):
         "SENTRY_REPORT_EVENT",
         "_SENTRY_SEGMENT_ID",
         "SENTRY_SOURCE",
+        "SENTRY_THREAD_ID",
         "SENTRY_TRACE_PARENT_SPAN_ID",
         "SENTRY_TRANSACTION",
         "SENTRY_USER_EMAIL",
@@ -7210,6 +7211,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Visibility: public
     Example: 200
+    """
+
+    # Path: model/attributes/sentry/sentry__thread__id.json
+    SENTRY_THREAD_ID: Literal["sentry.thread.id"] = "sentry.thread.id"
+    """Current “managed” thread ID.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    DEPRECATED: Use thread.id instead - This attribute is being deprecated in favor of the OTel-standard thread.id
+    Example: 56
     """
 
     # Path: model/attributes/sentry/sentry__timestamp__sequence.json
@@ -16439,6 +16452,22 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.4.0", prs=[223, 228]),
         ],
     ),
+    "sentry.thread.id": AttributeMetadata(
+        brief="Current “managed” thread ID.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=56,
+        deprecation=DeprecationInfo(
+            replacement="thread.id",
+            reason="This attribute is being deprecated in favor of the OTel-standard thread.id",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
     "sentry.timestamp.sequence": AttributeMetadata(
         brief="A sequencing counter for deterministic ordering of logs or metrics when timestamps share the same integer millisecond. Starts at 0 on SDK initialization, increments by 1 for each captured item, and resets to 0 when the integer millisecond of the current item differs from the previous one.",
         type=AttributeType.INTEGER,
@@ -18268,6 +18297,7 @@ Attributes = TypedDict(
         "sentry.span.source": str,
         "sentry.status.message": str,
         "sentry.status_code": int,
+        "sentry.thread.id": int,
         "sentry.timestamp.sequence": int,
         "sentry.trace.parent_span_id": str,
         "sentry.transaction": str,


### PR DESCRIPTION
Transaction-based spans wrote the current thread ID into `sentry.thread.id`. The Sentry backend [aliases this to `thread.id`](https://github.com/getsentry/sentry/blob/a7331a0f5a3af5f75981865a5cc41cb90ee7ae8d/src/sentry/search/eap/spans/attributes.py#L179).

Span streaming SDKs are correctly using our conventional `thread.id` directly, but the backend can't see them due to that existing alias.

Add a deprecated `sentry.thread.id` pointing to `thread.id` as its replacement. Once this is merged and updated in Snuba, coalescing will make this start working on the Sentry side. We should then be able to remove Sentry's custom mapping, relying on the definition here instead.

See DAIN-1733.