### PR TITLE
chore(ci): Stop inheriting secrets for `changelog-preview`

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -11,4 +11,3 @@ permissions:
 jobs:
   changelog-preview:
     uses: getsentry/craft/.github/workflows/changelog-preview.yml@f4889d04564e47311038ecb6b910fef6b6cf1363 # v2
-    secrets: inherit


### PR DESCRIPTION
The rationale for having the inherit secrets here is `(ensures caller's GITHUB_TOKEN is used)` - [docs](https://github.com/getsentry/craft/blob/7a65e77f6a0dea110484973afde1594f12bb23dd/.github/workflows/changelog-preview.yml#L19), however this should already be the case according to the [docs](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#github-context). As an example react-native already [omits it](https://github.com/getsentry/sentry-react-native/blob/main/.github/workflows/changelog-preview.yml).

Fix: INGEST-1001