### PR TITLE
feat(attributes): Add AWS DynamoDB instrumentation attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1679,6 +1679,447 @@ export const AWS_CLOUDWATCH_LOGS_URL = 'aws.cloudwatch.logs.url';
  */
 export type AWS_CLOUDWATCH_LOGS_URL_TYPE = string;
 
+// Path: model/attributes/aws/aws__dynamodb__attribute_definitions.json
+
+/**
+ * The JSON-serialized value of each item in the `AttributeDefinitions` request field. `aws.dynamodb.attribute_definitions`
+ *
+ * Attribute Value Type: `Array<string>` {@link AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["{ \"AttributeName\": \"string\", \"AttributeType\": \"string\" }"]
+ */
+export const AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS = 'aws.dynamodb.attribute_definitions';
+
+/**
+ * Type for {@link AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS} aws.dynamodb.attribute_definitions
+ */
+export type AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__dynamodb__consistent_read.json
+
+/**
+ * The value of the `ConsistentRead` request parameter. `aws.dynamodb.consistent_read`
+ *
+ * Attribute Value Type: `boolean` {@link AWS_DYNAMODB_CONSISTENT_READ_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example true
+ */
+export const AWS_DYNAMODB_CONSISTENT_READ = 'aws.dynamodb.consistent_read';
+
+/**
+ * Type for {@link AWS_DYNAMODB_CONSISTENT_READ} aws.dynamodb.consistent_read
+ */
+export type AWS_DYNAMODB_CONSISTENT_READ_TYPE = boolean;
+
+// Path: model/attributes/aws/aws__dynamodb__consumed_capacity.json
+
+/**
+ * The JSON-serialized value of each item in the `ConsumedCapacity` response field. `aws.dynamodb.consumed_capacity`
+ *
+ * Attribute Value Type: `Array<string>` {@link AWS_DYNAMODB_CONSUMED_CAPACITY_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["{ \"CapacityUnits\": number, \"GlobalSecondaryIndexes\": { \"string\" : { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }, \"LocalSecondaryIndexes\": { \"string\" : { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }, \"ReadCapacityUnits\": number, \"Table\": { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number }, \"TableName\": \"string\", \"WriteCapacityUnits\": number }"]
+ */
+export const AWS_DYNAMODB_CONSUMED_CAPACITY = 'aws.dynamodb.consumed_capacity';
+
+/**
+ * Type for {@link AWS_DYNAMODB_CONSUMED_CAPACITY} aws.dynamodb.consumed_capacity
+ */
+export type AWS_DYNAMODB_CONSUMED_CAPACITY_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__dynamodb__count.json
+
+/**
+ * The value of the `Count` response parameter. `aws.dynamodb.count`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_COUNT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 10
+ */
+export const AWS_DYNAMODB_COUNT = 'aws.dynamodb.count';
+
+/**
+ * Type for {@link AWS_DYNAMODB_COUNT} aws.dynamodb.count
+ */
+export type AWS_DYNAMODB_COUNT_TYPE = number;
+
+// Path: model/attributes/aws/aws__dynamodb__exclusive_start_table.json
+
+/**
+ * The value of the `ExclusiveStartTableName` request parameter. `aws.dynamodb.exclusive_start_table`
+ *
+ * Attribute Value Type: `string` {@link AWS_DYNAMODB_EXCLUSIVE_START_TABLE_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "Users"
+ */
+export const AWS_DYNAMODB_EXCLUSIVE_START_TABLE = 'aws.dynamodb.exclusive_start_table';
+
+/**
+ * Type for {@link AWS_DYNAMODB_EXCLUSIVE_START_TABLE} aws.dynamodb.exclusive_start_table
+ */
+export type AWS_DYNAMODB_EXCLUSIVE_START_TABLE_TYPE = string;
+
+// Path: model/attributes/aws/aws__dynamodb__global_secondary_indexes.json
+
+/**
+ * The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field. `aws.dynamodb.global_secondary_indexes`
+ *
+ * Attribute Value Type: `Array<string>` {@link AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["{ \"IndexName\": \"string\", \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" }, \"ProvisionedThroughput\": { \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }"]
+ */
+export const AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES = 'aws.dynamodb.global_secondary_indexes';
+
+/**
+ * Type for {@link AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES} aws.dynamodb.global_secondary_indexes
+ */
+export type AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__dynamodb__global_secondary_index_updates.json
+
+/**
+ * The JSON-serialized value of each item in the `GlobalSecondaryIndexUpdates` request field. `aws.dynamodb.global_secondary_index_updates`
+ *
+ * Attribute Value Type: `Array<string>` {@link AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["{ \"Create\": { \"IndexName\": \"string\", \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" }, \"ProvisionedThroughput\": { \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }"]
+ */
+export const AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES = 'aws.dynamodb.global_secondary_index_updates';
+
+/**
+ * Type for {@link AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES} aws.dynamodb.global_secondary_index_updates
+ */
+export type AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__dynamodb__index_name.json
+
+/**
+ * The value of the `IndexName` request parameter. `aws.dynamodb.index_name`
+ *
+ * Attribute Value Type: `string` {@link AWS_DYNAMODB_INDEX_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "name_to_group"
+ */
+export const AWS_DYNAMODB_INDEX_NAME = 'aws.dynamodb.index_name';
+
+/**
+ * Type for {@link AWS_DYNAMODB_INDEX_NAME} aws.dynamodb.index_name
+ */
+export type AWS_DYNAMODB_INDEX_NAME_TYPE = string;
+
+// Path: model/attributes/aws/aws__dynamodb__item_collection_metrics.json
+
+/**
+ * The JSON-serialized value of the `ItemCollectionMetrics` response field. `aws.dynamodb.item_collection_metrics`
+ *
+ * Attribute Value Type: `string` {@link AWS_DYNAMODB_ITEM_COLLECTION_METRICS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "{ \"string\" : [ { \"ItemCollectionKey\": { \"string\" : { \"B\": blob, \"BOOL\": boolean, \"BS\": [ blob ], \"L\": [ \"AttributeValue\" ], \"M\": { \"string\" : \"AttributeValue\" }, \"N\": \"string\", \"NS\": [ \"string\" ], \"NULL\": boolean, \"S\": \"string\", \"SS\": [ \"string\" ] } }, \"SizeEstimateRangeGB\": [ number ] } ] }"
+ */
+export const AWS_DYNAMODB_ITEM_COLLECTION_METRICS = 'aws.dynamodb.item_collection_metrics';
+
+/**
+ * Type for {@link AWS_DYNAMODB_ITEM_COLLECTION_METRICS} aws.dynamodb.item_collection_metrics
+ */
+export type AWS_DYNAMODB_ITEM_COLLECTION_METRICS_TYPE = string;
+
+// Path: model/attributes/aws/aws__dynamodb__limit.json
+
+/**
+ * The value of the `Limit` request parameter. `aws.dynamodb.limit`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_LIMIT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 10
+ */
+export const AWS_DYNAMODB_LIMIT = 'aws.dynamodb.limit';
+
+/**
+ * Type for {@link AWS_DYNAMODB_LIMIT} aws.dynamodb.limit
+ */
+export type AWS_DYNAMODB_LIMIT_TYPE = number;
+
+// Path: model/attributes/aws/aws__dynamodb__local_secondary_indexes.json
+
+/**
+ * The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field. `aws.dynamodb.local_secondary_indexes`
+ *
+ * Attribute Value Type: `Array<string>` {@link AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["{ \"IndexArn\": \"string\", \"IndexName\": \"string\", \"IndexSizeBytes\": number, \"ItemCount\": number, \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" } }"]
+ */
+export const AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES = 'aws.dynamodb.local_secondary_indexes';
+
+/**
+ * Type for {@link AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES} aws.dynamodb.local_secondary_indexes
+ */
+export type AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__dynamodb__projection.json
+
+/**
+ * The value of the `ProjectionExpression` request parameter. `aws.dynamodb.projection`
+ *
+ * Attribute Value Type: `string` {@link AWS_DYNAMODB_PROJECTION_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "Title, Price, Color"
+ */
+export const AWS_DYNAMODB_PROJECTION = 'aws.dynamodb.projection';
+
+/**
+ * Type for {@link AWS_DYNAMODB_PROJECTION} aws.dynamodb.projection
+ */
+export type AWS_DYNAMODB_PROJECTION_TYPE = string;
+
+// Path: model/attributes/aws/aws__dynamodb__provisioned_read_capacity.json
+
+/**
+ * The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter. `aws.dynamodb.provisioned_read_capacity`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_PROVISIONED_READ_CAPACITY_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 1
+ */
+export const AWS_DYNAMODB_PROVISIONED_READ_CAPACITY = 'aws.dynamodb.provisioned_read_capacity';
+
+/**
+ * Type for {@link AWS_DYNAMODB_PROVISIONED_READ_CAPACITY} aws.dynamodb.provisioned_read_capacity
+ */
+export type AWS_DYNAMODB_PROVISIONED_READ_CAPACITY_TYPE = number;
+
+// Path: model/attributes/aws/aws__dynamodb__provisioned_write_capacity.json
+
+/**
+ * The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter. `aws.dynamodb.provisioned_write_capacity`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 2
+ */
+export const AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY = 'aws.dynamodb.provisioned_write_capacity';
+
+/**
+ * Type for {@link AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY} aws.dynamodb.provisioned_write_capacity
+ */
+export type AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY_TYPE = number;
+
+// Path: model/attributes/aws/aws__dynamodb__scanned_count.json
+
+/**
+ * The value of the `ScannedCount` response parameter. `aws.dynamodb.scanned_count`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_SCANNED_COUNT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 50
+ */
+export const AWS_DYNAMODB_SCANNED_COUNT = 'aws.dynamodb.scanned_count';
+
+/**
+ * Type for {@link AWS_DYNAMODB_SCANNED_COUNT} aws.dynamodb.scanned_count
+ */
+export type AWS_DYNAMODB_SCANNED_COUNT_TYPE = number;
+
+// Path: model/attributes/aws/aws__dynamodb__scan_forward.json
+
+/**
+ * The value of the `ScanIndexForward` request parameter. `aws.dynamodb.scan_forward`
+ *
+ * Attribute Value Type: `boolean` {@link AWS_DYNAMODB_SCAN_FORWARD_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example true
+ */
+export const AWS_DYNAMODB_SCAN_FORWARD = 'aws.dynamodb.scan_forward';
+
+/**
+ * Type for {@link AWS_DYNAMODB_SCAN_FORWARD} aws.dynamodb.scan_forward
+ */
+export type AWS_DYNAMODB_SCAN_FORWARD_TYPE = boolean;
+
+// Path: model/attributes/aws/aws__dynamodb__segment.json
+
+/**
+ * The value of the `Segment` request parameter. `aws.dynamodb.segment`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_SEGMENT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 10
+ */
+export const AWS_DYNAMODB_SEGMENT = 'aws.dynamodb.segment';
+
+/**
+ * Type for {@link AWS_DYNAMODB_SEGMENT} aws.dynamodb.segment
+ */
+export type AWS_DYNAMODB_SEGMENT_TYPE = number;
+
+// Path: model/attributes/aws/aws__dynamodb__select.json
+
+/**
+ * The value of the `Select` request parameter. `aws.dynamodb.select`
+ *
+ * Attribute Value Type: `string` {@link AWS_DYNAMODB_SELECT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "ALL_ATTRIBUTES"
+ */
+export const AWS_DYNAMODB_SELECT = 'aws.dynamodb.select';
+
+/**
+ * Type for {@link AWS_DYNAMODB_SELECT} aws.dynamodb.select
+ */
+export type AWS_DYNAMODB_SELECT_TYPE = string;
+
+// Path: model/attributes/aws/aws__dynamodb__table_count.json
+
+/**
+ * The number of items in the `TableNames` response parameter. `aws.dynamodb.table_count`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_TABLE_COUNT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 20
+ */
+export const AWS_DYNAMODB_TABLE_COUNT = 'aws.dynamodb.table_count';
+
+/**
+ * Type for {@link AWS_DYNAMODB_TABLE_COUNT} aws.dynamodb.table_count
+ */
+export type AWS_DYNAMODB_TABLE_COUNT_TYPE = number;
+
+// Path: model/attributes/aws/aws__dynamodb__table_names.json
+
+/**
+ * The keys in the `RequestItems` object field. `aws.dynamodb.table_names`
+ *
+ * Attribute Value Type: `Array<string>` {@link AWS_DYNAMODB_TABLE_NAMES_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["Users","Cats"]
+ */
+export const AWS_DYNAMODB_TABLE_NAMES = 'aws.dynamodb.table_names';
+
+/**
+ * Type for {@link AWS_DYNAMODB_TABLE_NAMES} aws.dynamodb.table_names
+ */
+export type AWS_DYNAMODB_TABLE_NAMES_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__dynamodb__total_segments.json
+
+/**
+ * The value of the `TotalSegments` request parameter. `aws.dynamodb.total_segments`
+ *
+ * Attribute Value Type: `number` {@link AWS_DYNAMODB_TOTAL_SEGMENTS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example 100
+ */
+export const AWS_DYNAMODB_TOTAL_SEGMENTS = 'aws.dynamodb.total_segments';
+
+/**
+ * Type for {@link AWS_DYNAMODB_TOTAL_SEGMENTS} aws.dynamodb.total_segments
+ */
+export type AWS_DYNAMODB_TOTAL_SEGMENTS_TYPE = number;
+
 // Path: model/attributes/aws/aws__lambda__aws_request_id.json
 
 /**
@@ -15162,6 +15603,27 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'aws.cloudwatch.logs.log_group': 'string',
   'aws.cloudwatch.logs.log_stream': 'string',
   'aws.cloudwatch.logs.url': 'string',
+  'aws.dynamodb.attribute_definitions': 'string[]',
+  'aws.dynamodb.consistent_read': 'boolean',
+  'aws.dynamodb.consumed_capacity': 'string[]',
+  'aws.dynamodb.count': 'integer',
+  'aws.dynamodb.exclusive_start_table': 'string',
+  'aws.dynamodb.global_secondary_indexes': 'string[]',
+  'aws.dynamodb.global_secondary_index_updates': 'string[]',
+  'aws.dynamodb.index_name': 'string',
+  'aws.dynamodb.item_collection_metrics': 'string',
+  'aws.dynamodb.limit': 'integer',
+  'aws.dynamodb.local_secondary_indexes': 'string[]',
+  'aws.dynamodb.projection': 'string',
+  'aws.dynamodb.provisioned_read_capacity': 'double',
+  'aws.dynamodb.provisioned_write_capacity': 'double',
+  'aws.dynamodb.scanned_count': 'integer',
+  'aws.dynamodb.scan_forward': 'boolean',
+  'aws.dynamodb.segment': 'integer',
+  'aws.dynamodb.select': 'string',
+  'aws.dynamodb.table_count': 'integer',
+  'aws.dynamodb.table_names': 'string[]',
+  'aws.dynamodb.total_segments': 'integer',
   'aws.lambda.aws_request_id': 'string',
   'aws.lambda.execution_duration_in_millis': 'double',
   'aws.lambda.function_name': 'string',
@@ -15844,6 +16306,27 @@ export type AttributeName =
   | typeof AWS_CLOUDWATCH_LOGS_LOG_GROUP
   | typeof AWS_CLOUDWATCH_LOGS_LOG_STREAM
   | typeof AWS_CLOUDWATCH_LOGS_URL
+  | typeof AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS
+  | typeof AWS_DYNAMODB_CONSISTENT_READ
+  | typeof AWS_DYNAMODB_CONSUMED_CAPACITY
+  | typeof AWS_DYNAMODB_COUNT
+  | typeof AWS_DYNAMODB_EXCLUSIVE_START_TABLE
+  | typeof AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES
+  | typeof AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES
+  | typeof AWS_DYNAMODB_INDEX_NAME
+  | typeof AWS_DYNAMODB_ITEM_COLLECTION_METRICS
+  | typeof AWS_DYNAMODB_LIMIT
+  | typeof AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES
+  | typeof AWS_DYNAMODB_PROJECTION
+  | typeof AWS_DYNAMODB_PROVISIONED_READ_CAPACITY
+  | typeof AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY
+  | typeof AWS_DYNAMODB_SCANNED_COUNT
+  | typeof AWS_DYNAMODB_SCAN_FORWARD
+  | typeof AWS_DYNAMODB_SEGMENT
+  | typeof AWS_DYNAMODB_SELECT
+  | typeof AWS_DYNAMODB_TABLE_COUNT
+  | typeof AWS_DYNAMODB_TABLE_NAMES
+  | typeof AWS_DYNAMODB_TOTAL_SEGMENTS
   | typeof AWS_LAMBDA_AWS_REQUEST_ID
   | typeof AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS
   | typeof AWS_LAMBDA_FUNCTION_NAME
@@ -17523,6 +18006,250 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/my-log-group',
     changelog: [{ version: '0.7.0', prs: [369], description: 'Added aws.cloudwatch.logs.url attribute' }],
+  },
+  'aws.dynamodb.attribute_definitions': {
+    brief: 'The JSON-serialized value of each item in the `AttributeDefinitions` request field.',
+    type: 'string[]',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: ['{ "AttributeName": "string", "AttributeType": "string" }'],
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.attribute_definitions attribute' }],
+  },
+  'aws.dynamodb.consistent_read': {
+    brief: 'The value of the `ConsistentRead` request parameter.',
+    type: 'boolean',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: true,
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.consistent_read attribute' }],
+  },
+  'aws.dynamodb.consumed_capacity': {
+    brief: 'The JSON-serialized value of each item in the `ConsumedCapacity` response field.',
+    type: 'string[]',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: [
+      '{ "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "ReadCapacityUnits": number, "Table": { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName": "string", "WriteCapacityUnits": number }',
+    ],
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.consumed_capacity attribute' }],
+  },
+  'aws.dynamodb.count': {
+    brief: 'The value of the `Count` response parameter.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 10,
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.count attribute' }],
+  },
+  'aws.dynamodb.exclusive_start_table': {
+    brief: 'The value of the `ExclusiveStartTableName` request parameter.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'Users',
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.exclusive_start_table attribute' }],
+  },
+  'aws.dynamodb.global_secondary_indexes': {
+    brief: 'The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.',
+    type: 'string[]',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: [
+      '{ "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }',
+    ],
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.global_secondary_indexes attribute' }],
+  },
+  'aws.dynamodb.global_secondary_index_updates': {
+    brief: 'The JSON-serialized value of each item in the `GlobalSecondaryIndexUpdates` request field.',
+    type: 'string[]',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: [
+      '{ "Create": { "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }',
+    ],
+    changelog: [
+      { version: 'next', prs: [479], description: 'Added aws.dynamodb.global_secondary_index_updates attribute' },
+    ],
+  },
+  'aws.dynamodb.index_name': {
+    brief: 'The value of the `IndexName` request parameter.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'name_to_group',
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.index_name attribute' }],
+  },
+  'aws.dynamodb.item_collection_metrics': {
+    brief: 'The JSON-serialized value of the `ItemCollectionMetrics` response field.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example:
+      '{ "string" : [ { "ItemCollectionKey": { "string" : { "B": blob, "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" : "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S": "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }',
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.item_collection_metrics attribute' }],
+  },
+  'aws.dynamodb.limit': {
+    brief: 'The value of the `Limit` request parameter.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 10,
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.limit attribute' }],
+  },
+  'aws.dynamodb.local_secondary_indexes': {
+    brief: 'The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.',
+    type: 'string[]',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: [
+      '{ "IndexArn": "string", "IndexName": "string", "IndexSizeBytes": number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" } }',
+    ],
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.local_secondary_indexes attribute' }],
+  },
+  'aws.dynamodb.projection': {
+    brief: 'The value of the `ProjectionExpression` request parameter.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'Title, Price, Color',
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.projection attribute' }],
+  },
+  'aws.dynamodb.provisioned_read_capacity': {
+    brief: 'The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.',
+    type: 'double',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 1,
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.provisioned_read_capacity attribute' }],
+  },
+  'aws.dynamodb.provisioned_write_capacity': {
+    brief: 'The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.',
+    type: 'double',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 2,
+    changelog: [
+      { version: 'next', prs: [479], description: 'Added aws.dynamodb.provisioned_write_capacity attribute' },
+    ],
+  },
+  'aws.dynamodb.scanned_count': {
+    brief: 'The value of the `ScannedCount` response parameter.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 50,
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.scanned_count attribute' }],
+  },
+  'aws.dynamodb.scan_forward': {
+    brief: 'The value of the `ScanIndexForward` request parameter.',
+    type: 'boolean',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: true,
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.scan_forward attribute' }],
+  },
+  'aws.dynamodb.segment': {
+    brief: 'The value of the `Segment` request parameter.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 10,
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.segment attribute' }],
+  },
+  'aws.dynamodb.select': {
+    brief: 'The value of the `Select` request parameter.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'ALL_ATTRIBUTES',
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.select attribute' }],
+  },
+  'aws.dynamodb.table_count': {
+    brief: 'The number of items in the `TableNames` response parameter.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 20,
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.table_count attribute' }],
+  },
+  'aws.dynamodb.table_names': {
+    brief: 'The keys in the `RequestItems` object field.',
+    type: 'string[]',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: ['Users', 'Cats'],
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.table_names attribute' }],
+  },
+  'aws.dynamodb.total_segments': {
+    brief: 'The value of the `TotalSegments` request parameter.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 100,
+    changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.total_segments attribute' }],
   },
   'aws.lambda.aws_request_id': {
     brief: 'The AWS request ID as received by the Lambda function runtime',
@@ -25554,6 +26281,27 @@ export type Attributes = {
   [AWS_CLOUDWATCH_LOGS_LOG_GROUP]?: AWS_CLOUDWATCH_LOGS_LOG_GROUP_TYPE;
   [AWS_CLOUDWATCH_LOGS_LOG_STREAM]?: AWS_CLOUDWATCH_LOGS_LOG_STREAM_TYPE;
   [AWS_CLOUDWATCH_LOGS_URL]?: AWS_CLOUDWATCH_LOGS_URL_TYPE;
+  [AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS]?: AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS_TYPE;
+  [AWS_DYNAMODB_CONSISTENT_READ]?: AWS_DYNAMODB_CONSISTENT_READ_TYPE;
+  [AWS_DYNAMODB_CONSUMED_CAPACITY]?: AWS_DYNAMODB_CONSUMED_CAPACITY_TYPE;
+  [AWS_DYNAMODB_COUNT]?: AWS_DYNAMODB_COUNT_TYPE;
+  [AWS_DYNAMODB_EXCLUSIVE_START_TABLE]?: AWS_DYNAMODB_EXCLUSIVE_START_TABLE_TYPE;
+  [AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES]?: AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES_TYPE;
+  [AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES]?: AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES_TYPE;
+  [AWS_DYNAMODB_INDEX_NAME]?: AWS_DYNAMODB_INDEX_NAME_TYPE;
+  [AWS_DYNAMODB_ITEM_COLLECTION_METRICS]?: AWS_DYNAMODB_ITEM_COLLECTION_METRICS_TYPE;
+  [AWS_DYNAMODB_LIMIT]?: AWS_DYNAMODB_LIMIT_TYPE;
+  [AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES]?: AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES_TYPE;
+  [AWS_DYNAMODB_PROJECTION]?: AWS_DYNAMODB_PROJECTION_TYPE;
+  [AWS_DYNAMODB_PROVISIONED_READ_CAPACITY]?: AWS_DYNAMODB_PROVISIONED_READ_CAPACITY_TYPE;
+  [AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY]?: AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY_TYPE;
+  [AWS_DYNAMODB_SCANNED_COUNT]?: AWS_DYNAMODB_SCANNED_COUNT_TYPE;
+  [AWS_DYNAMODB_SCAN_FORWARD]?: AWS_DYNAMODB_SCAN_FORWARD_TYPE;
+  [AWS_DYNAMODB_SEGMENT]?: AWS_DYNAMODB_SEGMENT_TYPE;
+  [AWS_DYNAMODB_SELECT]?: AWS_DYNAMODB_SELECT_TYPE;
+  [AWS_DYNAMODB_TABLE_COUNT]?: AWS_DYNAMODB_TABLE_COUNT_TYPE;
+  [AWS_DYNAMODB_TABLE_NAMES]?: AWS_DYNAMODB_TABLE_NAMES_TYPE;
+  [AWS_DYNAMODB_TOTAL_SEGMENTS]?: AWS_DYNAMODB_TOTAL_SEGMENTS_TYPE;
   [AWS_LAMBDA_AWS_REQUEST_ID]?: AWS_LAMBDA_AWS_REQUEST_ID_TYPE;
   [AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS]?: AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS_TYPE;
   [AWS_LAMBDA_FUNCTION_NAME]?: AWS_LAMBDA_FUNCTION_NAME_TYPE;

--- a/model/attributes/aws/aws__dynamodb__attribute_definitions.json
+++ b/model/attributes/aws/aws__dynamodb__attribute_definitions.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.attribute_definitions",
+  "brief": "The JSON-serialized value of each item in the `AttributeDefinitions` request field.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": ["{ \"AttributeName\": \"string\", \"AttributeType\": \"string\" }"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.attribute_definitions attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__consistent_read.json
+++ b/model/attributes/aws/aws__dynamodb__consistent_read.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.consistent_read",
+  "brief": "The value of the `ConsistentRead` request parameter.",
+  "type": "boolean",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": true,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.consistent_read attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__consumed_capacity.json
+++ b/model/attributes/aws/aws__dynamodb__consumed_capacity.json
@@ -1,0 +1,20 @@
+{
+  "key": "aws.dynamodb.consumed_capacity",
+  "brief": "The JSON-serialized value of each item in the `ConsumedCapacity` response field.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": [
+    "{ \"CapacityUnits\": number, \"GlobalSecondaryIndexes\": { \"string\" : { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }, \"LocalSecondaryIndexes\": { \"string\" : { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }, \"ReadCapacityUnits\": number, \"Table\": { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number }, \"TableName\": \"string\", \"WriteCapacityUnits\": number }"
+  ],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.consumed_capacity attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__count.json
+++ b/model/attributes/aws/aws__dynamodb__count.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.count",
+  "brief": "The value of the `Count` response parameter.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 10,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.count attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__exclusive_start_table.json
+++ b/model/attributes/aws/aws__dynamodb__exclusive_start_table.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.exclusive_start_table",
+  "brief": "The value of the `ExclusiveStartTableName` request parameter.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "Users",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.exclusive_start_table attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__global_secondary_index_updates.json
+++ b/model/attributes/aws/aws__dynamodb__global_secondary_index_updates.json
@@ -1,0 +1,20 @@
+{
+  "key": "aws.dynamodb.global_secondary_index_updates",
+  "brief": "The JSON-serialized value of each item in the `GlobalSecondaryIndexUpdates` request field.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": [
+    "{ \"Create\": { \"IndexName\": \"string\", \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" }, \"ProvisionedThroughput\": { \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }"
+  ],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.global_secondary_index_updates attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__global_secondary_indexes.json
+++ b/model/attributes/aws/aws__dynamodb__global_secondary_indexes.json
@@ -1,0 +1,20 @@
+{
+  "key": "aws.dynamodb.global_secondary_indexes",
+  "brief": "The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": [
+    "{ \"IndexName\": \"string\", \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" }, \"ProvisionedThroughput\": { \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }"
+  ],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.global_secondary_indexes attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__index_name.json
+++ b/model/attributes/aws/aws__dynamodb__index_name.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.index_name",
+  "brief": "The value of the `IndexName` request parameter.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "name_to_group",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.index_name attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__item_collection_metrics.json
+++ b/model/attributes/aws/aws__dynamodb__item_collection_metrics.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.item_collection_metrics",
+  "brief": "The JSON-serialized value of the `ItemCollectionMetrics` response field.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "{ \"string\" : [ { \"ItemCollectionKey\": { \"string\" : { \"B\": blob, \"BOOL\": boolean, \"BS\": [ blob ], \"L\": [ \"AttributeValue\" ], \"M\": { \"string\" : \"AttributeValue\" }, \"N\": \"string\", \"NS\": [ \"string\" ], \"NULL\": boolean, \"S\": \"string\", \"SS\": [ \"string\" ] } }, \"SizeEstimateRangeGB\": [ number ] } ] }",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.item_collection_metrics attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__limit.json
+++ b/model/attributes/aws/aws__dynamodb__limit.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.limit",
+  "brief": "The value of the `Limit` request parameter.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 10,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.limit attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__local_secondary_indexes.json
+++ b/model/attributes/aws/aws__dynamodb__local_secondary_indexes.json
@@ -1,0 +1,20 @@
+{
+  "key": "aws.dynamodb.local_secondary_indexes",
+  "brief": "The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": [
+    "{ \"IndexArn\": \"string\", \"IndexName\": \"string\", \"IndexSizeBytes\": number, \"ItemCount\": number, \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" } }"
+  ],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.local_secondary_indexes attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__projection.json
+++ b/model/attributes/aws/aws__dynamodb__projection.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.projection",
+  "brief": "The value of the `ProjectionExpression` request parameter.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "Title, Price, Color",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.projection attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__provisioned_read_capacity.json
+++ b/model/attributes/aws/aws__dynamodb__provisioned_read_capacity.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.provisioned_read_capacity",
+  "brief": "The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.",
+  "type": "double",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 1,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.provisioned_read_capacity attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__provisioned_write_capacity.json
+++ b/model/attributes/aws/aws__dynamodb__provisioned_write_capacity.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.provisioned_write_capacity",
+  "brief": "The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.",
+  "type": "double",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 2,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.provisioned_write_capacity attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__scan_forward.json
+++ b/model/attributes/aws/aws__dynamodb__scan_forward.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.scan_forward",
+  "brief": "The value of the `ScanIndexForward` request parameter.",
+  "type": "boolean",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": true,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.scan_forward attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__scanned_count.json
+++ b/model/attributes/aws/aws__dynamodb__scanned_count.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.scanned_count",
+  "brief": "The value of the `ScannedCount` response parameter.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 50,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.scanned_count attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__segment.json
+++ b/model/attributes/aws/aws__dynamodb__segment.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.segment",
+  "brief": "The value of the `Segment` request parameter.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 10,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.segment attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__select.json
+++ b/model/attributes/aws/aws__dynamodb__select.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.select",
+  "brief": "The value of the `Select` request parameter.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "ALL_ATTRIBUTES",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.select attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__table_count.json
+++ b/model/attributes/aws/aws__dynamodb__table_count.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.table_count",
+  "brief": "The number of items in the `TableNames` response parameter.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 20,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.table_count attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__table_names.json
+++ b/model/attributes/aws/aws__dynamodb__table_names.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.table_names",
+  "brief": "The keys in the `RequestItems` object field.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": ["Users", "Cats"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.table_names attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__dynamodb__total_segments.json
+++ b/model/attributes/aws/aws__dynamodb__total_segments.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.dynamodb.total_segments",
+  "brief": "The value of the `TotalSegments` request parameter.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 100,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [479],
+      "description": "Added aws.dynamodb.total_segments attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1224,6 +1224,271 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/my-log-group"
     """
 
+    # Path: model/attributes/aws/aws__dynamodb__attribute_definitions.json
+    AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS: Literal[
+        "aws.dynamodb.attribute_definitions"
+    ] = "aws.dynamodb.attribute_definitions"
+    """The JSON-serialized value of each item in the `AttributeDefinitions` request field.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["{ \"AttributeName\": \"string\", \"AttributeType\": \"string\" }"]
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__consistent_read.json
+    AWS_DYNAMODB_CONSISTENT_READ: Literal["aws.dynamodb.consistent_read"] = (
+        "aws.dynamodb.consistent_read"
+    )
+    """The value of the `ConsistentRead` request parameter.
+
+    Type: bool
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: true
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__consumed_capacity.json
+    AWS_DYNAMODB_CONSUMED_CAPACITY: Literal["aws.dynamodb.consumed_capacity"] = (
+        "aws.dynamodb.consumed_capacity"
+    )
+    """The JSON-serialized value of each item in the `ConsumedCapacity` response field.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["{ \"CapacityUnits\": number, \"GlobalSecondaryIndexes\": { \"string\" : { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }, \"LocalSecondaryIndexes\": { \"string\" : { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }, \"ReadCapacityUnits\": number, \"Table\": { \"CapacityUnits\": number, \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number }, \"TableName\": \"string\", \"WriteCapacityUnits\": number }"]
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__count.json
+    AWS_DYNAMODB_COUNT: Literal["aws.dynamodb.count"] = "aws.dynamodb.count"
+    """The value of the `Count` response parameter.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 10
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__exclusive_start_table.json
+    AWS_DYNAMODB_EXCLUSIVE_START_TABLE: Literal[
+        "aws.dynamodb.exclusive_start_table"
+    ] = "aws.dynamodb.exclusive_start_table"
+    """The value of the `ExclusiveStartTableName` request parameter.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "Users"
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__global_secondary_index_updates.json
+    AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES: Literal[
+        "aws.dynamodb.global_secondary_index_updates"
+    ] = "aws.dynamodb.global_secondary_index_updates"
+    """The JSON-serialized value of each item in the `GlobalSecondaryIndexUpdates` request field.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["{ \"Create\": { \"IndexName\": \"string\", \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" }, \"ProvisionedThroughput\": { \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }"]
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__global_secondary_indexes.json
+    AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES: Literal[
+        "aws.dynamodb.global_secondary_indexes"
+    ] = "aws.dynamodb.global_secondary_indexes"
+    """The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["{ \"IndexName\": \"string\", \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" }, \"ProvisionedThroughput\": { \"ReadCapacityUnits\": number, \"WriteCapacityUnits\": number } }"]
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__index_name.json
+    AWS_DYNAMODB_INDEX_NAME: Literal["aws.dynamodb.index_name"] = (
+        "aws.dynamodb.index_name"
+    )
+    """The value of the `IndexName` request parameter.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "name_to_group"
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__item_collection_metrics.json
+    AWS_DYNAMODB_ITEM_COLLECTION_METRICS: Literal[
+        "aws.dynamodb.item_collection_metrics"
+    ] = "aws.dynamodb.item_collection_metrics"
+    """The JSON-serialized value of the `ItemCollectionMetrics` response field.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "{ \"string\" : [ { \"ItemCollectionKey\": { \"string\" : { \"B\": blob, \"BOOL\": boolean, \"BS\": [ blob ], \"L\": [ \"AttributeValue\" ], \"M\": { \"string\" : \"AttributeValue\" }, \"N\": \"string\", \"NS\": [ \"string\" ], \"NULL\": boolean, \"S\": \"string\", \"SS\": [ \"string\" ] } }, \"SizeEstimateRangeGB\": [ number ] } ] }"
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__limit.json
+    AWS_DYNAMODB_LIMIT: Literal["aws.dynamodb.limit"] = "aws.dynamodb.limit"
+    """The value of the `Limit` request parameter.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 10
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__local_secondary_indexes.json
+    AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES: Literal[
+        "aws.dynamodb.local_secondary_indexes"
+    ] = "aws.dynamodb.local_secondary_indexes"
+    """The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["{ \"IndexArn\": \"string\", \"IndexName\": \"string\", \"IndexSizeBytes\": number, \"ItemCount\": number, \"KeySchema\": [ { \"AttributeName\": \"string\", \"KeyType\": \"string\" } ], \"Projection\": { \"NonKeyAttributes\": [ \"string\" ], \"ProjectionType\": \"string\" } }"]
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__projection.json
+    AWS_DYNAMODB_PROJECTION: Literal["aws.dynamodb.projection"] = (
+        "aws.dynamodb.projection"
+    )
+    """The value of the `ProjectionExpression` request parameter.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "Title, Price, Color"
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__provisioned_read_capacity.json
+    AWS_DYNAMODB_PROVISIONED_READ_CAPACITY: Literal[
+        "aws.dynamodb.provisioned_read_capacity"
+    ] = "aws.dynamodb.provisioned_read_capacity"
+    """The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.
+
+    Type: float
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 1
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__provisioned_write_capacity.json
+    AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY: Literal[
+        "aws.dynamodb.provisioned_write_capacity"
+    ] = "aws.dynamodb.provisioned_write_capacity"
+    """The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.
+
+    Type: float
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 2
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__scan_forward.json
+    AWS_DYNAMODB_SCAN_FORWARD: Literal["aws.dynamodb.scan_forward"] = (
+        "aws.dynamodb.scan_forward"
+    )
+    """The value of the `ScanIndexForward` request parameter.
+
+    Type: bool
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: true
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__scanned_count.json
+    AWS_DYNAMODB_SCANNED_COUNT: Literal["aws.dynamodb.scanned_count"] = (
+        "aws.dynamodb.scanned_count"
+    )
+    """The value of the `ScannedCount` response parameter.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 50
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__segment.json
+    AWS_DYNAMODB_SEGMENT: Literal["aws.dynamodb.segment"] = "aws.dynamodb.segment"
+    """The value of the `Segment` request parameter.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 10
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__select.json
+    AWS_DYNAMODB_SELECT: Literal["aws.dynamodb.select"] = "aws.dynamodb.select"
+    """The value of the `Select` request parameter.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "ALL_ATTRIBUTES"
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__table_count.json
+    AWS_DYNAMODB_TABLE_COUNT: Literal["aws.dynamodb.table_count"] = (
+        "aws.dynamodb.table_count"
+    )
+    """The number of items in the `TableNames` response parameter.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 20
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__table_names.json
+    AWS_DYNAMODB_TABLE_NAMES: Literal["aws.dynamodb.table_names"] = (
+        "aws.dynamodb.table_names"
+    )
+    """The keys in the `RequestItems` object field.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["Users","Cats"]
+    """
+
+    # Path: model/attributes/aws/aws__dynamodb__total_segments.json
+    AWS_DYNAMODB_TOTAL_SEGMENTS: Literal["aws.dynamodb.total_segments"] = (
+        "aws.dynamodb.total_segments"
+    )
+    """The value of the `TotalSegments` request parameter.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: 100
+    """
+
     # Path: model/attributes/aws/aws__lambda__aws_request_id.json
     AWS_LAMBDA_AWS_REQUEST_ID: Literal["aws.lambda.aws_request_id"] = (
         "aws.lambda.aws_request_id"
@@ -9777,6 +10042,329 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "aws.dynamodb.attribute_definitions": AttributeMetadata(
+        brief="The JSON-serialized value of each item in the `AttributeDefinitions` request field.",
+        type=AttributeType.STRING_ARRAY,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=['{ "AttributeName": "string", "AttributeType": "string" }'],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.attribute_definitions attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.consistent_read": AttributeMetadata(
+        brief="The value of the `ConsistentRead` request parameter.",
+        type=AttributeType.BOOLEAN,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=True,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.consistent_read attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.consumed_capacity": AttributeMetadata(
+        brief="The JSON-serialized value of each item in the `ConsumedCapacity` response field.",
+        type=AttributeType.STRING_ARRAY,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=[
+            '{ "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "ReadCapacityUnits": number, "Table": { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName": "string", "WriteCapacityUnits": number }'
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.consumed_capacity attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.count": AttributeMetadata(
+        brief="The value of the `Count` response parameter.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=10,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.count attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.exclusive_start_table": AttributeMetadata(
+        brief="The value of the `ExclusiveStartTableName` request parameter.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="Users",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.exclusive_start_table attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.global_secondary_index_updates": AttributeMetadata(
+        brief="The JSON-serialized value of each item in the `GlobalSecondaryIndexUpdates` request field.",
+        type=AttributeType.STRING_ARRAY,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=[
+            '{ "Create": { "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }'
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.global_secondary_index_updates attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.global_secondary_indexes": AttributeMetadata(
+        brief="The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.",
+        type=AttributeType.STRING_ARRAY,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=[
+            '{ "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }'
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.global_secondary_indexes attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.index_name": AttributeMetadata(
+        brief="The value of the `IndexName` request parameter.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="name_to_group",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.index_name attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.item_collection_metrics": AttributeMetadata(
+        brief="The JSON-serialized value of the `ItemCollectionMetrics` response field.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example='{ "string" : [ { "ItemCollectionKey": { "string" : { "B": blob, "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" : "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S": "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }',
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.item_collection_metrics attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.limit": AttributeMetadata(
+        brief="The value of the `Limit` request parameter.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=10,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.limit attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.local_secondary_indexes": AttributeMetadata(
+        brief="The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.",
+        type=AttributeType.STRING_ARRAY,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=[
+            '{ "IndexArn": "string", "IndexName": "string", "IndexSizeBytes": number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" } }'
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.local_secondary_indexes attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.projection": AttributeMetadata(
+        brief="The value of the `ProjectionExpression` request parameter.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="Title, Price, Color",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.projection attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.provisioned_read_capacity": AttributeMetadata(
+        brief="The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.",
+        type=AttributeType.DOUBLE,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=1,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.provisioned_read_capacity attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.provisioned_write_capacity": AttributeMetadata(
+        brief="The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.",
+        type=AttributeType.DOUBLE,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=2,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.provisioned_write_capacity attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.scan_forward": AttributeMetadata(
+        brief="The value of the `ScanIndexForward` request parameter.",
+        type=AttributeType.BOOLEAN,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=True,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.scan_forward attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.scanned_count": AttributeMetadata(
+        brief="The value of the `ScannedCount` response parameter.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=50,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.scanned_count attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.segment": AttributeMetadata(
+        brief="The value of the `Segment` request parameter.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=10,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.segment attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.select": AttributeMetadata(
+        brief="The value of the `Select` request parameter.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="ALL_ATTRIBUTES",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.select attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.table_count": AttributeMetadata(
+        brief="The number of items in the `TableNames` response parameter.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=20,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.table_count attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.table_names": AttributeMetadata(
+        brief="The keys in the `RequestItems` object field.",
+        type=AttributeType.STRING_ARRAY,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=["Users", "Cats"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.table_names attribute",
+            ),
+        ],
+    ),
+    "aws.dynamodb.total_segments": AttributeMetadata(
+        brief="The value of the `TotalSegments` request parameter.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=100,
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[479],
+                description="Added aws.dynamodb.total_segments attribute",
+            ),
+        ],
+    ),
     "aws.lambda.aws_request_id": AttributeMetadata(
         brief="The AWS request ID as received by the Lambda function runtime",
         type=AttributeType.STRING,
@@ -18318,6 +18906,27 @@ Attributes = TypedDict(
         "aws.cloudwatch.logs.log_group": str,
         "aws.cloudwatch.logs.log_stream": str,
         "aws.cloudwatch.logs.url": str,
+        "aws.dynamodb.attribute_definitions": List[str],
+        "aws.dynamodb.consistent_read": bool,
+        "aws.dynamodb.consumed_capacity": List[str],
+        "aws.dynamodb.count": int,
+        "aws.dynamodb.exclusive_start_table": str,
+        "aws.dynamodb.global_secondary_index_updates": List[str],
+        "aws.dynamodb.global_secondary_indexes": List[str],
+        "aws.dynamodb.index_name": str,
+        "aws.dynamodb.item_collection_metrics": str,
+        "aws.dynamodb.limit": int,
+        "aws.dynamodb.local_secondary_indexes": List[str],
+        "aws.dynamodb.projection": str,
+        "aws.dynamodb.provisioned_read_capacity": float,
+        "aws.dynamodb.provisioned_write_capacity": float,
+        "aws.dynamodb.scan_forward": bool,
+        "aws.dynamodb.scanned_count": int,
+        "aws.dynamodb.segment": int,
+        "aws.dynamodb.select": str,
+        "aws.dynamodb.table_count": int,
+        "aws.dynamodb.table_names": List[str],
+        "aws.dynamodb.total_segments": int,
         "aws.lambda.aws_request_id": str,
         "aws.lambda.execution_duration_in_millis": float,
         "aws.lambda.function_name": str,


### PR DESCRIPTION
Adds the `aws.dynamodb.*` request/response attributes emitted by the vendored AWS SDK instrumentation
* attribute_definitions
* consistent_read
* consumed_capacity
* count
* exclusive_start_table
* global_secondary_index_updates
* global_secondary_indexes
* index_name
* item_collection_metrics
* limit
* local_secondary_indexes
* projection
* provisioned_read_capacity
* provisioned_write_capacity
* scan_forward
* scanned_count
* segment
* select
* table_count
* table_names
* total_segments

OTel sem conv for `aws.dynamodb` can be found at: https://opentelemetry.io/docs/specs/semconv/db/dynamodb/