### PR TITLE
feat(attributes): Add `db.response.status_code`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3794,6 +3794,27 @@ export const DB_REDIS_PARAMETERS = 'db.redis.parameters';
  */
 export type DB_REDIS_PARAMETERS_TYPE = Array<string>;
 
+// Path: model/attributes/db/db__response__status_code.json
+
+/**
+ * Database response status code. The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes. `db.response.status_code`
+ *
+ * Attribute Value Type: `string` {@link DB_RESPONSE_STATUS_CODE_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "ORA-17002"
+ */
+export const DB_RESPONSE_STATUS_CODE = 'db.response.status_code';
+
+/**
+ * Type for {@link DB_RESPONSE_STATUS_CODE} db.response.status_code
+ */
+export type DB_RESPONSE_STATUS_CODE_TYPE = string;
+
 // Path: model/attributes/db/db__sql__bindings.json
 
 /**
@@ -14993,6 +15014,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'db.redis.connection': 'string',
   'db.redis.key': 'string',
   'db.redis.parameters': 'string[]',
+  'db.response.status_code': 'string',
   'db.sql.bindings': 'string[]',
   'db.statement': 'string',
   'db.stored_procedure.name': 'string',
@@ -15667,6 +15689,7 @@ export type AttributeName =
   | typeof DB_REDIS_CONNECTION
   | typeof DB_REDIS_KEY
   | typeof DB_REDIS_PARAMETERS
+  | typeof DB_RESPONSE_STATUS_CODE
   | typeof DB_SQL_BINDINGS
   | typeof DB_STATEMENT
   | typeof DB_STORED_PROCEDURE_NAME
@@ -18457,6 +18480,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: ['test', '*'],
     changelog: [{ version: '0.0.0' }],
+  },
+  'db.response.status_code': {
+    brief:
+      'Database response status code. The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'ORA-17002',
+    changelog: [{ version: 'next', prs: [462], description: 'Added db.response.status_code attribute' }],
   },
   'db.sql.bindings': {
     brief: 'The array of query bindings.',
@@ -25236,6 +25271,7 @@ export type Attributes = {
   [DB_REDIS_CONNECTION]?: DB_REDIS_CONNECTION_TYPE;
   [DB_REDIS_KEY]?: DB_REDIS_KEY_TYPE;
   [DB_REDIS_PARAMETERS]?: DB_REDIS_PARAMETERS_TYPE;
+  [DB_RESPONSE_STATUS_CODE]?: DB_RESPONSE_STATUS_CODE_TYPE;
   [DB_SQL_BINDINGS]?: DB_SQL_BINDINGS_TYPE;
   [DB_STATEMENT]?: DB_STATEMENT_TYPE;
   [DB_STORED_PROCEDURE_NAME]?: DB_STORED_PROCEDURE_NAME_TYPE;

--- a/model/attributes/db/db__response__status_code.json
+++ b/model/attributes/db/db__response__status_code.json
@@ -1,0 +1,18 @@
+{
+  "key": "db.response.status_code",
+  "brief": "Database response status code. The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "visibility": "public",
+  "example": "ORA-17002",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [462],
+      "description": "Added db.response.status_code attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2425,6 +2425,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: ["test","*"]
     """
 
+    # Path: model/attributes/db/db__response__status_code.json
+    DB_RESPONSE_STATUS_CODE: Literal["db.response.status_code"] = (
+        "db.response.status_code"
+    )
+    """Database response status code. The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "ORA-17002"
+    """
+
     # Path: model/attributes/db/db__sql__bindings.json
     DB_SQL_BINDINGS: Literal["db.sql.bindings"] = "db.sql.bindings"
     """The array of query bindings.
@@ -11018,6 +11031,21 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "db.response.status_code": AttributeMetadata(
+        brief="Database response status code. The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="ORA-17002",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[462],
+                description="Added db.response.status_code attribute",
+            ),
+        ],
+    ),
     "db.sql.bindings": AttributeMetadata(
         brief="The array of query bindings.",
         type=AttributeType.STRING_ARRAY,
@@ -18156,6 +18184,7 @@ Attributes = TypedDict(
         "db.redis.connection": str,
         "db.redis.key": str,
         "db.redis.parameters": List[str],
+        "db.response.status_code": str,
         "db.sql.bindings": List[str],
         "db.statement": str,
         "db.stored_procedure.name": str,


### PR DESCRIPTION
## Description

Adds an OTel attribute for database error status codes: https://opentelemetry.io/docs/specs/semconv/db/database-metrics/

## PR Checklist

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
