### PR TITLE
feat(attributes): Add `faas.execution` (deprecated) in favor of `faas.invocation_id`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -19347,7 +19347,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     aliases: ['faas.invocation_id'],
     changelog: [
-      { version: 'next', description: 'Added faas.execution attribute, deprecated in favor of faas.invocation_id' },
+      {
+        version: 'next',
+        prs: [473],
+        description: 'Added faas.execution attribute, deprecated in favor of faas.invocation_id',
+      },
     ],
   },
   'faas.identity': {
@@ -19374,7 +19378,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'af9d5aa4-a685-4c5f-a22b-444f80b3cc28',
     aliases: ['aws.lambda.aws_request_id', 'faas.execution'],
     changelog: [
-      { version: 'next', description: 'Added faas.execution as an alias' },
+      { version: 'next', prs: [473], description: 'Added faas.execution as an alias' },
       { version: '0.11.1', prs: [414, 424] },
     ],
   },

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1691,7 +1691,7 @@ export type AWS_CLOUDWATCH_LOGS_URL_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link FAAS_INVOCATION_ID} `faas.invocation_id`
+ * Aliases: {@link FAAS_INVOCATION_ID} `faas.invocation_id`, {@link FAAS_EXECUTION} `faas.execution`
  *
  * @deprecated Use {@link FAAS_INVOCATION_ID} (faas.invocation_id) instead - This attribute is being deprecated in favor of faas.invocation_id
  * @example "8476a536-e9f4-11e8-9739-2dfe598c3fcd"
@@ -5070,7 +5070,7 @@ export type FAAS_ENTRY_POINT_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link FAAS_INVOCATION_ID} `faas.invocation_id`
+ * Aliases: {@link FAAS_INVOCATION_ID} `faas.invocation_id`, {@link AWS_LAMBDA_AWS_REQUEST_ID} `aws.lambda.aws_request_id`
  *
  * @deprecated Use {@link FAAS_INVOCATION_ID} (faas.invocation_id) instead - This attribute is being deprecated in favor of faas.invocation_id, which is the OTel-aligned replacement.
  * @example "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
@@ -17402,8 +17402,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'faas.invocation_id',
       reason: 'This attribute is being deprecated in favor of faas.invocation_id',
     },
