### PR TITLE
feat(attributes): Add sentry.status and sentry.trace.status

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -12401,6 +12401,27 @@ export const SENTRY_SPAN_SOURCE = 'sentry.span.source';
  */
 export type SENTRY_SPAN_SOURCE_TYPE = string;
 
+// Path: model/attributes/sentry/sentry__status.json
+
+/**
+ * The span's status (either "ok" or "error"). Older SDKs may set this to a more specific error, but this behaviour is deprecated. `sentry.status`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_STATUS_TYPE}
+ *
+ * Apply Scrubbing: never
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "ok"
+ */
+export const SENTRY_STATUS = 'sentry.status';
+
+/**
+ * Type for {@link SENTRY_STATUS} sentry.status
+ */
+export type SENTRY_STATUS_TYPE = string;
+
 // Path: model/attributes/sentry/sentry__status_code.json
 
 /**
@@ -12528,6 +12549,27 @@ export const SENTRY_TRACE_PARENT_SPAN_ID = 'sentry.trace.parent_span_id';
  * Type for {@link SENTRY_TRACE_PARENT_SPAN_ID} sentry.trace.parent_span_id
  */
 export type SENTRY_TRACE_PARENT_SPAN_ID_TYPE = string;
+
+// Path: model/attributes/sentry/sentry__trace__status.json
+
+/**
+ * The segment's status (either "ok" or "error"). Older SDKs may set this to a more specific error, but this behaviour is deprecated. `sentry.trace.status`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_TRACE_STATUS_TYPE}
+ *
+ * Apply Scrubbing: never
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "ok"
+ */
+export const SENTRY_TRACE_STATUS = 'sentry.trace.status';
+
+/**
+ * Type for {@link SENTRY_TRACE_STATUS} sentry.trace.status
+ */
+export type SENTRY_TRACE_STATUS_TYPE = string;
 
 // Path: model/attributes/sentry/sentry__transaction.json
 
@@ -15280,12 +15322,14 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   [SENTRY_SERVER_SAMPLE_RATE]: 'double',
   [SENTRY_SOURCE]: 'string',
   [SENTRY_SPAN_SOURCE]: 'string',
+  [SENTRY_STATUS]: 'string',
   [SENTRY_STATUS_CODE]: 'integer',
   [SENTRY_STATUS_MESSAGE]: 'string',
   [SENTRY_THREAD_ID]: 'integer',
   [SENTRY_TIMESTAMP_SEQUENCE]: 'integer',
   [SENTRY_TRACE_LIFECYCLE]: 'string',
   [SENTRY_TRACE_PARENT_SPAN_ID]: 'string',
+  [SENTRY_TRACE_STATUS]: 'string',
   [SENTRY_TRANSACTION]: 'string',
   [SENTRY_USER_EMAIL]: 'string',
   [SENTRY_USER_GEO_CITY]: 'string',
@@ -15949,12 +15993,14 @@ export type AttributeName =
   | typeof SENTRY_SERVER_SAMPLE_RATE
   | typeof SENTRY_SOURCE
   | typeof SENTRY_SPAN_SOURCE
+  | typeof SENTRY_STATUS
   | typeof SENTRY_STATUS_CODE
   | typeof SENTRY_STATUS_MESSAGE
   | typeof SENTRY_THREAD_ID
   | typeof SENTRY_TIMESTAMP_SEQUENCE
   | typeof SENTRY_TRACE_LIFECYCLE
   | typeof SENTRY_TRACE_PARENT_SPAN_ID
+  | typeof SENTRY_TRACE_STATUS
   | typeof SENTRY_TRANSACTION
   | typeof SENTRY_USER_EMAIL
   | typeof SENTRY_USER_GEO_CITY
@@ -23608,6 +23654,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'route',
     changelog: [{ version: '0.4.0', prs: [214] }, { version: '0.0.0' }],
   },
+  [SENTRY_STATUS]: {
+    brief:
+      'The span\'s status (either "ok" or "error"). Older SDKs may set this to a more specific error, but this behaviour is deprecated.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'never',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'ok',
+    changelog: [{ version: 'next' }],
+  },
   [SENTRY_STATUS_CODE]: {
     brief:
       'The HTTP status code used in Sentry Insights. Typically set by Sentry during ingestion, rather than by clients.',
@@ -23684,6 +23742,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: '0.5.0', prs: [287], description: 'Deprecate `sentry.trace.parent_span_id`' },
       { version: '0.1.0', prs: [116] },
     ],
