### PR TITLE
fix(build/js): Add subpath export shims for legacy bundlers

### DIFF
--- a/javascript/sentry-conventions/attributes.d.ts
+++ b/javascript/sentry-conventions/attributes.d.ts
@@ -1,0 +1,3 @@
+// This file is a compatibility shim for TypeScript compilers that do not
+// support the package.json `exports` field for resolving subpath exports.
+export * from './dist/attributes.d.ts';

--- a/javascript/sentry-conventions/attributes.d.ts
+++ b/javascript/sentry-conventions/attributes.d.ts
@@ -1,3 +1,3 @@
 // This file is a compatibility shim for TypeScript compilers that do not
 // support the package.json `exports` field for resolving subpath exports.
-export * from './dist/attributes.d.ts';
+export * from './dist/attributes';

--- a/javascript/sentry-conventions/attributes.js
+++ b/javascript/sentry-conventions/attributes.js
@@ -1,0 +1,3 @@
+// This file is a compatibility shim for bundlers (e.g. webpack 4) that do not
+// support the package.json `exports` field for resolving subpath exports.
+module.exports = require('./dist/attributes.cjs');

--- a/javascript/sentry-conventions/op.d.ts
+++ b/javascript/sentry-conventions/op.d.ts
@@ -1,3 +1,3 @@
 // This file is a compatibility shim for TypeScript compilers that do not
 // support the package.json `exports` field for resolving subpath exports.
-export * from './dist/op.d.ts';
+export * from './dist/op';

--- a/javascript/sentry-conventions/op.d.ts
+++ b/javascript/sentry-conventions/op.d.ts
@@ -1,0 +1,3 @@
+// This file is a compatibility shim for TypeScript compilers that do not
+// support the package.json `exports` field for resolving subpath exports.
+export * from './dist/op.d.ts';

--- a/javascript/sentry-conventions/op.js
+++ b/javascript/sentry-conventions/op.js
@@ -1,0 +1,3 @@
+// This file is a compatibility shim for bundlers (e.g. webpack 4) that do not
+// support the package.json `exports` field for resolving subpath exports.
+module.exports = require('./dist/op.cjs');

--- a/javascript/sentry-conventions/package.json
+++ b/javascript/sentry-conventions/package.json
@@ -31,7 +31,11 @@
     "node": ">=14"
   },
   "files": [
-    "dist"
+    "dist",
+    "attributes.js",
+    "attributes.d.ts",
+    "op.js",
+    "op.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently, adding `@sentry/conventions` to code bases using legacy tooling (old TS versions or, as we found out, webpack 4), results in build failures. These old tools don't support the `exports` conditions field or the subpath exports inside of them. Therefore, they'd resolve an `@sentry/conventions/attributes` import to the file `@sentry/coventions/attributes.js` rather than the entry point declared in `exports`.

This PR adds the shim file so that the import resolves to the shim file, which in turn re-exports from the corresponding subpath export entry point file. We're pointing to CJS on purpose here, given the age of said legacy tools.

Why do we care? We need this for using the conventions package in our JS SDKs. We have a webpack 4 e2e test to ensure our SDK packages stay compatible with legacy setups, which failed after adding and importing from the current sentry conventions package. (https://github.com/getsentry/sentry-javascript/pull/21855)