-    aliases: ['faas.invocation_id'],
+    aliases: ['faas.invocation_id', 'faas.execution'],
     changelog: [
+      { version: 'next', prs: [473], description: 'Added faas.execution as an alias' },
       {
         version: '0.11.1',
         prs: [414, 424],
@@ -19345,7 +19346,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason:
         'This attribute is being deprecated in favor of faas.invocation_id, which is the OTel-aligned replacement.',
     },
-    aliases: ['faas.invocation_id'],
+    aliases: ['faas.invocation_id', 'aws.lambda.aws_request_id'],
     changelog: [
       {
         version: 'next',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -5058,6 +5058,30 @@ export const FAAS_ENTRY_POINT = 'faas.entry_point';
  */
 export type FAAS_ENTRY_POINT_TYPE = string;
 
+// Path: model/attributes/faas/faas__execution.json
+
+/**
+ * The execution ID of the current function execution. `faas.execution`
+ *
+ * Attribute Value Type: `string` {@link FAAS_EXECUTION_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link FAAS_INVOCATION_ID} `faas.invocation_id`
+ *
+ * @deprecated Use {@link FAAS_INVOCATION_ID} (faas.invocation_id) instead - This attribute is being deprecated in favor of faas.invocation_id, which is the OTel-aligned replacement.
+ * @example "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
+ */
+export const FAAS_EXECUTION = 'faas.execution';
+
+/**
+ * Type for {@link FAAS_EXECUTION} faas.execution
+ */
+export type FAAS_EXECUTION_TYPE = string;
+
 // Path: model/attributes/faas/faas__identity.json
 
 /**
@@ -5091,7 +5115,7 @@ export type FAAS_IDENTITY_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link AWS_LAMBDA_AWS_REQUEST_ID} `aws.lambda.aws_request_id`
+ * Aliases: {@link AWS_LAMBDA_AWS_REQUEST_ID} `aws.lambda.aws_request_id`, {@link FAAS_EXECUTION} `faas.execution`
  *
  * @example "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
  */
@@ -15162,6 +15186,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'faas.cron': 'string',
   'faas.duration_in_ms': 'integer',
   'faas.entry_point': 'string',
+  'faas.execution': 'string',
   'faas.identity': 'string',
   'faas.invocation_id': 'string',
   'faas.name': 'string',
@@ -15841,6 +15866,7 @@ export type AttributeName =
   | typeof FAAS_CRON
   | typeof FAAS_DURATION_IN_MS
   | typeof FAAS_ENTRY_POINT
+  | typeof FAAS_EXECUTION
   | typeof FAAS_IDENTITY
   | typeof FAAS_INVOCATION_ID
   | typeof FAAS_NAME
@@ -19305,6 +19331,25 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'my_main_function',
     changelog: [{ version: '0.11.0', prs: [403, 415] }],
   },
+  'faas.execution': {
+    brief: 'The execution ID of the current function execution.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'af9d5aa4-a685-4c5f-a22b-444f80b3cc28',
+    deprecation: {
+      replacement: 'faas.invocation_id',
+      reason:
+        'This attribute is being deprecated in favor of faas.invocation_id, which is the OTel-aligned replacement.',
+    },
+    aliases: ['faas.invocation_id'],
+    changelog: [
+      { version: 'next', description: 'Added faas.execution attribute, deprecated in favor of faas.invocation_id' },
+    ],
+  },
   'faas.identity': {
     brief:
       'The Service Account (GCP), IAM Execution Role (AWS), or Managed Identity (Azure) used by the serverless function when interacting with other cloud services',
@@ -19327,8 +19372,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'af9d5aa4-a685-4c5f-a22b-444f80b3cc28',
-    aliases: ['aws.lambda.aws_request_id'],
-    changelog: [{ version: '0.11.1', prs: [414, 424] }],
+    aliases: ['aws.lambda.aws_request_id', 'faas.execution'],
+    changelog: [
+      { version: 'next', description: 'Added faas.execution as an alias' },
+      { version: '0.11.1', prs: [414, 424] },
+    ],
   },
   'faas.name': {
     brief: 'The name of the serverless function',
@@ -25486,6 +25534,7 @@ export type Attributes = {
   [FAAS_CRON]?: FAAS_CRON_TYPE;
   [FAAS_DURATION_IN_MS]?: FAAS_DURATION_IN_MS_TYPE;
   [FAAS_ENTRY_POINT]?: FAAS_ENTRY_POINT_TYPE;
+  [FAAS_EXECUTION]?: FAAS_EXECUTION_TYPE;
   [FAAS_IDENTITY]?: FAAS_IDENTITY_TYPE;
   [FAAS_INVOCATION_ID]?: FAAS_INVOCATION_ID_TYPE;
   [FAAS_NAME]?: FAAS_NAME_TYPE;

--- a/model/attributes/aws/aws__lambda__aws_request_id.json
+++ b/model/attributes/aws/aws__lambda__aws_request_id.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": false,
   "example": "8476a536-e9f4-11e8-9739-2dfe598c3fcd",
-  "alias": ["faas.invocation_id"],
+  "alias": ["faas.invocation_id", "faas.execution"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "faas.invocation_id",
@@ -15,6 +15,11 @@
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [473],
+      "description": "Added faas.execution as an alias"
+    },
     {
       "version": "0.11.1",
       "prs": [414, 424],

--- a/model/attributes/faas/faas__execution.json
+++ b/model/attributes/faas/faas__execution.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": false,
   "example": "af9d5aa4-a685-4c5f-a22b-444f80b3cc28",
-  "alias": ["faas.invocation_id"],
+  "alias": ["faas.invocation_id", "aws.lambda.aws_request_id"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "faas.invocation_id",

--- a/model/attributes/faas/faas__execution.json
+++ b/model/attributes/faas/faas__execution.json
@@ -17,6 +17,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [473],
       "description": "Added faas.execution attribute, deprecated in favor of faas.invocation_id"
     }
   ]

--- a/model/attributes/faas/faas__execution.json
+++ b/model/attributes/faas/faas__execution.json
@@ -1,0 +1,23 @@
+{
+  "key": "faas.execution",
+  "brief": "The execution ID of the current function execution.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": "af9d5aa4-a685-4c5f-a22b-444f80b3cc28",
+  "alias": ["faas.invocation_id"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "faas.invocation_id",
+    "reason": "This attribute is being deprecated in favor of faas.invocation_id, which is the OTel-aligned replacement."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added faas.execution attribute, deprecated in favor of faas.invocation_id"
+    }
+  ]
+}

--- a/model/attributes/faas/faas__invocation_id.json
+++ b/model/attributes/faas/faas__invocation_id.json
@@ -7,9 +7,13 @@
   },
   "is_in_otel": true,
   "example": "af9d5aa4-a685-4c5f-a22b-444f80b3cc28",
-  "alias": ["aws.lambda.aws_request_id"],
+  "alias": ["aws.lambda.aws_request_id", "faas.execution"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added faas.execution as an alias"
+    },
     {
       "version": "0.11.1",
       "prs": [414, 424]

--- a/model/attributes/faas/faas__invocation_id.json
+++ b/model/attributes/faas/faas__invocation_id.json
@@ -12,6 +12,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [473],
       "description": "Added faas.execution as an alias"
     },
     {

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -11949,6 +11949,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[473],
                 description="Added faas.execution attribute, deprecated in favor of faas.invocation_id",
             ),
         ],
@@ -11974,7 +11975,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         aliases=["aws.lambda.aws_request_id", "faas.execution"],
         changelog=[
             ChangelogEntry(
-                version="next", description="Added faas.execution as an alias"
+                version="next",
+                prs=[473],
+                description="Added faas.execution as an alias",
             ),
             ChangelogEntry(version="0.11.1", prs=[414, 424]),
         ],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1233,7 +1233,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: faas.invocation_id
+    Aliases: faas.invocation_id, faas.execution
     DEPRECATED: Use faas.invocation_id instead - This attribute is being deprecated in favor of faas.invocation_id
     Example: "8476a536-e9f4-11e8-9739-2dfe598c3fcd"
     """
@@ -3120,7 +3120,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: faas.invocation_id
+    Aliases: faas.invocation_id, aws.lambda.aws_request_id
     DEPRECATED: Use faas.invocation_id instead - This attribute is being deprecated in favor of faas.invocation_id, which is the OTel-aligned replacement.
     Example: "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
     """
@@ -9763,8 +9763,13 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             reason="This attribute is being deprecated in favor of faas.invocation_id",
             status=DeprecationStatus.BACKFILL,
         ),
