### PR TITLE
feat(attributes): Add AWS SDK instrumentation attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1679,6 +1679,468 @@ export const AWS_CLOUDWATCH_LOGS_URL = 'aws.cloudwatch.logs.url';
  */
 export type AWS_CLOUDWATCH_LOGS_URL_TYPE = string;
 
+// Path: model/attributes/aws/aws__dynamodb__attribute_definitions.json
+
+/**
+ * The JSON-serialized value of each item in the `AttributeDefinitions` request field. `aws.dynamodb.attribute_definitions`
+ *
+ * Attribute Value Type: `Array<string>` {@link AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["{ \"AttributeName\": \"string\", \"AttributeType\": \"string\" }"]
+ */
+export const AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS = 'aws.dynamodb.attribute_definitions';
+
+/**
+ * Type for {@link AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS} aws.dynamodb.attribute_definitions
+ */
+export type AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__dynamodb__consistent_read.json
+
+/**
+ * The value of the `ConsistentRead` request parameter. `aws.dynamodb.consistent_read`
+ *
+ * Attribute Value Type: `boolean` {@link AWS_DYNAMODB_CONSISTENT_READ_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example true
+ */
+export const AWS_DYNAMODB_CONSISTENT_READ = 'aws.dynamodb.consistent_read';
+
+/**
+ * Type for {@link AWS_DYNAMODB_CONSISTENT_READ} aws.dynamodb.consistent_read
+ */
+export type AWS_DYNAMODB_CONSISTENT_READ_TYPE = boolean;
+
+// Path: model/attributes/aws/aws__dynamodb__consumed_capacity.json
+
+/**
+ * The JSON-serialized value of each item in the `ConsumedCapacity` response field. `aws.dynamodb.consumed_capacity`
+ *
+ * Attribute Value Type: `Array<string>` {@link AWS_DYNAMODB_CONSUMED_CAPACITY_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["{ \"CapacityUnits\": number, \"GlobalSecondaryIndexes\": { \"string\" : { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }, \"LocalSecondaryIndexes\": { \"string\" : { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }, \"ReadCapacityUnits\": number, \"Table\": { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number }, \"TableName\": \"string\", \"WriteCapacityUnits\": number }"]
+ */
+export const AWS_DYNAMODB_CONSUMED_CAPACITY = 'aws.dynamodb.consumed_capacity';
+
+/**
+ * Type for {@link AWS_DYNAMODB_CONSUMED_CAPACITY} aws.dynamodb.consumed_capacity
+ */
+export type AWS_DYNAMODB_CONSUMED_CAPACITY_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__dynamodb__count.json
+
+/**
+ * The value of the `Count` response parameter. `aws.dynamodb.count`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_COUNT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 10
+ */
+export const AWS_DYNAMODB_COUNT = 'aws.dynamodb.count';
+
+/**
+ * Type for {@link AWS_DYNAMODB_COUNT} aws.dynamodb.count
+ */
+export type AWS_DYNAMODB_COUNT_TYPE = number;
+
+// Path: model/attributes/aws/aws__dynamodb__exclusive_start_table.json
+
+/**
+ * The value of the `ExclusiveStartTableName` request parameter. `aws.dynamodb.exclusive_start_table`
+ *
+ * Attribute Value Type: `string` {@link AWS_DYNAMODB_EXCLUSIVE_START_TABLE_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "Users"
+ */
+export const AWS_DYNAMODB_EXCLUSIVE_START_TABLE = 'aws.dynamodb.exclusive_start_table';
+
+/**
+ * Type for {@link AWS_DYNAMODB_EXCLUSIVE_START_TABLE} aws.dynamodb.exclusive_start_table
+ */
+export type AWS_DYNAMODB_EXCLUSIVE_START_TABLE_TYPE = string;
+
+// Path: model/attributes/aws/aws__dynamodb__global_secondary_indexes.json
+
+/**
+ * The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field. `aws.dynamodb.global_secondary_indexes`
+ *
+ * Attribute Value Type: `Array<string>` {@link AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["{ \"IndexName\": \"string\", \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" }, \"ProvisionedThroughput\": { \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }"]
+ */
+export const AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES = 'aws.dynamodb.global_secondary_indexes';
+
+/**
+ * Type for {@link AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES} aws.dynamodb.global_secondary_indexes
+ */
+export type AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__dynamodb__global_secondary_index_updates.json
+
+/**
+ * The JSON-serialized value of each item in the `GlobalSecondaryIndexUpdates` request field. `aws.dynamodb.global_secondary_index_updates`
+ *
+ * Attribute Value Type: `Array<string>` {@link AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["{ \"Create\": { \"IndexName\": \"string\", \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" }, \"ProvisionedThroughput\": { \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }"]
+ */
+export const AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES = 'aws.dynamodb.global_secondary_index_updates';
+
+/**
+ * Type for {@link AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES} aws.dynamodb.global_secondary_index_updates
+ */
+export type AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__dynamodb__index_name.json
+
+/**
+ * The value of the `IndexName` request parameter. `aws.dynamodb.index_name`
+ *
+ * Attribute Value Type: `string` {@link AWS_DYNAMODB_INDEX_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "name_to_group"
+ */
+export const AWS_DYNAMODB_INDEX_NAME = 'aws.dynamodb.index_name';
+
+/**
+ * Type for {@link AWS_DYNAMODB_INDEX_NAME} aws.dynamodb.index_name
+ */
+export type AWS_DYNAMODB_INDEX_NAME_TYPE = string;
+
+// Path: model/attributes/aws/aws__dynamodb__item_collection_metrics.json
+
+/**
+ * The JSON-serialized value of the `ItemCollectionMetrics` response field. `aws.dynamodb.item_collection_metrics`
+ *
+ * Attribute Value Type: `string` {@link AWS_DYNAMODB_ITEM_COLLECTION_METRICS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "{ \"string\" : [ { \"ItemCollectionKey\": { \"string\" : { \"B\": blob, \"BOOL\": boolean, \"BS\": [ blob ], \"L\": [ \"AttributeValue\" ], \"M\": { \"string\" : \"AttributeValue\" }, \"N\": \"string\", \"NS\": [ \"string\" ], \"NULL\": boolean, \"S\": \"string\", \"SS\": [ \"string\" ] } }, \"SizeEstimateRangeGB\": [ number ] } ] }"
+ */
+export const AWS_DYNAMODB_ITEM_COLLECTION_METRICS = 'aws.dynamodb.item_collection_metrics';
+
+/**
+ * Type for {@link AWS_DYNAMODB_ITEM_COLLECTION_METRICS} aws.dynamodb.item_collection_metrics
+ */
+export type AWS_DYNAMODB_ITEM_COLLECTION_METRICS_TYPE = string;
+
+// Path: model/attributes/aws/aws__dynamodb__limit.json
+
+/**
+ * The value of the `Limit` request parameter. `aws.dynamodb.limit`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_LIMIT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 10
+ */
+export const AWS_DYNAMODB_LIMIT = 'aws.dynamodb.limit';
+
+/**
+ * Type for {@link AWS_DYNAMODB_LIMIT} aws.dynamodb.limit
+ */
+export type AWS_DYNAMODB_LIMIT_TYPE = number;
+
+// Path: model/attributes/aws/aws__dynamodb__local_secondary_indexes.json
+
+/**
+ * The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field. `aws.dynamodb.local_secondary_indexes`
+ *
+ * Attribute Value Type: `Array<string>` {@link AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["{ \"IndexArn\": \"string\", \"IndexName\": \"string\", \"IndexSizeBytes\": number, \"ItemCount\": number, \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" } }"]
+ */
+export const AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES = 'aws.dynamodb.local_secondary_indexes';
+
+/**
+ * Type for {@link AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES} aws.dynamodb.local_secondary_indexes
+ */
+export type AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__dynamodb__projection.json
+
+/**
+ * The value of the `ProjectionExpression` request parameter. `aws.dynamodb.projection`
+ *
+ * Attribute Value Type: `string` {@link AWS_DYNAMODB_PROJECTION_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "Title, Price, Color"
+ */
+export const AWS_DYNAMODB_PROJECTION = 'aws.dynamodb.projection';
+
+/**
+ * Type for {@link AWS_DYNAMODB_PROJECTION} aws.dynamodb.projection
+ */
+export type AWS_DYNAMODB_PROJECTION_TYPE = string;
+
+// Path: model/attributes/aws/aws__dynamodb__provisioned_read_capacity.json
+
+/**
+ * The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter. `aws.dynamodb.provisioned_read_capacity`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_PROVISIONED_READ_CAPACITY_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 1
+ */
+export const AWS_DYNAMODB_PROVISIONED_READ_CAPACITY = 'aws.dynamodb.provisioned_read_capacity';
+
+/**
+ * Type for {@link AWS_DYNAMODB_PROVISIONED_READ_CAPACITY} aws.dynamodb.provisioned_read_capacity
+ */
+export type AWS_DYNAMODB_PROVISIONED_READ_CAPACITY_TYPE = number;
+
+// Path: model/attributes/aws/aws__dynamodb__provisioned_write_capacity.json
+
+/**
+ * The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter. `aws.dynamodb.provisioned_write_capacity`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 2
+ */
+export const AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY = 'aws.dynamodb.provisioned_write_capacity';
+
+/**
+ * Type for {@link AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY} aws.dynamodb.provisioned_write_capacity
+ */
+export type AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY_TYPE = number;
+
+// Path: model/attributes/aws/aws__dynamodb__scanned_count.json
+
+/**
+ * The value of the `ScannedCount` response parameter. `aws.dynamodb.scanned_count`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_SCANNED_COUNT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 50
+ */
+export const AWS_DYNAMODB_SCANNED_COUNT = 'aws.dynamodb.scanned_count';
+
+/**
+ * Type for {@link AWS_DYNAMODB_SCANNED_COUNT} aws.dynamodb.scanned_count
+ */
+export type AWS_DYNAMODB_SCANNED_COUNT_TYPE = number;
+
+// Path: model/attributes/aws/aws__dynamodb__scan_forward.json
+
+/**
+ * The value of the `ScanIndexForward` request parameter. `aws.dynamodb.scan_forward`
+ *
+ * Attribute Value Type: `boolean` {@link AWS_DYNAMODB_SCAN_FORWARD_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example true
+ */
+export const AWS_DYNAMODB_SCAN_FORWARD = 'aws.dynamodb.scan_forward';
+
+/**
+ * Type for {@link AWS_DYNAMODB_SCAN_FORWARD} aws.dynamodb.scan_forward
+ */
+export type AWS_DYNAMODB_SCAN_FORWARD_TYPE = boolean;
+
+// Path: model/attributes/aws/aws__dynamodb__segment.json
+
+/**
+ * The value of the `Segment` request parameter. `aws.dynamodb.segment`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_SEGMENT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 10
+ */
+export const AWS_DYNAMODB_SEGMENT = 'aws.dynamodb.segment';
+
+/**
+ * Type for {@link AWS_DYNAMODB_SEGMENT} aws.dynamodb.segment
+ */
+export type AWS_DYNAMODB_SEGMENT_TYPE = number;
+
+// Path: model/attributes/aws/aws__dynamodb__select.json
+
+/**
+ * The value of the `Select` request parameter. `aws.dynamodb.select`
+ *
+ * Attribute Value Type: `string` {@link AWS_DYNAMODB_SELECT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "ALL_ATTRIBUTES"
+ */
+export const AWS_DYNAMODB_SELECT = 'aws.dynamodb.select';
+
+/**
+ * Type for {@link AWS_DYNAMODB_SELECT} aws.dynamodb.select
+ */
+export type AWS_DYNAMODB_SELECT_TYPE = string;
+
+// Path: model/attributes/aws/aws__dynamodb__table_count.json
+
+/**
+ * The number of items in the `TableNames` response parameter. `aws.dynamodb.table_count`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_TABLE_COUNT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 20
+ */
+export const AWS_DYNAMODB_TABLE_COUNT = 'aws.dynamodb.table_count';
+
+/**
+ * Type for {@link AWS_DYNAMODB_TABLE_COUNT} aws.dynamodb.table_count
+ */
+export type AWS_DYNAMODB_TABLE_COUNT_TYPE = number;
+
+// Path: model/attributes/aws/aws__dynamodb__table_names.json
+
+/**
+ * The keys in the `RequestItems` object field. `aws.dynamodb.table_names`
+ *
+ * Attribute Value Type: `Array<string>` {@link AWS_DYNAMODB_TABLE_NAMES_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["Users","Cats"]
+ */
+export const AWS_DYNAMODB_TABLE_NAMES = 'aws.dynamodb.table_names';
+
+/**
+ * Type for {@link AWS_DYNAMODB_TABLE_NAMES} aws.dynamodb.table_names
+ */
+export type AWS_DYNAMODB_TABLE_NAMES_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__dynamodb__total_segments.json
+
+/**
+ * The value of the `TotalSegments` request parameter. `aws.dynamodb.total_segments`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_TOTAL_SEGMENTS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 100
+ */
+export const AWS_DYNAMODB_TOTAL_SEGMENTS = 'aws.dynamodb.total_segments';
+
+/**
+ * Type for {@link AWS_DYNAMODB_TOTAL_SEGMENTS} aws.dynamodb.total_segments
+ */
+export type AWS_DYNAMODB_TOTAL_SEGMENTS_TYPE = number;
+
+// Path: model/attributes/aws/aws__kinesis__stream__name.json
+
+/**
+ * The name of the AWS Kinesis stream the request refers to. `aws.kinesis.stream.name`
+ *
+ * Attribute Value Type: `string` {@link AWS_KINESIS_STREAM_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "some-stream-name"
+ */
+export const AWS_KINESIS_STREAM_NAME = 'aws.kinesis.stream.name';
+
+/**
+ * Type for {@link AWS_KINESIS_STREAM_NAME} aws.kinesis.stream.name
+ */
+export type AWS_KINESIS_STREAM_NAME_TYPE = string;
+
 // Path: model/attributes/aws/aws__lambda__aws_request_id.json
 
 /**
@@ -1881,6 +2343,153 @@ export const AWS_LOG_STREAM_NAMES = 'aws.log.stream.names';
  * Type for {@link AWS_LOG_STREAM_NAMES} aws.log.stream.names
  */
 export type AWS_LOG_STREAM_NAMES_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__request__extended_id.json
