### PR TITLE
feat(docs): Add span operations reference page

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -85,6 +85,24 @@ const descriptions = defineCollection({
   schema: descriptionSchema,
 });
 
+// Schema matching schemas/op.schema.json
+const opFieldSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+});
+
+const opSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  fields: z.array(opFieldSchema),
+});
+
+// Define the ops collection - loads all JSON files from model/op
+const ops = defineCollection({
+  loader: glob({ pattern: '*.json', base: '../model/op' }),
+  schema: opSchema,
+});
+
 // Schema matching schemas/measurements.schema.json
 const measurementSchema = z.object({
   key: z.string(),
@@ -101,7 +119,7 @@ const measurements = defineCollection({
   schema: measurementSchema,
 });
 
-export const collections = { attributes, names, descriptions, measurements };
+export const collections = { attributes, names, descriptions, measurements, ops };
 
 // Export types for use in pages
 export type Attribute = z.infer<typeof attributeSchema>;
@@ -110,3 +128,5 @@ export type SpanOperation = z.infer<typeof spanOperationSchema>;
 export type SpanDescription = z.infer<typeof descriptionSchema>;
 export type DescriptionOperation = z.infer<typeof descriptionOperationSchema>;
 export type Measurement = z.infer<typeof measurementSchema>;
+export type SpanOp = z.infer<typeof opSchema>;
+export type SpanOpField = z.infer<typeof opFieldSchema>;

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -91,6 +91,17 @@ const currentPath = Astro.url.pathname;
               Span Descriptions
             </a>
             <a
+              href={`${import.meta.env.BASE_URL}ops/`}
+              class:list={[
+                "nav-link",
+                currentPath.includes('/ops')
+                  ? "text-accent bg-accent-soft"
+                  : "text-text-secondary hover:text-text-primary hover:bg-bg-hover"
+              ]}
+            >
+              Span Operations
+            </a>
+            <a
               href="https://github.com/getsentry/sentry-conventions"
               class="nav-link text-text-secondary hover:text-text-primary hover:bg-bg-hover"
               target="_blank"

--- a/docs/src/pages/llms.txt.ts
+++ b/docs/src/pages/llms.txt.ts
@@ -14,6 +14,7 @@ Sentry Semantic Conventions define standardized attribute keys, span operation n
 - [All Attributes](${baseUrl}llms-full.txt): Complete list of all span and breadcrumb attributes in plain text
 - [Attributes Reference](${baseUrl}attributes/): Browse attributes grouped by category
 - [Span Names](${baseUrl}names/): How to construct span names using templates
+- [Span Operations](${baseUrl}ops/): Known span operations (the sentry.op attribute) grouped by category
 
 ## Optional
 

--- a/docs/src/pages/ops/index.astro
+++ b/docs/src/pages/ops/index.astro
@@ -1,0 +1,110 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import CategoryChip from '../../components/CategoryChip.astro';
+import AttributeLink from '../../components/AttributeLink.astro';
+import AnchorIcon from '../../components/icons/AnchorIcon.astro';
+import { renderMarkdownLinks } from '../../utils/markdown';
+import { getCollection } from 'astro:content';
+
+// Get all span operation categories
+const allOps = await getCollection('ops');
+
+// Sort categories alphabetically, but put 'general' first
+allOps.sort((a, b) => {
+  if (a.id === 'general') return -1;
+  if (b.id === 'general') return 1;
+  return a.id.localeCompare(b.id);
+});
+
+// Count total operations across all categories
+const totalOps = allOps.reduce((acc, op) => acc + op.data.fields.length, 0);
+---
+
+<BaseLayout
+  title="Span Operations"
+  description="Reference for Sentry span operations (the sentry.op attribute) grouped by category"
+>
+  <div class="mb-8">
+    <h1>Span Operation Documentation</h1>
+    <p class="text-lg text-text-secondary max-w-3xl">
+      This page lists known span operations. The operation is a low-cardinality string that describes
+      the category of work a span represents, and is stored in the <AttributeLink name="sentry.op" /> attribute.
+    </p>
+  </div>
+
+  <section class="bg-bg-secondary border border-border rounded-lg p-6 mb-8">
+    <h2 class="text-xl mb-4">Choosing an Operation</h2>
+    <p class="text-sm max-w-2xl">
+      Operations are grouped by category (for example <code>database</code> or <code>browser</code>).
+      Within a category, more specific operations use a dotted hierarchy such as
+      <code>ui.react.render</code>, where each segment narrows down the kind of work being measured.
+    </p>
+    <p class="text-sm max-w-2xl">
+      Use the most specific operation that accurately describes the span. When no specific operation
+      fits, fall back to the closest broader operation in the same category.
+    </p>
+
+    <div class="mt-6 p-4 bg-bg-elevated rounded-md border-l-[3px] border-accent">
+      <h4 class="text-sm text-accent mb-3">Example</h4>
+      <p class="text-sm mb-2">A span measuring a database query sets:</p>
+      <p class="text-sm m-0"><code>sentry.op = "db.query"</code></p>
+    </div>
+  </section>
+
+  <nav class="flex items-start gap-4 p-4 bg-bg-secondary border border-border rounded-lg mb-8 flex-col md:flex-row">
+    <span class="text-sm text-text-muted whitespace-nowrap pt-1">Categories ({allOps.length}):</span>
+    <div class="flex flex-wrap gap-2">
+      {allOps.map(op => (
+        <CategoryChip
+          name={op.data.name}
+          count={op.data.fields.length}
+          href={`#${op.id}`}
+        />
+      ))}
+    </div>
+  </nav>
+
+  <div class="flex flex-col gap-12">
+    {allOps.map(op => (
+      <section class="scroll-mt-20" id={op.id}>
+        <div class="flex items-baseline gap-4 mb-2 group">
+          <h2 class="m-0 text-2xl">
+            <a href={`#${op.id}`} class="section-anchor">
+              {op.data.name}
+              <AnchorIcon class="section-anchor-marker w-4 h-4" />
+            </a>
+          </h2>
+          <span class="text-sm text-text-muted">{op.data.fields.length} operations</span>
+        </div>
+        {op.data.description && (
+          <p class="text-sm text-text-secondary mb-4 max-w-3xl">{op.data.description}</p>
+        )}
+
+        <div class="overflow-x-auto">
+          <table>
+            <thead>
+              <tr>
+                <th>Operation</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {op.data.fields.map(field => (
+                <tr>
+                  <td class="whitespace-nowrap align-top"><code class="text-xs">{field.name}</code></td>
+                  <td class="text-text-secondary">
+                    {field.description ? (
+                      <span set:html={renderMarkdownLinks(field.description)} />
+                    ) : (
+                      <span class="text-text-muted">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    ))}
+  </div>
+</BaseLayout>

--- a/docs/src/utils/markdown.ts
+++ b/docs/src/utils/markdown.ts
@@ -1,0 +1,31 @@
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Renders a string containing inline markdown links (`[label](https://...)`) to HTML.
+ * Everything except recognized http(s) links is HTML-escaped, so the output is safe to
+ * pass to `set:html`.
+ */
+export function renderMarkdownLinks(text: string): string {
+  const linkPattern = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+  let result = '';
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = linkPattern.exec(text)) !== null) {
+    result += escapeHtml(text.slice(lastIndex, match.index));
+    const label = escapeHtml(match[1]);
+    const url = escapeHtml(match[2]);
+    result += `<a href="${url}" target="_blank" rel="noopener" class="text-accent hover:text-accent-hover">${label}</a>`;
+    lastIndex = linkPattern.lastIndex;
+  }
+
+  result += escapeHtml(text.slice(lastIndex));
+  return result;
+}


### PR DESCRIPTION
Add a Span Operations page displaying the span operations data (`op` schema). 

There are some inconsistencies here like missing ops and op descriptions, but this is rather a data issue to be addressed in a follow-up. Ideally we can phase out the develop docs [span operations](https://develop.sentry.dev/sdk/telemetry/traces/span-operations/#list-of-operations) list since in conventions we can much easier cross-check and reference ops and their influence on span name/description rules.

Similarly, as a follow-up I'm thinking of adding tests that for span description inference rules, the ops must be present in the operations page. At this point we can also link from description and name rule ops to the respective op entry. 

<img width="1283" height="1297" alt="image" src="https://github.com/user-attachments/assets/7ba0f268-b7aa-4089-99f1-2650beba95eb" />