-        aliases=["faas.invocation_id"],
+        aliases=["faas.invocation_id", "faas.execution"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[473],
+                description="Added faas.execution as an alias",
+            ),
             ChangelogEntry(
                 version="0.11.1",
                 prs=[414, 424],
@@ -11945,7 +11950,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             reason="This attribute is being deprecated in favor of faas.invocation_id, which is the OTel-aligned replacement.",
             status=DeprecationStatus.BACKFILL,
         ),
-        aliases=["faas.invocation_id"],
+        aliases=["faas.invocation_id", "aws.lambda.aws_request_id"],
         changelog=[
             ChangelogEntry(
                 version="next",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -172,6 +172,7 @@ class _AttributeNamesMeta(type):
         "DEVICEMEMORY",
         "EFFECTIVECONNECTIONTYPE",
         "ENVIRONMENT",
+        "FAAS_EXECUTION",
         "FCP",
         "FP",
         "FRAMES_DELAY",
@@ -3111,6 +3112,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "my_main_function"
     """
 
+    # Path: model/attributes/faas/faas__execution.json
+    FAAS_EXECUTION: Literal["faas.execution"] = "faas.execution"
+    """The execution ID of the current function execution.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: faas.invocation_id
+    DEPRECATED: Use faas.invocation_id instead - This attribute is being deprecated in favor of faas.invocation_id, which is the OTel-aligned replacement.
+    Example: "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
+    """
+
     # Path: model/attributes/faas/faas__identity.json
     FAAS_IDENTITY: Literal["faas.identity"] = "faas.identity"
     """The Service Account (GCP), IAM Execution Role (AWS), or Managed Identity (Azure) used by the serverless function when interacting with other cloud services
@@ -3130,7 +3144,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: aws.lambda.aws_request_id
+    Aliases: aws.lambda.aws_request_id, faas.execution
     Example: "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
     """
 
@@ -11919,6 +11933,26 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.11.0", prs=[403, 415]),
         ],
     ),
+    "faas.execution": AttributeMetadata(
+        brief="The execution ID of the current function execution.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="af9d5aa4-a685-4c5f-a22b-444f80b3cc28",
+        deprecation=DeprecationInfo(
+            replacement="faas.invocation_id",
+            reason="This attribute is being deprecated in favor of faas.invocation_id, which is the OTel-aligned replacement.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["faas.invocation_id"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added faas.execution attribute, deprecated in favor of faas.invocation_id",
+            ),
+        ],
+    ),
     "faas.identity": AttributeMetadata(
         brief="The Service Account (GCP), IAM Execution Role (AWS), or Managed Identity (Azure) used by the serverless function when interacting with other cloud services",
         type=AttributeType.STRING,
@@ -11937,8 +11971,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="af9d5aa4-a685-4c5f-a22b-444f80b3cc28",
-        aliases=["aws.lambda.aws_request_id"],
+        aliases=["aws.lambda.aws_request_id", "faas.execution"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added faas.execution as an alias"
+            ),
             ChangelogEntry(version="0.11.1", prs=[414, 424]),
         ],
     ),
@@ -18364,6 +18401,7 @@ Attributes = TypedDict(
         "faas.cron": str,
         "faas.duration_in_ms": int,
         "faas.entry_point": str,
+        "faas.execution": str,
         "faas.identity": str,
         "faas.invocation_id": str,
         "faas.name": str,


### PR DESCRIPTION
Add `faas.execution` as a deprecated attribute in favor of `faas.invocation_id` (the OTel-aligned replacement). The AWS serverless SDK still emits `faas.execution` today, so it is marked `_status: backfill` and cross-aliased with `faas.invocation_id` so ingestion copies the value forward.

Follow-up to getsentry/sentry-javascript#22079, where the vendored `faas.execution` constant was flagged as missing from `@sentry/conventions`.

### Changes
- New `model/attributes/faas/faas__execution.json` (deprecated, `_status: backfill`, `replacement: faas.invocation_id`).
- Added `faas.execution` to `faas.invocation_id`'s alias list.
- Regenerated JS + Python attribute code and docs.