+
+/**
+ * The AWS extended request ID as returned in the response headers. `aws.request.extended_id`
+ *
+ * Attribute Value Type: `string` {@link AWS_REQUEST_EXTENDED_ID_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ="
+ */
+export const AWS_REQUEST_EXTENDED_ID = 'aws.request.extended_id';
+
+/**
+ * Type for {@link AWS_REQUEST_EXTENDED_ID} aws.request.extended_id
+ */
+export type AWS_REQUEST_EXTENDED_ID_TYPE = string;
+
+// Path: model/attributes/aws/aws__request__id.json
+
+/**
+ * The AWS request ID as returned in the response headers. `aws.request.id`
+ *
+ * Attribute Value Type: `string` {@link AWS_REQUEST_ID_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "79b9da39-b7ae-508a-a6bc-864b2829c622"
+ */
+export const AWS_REQUEST_ID = 'aws.request.id';
+
+/**
+ * Type for {@link AWS_REQUEST_ID} aws.request.id
+ */
+export type AWS_REQUEST_ID_TYPE = string;
+
+// Path: model/attributes/aws/aws__s3__bucket.json
+
+/**
+ * The S3 bucket name the request refers to. `aws.s3.bucket`
+ *
+ * Attribute Value Type: `string` {@link AWS_S3_BUCKET_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "ot-demo-test"
+ */
+export const AWS_S3_BUCKET = 'aws.s3.bucket';
+
+/**
+ * Type for {@link AWS_S3_BUCKET} aws.s3.bucket
+ */
+export type AWS_S3_BUCKET_TYPE = string;
+
+// Path: model/attributes/aws/aws__secretsmanager__secret__arn.json
+
+/**
+ * The ARN of the Secret stored in Secrets Manager. `aws.secretsmanager.secret.arn`
+ *
+ * Attribute Value Type: `string` {@link AWS_SECRETSMANAGER_SECRET_ARN_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "arn:aws:secretsmanager:us-east-1:123456789012:secret:SecretName-6RandomCharacters"
+ */
+export const AWS_SECRETSMANAGER_SECRET_ARN = 'aws.secretsmanager.secret.arn';
+
+/**
+ * Type for {@link AWS_SECRETSMANAGER_SECRET_ARN} aws.secretsmanager.secret.arn
+ */
+export type AWS_SECRETSMANAGER_SECRET_ARN_TYPE = string;
+
+// Path: model/attributes/aws/aws__sns__topic__arn.json
+
+/**
+ * The ARN of the AWS SNS Topic. An Amazon SNS topic is a logical access point that acts as a communication channel. `aws.sns.topic.arn`
+ *
+ * Attribute Value Type: `string` {@link AWS_SNS_TOPIC_ARN_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE"
+ */
+export const AWS_SNS_TOPIC_ARN = 'aws.sns.topic.arn';
+
+/**
+ * Type for {@link AWS_SNS_TOPIC_ARN} aws.sns.topic.arn
+ */
+export type AWS_SNS_TOPIC_ARN_TYPE = string;
+
+// Path: model/attributes/aws/aws__step_functions__activity__arn.json
+
+/**
+ * The ARN of the AWS Step Functions Activity. `aws.step_functions.activity.arn`
+ *
+ * Attribute Value Type: `string` {@link AWS_STEP_FUNCTIONS_ACTIVITY_ARN_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "arn:aws:states:us-east-1:123456789012:activity:get-greeting"
+ */
+export const AWS_STEP_FUNCTIONS_ACTIVITY_ARN = 'aws.step_functions.activity.arn';
+
+/**
+ * Type for {@link AWS_STEP_FUNCTIONS_ACTIVITY_ARN} aws.step_functions.activity.arn
+ */
+export type AWS_STEP_FUNCTIONS_ACTIVITY_ARN_TYPE = string;
+
+// Path: model/attributes/aws/aws__step_functions__state_machine__arn.json
+
+/**
+ * The ARN of the AWS Step Functions State Machine. `aws.step_functions.state_machine.arn`
+ *
+ * Attribute Value Type: `string` {@link AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine:1"
+ */
+export const AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN = 'aws.step_functions.state_machine.arn';
+
+/**
+ * Type for {@link AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN} aws.step_functions.state_machine.arn
+ */
+export type AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN_TYPE = string;
 
 // Path: model/attributes/blocked_main_thread.json
 
@@ -5152,6 +5761,69 @@ export const FAAS_INVOCATION_ID = 'faas.invocation_id';
  */
 export type FAAS_INVOCATION_ID_TYPE = string;
 
+// Path: model/attributes/faas/faas__invoked_name.json
+
+/**
+ * The name of the invoked function. `faas.invoked_name`
+ *
+ * Attribute Value Type: `string` {@link FAAS_INVOKED_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "my-function"
+ */
+export const FAAS_INVOKED_NAME = 'faas.invoked_name';
+
+/**
+ * Type for {@link FAAS_INVOKED_NAME} faas.invoked_name
+ */
+export type FAAS_INVOKED_NAME_TYPE = string;
+
+// Path: model/attributes/faas/faas__invoked_provider.json
+
+/**
+ * The cloud provider of the invoked function. `faas.invoked_provider`
+ *
+ * Attribute Value Type: `string` {@link FAAS_INVOKED_PROVIDER_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "aws"
+ */
+export const FAAS_INVOKED_PROVIDER = 'faas.invoked_provider';
+
+/**
+ * Type for {@link FAAS_INVOKED_PROVIDER} faas.invoked_provider
+ */
+export type FAAS_INVOKED_PROVIDER_TYPE = string;
+
+// Path: model/attributes/faas/faas__invoked_region.json
+
+/**
+ * The cloud region of the invoked function. `faas.invoked_region`
+ *
+ * Attribute Value Type: `string` {@link FAAS_INVOKED_REGION_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "eu-central-1"
+ */
+export const FAAS_INVOKED_REGION = 'faas.invoked_region';
+
+/**
+ * Type for {@link FAAS_INVOKED_REGION} faas.invoked_region
+ */
+export type FAAS_INVOKED_REGION_TYPE = string;
+
 // Path: model/attributes/faas/faas__name.json
 
 /**
@@ -6285,6 +6957,27 @@ export const GEN_AI_REQUEST_SEED = 'gen_ai.request.seed';
  * Type for {@link GEN_AI_REQUEST_SEED} gen_ai.request.seed
  */
 export type GEN_AI_REQUEST_SEED_TYPE = string;
+
+// Path: model/attributes/gen_ai/gen_ai__request__stop_sequences.json
+
+/**
+ * List of sequences that the model will use to stop generating further tokens. `gen_ai.request.stop_sequences`
+ *
+ * Attribute Value Type: `Array<string>` {@link GEN_AI_REQUEST_STOP_SEQUENCES_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["forest","lived"]
+ */
+export const GEN_AI_REQUEST_STOP_SEQUENCES = 'gen_ai.request.stop_sequences';
+
+/**
+ * Type for {@link GEN_AI_REQUEST_STOP_SEQUENCES} gen_ai.request.stop_sequences
+ */
+export type GEN_AI_REQUEST_STOP_SEQUENCES_TYPE = Array<string>;
 
 // Path: model/attributes/gen_ai/gen_ai__request__temperature.json
 
@@ -9361,6 +10054,30 @@ export const MESSAGING_BATCH_MESSAGE_COUNT = 'messaging.batch.message_count';
  */
 export type MESSAGING_BATCH_MESSAGE_COUNT_TYPE = number;
 
+// Path: model/attributes/messaging/messaging__destination.json
+
+/**
+ * The message destination name. `messaging.destination`
+ *
+ * Attribute Value Type: `string` {@link MESSAGING_DESTINATION_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link MESSAGING_DESTINATION_NAME} `messaging.destination.name`
+ *
+ * @deprecated Use {@link MESSAGING_DESTINATION_NAME} (messaging.destination.name) instead - This attribute is being deprecated in favor of messaging.destination.name, which is the OTel-aligned replacement.
+ * @example "BestTopic"
+ */
+export const MESSAGING_DESTINATION = 'messaging.destination';
+
+/**
+ * Type for {@link MESSAGING_DESTINATION} messaging.destination
+ */
+export type MESSAGING_DESTINATION_TYPE = string;
+
 // Path: model/attributes/messaging/messaging__destination__connection.json
 
 /**
@@ -9393,6 +10110,8 @@ export type MESSAGING_DESTINATION_CONNECTION_TYPE = string;
  *
  * Attribute defined in OTEL: Yes
  * Visibility: public
+ *
+ * Aliases: {@link MESSAGING_DESTINATION} `messaging.destination`
  *
  * @example "BestTopic"
  */
@@ -11262,6 +11981,27 @@ export const RPC_SERVICE = 'rpc.service';
  * Type for {@link RPC_SERVICE} rpc.service
  */
 export type RPC_SERVICE_TYPE = string;
+
+// Path: model/attributes/rpc/rpc__system.json
+
+/**
+ * A string identifying the remoting system. `rpc.system`
+ *
+ * Attribute Value Type: `string` {@link RPC_SYSTEM_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "aws-api"
+ */
+export const RPC_SYSTEM = 'rpc.system';
+
+/**
+ * Type for {@link RPC_SYSTEM} rpc.system
+ */
+export type RPC_SYSTEM_TYPE = string;
 
 // Path: model/attributes/runtime/runtime__build.json
 
@@ -15078,6 +15818,28 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'aws.cloudwatch.logs.log_group': 'string',
   'aws.cloudwatch.logs.log_stream': 'string',
   'aws.cloudwatch.logs.url': 'string',
+  'aws.dynamodb.attribute_definitions': 'string[]',
+  'aws.dynamodb.consistent_read': 'boolean',
+  'aws.dynamodb.consumed_capacity': 'string[]',
+  'aws.dynamodb.count': 'integer',
+  'aws.dynamodb.exclusive_start_table': 'string',
+  'aws.dynamodb.global_secondary_indexes': 'string[]',
+  'aws.dynamodb.global_secondary_index_updates': 'string[]',
+  'aws.dynamodb.index_name': 'string',
+  'aws.dynamodb.item_collection_metrics': 'string',
+  'aws.dynamodb.limit': 'integer',
+  'aws.dynamodb.local_secondary_indexes': 'string[]',
+  'aws.dynamodb.projection': 'string',
+  'aws.dynamodb.provisioned_read_capacity': 'double',
+  'aws.dynamodb.provisioned_write_capacity': 'double',
+  'aws.dynamodb.scanned_count': 'integer',
+  'aws.dynamodb.scan_forward': 'boolean',
+  'aws.dynamodb.segment': 'integer',
+  'aws.dynamodb.select': 'string',
+  'aws.dynamodb.table_count': 'integer',
+  'aws.dynamodb.table_names': 'string[]',
+  'aws.dynamodb.total_segments': 'integer',
+  'aws.kinesis.stream.name': 'string',
   'aws.lambda.aws_request_id': 'string',
   'aws.lambda.execution_duration_in_millis': 'double',
   'aws.lambda.function_name': 'string',
@@ -15087,6 +15849,13 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'aws.lambda.remaining_time_in_millis': 'double',
   'aws.log.group.names': 'string[]',
   'aws.log.stream.names': 'string[]',
+  'aws.request.extended_id': 'string',
+  'aws.request.id': 'string',
+  'aws.s3.bucket': 'string',
+  'aws.secretsmanager.secret.arn': 'string',
+  'aws.sns.topic.arn': 'string',
+  'aws.step_functions.activity.arn': 'string',
+  'aws.step_functions.state_machine.arn': 'string',
   blocked_main_thread: 'boolean',
   'browser.name': 'string',
   'browser.performance.navigation.activation_start': 'double',
@@ -15237,6 +16006,9 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'faas.id': 'string',
   'faas.identity': 'string',
   'faas.invocation_id': 'string',
+  'faas.invoked_name': 'string',
+  'faas.invoked_provider': 'string',
+  'faas.invoked_region': 'string',
   'faas.name': 'string',
   'faas.time': 'string',
   'faas.trigger': 'string',
@@ -15289,6 +16061,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'gen_ai.request.presence_penalty': 'double',
   'gen_ai.request.reasoning_effort': 'string',
   'gen_ai.request.seed': 'string',
+  'gen_ai.request.stop_sequences': 'string[]',
   'gen_ai.request.temperature': 'double',
   'gen_ai.request.top_k': 'integer',
   'gen_ai.request.top_p': 'double',
@@ -15427,6 +16200,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'mcp.transport': 'string',
   'mdc.<key>': 'string',
   'messaging.batch.message_count': 'integer',
+  'messaging.destination': 'string',
   'messaging.destination.connection': 'string',
   'messaging.destination.name': 'string',
   'messaging.message.body.size': 'integer',
@@ -15513,6 +16287,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'rpc.method': 'string',
   'rpc.response.status_code': 'string',
   'rpc.service': 'string',
+  'rpc.system': 'string',
   'runtime.build': 'string',
   'runtime.name': 'string',
   'runtime.raw_description': 'string',
@@ -15760,6 +16535,28 @@ export type AttributeName =
   | typeof AWS_CLOUDWATCH_LOGS_LOG_GROUP
   | typeof AWS_CLOUDWATCH_LOGS_LOG_STREAM
   | typeof AWS_CLOUDWATCH_LOGS_URL
