### PR TITLE
feat(attributes): Add `faas.id` (deprecated) in favor of `cloud.resource_id`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3134,6 +3134,8 @@ export type CLOUD_REGION_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
+ * Aliases: {@link FAAS_ID} `faas.id`
+ *
  * @example "arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function"
  */
 export const CLOUD_RESOURCE_ID = 'cloud.resource_id';
@@ -5081,6 +5083,30 @@ export const FAAS_EXECUTION = 'faas.execution';
  * Type for {@link FAAS_EXECUTION} faas.execution
  */
 export type FAAS_EXECUTION_TYPE = string;
+
+// Path: model/attributes/faas/faas__id.json
+
+/**
+ * The unique ID of the single function that this runtime instance executes. `faas.id`
+ *
+ * Attribute Value Type: `string` {@link FAAS_ID_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link CLOUD_RESOURCE_ID} `cloud.resource_id`
+ *
+ * @deprecated Use {@link CLOUD_RESOURCE_ID} (cloud.resource_id) instead - This attribute is being deprecated in favor of cloud.resource_id, which is the OTel-aligned replacement (renamed in OTel semantic conventions v1.19.0).
+ * @example "arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function"
+ */
+export const FAAS_ID = 'faas.id';
+
+/**
+ * Type for {@link FAAS_ID} faas.id
+ */
+export type FAAS_ID_TYPE = string;
 
 // Path: model/attributes/faas/faas__identity.json
 
@@ -15187,6 +15213,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'faas.duration_in_ms': 'integer',
   'faas.entry_point': 'string',
   'faas.execution': 'string',
+  'faas.id': 'string',
   'faas.identity': 'string',
   'faas.invocation_id': 'string',
   'faas.name': 'string',
@@ -15867,6 +15894,7 @@ export type AttributeName =
   | typeof FAAS_DURATION_IN_MS
   | typeof FAAS_ENTRY_POINT
   | typeof FAAS_EXECUTION
+  | typeof FAAS_ID
   | typeof FAAS_IDENTITY
   | typeof FAAS_INVOCATION_ID
   | typeof FAAS_NAME
@@ -18208,7 +18236,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function',
-    changelog: [{ version: '0.11.1', prs: [414] }],
+    aliases: ['faas.id'],
+    changelog: [
+      { version: 'next', description: 'Added faas.id as an alias' },
+      { version: '0.11.1', prs: [414] },
+    ],
     additionalContext: [
       'This can be an identifier for a resource in AWS, GCP, or Azure. There may be some overlap in values found here with other attributes. For instance, an AWS lambda ARN may be found here as well as in `aws.lambda.invoked_arn`. OTEL recommends setting them alongside each other.',
     ],
@@ -19354,6 +19386,23 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
         description: 'Added faas.execution attribute, deprecated in favor of faas.invocation_id',
       },
     ],
+  },
+  'faas.id': {
+    brief: 'The unique ID of the single function that this runtime instance executes.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function',
+    deprecation: {
+      replacement: 'cloud.resource_id',
+      reason:
+        'This attribute is being deprecated in favor of cloud.resource_id, which is the OTel-aligned replacement (renamed in OTel semantic conventions v1.19.0).',
+    },
+    aliases: ['cloud.resource_id'],
+    changelog: [{ version: 'next', description: 'Added faas.id attribute, deprecated in favor of cloud.resource_id' }],
   },
   'faas.identity': {
     brief:
@@ -25540,6 +25589,7 @@ export type Attributes = {
   [FAAS_DURATION_IN_MS]?: FAAS_DURATION_IN_MS_TYPE;
   [FAAS_ENTRY_POINT]?: FAAS_ENTRY_POINT_TYPE;
   [FAAS_EXECUTION]?: FAAS_EXECUTION_TYPE;
+  [FAAS_ID]?: FAAS_ID_TYPE;
   [FAAS_IDENTITY]?: FAAS_IDENTITY_TYPE;
   [FAAS_INVOCATION_ID]?: FAAS_INVOCATION_ID_TYPE;
   [FAAS_NAME]?: FAAS_NAME_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -18238,7 +18238,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function',
     aliases: ['faas.id'],
     changelog: [
-      { version: 'next', description: 'Added faas.id as an alias' },
+      { version: 'next', prs: [475], description: 'Added faas.id as an alias' },
       { version: '0.11.1', prs: [414] },
     ],
     additionalContext: [
@@ -19402,7 +19402,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
         'This attribute is being deprecated in favor of cloud.resource_id, which is the OTel-aligned replacement (renamed in OTel semantic conventions v1.19.0).',
     },
     aliases: ['cloud.resource_id'],
-    changelog: [{ version: 'next', description: 'Added faas.id attribute, deprecated in favor of cloud.resource_id' }],
+    changelog: [
+      { version: 'next', prs: [475], description: 'Added faas.id attribute, deprecated in favor of cloud.resource_id' },
+    ],
   },
   'faas.identity': {
     brief:

--- a/model/attributes/cloud/cloud__resource_id.json
+++ b/model/attributes/cloud/cloud__resource_id.json
@@ -10,8 +10,13 @@
   "additional_context": [
     "This can be an identifier for a resource in AWS, GCP, or Azure. There may be some overlap in values found here with other attributes. For instance, an AWS lambda ARN may be found here as well as in `aws.lambda.invoked_arn`. OTEL recommends setting them alongside each other."
   ],
+  "alias": ["faas.id"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added faas.id as an alias"
+    },
     {
       "version": "0.11.1",
       "prs": [414]

--- a/model/attributes/cloud/cloud__resource_id.json
+++ b/model/attributes/cloud/cloud__resource_id.json
@@ -15,6 +15,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [475],
       "description": "Added faas.id as an alias"
     },
     {

--- a/model/attributes/faas/faas__id.json
+++ b/model/attributes/faas/faas__id.json
@@ -1,0 +1,23 @@
+{
+  "key": "faas.id",
+  "brief": "The unique ID of the single function that this runtime instance executes.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": "arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function",
+  "alias": ["cloud.resource_id"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "cloud.resource_id",
+    "reason": "This attribute is being deprecated in favor of cloud.resource_id, which is the OTel-aligned replacement (renamed in OTel semantic conventions v1.19.0)."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added faas.id attribute, deprecated in favor of cloud.resource_id"
+    }
+  ]
+}

--- a/model/attributes/faas/faas__id.json
+++ b/model/attributes/faas/faas__id.json
@@ -17,6 +17,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [475],
       "description": "Added faas.id attribute, deprecated in favor of cloud.resource_id"
     }
   ]

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -10449,7 +10449,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function",
         aliases=["faas.id"],
         changelog=[
-            ChangelogEntry(version="next", description="Added faas.id as an alias"),
+            ChangelogEntry(
+                version="next", prs=[475], description="Added faas.id as an alias"
+            ),
             ChangelogEntry(version="0.11.1", prs=[414]),
         ],
         additional_context=[
@@ -11992,6 +11994,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[475],
                 description="Added faas.id attribute, deprecated in favor of cloud.resource_id",
             ),
         ],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -173,6 +173,7 @@ class _AttributeNamesMeta(type):
         "EFFECTIVECONNECTIONTYPE",
         "ENVIRONMENT",
         "FAAS_EXECUTION",