+  },
+  [SENTRY_TRACE_STATUS]: {
+    brief:
+      'The segment\'s status (either "ok" or "error"). Older SDKs may set this to a more specific error, but this behaviour is deprecated.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'never',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'ok',
+    changelog: [{ version: 'next' }],
   },
   [SENTRY_TRANSACTION]: {
     brief: 'The sentry transaction (segment name).',
@@ -25441,12 +25511,14 @@ export type Attributes = {
   [SENTRY_SERVER_SAMPLE_RATE]?: SENTRY_SERVER_SAMPLE_RATE_TYPE;
   [SENTRY_SOURCE]?: SENTRY_SOURCE_TYPE;
   [SENTRY_SPAN_SOURCE]?: SENTRY_SPAN_SOURCE_TYPE;
+  [SENTRY_STATUS]?: SENTRY_STATUS_TYPE;
   [SENTRY_STATUS_CODE]?: SENTRY_STATUS_CODE_TYPE;
   [SENTRY_STATUS_MESSAGE]?: SENTRY_STATUS_MESSAGE_TYPE;
   [SENTRY_THREAD_ID]?: SENTRY_THREAD_ID_TYPE;
   [SENTRY_TIMESTAMP_SEQUENCE]?: SENTRY_TIMESTAMP_SEQUENCE_TYPE;
   [SENTRY_TRACE_LIFECYCLE]?: SENTRY_TRACE_LIFECYCLE_TYPE;
   [SENTRY_TRACE_PARENT_SPAN_ID]?: SENTRY_TRACE_PARENT_SPAN_ID_TYPE;
+  [SENTRY_TRACE_STATUS]?: SENTRY_TRACE_STATUS_TYPE;
   [SENTRY_TRANSACTION]?: SENTRY_TRANSACTION_TYPE;
   [SENTRY_USER_EMAIL]?: SENTRY_USER_EMAIL_TYPE;
   [SENTRY_USER_GEO_CITY]?: SENTRY_USER_GEO_CITY_TYPE;

--- a/model/attributes/sentry/sentry__status.json
+++ b/model/attributes/sentry/sentry__status.json
@@ -1,0 +1,16 @@
+{
+  "key": "sentry.status",
+  "brief": "The span's status (either \"ok\" or \"error\"). Older SDKs may set this to a more specific error, but this behaviour is deprecated.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "never"
+  },
+  "is_in_otel": false,
+  "example": "ok",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/sentry/sentry__trace__status.json
+++ b/model/attributes/sentry/sentry__trace__status.json
@@ -1,0 +1,16 @@
+{
+  "key": "sentry.trace.status",
+  "brief": "The segment's status (either \"ok\" or \"error\"). Older SDKs may set this to a more specific error, but this behaviour is deprecated.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "never"
+  },
+  "is_in_otel": false,
+  "example": "ok",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -7230,6 +7230,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "route"
     """
 
+    # Path: model/attributes/sentry/sentry__status.json
+    SENTRY_STATUS: Literal["sentry.status"] = "sentry.status"
+    """The span's status (either "ok" or "error"). Older SDKs may set this to a more specific error, but this behaviour is deprecated.
+
+    Type: str
+    Apply Scrubbing: never
+    Defined in OTEL: No
+    Visibility: public
+    Example: "ok"
+    """
+
     # Path: model/attributes/sentry/sentry__status__message.json
     SENTRY_STATUS_MESSAGE: Literal["sentry.status.message"] = "sentry.status.message"
     """The from OTLP extracted status message.
@@ -7289,6 +7300,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Visibility: public
     DEPRECATED: No replacement at this time
     Example: "b0e6f15b45c36b12"
+    """
+
+    # Path: model/attributes/sentry/sentry__trace__status.json
+    SENTRY_TRACE_STATUS: Literal["sentry.trace.status"] = "sentry.trace.status"
+    """The segment's status (either "ok" or "error"). Older SDKs may set this to a more specific error, but this behaviour is deprecated.
+
+    Type: str
+    Apply Scrubbing: never
+    Defined in OTEL: No
+    Visibility: public
+    Example: "ok"
     """
 
     # Path: model/attributes/sentry/sentry__trace_lifecycle.json
@@ -16525,6 +16547,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "sentry.status": AttributeMetadata(
+        brief='The span\'s status (either "ok" or "error"). Older SDKs may set this to a more specific error, but this behaviour is deprecated.',
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="ok",
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
     "sentry.status.message": AttributeMetadata(
         brief="The from OTLP extracted status message.",
         type=AttributeType.STRING,
@@ -16589,6 +16622,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
                 description="Deprecate `sentry.trace.parent_span_id`",
             ),
             ChangelogEntry(version="0.1.0", prs=[116]),
+        ],
+    ),
+    "sentry.trace.status": AttributeMetadata(
+        brief='The segment\'s status (either "ok" or "error"). Older SDKs may set this to a more specific error, but this behaviour is deprecated.',
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="ok",
+        changelog=[
+            ChangelogEntry(version="next"),
         ],
     ),
     "sentry.trace_lifecycle": AttributeMetadata(
@@ -18408,11 +18452,13 @@ Attributes = TypedDict(
         "sentry.server_sample_rate": float,
         "sentry.source": str,
         "sentry.span.source": str,
+        "sentry.status": str,
         "sentry.status.message": str,
         "sentry.status_code": int,
         "sentry.thread.id": int,
         "sentry.timestamp.sequence": int,
         "sentry.trace.parent_span_id": str,
+        "sentry.trace.status": str,
         "sentry.trace_lifecycle": str,
         "sentry.transaction": str,
         "sentry.user.email": str,


### PR DESCRIPTION
## Description

Both of these attributes are set during ingestion. For v2 spans they can only be "ok" or "error"; for v1 spans they have a [longer list of valid attributes](https://github.com/getsentry/relay/blob/c3889b5fe575c623260bccfed831f4a12cd4f9fe/relay-base-schema/src/spans.rs#L100-L116).

⚠️ I set these both to `apply_scrubbing: never` because they're meant to be hardcoded values and scrubbing would break them. Maybe these should be `manual` anyway though?

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)