+  | typeof AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS
+  | typeof AWS_DYNAMODB_CONSISTENT_READ
+  | typeof AWS_DYNAMODB_CONSUMED_CAPACITY
+  | typeof AWS_DYNAMODB_COUNT
+  | typeof AWS_DYNAMODB_EXCLUSIVE_START_TABLE
+  | typeof AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES
+  | typeof AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES
+  | typeof AWS_DYNAMODB_INDEX_NAME
+  | typeof AWS_DYNAMODB_ITEM_COLLECTION_METRICS
+  | typeof AWS_DYNAMODB_LIMIT
+  | typeof AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES
+  | typeof AWS_DYNAMODB_PROJECTION
+  | typeof AWS_DYNAMODB_PROVISIONED_READ_CAPACITY
+  | typeof AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY
+  | typeof AWS_DYNAMODB_SCANNED_COUNT
+  | typeof AWS_DYNAMODB_SCAN_FORWARD
+  | typeof AWS_DYNAMODB_SEGMENT
+  | typeof AWS_DYNAMODB_SELECT
+  | typeof AWS_DYNAMODB_TABLE_COUNT
+  | typeof AWS_DYNAMODB_TABLE_NAMES
+  | typeof AWS_DYNAMODB_TOTAL_SEGMENTS
+  | typeof AWS_KINESIS_STREAM_NAME
   | typeof AWS_LAMBDA_AWS_REQUEST_ID
   | typeof AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS
   | typeof AWS_LAMBDA_FUNCTION_NAME
@@ -15769,6 +16566,13 @@ export type AttributeName =
   | typeof AWS_LAMBDA_REMAINING_TIME_IN_MILLIS
   | typeof AWS_LOG_GROUP_NAMES
   | typeof AWS_LOG_STREAM_NAMES
+  | typeof AWS_REQUEST_EXTENDED_ID
+  | typeof AWS_REQUEST_ID
+  | typeof AWS_S3_BUCKET
+  | typeof AWS_SECRETSMANAGER_SECRET_ARN
+  | typeof AWS_SNS_TOPIC_ARN
+  | typeof AWS_STEP_FUNCTIONS_ACTIVITY_ARN
+  | typeof AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN
   | typeof BLOCKED_MAIN_THREAD
   | typeof BROWSER_NAME
   | typeof BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START
@@ -15919,6 +16723,9 @@ export type AttributeName =
   | typeof FAAS_ID
   | typeof FAAS_IDENTITY
   | typeof FAAS_INVOCATION_ID
+  | typeof FAAS_INVOKED_NAME
+  | typeof FAAS_INVOKED_PROVIDER
+  | typeof FAAS_INVOKED_REGION
   | typeof FAAS_NAME
   | typeof FAAS_TIME
   | typeof FAAS_TRIGGER
@@ -15971,6 +16778,7 @@ export type AttributeName =
   | typeof GEN_AI_REQUEST_PRESENCE_PENALTY
   | typeof GEN_AI_REQUEST_REASONING_EFFORT
   | typeof GEN_AI_REQUEST_SEED
+  | typeof GEN_AI_REQUEST_STOP_SEQUENCES
   | typeof GEN_AI_REQUEST_TEMPERATURE
   | typeof GEN_AI_REQUEST_TOP_K
   | typeof GEN_AI_REQUEST_TOP_P
@@ -16109,6 +16917,7 @@ export type AttributeName =
   | typeof MCP_TRANSPORT
   | typeof MDC_KEY
   | typeof MESSAGING_BATCH_MESSAGE_COUNT
+  | typeof MESSAGING_DESTINATION
   | typeof MESSAGING_DESTINATION_CONNECTION
   | typeof MESSAGING_DESTINATION_NAME
   | typeof MESSAGING_MESSAGE_BODY_SIZE
@@ -16195,6 +17004,7 @@ export type AttributeName =
   | typeof RPC_METHOD
   | typeof RPC_RESPONSE_STATUS_CODE
   | typeof RPC_SERVICE
+  | typeof RPC_SYSTEM
   | typeof RUNTIME_BUILD
   | typeof RUNTIME_NAME
   | typeof RUNTIME_RAW_DESCRIPTION
@@ -17440,6 +18250,257 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/my-log-group',
     changelog: [{ version: '0.7.0', prs: [369], description: 'Added aws.cloudwatch.logs.url attribute' }],
   },
+  'aws.dynamodb.attribute_definitions': {
+    brief: 'The JSON-serialized value of each item in the `AttributeDefinitions` request field.',
+    type: 'string[]',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: ['{ "AttributeName": "string", "AttributeType": "string" }'],
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.attribute_definitions attribute' }],
+  },
+  'aws.dynamodb.consistent_read': {
+    brief: 'The value of the `ConsistentRead` request parameter.',
+    type: 'boolean',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: true,
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.consistent_read attribute' }],
+  },
+  'aws.dynamodb.consumed_capacity': {
+    brief: 'The JSON-serialized value of each item in the `ConsumedCapacity` response field.',
+    type: 'string[]',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: [
+      '{ "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "ReadCapacityUnits": number, "Table": { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName": "string", "WriteCapacityUnits": number }',
+    ],
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.consumed_capacity attribute' }],
+  },
+  'aws.dynamodb.count': {
+    brief: 'The value of the `Count` response parameter.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 10,
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.count attribute' }],
+  },
+  'aws.dynamodb.exclusive_start_table': {
+    brief: 'The value of the `ExclusiveStartTableName` request parameter.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'Users',
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.exclusive_start_table attribute' }],
+  },
+  'aws.dynamodb.global_secondary_indexes': {
+    brief: 'The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.',
+    type: 'string[]',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: [
+      '{ "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }',
+    ],
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.global_secondary_indexes attribute' }],
+  },
+  'aws.dynamodb.global_secondary_index_updates': {
+    brief: 'The JSON-serialized value of each item in the `GlobalSecondaryIndexUpdates` request field.',
+    type: 'string[]',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: [
+      '{ "Create": { "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }',
+    ],
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.global_secondary_index_updates attribute' }],
+  },
+  'aws.dynamodb.index_name': {
+    brief: 'The value of the `IndexName` request parameter.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'name_to_group',
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.index_name attribute' }],
+  },
+  'aws.dynamodb.item_collection_metrics': {
+    brief: 'The JSON-serialized value of the `ItemCollectionMetrics` response field.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example:
+      '{ "string" : [ { "ItemCollectionKey": { "string" : { "B": blob, "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" : "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S": "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }',
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.item_collection_metrics attribute' }],
+  },
+  'aws.dynamodb.limit': {
+    brief: 'The value of the `Limit` request parameter.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 10,
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.limit attribute' }],
+  },
+  'aws.dynamodb.local_secondary_indexes': {
+    brief: 'The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.',
+    type: 'string[]',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: [
+      '{ "IndexArn": "string", "IndexName": "string", "IndexSizeBytes": number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" } }',
+    ],
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.local_secondary_indexes attribute' }],
+  },
+  'aws.dynamodb.projection': {
+    brief: 'The value of the `ProjectionExpression` request parameter.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'Title, Price, Color',
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.projection attribute' }],
+  },
+  'aws.dynamodb.provisioned_read_capacity': {
+    brief: 'The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.',
+    type: 'double',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 1,
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.provisioned_read_capacity attribute' }],
+  },
+  'aws.dynamodb.provisioned_write_capacity': {
+    brief: 'The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.',
+    type: 'double',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 2,
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.provisioned_write_capacity attribute' }],
+  },
+  'aws.dynamodb.scanned_count': {
+    brief: 'The value of the `ScannedCount` response parameter.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 50,
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.scanned_count attribute' }],
+  },
+  'aws.dynamodb.scan_forward': {
+    brief: 'The value of the `ScanIndexForward` request parameter.',
+    type: 'boolean',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: true,
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.scan_forward attribute' }],
+  },
+  'aws.dynamodb.segment': {
+    brief: 'The value of the `Segment` request parameter.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 10,
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.segment attribute' }],
+  },
+  'aws.dynamodb.select': {
+    brief: 'The value of the `Select` request parameter.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'ALL_ATTRIBUTES',
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.select attribute' }],
+  },
+  'aws.dynamodb.table_count': {
+    brief: 'The number of items in the `TableNames` response parameter.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 20,
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.table_count attribute' }],
+  },
+  'aws.dynamodb.table_names': {
+    brief: 'The keys in the `RequestItems` object field.',
+    type: 'string[]',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: ['Users', 'Cats'],
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.table_names attribute' }],
+  },
+  'aws.dynamodb.total_segments': {
+    brief: 'The value of the `TotalSegments` request parameter.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 100,
+    changelog: [{ version: 'next', description: 'Added aws.dynamodb.total_segments attribute' }],
+  },
+  'aws.kinesis.stream.name': {
+    brief: 'The name of the AWS Kinesis stream the request refers to.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'some-stream-name',
+    changelog: [{ version: 'next', description: 'Added aws.kinesis.stream.name attribute' }],
+  },
   'aws.lambda.aws_request_id': {
     brief: 'The AWS request ID as received by the Lambda function runtime',
     type: 'string',
@@ -17586,6 +18647,84 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: ['logs/main/10838bed-421f-43ef-870a-f43feacbbb5b'],
     changelog: [{ version: '0.11.1', prs: [414] }],
+  },
+  'aws.request.extended_id': {
+    brief: 'The AWS extended request ID as returned in the response headers.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=',
+    changelog: [{ version: 'next', description: 'Added aws.request.extended_id attribute' }],
+  },
+  'aws.request.id': {
+    brief: 'The AWS request ID as returned in the response headers.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '79b9da39-b7ae-508a-a6bc-864b2829c622',
+    changelog: [{ version: 'next', description: 'Added aws.request.id attribute' }],
+  },
+  'aws.s3.bucket': {
+    brief: 'The S3 bucket name the request refers to.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'ot-demo-test',
+    changelog: [{ version: 'next', description: 'Added aws.s3.bucket attribute' }],
+  },
+  'aws.secretsmanager.secret.arn': {
+    brief: 'The ARN of the Secret stored in Secrets Manager.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:SecretName-6RandomCharacters',
+    changelog: [{ version: 'next', description: 'Added aws.secretsmanager.secret.arn attribute' }],
+  },
+  'aws.sns.topic.arn': {
+    brief:
+      'The ARN of the AWS SNS Topic. An Amazon SNS topic is a logical access point that acts as a communication channel.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE',
+    changelog: [{ version: 'next', description: 'Added aws.sns.topic.arn attribute' }],
+  },
+  'aws.step_functions.activity.arn': {
+    brief: 'The ARN of the AWS Step Functions Activity.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'arn:aws:states:us-east-1:123456789012:activity:get-greeting',
+    changelog: [{ version: 'next', description: 'Added aws.step_functions.activity.arn attribute' }],
+  },
+  'aws.step_functions.state_machine.arn': {
+    brief: 'The ARN of the AWS Step Functions State Machine.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine:1',
+    changelog: [{ version: 'next', description: 'Added aws.step_functions.state_machine.arn attribute' }],
   },
   blocked_main_thread: {
     brief: 'Whether the main thread was blocked by the span.',
@@ -19457,6 +20596,39 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: '0.11.1', prs: [414, 424] },
     ],
   },
+  'faas.invoked_name': {
+    brief: 'The name of the invoked function.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'my-function',
+    changelog: [{ version: 'next', description: 'Added faas.invoked_name attribute' }],
+  },
+  'faas.invoked_provider': {
+    brief: 'The cloud provider of the invoked function.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'aws',
+    changelog: [{ version: 'next', description: 'Added faas.invoked_provider attribute' }],
+  },
+  'faas.invoked_region': {
+    brief: 'The cloud region of the invoked function.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'eu-central-1',
+    changelog: [{ version: 'next', description: 'Added faas.invoked_region attribute' }],
+  },
   'faas.name': {
     brief: 'The name of the serverless function',
     type: 'string',
@@ -20185,6 +21357,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '1234567890',
     aliases: ['ai.seed'],
     changelog: [{ version: '0.1.0', prs: [57, 127] }],
+  },
+  'gen_ai.request.stop_sequences': {
+    brief: 'List of sequences that the model will use to stop generating further tokens.',
+    type: 'string[]',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: ['forest', 'lived'],
+    changelog: [{ version: 'next', description: 'Added gen_ai.request.stop_sequences attribute' }],
   },
   'gen_ai.request.temperature': {
     brief:
@@ -22188,6 +23371,28 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 10,
     changelog: [{ version: '0.6.0', prs: [341], description: 'Added messaging.batch.message_count attribute' }],
   },