+        "FAAS_ID",
         "FCP",
         "FP",
         "FRAMES_DELAY",
@@ -1842,6 +1843,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: faas.id
     Example: "arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function"
     """
 
@@ -3123,6 +3125,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Aliases: faas.invocation_id, aws.lambda.aws_request_id
     DEPRECATED: Use faas.invocation_id instead - This attribute is being deprecated in favor of faas.invocation_id, which is the OTel-aligned replacement.
     Example: "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
+    """
+
+    # Path: model/attributes/faas/faas__id.json
+    FAAS_ID: Literal["faas.id"] = "faas.id"
+    """The unique ID of the single function that this runtime instance executes.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: cloud.resource_id
+    DEPRECATED: Use cloud.resource_id instead - This attribute is being deprecated in favor of cloud.resource_id, which is the OTel-aligned replacement (renamed in OTel semantic conventions v1.19.0).
+    Example: "arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function"
     """
 
     # Path: model/attributes/faas/faas__identity.json
@@ -10432,7 +10447,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function",
+        aliases=["faas.id"],
         changelog=[
+            ChangelogEntry(version="next", description="Added faas.id as an alias"),
             ChangelogEntry(version="0.11.1", prs=[414]),
         ],
         additional_context=[
@@ -11956,6 +11973,26 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
                 version="next",
                 prs=[473],
                 description="Added faas.execution attribute, deprecated in favor of faas.invocation_id",
+            ),
+        ],
+    ),
+    "faas.id": AttributeMetadata(
+        brief="The unique ID of the single function that this runtime instance executes.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function",
+        deprecation=DeprecationInfo(
+            replacement="cloud.resource_id",
+            reason="This attribute is being deprecated in favor of cloud.resource_id, which is the OTel-aligned replacement (renamed in OTel semantic conventions v1.19.0).",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["cloud.resource_id"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added faas.id attribute, deprecated in favor of cloud.resource_id",
             ),
         ],
     ),
@@ -18410,6 +18447,7 @@ Attributes = TypedDict(
         "faas.duration_in_ms": int,
         "faas.entry_point": str,
         "faas.execution": str,
+        "faas.id": str,
         "faas.identity": str,
         "faas.invocation_id": str,
         "faas.name": str,


### PR DESCRIPTION
Add `faas.id` as a deprecated attribute in favor of `cloud.resource_id`. `faas.id` was renamed to `cloud.resource_id` in OTel semantic conventions v1.19.0 (`rename_attributes: { faas.id: cloud.resource_id }`). The AWS serverless SDK still emits `faas.id` (set to the Lambda ARN, `context.invokedFunctionArn`), so it is marked `_status: backfill` and cross-aliased with `cloud.resource_id` so ingestion copies the value forward.

Follow-up to getsentry/sentry-javascript#22079, where the vendored `faas.id` constant was flagged as missing from `@sentry/conventions`.

### Changes
- New `model/attributes/faas/faas__id.json` (deprecated, `_status: backfill`, `replacement: cloud.resource_id`).
- Added `faas.id` to `cloud.resource_id`'s alias list.
- Regenerated JS + Python attribute code and docs.