+  'messaging.destination': {
+    brief: 'The message destination name.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'BestTopic',
+    deprecation: {
+      replacement: 'messaging.destination.name',
+      reason:
+        'This attribute is being deprecated in favor of messaging.destination.name, which is the OTel-aligned replacement.',
+    },
+    aliases: ['messaging.destination.name'],
+    changelog: [
+      {
+        version: 'next',
+        description: 'Added messaging.destination attribute, deprecated in favor of messaging.destination.name',
+      },
+    ],
+  },
   'messaging.destination.connection': {
     brief: 'The message destination connection.',
     type: 'string',
@@ -22208,7 +23413,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'BestTopic',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    aliases: ['messaging.destination'],
+    changelog: [
+      { version: 'next', description: 'Added messaging.destination as an alias' },
+      { version: '0.1.0', prs: [127] },
+      { version: '0.0.0' },
+    ],
   },
   'messaging.message.body.size': {
     brief: 'The size of the message body in bytes.',
@@ -23296,6 +24506,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'myService.BestService',
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+  },
+  'rpc.system': {
+    brief: 'A string identifying the remoting system.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'aws-api',
+    changelog: [{ version: 'next', description: 'Added rpc.system attribute' }],
   },
   'runtime.build': {
     brief: 'The application build string, when it is separate from the version.',
@@ -25470,6 +26691,28 @@ export type Attributes = {
   [AWS_CLOUDWATCH_LOGS_LOG_GROUP]?: AWS_CLOUDWATCH_LOGS_LOG_GROUP_TYPE;
   [AWS_CLOUDWATCH_LOGS_LOG_STREAM]?: AWS_CLOUDWATCH_LOGS_LOG_STREAM_TYPE;
   [AWS_CLOUDWATCH_LOGS_URL]?: AWS_CLOUDWATCH_LOGS_URL_TYPE;
+  [AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS]?: AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS_TYPE;
+  [AWS_DYNAMODB_CONSISTENT_READ]?: AWS_DYNAMODB_CONSISTENT_READ_TYPE;
+  [AWS_DYNAMODB_CONSUMED_CAPACITY]?: AWS_DYNAMODB_CONSUMED_CAPACITY_TYPE;
+  [AWS_DYNAMODB_COUNT]?: AWS_DYNAMODB_COUNT_TYPE;
+  [AWS_DYNAMODB_EXCLUSIVE_START_TABLE]?: AWS_DYNAMODB_EXCLUSIVE_START_TABLE_TYPE;
+  [AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES]?: AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES_TYPE;
+  [AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES]?: AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES_TYPE;
+  [AWS_DYNAMODB_INDEX_NAME]?: AWS_DYNAMODB_INDEX_NAME_TYPE;
+  [AWS_DYNAMODB_ITEM_COLLECTION_METRICS]?: AWS_DYNAMODB_ITEM_COLLECTION_METRICS_TYPE;
+  [AWS_DYNAMODB_LIMIT]?: AWS_DYNAMODB_LIMIT_TYPE;
+  [AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES]?: AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES_TYPE;
+  [AWS_DYNAMODB_PROJECTION]?: AWS_DYNAMODB_PROJECTION_TYPE;
+  [AWS_DYNAMODB_PROVISIONED_READ_CAPACITY]?: AWS_DYNAMODB_PROVISIONED_READ_CAPACITY_TYPE;
+  [AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY]?: AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY_TYPE;
+  [AWS_DYNAMODB_SCANNED_COUNT]?: AWS_DYNAMODB_SCANNED_COUNT_TYPE;
+  [AWS_DYNAMODB_SCAN_FORWARD]?: AWS_DYNAMODB_SCAN_FORWARD_TYPE;
+  [AWS_DYNAMODB_SEGMENT]?: AWS_DYNAMODB_SEGMENT_TYPE;
+  [AWS_DYNAMODB_SELECT]?: AWS_DYNAMODB_SELECT_TYPE;
+  [AWS_DYNAMODB_TABLE_COUNT]?: AWS_DYNAMODB_TABLE_COUNT_TYPE;
+  [AWS_DYNAMODB_TABLE_NAMES]?: AWS_DYNAMODB_TABLE_NAMES_TYPE;
+  [AWS_DYNAMODB_TOTAL_SEGMENTS]?: AWS_DYNAMODB_TOTAL_SEGMENTS_TYPE;
+  [AWS_KINESIS_STREAM_NAME]?: AWS_KINESIS_STREAM_NAME_TYPE;
   [AWS_LAMBDA_AWS_REQUEST_ID]?: AWS_LAMBDA_AWS_REQUEST_ID_TYPE;
   [AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS]?: AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS_TYPE;
   [AWS_LAMBDA_FUNCTION_NAME]?: AWS_LAMBDA_FUNCTION_NAME_TYPE;
@@ -25479,6 +26722,13 @@ export type Attributes = {
   [AWS_LAMBDA_REMAINING_TIME_IN_MILLIS]?: AWS_LAMBDA_REMAINING_TIME_IN_MILLIS_TYPE;
   [AWS_LOG_GROUP_NAMES]?: AWS_LOG_GROUP_NAMES_TYPE;
   [AWS_LOG_STREAM_NAMES]?: AWS_LOG_STREAM_NAMES_TYPE;
+  [AWS_REQUEST_EXTENDED_ID]?: AWS_REQUEST_EXTENDED_ID_TYPE;
+  [AWS_REQUEST_ID]?: AWS_REQUEST_ID_TYPE;
+  [AWS_S3_BUCKET]?: AWS_S3_BUCKET_TYPE;
+  [AWS_SECRETSMANAGER_SECRET_ARN]?: AWS_SECRETSMANAGER_SECRET_ARN_TYPE;
+  [AWS_SNS_TOPIC_ARN]?: AWS_SNS_TOPIC_ARN_TYPE;
+  [AWS_STEP_FUNCTIONS_ACTIVITY_ARN]?: AWS_STEP_FUNCTIONS_ACTIVITY_ARN_TYPE;
+  [AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN]?: AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN_TYPE;
   [BLOCKED_MAIN_THREAD]?: BLOCKED_MAIN_THREAD_TYPE;
   [BROWSER_NAME]?: BROWSER_NAME_TYPE;
   [BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START]?: BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START_TYPE;
@@ -25629,6 +26879,9 @@ export type Attributes = {
   [FAAS_ID]?: FAAS_ID_TYPE;
   [FAAS_IDENTITY]?: FAAS_IDENTITY_TYPE;
   [FAAS_INVOCATION_ID]?: FAAS_INVOCATION_ID_TYPE;
+  [FAAS_INVOKED_NAME]?: FAAS_INVOKED_NAME_TYPE;
+  [FAAS_INVOKED_PROVIDER]?: FAAS_INVOKED_PROVIDER_TYPE;
+  [FAAS_INVOKED_REGION]?: FAAS_INVOKED_REGION_TYPE;
   [FAAS_NAME]?: FAAS_NAME_TYPE;
   [FAAS_TIME]?: FAAS_TIME_TYPE;
   [FAAS_TRIGGER]?: FAAS_TRIGGER_TYPE;
@@ -25681,6 +26934,7 @@ export type Attributes = {
   [GEN_AI_REQUEST_PRESENCE_PENALTY]?: GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE;
   [GEN_AI_REQUEST_REASONING_EFFORT]?: GEN_AI_REQUEST_REASONING_EFFORT_TYPE;
   [GEN_AI_REQUEST_SEED]?: GEN_AI_REQUEST_SEED_TYPE;
+  [GEN_AI_REQUEST_STOP_SEQUENCES]?: GEN_AI_REQUEST_STOP_SEQUENCES_TYPE;
   [GEN_AI_REQUEST_TEMPERATURE]?: GEN_AI_REQUEST_TEMPERATURE_TYPE;
   [GEN_AI_REQUEST_TOP_K]?: GEN_AI_REQUEST_TOP_K_TYPE;
   [GEN_AI_REQUEST_TOP_P]?: GEN_AI_REQUEST_TOP_P_TYPE;
@@ -25819,6 +27073,7 @@ export type Attributes = {
   [MCP_TRANSPORT]?: MCP_TRANSPORT_TYPE;
   [MDC_KEY]?: MDC_KEY_TYPE;
   [MESSAGING_BATCH_MESSAGE_COUNT]?: MESSAGING_BATCH_MESSAGE_COUNT_TYPE;
+  [MESSAGING_DESTINATION]?: MESSAGING_DESTINATION_TYPE;
   [MESSAGING_DESTINATION_CONNECTION]?: MESSAGING_DESTINATION_CONNECTION_TYPE;
   [MESSAGING_DESTINATION_NAME]?: MESSAGING_DESTINATION_NAME_TYPE;
   [MESSAGING_MESSAGE_BODY_SIZE]?: MESSAGING_MESSAGE_BODY_SIZE_TYPE;
@@ -25905,6 +27160,7 @@ export type Attributes = {
   [RPC_METHOD]?: RPC_METHOD_TYPE;
   [RPC_RESPONSE_STATUS_CODE]?: RPC_RESPONSE_STATUS_CODE_TYPE;
   [RPC_SERVICE]?: RPC_SERVICE_TYPE;
+  [RPC_SYSTEM]?: RPC_SYSTEM_TYPE;
   [RUNTIME_BUILD]?: RUNTIME_BUILD_TYPE;
   [RUNTIME_NAME]?: RUNTIME_NAME_TYPE;
   [RUNTIME_RAW_DESCRIPTION]?: RUNTIME_RAW_DESCRIPTION_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -18259,7 +18259,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: ['{ "AttributeName": "string", "AttributeType": "string" }'],
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.attribute_definitions attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.attribute_definitions attribute' }],
   },
   'aws.dynamodb.consistent_read': {
     brief: 'The value of the `ConsistentRead` request parameter.',
@@ -18270,7 +18270,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: true,
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.consistent_read attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.consistent_read attribute' }],
   },
   'aws.dynamodb.consumed_capacity': {
     brief: 'The JSON-serialized value of each item in the `ConsumedCapacity` response field.',
@@ -18283,7 +18283,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: [
       '{ "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "ReadCapacityUnits": number, "Table": { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName": "string", "WriteCapacityUnits": number }',
     ],
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.consumed_capacity attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.consumed_capacity attribute' }],
   },
   'aws.dynamodb.count': {
     brief: 'The value of the `Count` response parameter.',
@@ -18294,7 +18294,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 10,
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.count attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.count attribute' }],
   },
   'aws.dynamodb.exclusive_start_table': {
     brief: 'The value of the `ExclusiveStartTableName` request parameter.',
@@ -18305,7 +18305,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'Users',
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.exclusive_start_table attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.exclusive_start_table attribute' }],
   },
   'aws.dynamodb.global_secondary_indexes': {
     brief: 'The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.',
@@ -18318,7 +18318,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: [
       '{ "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }',
     ],
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.global_secondary_indexes attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.global_secondary_indexes attribute' }],
   },
   'aws.dynamodb.global_secondary_index_updates': {
     brief: 'The JSON-serialized value of each item in the `GlobalSecondaryIndexUpdates` request field.',
@@ -18331,7 +18331,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: [
       '{ "Create": { "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }',
     ],
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.global_secondary_index_updates attribute' }],
+    changelog: [
+      { version: 'next', prs: [478], description: 'Added aws.dynamodb.global_secondary_index_updates attribute' },
+    ],
   },
   'aws.dynamodb.index_name': {
     brief: 'The value of the `IndexName` request parameter.',
@@ -18342,7 +18344,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'name_to_group',
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.index_name attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.index_name attribute' }],
   },
   'aws.dynamodb.item_collection_metrics': {
     brief: 'The JSON-serialized value of the `ItemCollectionMetrics` response field.',
@@ -18354,7 +18356,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example:
       '{ "string" : [ { "ItemCollectionKey": { "string" : { "B": blob, "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" : "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S": "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }',
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.item_collection_metrics attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.item_collection_metrics attribute' }],
   },
   'aws.dynamodb.limit': {
     brief: 'The value of the `Limit` request parameter.',
@@ -18365,7 +18367,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 10,
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.limit attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.limit attribute' }],
   },
   'aws.dynamodb.local_secondary_indexes': {
     brief: 'The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.',
@@ -18378,7 +18380,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: [
       '{ "IndexArn": "string", "IndexName": "string", "IndexSizeBytes": number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" } }',
     ],
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.local_secondary_indexes attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.local_secondary_indexes attribute' }],
   },
   'aws.dynamodb.projection': {
     brief: 'The value of the `ProjectionExpression` request parameter.',
@@ -18389,7 +18391,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'Title, Price, Color',
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.projection attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.projection attribute' }],
   },
   'aws.dynamodb.provisioned_read_capacity': {
     brief: 'The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.',
@@ -18400,7 +18402,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 1,
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.provisioned_read_capacity attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.provisioned_read_capacity attribute' }],
   },
   'aws.dynamodb.provisioned_write_capacity': {
     brief: 'The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.',
@@ -18411,7 +18413,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 2,
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.provisioned_write_capacity attribute' }],
+    changelog: [
+      { version: 'next', prs: [478], description: 'Added aws.dynamodb.provisioned_write_capacity attribute' },
+    ],
   },
   'aws.dynamodb.scanned_count': {
     brief: 'The value of the `ScannedCount` response parameter.',
@@ -18422,7 +18426,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 50,
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.scanned_count attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.scanned_count attribute' }],
   },
   'aws.dynamodb.scan_forward': {
     brief: 'The value of the `ScanIndexForward` request parameter.',
@@ -18433,7 +18437,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: true,
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.scan_forward attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.scan_forward attribute' }],
   },
   'aws.dynamodb.segment': {
     brief: 'The value of the `Segment` request parameter.',
@@ -18444,7 +18448,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 10,
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.segment attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.segment attribute' }],
   },
   'aws.dynamodb.select': {
     brief: 'The value of the `Select` request parameter.',
@@ -18455,7 +18459,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'ALL_ATTRIBUTES',
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.select attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.select attribute' }],
   },
   'aws.dynamodb.table_count': {
     brief: 'The number of items in the `TableNames` response parameter.',
@@ -18466,7 +18470,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 20,
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.table_count attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.table_count attribute' }],
   },
   'aws.dynamodb.table_names': {
     brief: 'The keys in the `RequestItems` object field.',
@@ -18477,7 +18481,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: ['Users', 'Cats'],
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.table_names attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.table_names attribute' }],
   },
   'aws.dynamodb.total_segments': {
     brief: 'The value of the `TotalSegments` request parameter.',
@@ -18488,7 +18492,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 100,
-    changelog: [{ version: 'next', description: 'Added aws.dynamodb.total_segments attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.dynamodb.total_segments attribute' }],
   },
   'aws.kinesis.stream.name': {
     brief: 'The name of the AWS Kinesis stream the request refers to.',
@@ -18499,7 +18503,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'some-stream-name',
-    changelog: [{ version: 'next', description: 'Added aws.kinesis.stream.name attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.kinesis.stream.name attribute' }],
   },
   'aws.lambda.aws_request_id': {
     brief: 'The AWS request ID as received by the Lambda function runtime',
@@ -18657,7 +18661,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=',
-    changelog: [{ version: 'next', description: 'Added aws.request.extended_id attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.request.extended_id attribute' }],
   },
   'aws.request.id': {
     brief: 'The AWS request ID as returned in the response headers.',
@@ -18668,7 +18672,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: '79b9da39-b7ae-508a-a6bc-864b2829c622',
-    changelog: [{ version: 'next', description: 'Added aws.request.id attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.request.id attribute' }],
   },
   'aws.s3.bucket': {
     brief: 'The S3 bucket name the request refers to.',
@@ -18679,7 +18683,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'ot-demo-test',
-    changelog: [{ version: 'next', description: 'Added aws.s3.bucket attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.s3.bucket attribute' }],
   },
   'aws.secretsmanager.secret.arn': {
     brief: 'The ARN of the Secret stored in Secrets Manager.',
@@ -18690,7 +18694,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:SecretName-6RandomCharacters',
-    changelog: [{ version: 'next', description: 'Added aws.secretsmanager.secret.arn attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.secretsmanager.secret.arn attribute' }],
   },
   'aws.sns.topic.arn': {
     brief:
@@ -18702,7 +18706,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE',
-    changelog: [{ version: 'next', description: 'Added aws.sns.topic.arn attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.sns.topic.arn attribute' }],
   },
   'aws.step_functions.activity.arn': {
     brief: 'The ARN of the AWS Step Functions Activity.',
@@ -18713,7 +18717,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'arn:aws:states:us-east-1:123456789012:activity:get-greeting',
-    changelog: [{ version: 'next', description: 'Added aws.step_functions.activity.arn attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.step_functions.activity.arn attribute' }],
   },
   'aws.step_functions.state_machine.arn': {
     brief: 'The ARN of the AWS Step Functions State Machine.',
@@ -18724,7 +18728,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine:1',
-    changelog: [{ version: 'next', description: 'Added aws.step_functions.state_machine.arn attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added aws.step_functions.state_machine.arn attribute' }],
   },
   blocked_main_thread: {
     brief: 'Whether the main thread was blocked by the span.',
@@ -20605,7 +20609,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'my-function',
-    changelog: [{ version: 'next', description: 'Added faas.invoked_name attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added faas.invoked_name attribute' }],
   },
   'faas.invoked_provider': {
     brief: 'The cloud provider of the invoked function.',
@@ -20616,7 +20620,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'aws',
-    changelog: [{ version: 'next', description: 'Added faas.invoked_provider attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added faas.invoked_provider attribute' }],
   },
   'faas.invoked_region': {
     brief: 'The cloud region of the invoked function.',
@@ -20627,7 +20631,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'eu-central-1',
-    changelog: [{ version: 'next', description: 'Added faas.invoked_region attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added faas.invoked_region attribute' }],
   },
   'faas.name': {
     brief: 'The name of the serverless function',
@@ -21367,7 +21371,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: ['forest', 'lived'],
-    changelog: [{ version: 'next', description: 'Added gen_ai.request.stop_sequences attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added gen_ai.request.stop_sequences attribute' }],
   },
   'gen_ai.request.temperature': {
     brief:
@@ -23389,6 +23393,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     changelog: [
       {
         version: 'next',
+        prs: [478],
         description: 'Added messaging.destination attribute, deprecated in favor of messaging.destination.name',
       },
     ],
@@ -23415,7 +23420,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'BestTopic',
     aliases: ['messaging.destination'],
     changelog: [
-      { version: 'next', description: 'Added messaging.destination as an alias' },
+      { version: 'next', prs: [478], description: 'Added messaging.destination as an alias' },
       { version: '0.1.0', prs: [127] },
       { version: '0.0.0' },
     ],
@@ -24516,7 +24521,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'aws-api',
-    changelog: [{ version: 'next', description: 'Added rpc.system attribute' }],
+    changelog: [{ version: 'next', prs: [478], description: 'Added rpc.system attribute' }],
   },
   'runtime.build': {
     brief: 'The application build string, when it is separate from the version.',

--- a/model/attributes/aws/aws__dynamodb__attribute_definitions.json
+++ b/model/attributes/aws/aws__dynamodb__attribute_definitions.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.attribute_definitions",
+  "brief": "The JSON-serialized value of each item in the `AttributeDefinitions` request field.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": ["{ \"AttributeName\": \"string\", \"AttributeType\": \"string\" }"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.attribute_definitions attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__attribute_definitions.json
+++ b/model/attributes/aws/aws__dynamodb__attribute_definitions.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.attribute_definitions attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__consistent_read.json
+++ b/model/attributes/aws/aws__dynamodb__consistent_read.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.consistent_read attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__consistent_read.json
+++ b/model/attributes/aws/aws__dynamodb__consistent_read.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.consistent_read",
+  "brief": "The value of the `ConsistentRead` request parameter.",
+  "type": "boolean",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": true,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.consistent_read attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__consumed_capacity.json
+++ b/model/attributes/aws/aws__dynamodb__consumed_capacity.json
@@ -13,6 +13,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.consumed_capacity attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__consumed_capacity.json
+++ b/model/attributes/aws/aws__dynamodb__consumed_capacity.json
@@ -1,0 +1,19 @@
+{
+  "key": "aws.dynamodb.consumed_capacity",
+  "brief": "The JSON-serialized value of each item in the `ConsumedCapacity` response field.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": [
+    "{ \"CapacityUnits\": number, \"GlobalSecondaryIndexes\": { \"string\" : { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }, \"LocalSecondaryIndexes\": { \"string\" : { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }, \"ReadCapacityUnits\": number, \"Table\": { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number }, \"TableName\": \"string\", \"WriteCapacityUnits\": number }"
+  ],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.consumed_capacity attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__count.json
+++ b/model/attributes/aws/aws__dynamodb__count.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.count attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__count.json
+++ b/model/attributes/aws/aws__dynamodb__count.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.count",
+  "brief": "The value of the `Count` response parameter.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 10,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.count attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__exclusive_start_table.json
+++ b/model/attributes/aws/aws__dynamodb__exclusive_start_table.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.exclusive_start_table attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__exclusive_start_table.json
+++ b/model/attributes/aws/aws__dynamodb__exclusive_start_table.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.exclusive_start_table",
+  "brief": "The value of the `ExclusiveStartTableName` request parameter.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "Users",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.exclusive_start_table attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__global_secondary_index_updates.json
+++ b/model/attributes/aws/aws__dynamodb__global_secondary_index_updates.json
@@ -13,6 +13,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.global_secondary_index_updates attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__global_secondary_index_updates.json
+++ b/model/attributes/aws/aws__dynamodb__global_secondary_index_updates.json
@@ -1,0 +1,19 @@
+{
+  "key": "aws.dynamodb.global_secondary_index_updates",
+  "brief": "The JSON-serialized value of each item in the `GlobalSecondaryIndexUpdates` request field.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": [
+    "{ \"Create\": { \"IndexName\": \"string\", \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" }, \"ProvisionedThroughput\": { \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }"
+  ],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.global_secondary_index_updates attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__global_secondary_indexes.json
+++ b/model/attributes/aws/aws__dynamodb__global_secondary_indexes.json
@@ -1,0 +1,19 @@
+{
+  "key": "aws.dynamodb.global_secondary_indexes",
+  "brief": "The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": [
+    "{ \"IndexName\": \"string\", \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" }, \"ProvisionedThroughput\": { \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }"
+  ],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.global_secondary_indexes attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__global_secondary_indexes.json
+++ b/model/attributes/aws/aws__dynamodb__global_secondary_indexes.json
@@ -13,6 +13,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.global_secondary_indexes attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__index_name.json
+++ b/model/attributes/aws/aws__dynamodb__index_name.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.index_name attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__index_name.json
+++ b/model/attributes/aws/aws__dynamodb__index_name.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.index_name",
+  "brief": "The value of the `IndexName` request parameter.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "name_to_group",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.index_name attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__item_collection_metrics.json
+++ b/model/attributes/aws/aws__dynamodb__item_collection_metrics.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.item_collection_metrics attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__item_collection_metrics.json
+++ b/model/attributes/aws/aws__dynamodb__item_collection_metrics.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.item_collection_metrics",
+  "brief": "The JSON-serialized value of the `ItemCollectionMetrics` response field.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "{ \"string\" : [ { \"ItemCollectionKey\": { \"string\" : { \"B\": blob, \"BOOL\": boolean, \"BS\": [ blob ], \"L\": [ \"AttributeValue\" ], \"M\": { \"string\" : \"AttributeValue\" }, \"N\": \"string\", \"NS\": [ \"string\" ], \"NULL\": boolean, \"S\": \"string\", \"SS\": [ \"string\" ] } }, \"SizeEstimateRangeGB\": [ number ] } ] }",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.item_collection_metrics attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__limit.json
+++ b/model/attributes/aws/aws__dynamodb__limit.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.limit attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__limit.json
+++ b/model/attributes/aws/aws__dynamodb__limit.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.limit",
+  "brief": "The value of the `Limit` request parameter.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 10,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.limit attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__local_secondary_indexes.json
+++ b/model/attributes/aws/aws__dynamodb__local_secondary_indexes.json
@@ -1,0 +1,19 @@
+{
+  "key": "aws.dynamodb.local_secondary_indexes",
+  "brief": "The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": [
+    "{ \"IndexArn\": \"string\", \"IndexName\": \"string\", \"IndexSizeBytes\": number, \"ItemCount\": number, \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" } }"
+  ],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.local_secondary_indexes attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__local_secondary_indexes.json
+++ b/model/attributes/aws/aws__dynamodb__local_secondary_indexes.json
@@ -13,6 +13,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.local_secondary_indexes attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__projection.json
+++ b/model/attributes/aws/aws__dynamodb__projection.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.projection",
+  "brief": "The value of the `ProjectionExpression` request parameter.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "Title, Price, Color",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.projection attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__projection.json
+++ b/model/attributes/aws/aws__dynamodb__projection.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.projection attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__provisioned_read_capacity.json
+++ b/model/attributes/aws/aws__dynamodb__provisioned_read_capacity.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.provisioned_read_capacity attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__provisioned_read_capacity.json
+++ b/model/attributes/aws/aws__dynamodb__provisioned_read_capacity.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.provisioned_read_capacity",
+  "brief": "The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.",
+  "type": "double",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 1,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.provisioned_read_capacity attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__provisioned_write_capacity.json
+++ b/model/attributes/aws/aws__dynamodb__provisioned_write_capacity.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.provisioned_write_capacity",
+  "brief": "The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.",
+  "type": "double",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 2,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.provisioned_write_capacity attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__provisioned_write_capacity.json
+++ b/model/attributes/aws/aws__dynamodb__provisioned_write_capacity.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.provisioned_write_capacity attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__scan_forward.json
+++ b/model/attributes/aws/aws__dynamodb__scan_forward.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.scan_forward attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__scan_forward.json
+++ b/model/attributes/aws/aws__dynamodb__scan_forward.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.scan_forward",
+  "brief": "The value of the `ScanIndexForward` request parameter.",
+  "type": "boolean",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": true,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.scan_forward attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__scanned_count.json
+++ b/model/attributes/aws/aws__dynamodb__scanned_count.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.scanned_count",
+  "brief": "The value of the `ScannedCount` response parameter.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 50,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.scanned_count attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__scanned_count.json
+++ b/model/attributes/aws/aws__dynamodb__scanned_count.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.scanned_count attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__segment.json
+++ b/model/attributes/aws/aws__dynamodb__segment.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.segment",
+  "brief": "The value of the `Segment` request parameter.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 10,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.segment attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__segment.json
+++ b/model/attributes/aws/aws__dynamodb__segment.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.segment attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__select.json
+++ b/model/attributes/aws/aws__dynamodb__select.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.select attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__select.json
+++ b/model/attributes/aws/aws__dynamodb__select.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.select",
+  "brief": "The value of the `Select` request parameter.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "ALL_ATTRIBUTES",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.select attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__table_count.json
+++ b/model/attributes/aws/aws__dynamodb__table_count.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.table_count attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__table_count.json
+++ b/model/attributes/aws/aws__dynamodb__table_count.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.table_count",
+  "brief": "The number of items in the `TableNames` response parameter.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 20,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.table_count attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__table_names.json
+++ b/model/attributes/aws/aws__dynamodb__table_names.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.table_names",
+  "brief": "The keys in the `RequestItems` object field.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": ["Users", "Cats"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.table_names attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__table_names.json
+++ b/model/attributes/aws/aws__dynamodb__table_names.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.table_names attribute"
     }
   ]

--- a/model/attributes/aws/aws__dynamodb__total_segments.json
+++ b/model/attributes/aws/aws__dynamodb__total_segments.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.dynamodb.total_segments",
+  "brief": "The value of the `TotalSegments` request parameter.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 100,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.dynamodb.total_segments attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__total_segments.json
+++ b/model/attributes/aws/aws__dynamodb__total_segments.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.dynamodb.total_segments attribute"
     }
   ]

--- a/model/attributes/aws/aws__kinesis__stream__name.json
+++ b/model/attributes/aws/aws__kinesis__stream__name.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.kinesis.stream.name attribute"
     }
   ]

--- a/model/attributes/aws/aws__kinesis__stream__name.json
+++ b/model/attributes/aws/aws__kinesis__stream__name.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.kinesis.stream.name",
+  "brief": "The name of the AWS Kinesis stream the request refers to.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": "some-stream-name",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.kinesis.stream.name attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__request__extended_id.json
+++ b/model/attributes/aws/aws__request__extended_id.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.request.extended_id attribute"
     }
   ]

--- a/model/attributes/aws/aws__request__extended_id.json
+++ b/model/attributes/aws/aws__request__extended_id.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.request.extended_id",
+  "brief": "The AWS extended request ID as returned in the response headers.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": "wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.request.extended_id attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__request__id.json
+++ b/model/attributes/aws/aws__request__id.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.request.id",
+  "brief": "The AWS request ID as returned in the response headers.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": "79b9da39-b7ae-508a-a6bc-864b2829c622",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.request.id attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__request__id.json
+++ b/model/attributes/aws/aws__request__id.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.request.id attribute"
     }
   ]

--- a/model/attributes/aws/aws__s3__bucket.json
+++ b/model/attributes/aws/aws__s3__bucket.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.s3.bucket",
+  "brief": "The S3 bucket name the request refers to.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "ot-demo-test",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.s3.bucket attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__s3__bucket.json
+++ b/model/attributes/aws/aws__s3__bucket.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.s3.bucket attribute"
     }
   ]

--- a/model/attributes/aws/aws__secretsmanager__secret__arn.json
+++ b/model/attributes/aws/aws__secretsmanager__secret__arn.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.secretsmanager.secret.arn attribute"
     }
   ]

--- a/model/attributes/aws/aws__secretsmanager__secret__arn.json
+++ b/model/attributes/aws/aws__secretsmanager__secret__arn.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.secretsmanager.secret.arn",
+  "brief": "The ARN of the Secret stored in Secrets Manager.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "arn:aws:secretsmanager:us-east-1:123456789012:secret:SecretName-6RandomCharacters",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.secretsmanager.secret.arn attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__sns__topic__arn.json
+++ b/model/attributes/aws/aws__sns__topic__arn.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.sns.topic.arn attribute"
     }
   ]

--- a/model/attributes/aws/aws__sns__topic__arn.json
+++ b/model/attributes/aws/aws__sns__topic__arn.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.sns.topic.arn",
+  "brief": "The ARN of the AWS SNS Topic. An Amazon SNS topic is a logical access point that acts as a communication channel.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.sns.topic.arn attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__step_functions__activity__arn.json
+++ b/model/attributes/aws/aws__step_functions__activity__arn.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.step_functions.activity.arn attribute"
     }
   ]

--- a/model/attributes/aws/aws__step_functions__activity__arn.json
+++ b/model/attributes/aws/aws__step_functions__activity__arn.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.step_functions.activity.arn",
+  "brief": "The ARN of the AWS Step Functions Activity.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "arn:aws:states:us-east-1:123456789012:activity:get-greeting",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.step_functions.activity.arn attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__step_functions__state_machine__arn.json
+++ b/model/attributes/aws/aws__step_functions__state_machine__arn.json
@@ -1,0 +1,17 @@
+{
+  "key": "aws.step_functions.state_machine.arn",
+  "brief": "The ARN of the AWS Step Functions State Machine.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine:1",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws.step_functions.state_machine.arn attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__step_functions__state_machine__arn.json
+++ b/model/attributes/aws/aws__step_functions__state_machine__arn.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added aws.step_functions.state_machine.arn attribute"
     }
   ]

--- a/model/attributes/faas/faas__invoked_name.json
+++ b/model/attributes/faas/faas__invoked_name.json
@@ -1,0 +1,17 @@
+{
+  "key": "faas.invoked_name",
+  "brief": "The name of the invoked function.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "my-function",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added faas.invoked_name attribute"
+    }
+  ]
+}

--- a/model/attributes/faas/faas__invoked_name.json
+++ b/model/attributes/faas/faas__invoked_name.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added faas.invoked_name attribute"
     }
   ]

--- a/model/attributes/faas/faas__invoked_provider.json
+++ b/model/attributes/faas/faas__invoked_provider.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added faas.invoked_provider attribute"
     }
   ]

--- a/model/attributes/faas/faas__invoked_provider.json
+++ b/model/attributes/faas/faas__invoked_provider.json
@@ -1,0 +1,17 @@
+{
+  "key": "faas.invoked_provider",
+  "brief": "The cloud provider of the invoked function.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "aws",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added faas.invoked_provider attribute"
+    }
+  ]
+}

--- a/model/attributes/faas/faas__invoked_region.json
+++ b/model/attributes/faas/faas__invoked_region.json
@@ -1,0 +1,17 @@
+{
+  "key": "faas.invoked_region",
+  "brief": "The cloud region of the invoked function.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "eu-central-1",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added faas.invoked_region attribute"
+    }
+  ]
+}

--- a/model/attributes/faas/faas__invoked_region.json
+++ b/model/attributes/faas/faas__invoked_region.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added faas.invoked_region attribute"
     }
   ]

--- a/model/attributes/gen_ai/gen_ai__request__stop_sequences.json
+++ b/model/attributes/gen_ai/gen_ai__request__stop_sequences.json
@@ -1,0 +1,17 @@
+{
+  "key": "gen_ai.request.stop_sequences",
+  "brief": "List of sequences that the model will use to stop generating further tokens.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": ["forest", "lived"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added gen_ai.request.stop_sequences attribute"
+    }
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__request__stop_sequences.json
+++ b/model/attributes/gen_ai/gen_ai__request__stop_sequences.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added gen_ai.request.stop_sequences attribute"
     }
   ]

--- a/model/attributes/messaging/messaging__destination.json
+++ b/model/attributes/messaging/messaging__destination.json
@@ -1,0 +1,23 @@
+{
+  "key": "messaging.destination",
+  "brief": "The message destination name.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": "BestTopic",
+  "alias": ["messaging.destination.name"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "messaging.destination.name",
+    "reason": "This attribute is being deprecated in favor of messaging.destination.name, which is the OTel-aligned replacement."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.destination attribute, deprecated in favor of messaging.destination.name"
+    }
+  ]
+}

--- a/model/attributes/messaging/messaging__destination.json
+++ b/model/attributes/messaging/messaging__destination.json
@@ -17,6 +17,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added messaging.destination attribute, deprecated in favor of messaging.destination.name"
     }
   ]

--- a/model/attributes/messaging/messaging__destination__name.json
+++ b/model/attributes/messaging/messaging__destination__name.json
@@ -12,6 +12,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added messaging.destination as an alias"
     },
     {

--- a/model/attributes/messaging/messaging__destination__name.json
+++ b/model/attributes/messaging/messaging__destination__name.json
@@ -7,8 +7,13 @@
   },
   "is_in_otel": true,
   "example": "BestTopic",
+  "alias": ["messaging.destination"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.destination as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [127]

--- a/model/attributes/rpc/rpc__system.json
+++ b/model/attributes/rpc/rpc__system.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [478],
       "description": "Added rpc.system attribute"
     }
   ]

--- a/model/attributes/rpc/rpc__system.json
+++ b/model/attributes/rpc/rpc__system.json
@@ -1,0 +1,17 @@
+{
+  "key": "rpc.system",
+  "brief": "A string identifying the remoting system.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "aws-api",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added rpc.system attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -10222,6 +10222,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added aws.dynamodb.attribute_definitions attribute",
             ),
         ],
@@ -10236,6 +10237,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added aws.dynamodb.consistent_read attribute",
             ),
         ],
@@ -10252,6 +10254,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added aws.dynamodb.consumed_capacity attribute",
             ),
         ],
@@ -10265,7 +10268,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=10,
         changelog=[
             ChangelogEntry(
-                version="next", description="Added aws.dynamodb.count attribute"
+                version="next",
+                prs=[478],
+                description="Added aws.dynamodb.count attribute",
             ),
         ],
     ),
@@ -10279,6 +10284,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added aws.dynamodb.exclusive_start_table attribute",
             ),
         ],
@@ -10295,6 +10301,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added aws.dynamodb.global_secondary_index_updates attribute",
             ),
         ],
@@ -10311,6 +10318,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added aws.dynamodb.global_secondary_indexes attribute",
             ),
         ],
@@ -10324,7 +10332,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="name_to_group",
         changelog=[
             ChangelogEntry(
-                version="next", description="Added aws.dynamodb.index_name attribute"
+                version="next",
+                prs=[478],
+                description="Added aws.dynamodb.index_name attribute",
             ),
         ],
     ),
@@ -10338,6 +10348,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added aws.dynamodb.item_collection_metrics attribute",
             ),
         ],
@@ -10351,7 +10362,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=10,
         changelog=[
             ChangelogEntry(
-                version="next", description="Added aws.dynamodb.limit attribute"
+                version="next",
+                prs=[478],
+                description="Added aws.dynamodb.limit attribute",
             ),
         ],
     ),
@@ -10367,6 +10380,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added aws.dynamodb.local_secondary_indexes attribute",
             ),
         ],
@@ -10380,7 +10394,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="Title, Price, Color",
         changelog=[
             ChangelogEntry(
-                version="next", description="Added aws.dynamodb.projection attribute"
+                version="next",
+                prs=[478],
+                description="Added aws.dynamodb.projection attribute",
             ),
         ],
     ),
@@ -10394,6 +10410,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added aws.dynamodb.provisioned_read_capacity attribute",
             ),
         ],
@@ -10408,6 +10425,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added aws.dynamodb.provisioned_write_capacity attribute",
             ),
         ],
@@ -10421,7 +10439,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=True,
         changelog=[
             ChangelogEntry(
-                version="next", description="Added aws.dynamodb.scan_forward attribute"
+                version="next",
+                prs=[478],
+                description="Added aws.dynamodb.scan_forward attribute",
             ),
         ],
     ),
@@ -10434,7 +10454,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=50,
         changelog=[
             ChangelogEntry(
-                version="next", description="Added aws.dynamodb.scanned_count attribute"
+                version="next",
+                prs=[478],
+                description="Added aws.dynamodb.scanned_count attribute",
             ),
         ],
     ),
@@ -10447,7 +10469,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=10,
         changelog=[
             ChangelogEntry(
-                version="next", description="Added aws.dynamodb.segment attribute"
+                version="next",
+                prs=[478],
+                description="Added aws.dynamodb.segment attribute",
             ),
         ],
     ),
@@ -10460,7 +10484,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="ALL_ATTRIBUTES",
         changelog=[
             ChangelogEntry(
-                version="next", description="Added aws.dynamodb.select attribute"
+                version="next",
+                prs=[478],
+                description="Added aws.dynamodb.select attribute",
             ),
         ],
     ),
@@ -10473,7 +10499,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=20,
         changelog=[
             ChangelogEntry(
-                version="next", description="Added aws.dynamodb.table_count attribute"
+                version="next",
+                prs=[478],
+                description="Added aws.dynamodb.table_count attribute",
             ),
         ],
     ),
@@ -10486,7 +10514,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=["Users", "Cats"],
         changelog=[
             ChangelogEntry(
-                version="next", description="Added aws.dynamodb.table_names attribute"
+                version="next",
+                prs=[478],
+                description="Added aws.dynamodb.table_names attribute",
             ),
         ],
     ),
@@ -10500,6 +10530,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added aws.dynamodb.total_segments attribute",
             ),
         ],
@@ -10513,7 +10544,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="some-stream-name",
         changelog=[
             ChangelogEntry(
-                version="next", description="Added aws.kinesis.stream.name attribute"
+                version="next",
+                prs=[478],
+                description="Added aws.kinesis.stream.name attribute",
             ),
         ],
     ),
@@ -10699,7 +10732,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=",
         changelog=[
             ChangelogEntry(
-                version="next", description="Added aws.request.extended_id attribute"
+                version="next",
+                prs=[478],
+                description="Added aws.request.extended_id attribute",
             ),
         ],
     ),
@@ -10712,7 +10747,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="79b9da39-b7ae-508a-a6bc-864b2829c622",
         changelog=[
             ChangelogEntry(
-                version="next", description="Added aws.request.id attribute"
+                version="next", prs=[478], description="Added aws.request.id attribute"
             ),
         ],
     ),
@@ -10724,7 +10759,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="ot-demo-test",
         changelog=[
-            ChangelogEntry(version="next", description="Added aws.s3.bucket attribute"),
+            ChangelogEntry(
+                version="next", prs=[478], description="Added aws.s3.bucket attribute"
+            ),
         ],
     ),
     "aws.secretsmanager.secret.arn": AttributeMetadata(
@@ -10737,6 +10774,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added aws.secretsmanager.secret.arn attribute",
             ),
         ],
@@ -10750,7 +10788,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
         changelog=[
             ChangelogEntry(
-                version="next", description="Added aws.sns.topic.arn attribute"
+                version="next",
+                prs=[478],
+                description="Added aws.sns.topic.arn attribute",
             ),
         ],
     ),
@@ -10764,6 +10804,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added aws.step_functions.activity.arn attribute",
             ),
         ],
@@ -10778,6 +10819,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added aws.step_functions.state_machine.arn attribute",
             ),
         ],
@@ -12879,7 +12921,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="my-function",
         changelog=[
             ChangelogEntry(
-                version="next", description="Added faas.invoked_name attribute"
+                version="next",
+                prs=[478],
+                description="Added faas.invoked_name attribute",
             ),
         ],
     ),
@@ -12892,7 +12936,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="aws",
         changelog=[
             ChangelogEntry(
-                version="next", description="Added faas.invoked_provider attribute"
+                version="next",
+                prs=[478],
+                description="Added faas.invoked_provider attribute",
             ),
         ],
     ),
@@ -12905,7 +12951,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="eu-central-1",
         changelog=[
             ChangelogEntry(
-                version="next", description="Added faas.invoked_region attribute"
+                version="next",
+                prs=[478],
+                description="Added faas.invoked_region attribute",
             ),
         ],
     ),
@@ -13704,6 +13752,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added gen_ai.request.stop_sequences attribute",
             ),
         ],
@@ -15822,6 +15871,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[478],
                 description="Added messaging.destination attribute, deprecated in favor of messaging.destination.name",
             ),
         ],
@@ -15848,7 +15898,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         aliases=["messaging.destination"],
         changelog=[
             ChangelogEntry(
-                version="next", description="Added messaging.destination as an alias"
+                version="next",
+                prs=[478],
+                description="Added messaging.destination as an alias",
             ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -17006,7 +17058,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="aws-api",
         changelog=[
-            ChangelogEntry(version="next", description="Added rpc.system attribute"),
+            ChangelogEntry(
+                version="next", prs=[478], description="Added rpc.system attribute"
+            ),
         ],
     ),
     "runtime.build": AttributeMetadata(

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -227,6 +227,7 @@ class _AttributeNamesMeta(type):
         "MCP_TOOL_RESULT_CONTENT",
         "MCP_TOOL_RESULT_IS_ERROR",
         "MCP_TRANSPORT",
+        "MESSAGING_DESTINATION",
         "METHOD",
         "NET_HOST_IP",
         "NET_HOST_NAME",
@@ -1224,6 +1225,284 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/my-log-group"
     """
 
+    # Path: model/attributes/aws/aws__dynamodb__attribute_definitions.json
+    AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS: Literal[
+        "aws.dynamodb.attribute_definitions"
+    ] = "aws.dynamodb.attribute_definitions"
+    """The JSON-serialized value of each item in the `AttributeDefinitions` request field.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["{ \"AttributeName\": \"string\", \"AttributeType\": \"string\" }"]
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__consistent_read.json
+    AWS_DYNAMODB_CONSISTENT_READ: Literal["aws.dynamodb.consistent_read"] = (
+        "aws.dynamodb.consistent_read"
+    )
+    """The value of the `ConsistentRead` request parameter.
+
+    Type: bool
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: true
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__consumed_capacity.json
+    AWS_DYNAMODB_CONSUMED_CAPACITY: Literal["aws.dynamodb.consumed_capacity"] = (
+        "aws.dynamodb.consumed_capacity"
+    )
+    """The JSON-serialized value of each item in the `ConsumedCapacity` response field.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["{ \"CapacityUnits\": number, \"GlobalSecondaryIndexes\": { \"string\" : { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }, \"LocalSecondaryIndexes\": { \"string\" : { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }, \"ReadCapacityUnits\": number, \"Table\": { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number }, \"TableName\": \"string\", \"WriteCapacityUnits\": number }"]
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__count.json
+    AWS_DYNAMODB_COUNT: Literal["aws.dynamodb.count"] = "aws.dynamodb.count"
+    """The value of the `Count` response parameter.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 10
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__exclusive_start_table.json
+    AWS_DYNAMODB_EXCLUSIVE_START_TABLE: Literal[
+        "aws.dynamodb.exclusive_start_table"
+    ] = "aws.dynamodb.exclusive_start_table"
+    """The value of the `ExclusiveStartTableName` request parameter.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "Users"
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__global_secondary_index_updates.json
+    AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES: Literal[
+        "aws.dynamodb.global_secondary_index_updates"
+    ] = "aws.dynamodb.global_secondary_index_updates"
+    """The JSON-serialized value of each item in the `GlobalSecondaryIndexUpdates` request field.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["{ \"Create\": { \"IndexName\": \"string\", \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" }, \"ProvisionedThroughput\": { \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }"]
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__global_secondary_indexes.json
+    AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES: Literal[
+        "aws.dynamodb.global_secondary_indexes"
+    ] = "aws.dynamodb.global_secondary_indexes"
+    """The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["{ \"IndexName\": \"string\", \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" }, \"ProvisionedThroughput\": { \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }"]
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__index_name.json
+    AWS_DYNAMODB_INDEX_NAME: Literal["aws.dynamodb.index_name"] = (
+        "aws.dynamodb.index_name"
+    )
+    """The value of the `IndexName` request parameter.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "name_to_group"
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__item_collection_metrics.json
+    AWS_DYNAMODB_ITEM_COLLECTION_METRICS: Literal[
+        "aws.dynamodb.item_collection_metrics"
+    ] = "aws.dynamodb.item_collection_metrics"
+    """The JSON-serialized value of the `ItemCollectionMetrics` response field.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "{ \"string\" : [ { \"ItemCollectionKey\": { \"string\" : { \"B\": blob, \"BOOL\": boolean, \"BS\": [ blob ], \"L\": [ \"AttributeValue\" ], \"M\": { \"string\" : \"AttributeValue\" }, \"N\": \"string\", \"NS\": [ \"string\" ], \"NULL\": boolean, \"S\": \"string\", \"SS\": [ \"string\" ] } }, \"SizeEstimateRangeGB\": [ number ] } ] }"
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__limit.json
+    AWS_DYNAMODB_LIMIT: Literal["aws.dynamodb.limit"] = "aws.dynamodb.limit"
+    """The value of the `Limit` request parameter.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 10
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__local_secondary_indexes.json
+    AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES: Literal[
+        "aws.dynamodb.local_secondary_indexes"
+    ] = "aws.dynamodb.local_secondary_indexes"
+    """The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["{ \"IndexArn\": \"string\", \"IndexName\": \"string\", \"IndexSizeBytes\": number, \"ItemCount\": number, \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" } }"]
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__projection.json
+    AWS_DYNAMODB_PROJECTION: Literal["aws.dynamodb.projection"] = (
+        "aws.dynamodb.projection"
+    )
+    """The value of the `ProjectionExpression` request parameter.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "Title, Price, Color"
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__provisioned_read_capacity.json
+    AWS_DYNAMODB_PROVISIONED_READ_CAPACITY: Literal[
+        "aws.dynamodb.provisioned_read_capacity"
+    ] = "aws.dynamodb.provisioned_read_capacity"
+    """The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.
+
+    Type: float
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 1
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__provisioned_write_capacity.json
+    AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY: Literal[
+        "aws.dynamodb.provisioned_write_capacity"
+    ] = "aws.dynamodb.provisioned_write_capacity"
+    """The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.
+
+    Type: float
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 2
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__scan_forward.json
+    AWS_DYNAMODB_SCAN_FORWARD: Literal["aws.dynamodb.scan_forward"] = (
+        "aws.dynamodb.scan_forward"
+    )
+    """The value of the `ScanIndexForward` request parameter.
+
+    Type: bool
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: true
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__scanned_count.json
+    AWS_DYNAMODB_SCANNED_COUNT: Literal["aws.dynamodb.scanned_count"] = (
+        "aws.dynamodb.scanned_count"
+    )
+    """The value of the `ScannedCount` response parameter.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 50
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__segment.json
+    AWS_DYNAMODB_SEGMENT: Literal["aws.dynamodb.segment"] = "aws.dynamodb.segment"
+    """The value of the `Segment` request parameter.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 10
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__select.json
+    AWS_DYNAMODB_SELECT: Literal["aws.dynamodb.select"] = "aws.dynamodb.select"
+    """The value of the `Select` request parameter.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "ALL_ATTRIBUTES"
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__table_count.json
+    AWS_DYNAMODB_TABLE_COUNT: Literal["aws.dynamodb.table_count"] = (
+        "aws.dynamodb.table_count"
+    )
+    """The number of items in the `TableNames` response parameter.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 20
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__table_names.json
+    AWS_DYNAMODB_TABLE_NAMES: Literal["aws.dynamodb.table_names"] = (
+        "aws.dynamodb.table_names"
+    )
+    """The keys in the `RequestItems` object field.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["Users","Cats"]
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__total_segments.json
+    AWS_DYNAMODB_TOTAL_SEGMENTS: Literal["aws.dynamodb.total_segments"] = (
+        "aws.dynamodb.total_segments"
+    )
+    """The value of the `TotalSegments` request parameter.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 100
+    """
+
+    # Path: model/attributes/aws/aws__kinesis__stream__name.json
+    AWS_KINESIS_STREAM_NAME: Literal["aws.kinesis.stream.name"] = (
+        "aws.kinesis.stream.name"
+    )
+    """The name of the AWS Kinesis stream the request refers to.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "some-stream-name"
+    """
+
     # Path: model/attributes/aws/aws__lambda__aws_request_id.json
     AWS_LAMBDA_AWS_REQUEST_ID: Literal["aws.lambda.aws_request_id"] = (
         "aws.lambda.aws_request_id"
@@ -1342,6 +1621,91 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Example: ["logs/main/10838bed-421f-43ef-870a-f43feacbbb5b"]
+    """
+
+    # Path: model/attributes/aws/aws__request__extended_id.json
+    AWS_REQUEST_EXTENDED_ID: Literal["aws.request.extended_id"] = (
+        "aws.request.extended_id"
+    )
+    """The AWS extended request ID as returned in the response headers.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ="
+    """
+
+    # Path: model/attributes/aws/aws__request__id.json
+    AWS_REQUEST_ID: Literal["aws.request.id"] = "aws.request.id"
+    """The AWS request ID as returned in the response headers.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "79b9da39-b7ae-508a-a6bc-864b2829c622"
+    """
+
+    # Path: model/attributes/aws/aws__s3__bucket.json
+    AWS_S3_BUCKET: Literal["aws.s3.bucket"] = "aws.s3.bucket"
+    """The S3 bucket name the request refers to.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "ot-demo-test"
+    """
+
+    # Path: model/attributes/aws/aws__secretsmanager__secret__arn.json
+    AWS_SECRETSMANAGER_SECRET_ARN: Literal["aws.secretsmanager.secret.arn"] = (
+        "aws.secretsmanager.secret.arn"
+    )
+    """The ARN of the Secret stored in Secrets Manager.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "arn:aws:secretsmanager:us-east-1:123456789012:secret:SecretName-6RandomCharacters"
+    """
+
+    # Path: model/attributes/aws/aws__sns__topic__arn.json
+    AWS_SNS_TOPIC_ARN: Literal["aws.sns.topic.arn"] = "aws.sns.topic.arn"
+    """The ARN of the AWS SNS Topic. An Amazon SNS topic is a logical access point that acts as a communication channel.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE"
+    """
+
+    # Path: model/attributes/aws/aws__step_functions__activity__arn.json
+    AWS_STEP_FUNCTIONS_ACTIVITY_ARN: Literal["aws.step_functions.activity.arn"] = (
+        "aws.step_functions.activity.arn"
+    )
+    """The ARN of the AWS Step Functions Activity.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "arn:aws:states:us-east-1:123456789012:activity:get-greeting"
+    """
+
+    # Path: model/attributes/aws/aws__step_functions__state_machine__arn.json
+    AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN: Literal[
+        "aws.step_functions.state_machine.arn"
+    ] = "aws.step_functions.state_machine.arn"
+    """The ARN of the AWS Step Functions State Machine.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine:1"
     """
 
     # Path: model/attributes/blocked_main_thread.json
@@ -3163,6 +3527,39 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
     """
 
+    # Path: model/attributes/faas/faas__invoked_name.json
+    FAAS_INVOKED_NAME: Literal["faas.invoked_name"] = "faas.invoked_name"
+    """The name of the invoked function.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "my-function"
+    """
+
+    # Path: model/attributes/faas/faas__invoked_provider.json
+    FAAS_INVOKED_PROVIDER: Literal["faas.invoked_provider"] = "faas.invoked_provider"
+    """The cloud provider of the invoked function.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "aws"
+    """
+
+    # Path: model/attributes/faas/faas__invoked_region.json
+    FAAS_INVOKED_REGION: Literal["faas.invoked_region"] = "faas.invoked_region"
+    """The cloud region of the invoked function.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "eu-central-1"
+    """
+
     # Path: model/attributes/faas/faas__name.json
     FAAS_NAME: Literal["faas.name"] = "faas.name"
     """The name of the serverless function
@@ -3807,6 +4204,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Visibility: public
     Aliases: ai.seed
     Example: "1234567890"
+    """
+
+    # Path: model/attributes/gen_ai/gen_ai__request__stop_sequences.json
+    GEN_AI_REQUEST_STOP_SEQUENCES: Literal["gen_ai.request.stop_sequences"] = (
+        "gen_ai.request.stop_sequences"
+    )
+    """List of sequences that the model will use to stop generating further tokens.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["forest","lived"]
     """
 
     # Path: model/attributes/gen_ai/gen_ai__request__temperature.json
@@ -5559,6 +5969,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 10
     """
 
+    # Path: model/attributes/messaging/messaging__destination.json
+    MESSAGING_DESTINATION: Literal["messaging.destination"] = "messaging.destination"
+    """The message destination name.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: messaging.destination.name
+    DEPRECATED: Use messaging.destination.name instead - This attribute is being deprecated in favor of messaging.destination.name, which is the OTel-aligned replacement.
+    Example: "BestTopic"
+    """
+
     # Path: model/attributes/messaging/messaging__destination__connection.json
     MESSAGING_DESTINATION_CONNECTION: Literal["messaging.destination.connection"] = (
         "messaging.destination.connection"
@@ -5582,6 +6005,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: messaging.destination
     Example: "BestTopic"
     """
 
@@ -6614,6 +7038,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Example: "myService.BestService"
+    """
+
+    # Path: model/attributes/rpc/rpc__system.json
+    RPC_SYSTEM: Literal["rpc.system"] = "rpc.system"
+    """A string identifying the remoting system.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "aws-api"
     """
 
     # Path: model/attributes/runtime/runtime__build.json
@@ -9777,6 +10212,311 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "aws.dynamodb.attribute_definitions": AttributeMetadata(
+        brief="The JSON-serialized value of each item in the `AttributeDefinitions` request field.",
+        type=AttributeType.STRING_ARRAY,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=['{ "AttributeName": "string", "AttributeType": "string" }'],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added aws.dynamodb.attribute_definitions attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.consistent_read": AttributeMetadata(
+        brief="The value of the `ConsistentRead` request parameter.",
+        type=AttributeType.BOOLEAN,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=True,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added aws.dynamodb.consistent_read attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.consumed_capacity": AttributeMetadata(
+        brief="The JSON-serialized value of each item in the `ConsumedCapacity` response field.",
+        type=AttributeType.STRING_ARRAY,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=[
+            '{ "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "ReadCapacityUnits": number, "Table": { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName": "string", "WriteCapacityUnits": number }'
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added aws.dynamodb.consumed_capacity attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.count": AttributeMetadata(
+        brief="The value of the `Count` response parameter.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=10,
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added aws.dynamodb.count attribute"
+            ),
+        ],
+    ),
+    "aws.dynamodb.exclusive_start_table": AttributeMetadata(
+        brief="The value of the `ExclusiveStartTableName` request parameter.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="Users",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added aws.dynamodb.exclusive_start_table attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.global_secondary_index_updates": AttributeMetadata(
+        brief="The JSON-serialized value of each item in the `GlobalSecondaryIndexUpdates` request field.",
+        type=AttributeType.STRING_ARRAY,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=[
+            '{ "Create": { "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }'
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added aws.dynamodb.global_secondary_index_updates attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.global_secondary_indexes": AttributeMetadata(
+        brief="The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.",
+        type=AttributeType.STRING_ARRAY,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=[
+            '{ "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }'
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added aws.dynamodb.global_secondary_indexes attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.index_name": AttributeMetadata(
+        brief="The value of the `IndexName` request parameter.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="name_to_group",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added aws.dynamodb.index_name attribute"
+            ),
+        ],
+    ),
+    "aws.dynamodb.item_collection_metrics": AttributeMetadata(
+        brief="The JSON-serialized value of the `ItemCollectionMetrics` response field.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example='{ "string" : [ { "ItemCollectionKey": { "string" : { "B": blob, "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" : "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S": "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }',
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added aws.dynamodb.item_collection_metrics attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.limit": AttributeMetadata(
+        brief="The value of the `Limit` request parameter.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=10,
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added aws.dynamodb.limit attribute"
+            ),
+        ],
+    ),
+    "aws.dynamodb.local_secondary_indexes": AttributeMetadata(
+        brief="The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.",
+        type=AttributeType.STRING_ARRAY,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=[
+            '{ "IndexArn": "string", "IndexName": "string", "IndexSizeBytes": number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" } }'
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added aws.dynamodb.local_secondary_indexes attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.projection": AttributeMetadata(
+        brief="The value of the `ProjectionExpression` request parameter.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="Title, Price, Color",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added aws.dynamodb.projection attribute"
+            ),
+        ],
+    ),
+    "aws.dynamodb.provisioned_read_capacity": AttributeMetadata(
+        brief="The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.",
+        type=AttributeType.DOUBLE,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=1,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added aws.dynamodb.provisioned_read_capacity attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.provisioned_write_capacity": AttributeMetadata(
+        brief="The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.",
+        type=AttributeType.DOUBLE,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=2,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added aws.dynamodb.provisioned_write_capacity attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.scan_forward": AttributeMetadata(
+        brief="The value of the `ScanIndexForward` request parameter.",
+        type=AttributeType.BOOLEAN,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=True,
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added aws.dynamodb.scan_forward attribute"
+            ),
+        ],
+    ),
+    "aws.dynamodb.scanned_count": AttributeMetadata(
+        brief="The value of the `ScannedCount` response parameter.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=50,
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added aws.dynamodb.scanned_count attribute"
+            ),
+        ],
+    ),
+    "aws.dynamodb.segment": AttributeMetadata(
+        brief="The value of the `Segment` request parameter.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=10,
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added aws.dynamodb.segment attribute"
+            ),
+        ],
+    ),
+    "aws.dynamodb.select": AttributeMetadata(
+        brief="The value of the `Select` request parameter.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="ALL_ATTRIBUTES",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added aws.dynamodb.select attribute"
+            ),
+        ],
+    ),
+    "aws.dynamodb.table_count": AttributeMetadata(
+        brief="The number of items in the `TableNames` response parameter.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=20,
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added aws.dynamodb.table_count attribute"
+            ),
+        ],
+    ),
+    "aws.dynamodb.table_names": AttributeMetadata(
+        brief="The keys in the `RequestItems` object field.",
+        type=AttributeType.STRING_ARRAY,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=["Users", "Cats"],
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added aws.dynamodb.table_names attribute"
+            ),
+        ],
+    ),
+    "aws.dynamodb.total_segments": AttributeMetadata(
+        brief="The value of the `TotalSegments` request parameter.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=100,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added aws.dynamodb.total_segments attribute",
+            ),
+        ],
+    ),
+    "aws.kinesis.stream.name": AttributeMetadata(
+        brief="The name of the AWS Kinesis stream the request refers to.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="some-stream-name",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added aws.kinesis.stream.name attribute"
+            ),
+        ],
+    ),
     "aws.lambda.aws_request_id": AttributeMetadata(
         brief="The AWS request ID as received by the Lambda function runtime",
         type=AttributeType.STRING,
@@ -9948,6 +10688,98 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=["logs/main/10838bed-421f-43ef-870a-f43feacbbb5b"],
         changelog=[
             ChangelogEntry(version="0.11.1", prs=[414]),
+        ],
+    ),
+    "aws.request.extended_id": AttributeMetadata(
+        brief="The AWS extended request ID as returned in the response headers.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added aws.request.extended_id attribute"
+            ),
+        ],
+    ),
+    "aws.request.id": AttributeMetadata(
+        brief="The AWS request ID as returned in the response headers.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="79b9da39-b7ae-508a-a6bc-864b2829c622",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added aws.request.id attribute"
+            ),
+        ],
+    ),
+    "aws.s3.bucket": AttributeMetadata(
+        brief="The S3 bucket name the request refers to.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="ot-demo-test",
+        changelog=[
+            ChangelogEntry(version="next", description="Added aws.s3.bucket attribute"),
+        ],
+    ),
+    "aws.secretsmanager.secret.arn": AttributeMetadata(
+        brief="The ARN of the Secret stored in Secrets Manager.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="arn:aws:secretsmanager:us-east-1:123456789012:secret:SecretName-6RandomCharacters",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added aws.secretsmanager.secret.arn attribute",
+            ),
+        ],
+    ),
+    "aws.sns.topic.arn": AttributeMetadata(
+        brief="The ARN of the AWS SNS Topic. An Amazon SNS topic is a logical access point that acts as a communication channel.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added aws.sns.topic.arn attribute"
+            ),
+        ],
+    ),
+    "aws.step_functions.activity.arn": AttributeMetadata(
+        brief="The ARN of the AWS Step Functions Activity.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="arn:aws:states:us-east-1:123456789012:activity:get-greeting",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added aws.step_functions.activity.arn attribute",
+            ),
+        ],
+    ),
+    "aws.step_functions.state_machine.arn": AttributeMetadata(
+        brief="The ARN of the AWS Step Functions State Machine.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine:1",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added aws.step_functions.state_machine.arn attribute",
+            ),
         ],
     ),
     "blocked_main_thread": AttributeMetadata(
@@ -12038,6 +12870,45 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.11.1", prs=[414, 424]),
         ],
     ),
+    "faas.invoked_name": AttributeMetadata(
+        brief="The name of the invoked function.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="my-function",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added faas.invoked_name attribute"
+            ),
+        ],
+    ),
+    "faas.invoked_provider": AttributeMetadata(
+        brief="The cloud provider of the invoked function.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="aws",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added faas.invoked_provider attribute"
+            ),
+        ],
+    ),
+    "faas.invoked_region": AttributeMetadata(
+        brief="The cloud region of the invoked function.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="eu-central-1",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added faas.invoked_region attribute"
+            ),
+        ],
+    ),
     "faas.name": AttributeMetadata(
         brief="The name of the serverless function",
         type=AttributeType.STRING,
@@ -12821,6 +13692,20 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         aliases=["ai.seed"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[57, 127]),
+        ],
+    ),
+    "gen_ai.request.stop_sequences": AttributeMetadata(
+        brief="List of sequences that the model will use to stop generating further tokens.",
+        type=AttributeType.STRING_ARRAY,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=["forest", "lived"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added gen_ai.request.stop_sequences attribute",
+            ),
         ],
     ),
     "gen_ai.request.temperature": AttributeMetadata(
@@ -14921,6 +15806,26 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "messaging.destination": AttributeMetadata(
+        brief="The message destination name.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="BestTopic",
+        deprecation=DeprecationInfo(
+            replacement="messaging.destination.name",
+            reason="This attribute is being deprecated in favor of messaging.destination.name, which is the OTel-aligned replacement.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["messaging.destination.name"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added messaging.destination attribute, deprecated in favor of messaging.destination.name",
+            ),
+        ],
+    ),
     "messaging.destination.connection": AttributeMetadata(
         brief="The message destination connection.",
         type=AttributeType.STRING,
@@ -14940,7 +15845,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="BestTopic",
+        aliases=["messaging.destination"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added messaging.destination as an alias"
+            ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -16087,6 +16996,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "rpc.system": AttributeMetadata(
+        brief="A string identifying the remoting system.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="aws-api",
+        changelog=[
+            ChangelogEntry(version="next", description="Added rpc.system attribute"),
         ],
     ),
     "runtime.build": AttributeMetadata(
@@ -18318,6 +19238,28 @@ Attributes = TypedDict(
         "aws.cloudwatch.logs.log_group": str,
         "aws.cloudwatch.logs.log_stream": str,
         "aws.cloudwatch.logs.url": str,
+        "aws.dynamodb.attribute_definitions": List[str],
+        "aws.dynamodb.consistent_read": bool,
+        "aws.dynamodb.consumed_capacity": List[str],
+        "aws.dynamodb.count": int,
+        "aws.dynamodb.exclusive_start_table": str,
+        "aws.dynamodb.global_secondary_index_updates": List[str],
+        "aws.dynamodb.global_secondary_indexes": List[str],
+        "aws.dynamodb.index_name": str,
+        "aws.dynamodb.item_collection_metrics": str,
+        "aws.dynamodb.limit": int,
+        "aws.dynamodb.local_secondary_indexes": List[str],
+        "aws.dynamodb.projection": str,
+        "aws.dynamodb.provisioned_read_capacity": float,
+        "aws.dynamodb.provisioned_write_capacity": float,
+        "aws.dynamodb.scan_forward": bool,
+        "aws.dynamodb.scanned_count": int,
+        "aws.dynamodb.segment": int,
+        "aws.dynamodb.select": str,
+        "aws.dynamodb.table_count": int,
+        "aws.dynamodb.table_names": List[str],
+        "aws.dynamodb.total_segments": int,
+        "aws.kinesis.stream.name": str,
         "aws.lambda.aws_request_id": str,
         "aws.lambda.execution_duration_in_millis": float,
         "aws.lambda.function_name": str,
@@ -18327,6 +19269,13 @@ Attributes = TypedDict(
         "aws.lambda.remaining_time_in_millis": float,
         "aws.log.group.names": List[str],
         "aws.log.stream.names": List[str],
+        "aws.request.extended_id": str,
+        "aws.request.id": str,
+        "aws.s3.bucket": str,
+        "aws.secretsmanager.secret.arn": str,
+        "aws.sns.topic.arn": str,
+        "aws.step_functions.activity.arn": str,
+        "aws.step_functions.state_machine.arn": str,
         "blocked_main_thread": bool,
         "browser.name": str,
         "browser.performance.navigation.activation_start": float,
@@ -18477,6 +19426,9 @@ Attributes = TypedDict(
         "faas.id": str,
         "faas.identity": str,
         "faas.invocation_id": str,
+        "faas.invoked_name": str,
+        "faas.invoked_provider": str,
+        "faas.invoked_region": str,
         "faas.name": str,
         "faas.time": str,
         "faas.trigger": str,
@@ -18529,6 +19481,7 @@ Attributes = TypedDict(
         "gen_ai.request.presence_penalty": float,
         "gen_ai.request.reasoning_effort": str,
         "gen_ai.request.seed": str,
+        "gen_ai.request.stop_sequences": List[str],
         "gen_ai.request.temperature": float,
         "gen_ai.request.top_k": int,
         "gen_ai.request.top_p": float,
@@ -18667,6 +19620,7 @@ Attributes = TypedDict(
         "mcp.transport": str,
         "mdc.<key>": str,
         "messaging.batch.message_count": int,
+        "messaging.destination": str,
         "messaging.destination.connection": str,
         "messaging.destination.name": str,
         "messaging.message.body.size": int,
@@ -18753,6 +19707,7 @@ Attributes = TypedDict(
         "rpc.method": str,
         "rpc.response.status_code": str,
         "rpc.service": str,
+        "rpc.system": str,
         "runtime.build": str,
         "runtime.name": str,
         "runtime.raw_description": str,


### PR DESCRIPTION
Adds the attributes emitted by the aws-sdk instrumentation in sentry-javascript (getsentry/sentry-javascript#22142), used by both the vendored OTel integration and its orchestrion port.

- 21x `aws.dynamodb.*` request/response attributes
- `aws.request.id`, `aws.request.extended_id`, `rpc.system`
- `aws.s3.bucket`, `aws.kinesis.stream.name`
- `aws.secretsmanager.secret.arn`, `aws.sns.topic.arn`, `aws.step_functions.state_machine.arn`, `aws.step_functions.activity.arn`
- `faas.invoked_name`, `faas.invoked_provider`, `faas.invoked_region`
- `gen_ai.request.stop_sequences`
- `messaging.destination`, deprecated in favor of `messaging.destination.name` (same pattern as #473)

`messaging.destination.name` gained the reverse `alias` entry since the schema tests enforce alias-group symmetry.