### PR TITLE
feat(attributes): Add AWS service instrumentation attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2120,26 +2120,75 @@ export const AWS_DYNAMODB_TOTAL_SEGMENTS = 'aws.dynamodb.total_segments';
  */
 export type AWS_DYNAMODB_TOTAL_SEGMENTS_TYPE = number;
 
+// Path: model/attributes/aws/aws__extended_request_id.json
+
+/**
+ * The AWS extended request ID as returned in the response headers. `aws.extended_request_id`
+ *
+ * Attribute Value Type: `string` {@link AWS_EXTENDED_REQUEST_ID_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * Aliases: {@link AWS_REQUEST_EXTENDED_ID} `aws.request.extended_id`
+ *
+ * @example "wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ="
+ */
+export const AWS_EXTENDED_REQUEST_ID = 'aws.extended_request_id';
+
+/**
+ * Type for {@link AWS_EXTENDED_REQUEST_ID} aws.extended_request_id
+ */
+export type AWS_EXTENDED_REQUEST_ID_TYPE = string;
+
+// Path: model/attributes/aws/aws__kinesis__stream_name.json
+
+/**
+ * The name of the AWS Kinesis stream the request refers to. `aws.kinesis.stream_name`
+ *
+ * Attribute Value Type: `string` {@link AWS_KINESIS_STREAM_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * Aliases: {@link _AWS_KINESIS_STREAM_NAME} `aws.kinesis.stream.name`
+ *
+ * @example "some-stream-name"
+ */
+export const AWS_KINESIS_STREAM_NAME = 'aws.kinesis.stream_name';
+
+/**
+ * Type for {@link AWS_KINESIS_STREAM_NAME} aws.kinesis.stream_name
+ */
+export type AWS_KINESIS_STREAM_NAME_TYPE = string;
+
 // Path: model/attributes/aws/aws__kinesis__stream__name.json
 
 /**
  * The name of the AWS Kinesis stream the request refers to. `aws.kinesis.stream.name`
  *
- * Attribute Value Type: `string` {@link AWS_KINESIS_STREAM_NAME_TYPE}
+ * Attribute Value Type: `string` {@link _AWS_KINESIS_STREAM_NAME_TYPE}
  *
  * Apply Scrubbing: manual
  *
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link AWS_KINESIS_STREAM_NAME} `aws.kinesis.stream_name`
+ *
+ * @deprecated Use {@link AWS_KINESIS_STREAM_NAME} (aws.kinesis.stream_name) instead - This attribute is being deprecated in favor of aws.kinesis.stream_name, which is the OTel-aligned replacement.
  * @example "some-stream-name"
  */
-export const AWS_KINESIS_STREAM_NAME = 'aws.kinesis.stream.name';
+export const _AWS_KINESIS_STREAM_NAME = 'aws.kinesis.stream.name';
 
 /**
- * Type for {@link AWS_KINESIS_STREAM_NAME} aws.kinesis.stream.name
+ * Type for {@link _AWS_KINESIS_STREAM_NAME} aws.kinesis.stream.name
  */
-export type AWS_KINESIS_STREAM_NAME_TYPE = string;
+export type _AWS_KINESIS_STREAM_NAME_TYPE = string;
 
 // Path: model/attributes/aws/aws__lambda__aws_request_id.json
 
@@ -2356,6 +2405,9 @@ export type AWS_LOG_STREAM_NAMES_TYPE = Array<string>;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link AWS_EXTENDED_REQUEST_ID} `aws.extended_request_id`
+ *
+ * @deprecated Use {@link AWS_EXTENDED_REQUEST_ID} (aws.extended_request_id) instead - This attribute is being deprecated in favor of aws.extended_request_id, which is the OTel-aligned replacement.
  * @example "wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ="
  */
 export const AWS_REQUEST_EXTENDED_ID = 'aws.request.extended_id';
@@ -2365,26 +2417,52 @@ export const AWS_REQUEST_EXTENDED_ID = 'aws.request.extended_id';
  */
 export type AWS_REQUEST_EXTENDED_ID_TYPE = string;
 
+// Path: model/attributes/aws/aws__request_id.json
+
+/**
+ * The AWS request ID as returned in the response headers. `aws.request_id`
+ *
+ * Attribute Value Type: `string` {@link AWS_REQUEST_ID_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * Aliases: {@link _AWS_REQUEST_ID} `aws.request.id`
+ *
+ * @example "79b9da39-b7ae-508a-a6bc-864b2829c622"
+ */
+export const AWS_REQUEST_ID = 'aws.request_id';
+
+/**
+ * Type for {@link AWS_REQUEST_ID} aws.request_id
+ */
+export type AWS_REQUEST_ID_TYPE = string;
+
 // Path: model/attributes/aws/aws__request__id.json
 
 /**
  * The AWS request ID as returned in the response headers. `aws.request.id`
  *
- * Attribute Value Type: `string` {@link AWS_REQUEST_ID_TYPE}
+ * Attribute Value Type: `string` {@link _AWS_REQUEST_ID_TYPE}
  *
  * Apply Scrubbing: manual
  *
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link AWS_REQUEST_ID} `aws.request_id`
+ *
+ * @deprecated Use {@link AWS_REQUEST_ID} (aws.request_id) instead - This attribute is being deprecated in favor of aws.request_id, which is the OTel-aligned replacement.
  * @example "79b9da39-b7ae-508a-a6bc-864b2829c622"
  */
-export const AWS_REQUEST_ID = 'aws.request.id';
+export const _AWS_REQUEST_ID = 'aws.request.id';
 
 /**
- * Type for {@link AWS_REQUEST_ID} aws.request.id
+ * Type for {@link _AWS_REQUEST_ID} aws.request.id
  */
-export type AWS_REQUEST_ID_TYPE = string;
+export type _AWS_REQUEST_ID_TYPE = string;
 
 // Path: model/attributes/aws/aws__s3__bucket.json
 
@@ -15949,6 +16027,8 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'aws.dynamodb.table_count': 'integer',
   'aws.dynamodb.table_names': 'string[]',
   'aws.dynamodb.total_segments': 'integer',
+  'aws.extended_request_id': 'string',
+  'aws.kinesis.stream_name': 'string',
   'aws.kinesis.stream.name': 'string',
   'aws.lambda.aws_request_id': 'string',
   'aws.lambda.execution_duration_in_millis': 'double',
@@ -15960,6 +16040,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'aws.log.group.names': 'string[]',
   'aws.log.stream.names': 'string[]',
   'aws.request.extended_id': 'string',
+  'aws.request_id': 'string',
   'aws.request.id': 'string',
   'aws.s3.bucket': 'string',
   'aws.secretsmanager.secret.arn': 'string',
@@ -16667,7 +16748,9 @@ export type AttributeName =
   | typeof AWS_DYNAMODB_TABLE_COUNT
   | typeof AWS_DYNAMODB_TABLE_NAMES
   | typeof AWS_DYNAMODB_TOTAL_SEGMENTS
+  | typeof AWS_EXTENDED_REQUEST_ID
   | typeof AWS_KINESIS_STREAM_NAME
+  | typeof _AWS_KINESIS_STREAM_NAME
   | typeof AWS_LAMBDA_AWS_REQUEST_ID
   | typeof AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS
   | typeof AWS_LAMBDA_FUNCTION_NAME
@@ -16679,6 +16762,7 @@ export type AttributeName =
   | typeof AWS_LOG_STREAM_NAMES
   | typeof AWS_REQUEST_EXTENDED_ID
   | typeof AWS_REQUEST_ID
+  | typeof _AWS_REQUEST_ID
   | typeof AWS_S3_BUCKET
   | typeof AWS_SECRETSMANAGER_SECRET_ARN
   | typeof AWS_SNS_TOPIC_ARN
@@ -18606,6 +18690,30 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 100,
     changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.total_segments attribute' }],
   },
+  'aws.extended_request_id': {
+    brief: 'The AWS extended request ID as returned in the response headers.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=',
+    aliases: ['aws.request.extended_id'],
+    changelog: [{ version: 'next', prs: [480], description: 'Added aws.extended_request_id attribute' }],
+  },
+  'aws.kinesis.stream_name': {
+    brief: 'The name of the AWS Kinesis stream the request refers to.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'some-stream-name',
+    aliases: ['aws.kinesis.stream.name'],
+    changelog: [{ version: 'next', prs: [480], description: 'Added aws.kinesis.stream_name attribute' }],
+  },
   'aws.kinesis.stream.name': {
     brief: 'The name of the AWS Kinesis stream the request refers to.',
     type: 'string',
@@ -18615,7 +18723,19 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'some-stream-name',
-    changelog: [{ version: 'next', prs: [480], description: 'Added aws.kinesis.stream.name attribute' }],
+    deprecation: {
+      replacement: 'aws.kinesis.stream_name',
+      reason:
+        'This attribute is being deprecated in favor of aws.kinesis.stream_name, which is the OTel-aligned replacement.',
+    },
+    aliases: ['aws.kinesis.stream_name'],
+    changelog: [
+      {
+        version: 'next',
+        prs: [480],
+        description: 'Added aws.kinesis.stream.name attribute, deprecated in favor of aws.kinesis.stream_name',
+      },
+    ],
   },
   'aws.lambda.aws_request_id': {
     brief: 'The AWS request ID as received by the Lambda function runtime',
@@ -18773,7 +18893,31 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=',
-    changelog: [{ version: 'next', prs: [480], description: 'Added aws.request.extended_id attribute' }],
+    deprecation: {
+      replacement: 'aws.extended_request_id',
+      reason:
+        'This attribute is being deprecated in favor of aws.extended_request_id, which is the OTel-aligned replacement.',
+    },
+    aliases: ['aws.extended_request_id'],
+    changelog: [
+      {
+        version: 'next',
+        prs: [480],
+        description: 'Added aws.request.extended_id attribute, deprecated in favor of aws.extended_request_id',
+      },
+    ],
+  },
+  'aws.request_id': {
+    brief: 'The AWS request ID as returned in the response headers.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: '79b9da39-b7ae-508a-a6bc-864b2829c622',
+    aliases: ['aws.request.id'],
+    changelog: [{ version: 'next', prs: [480], description: 'Added aws.request_id attribute' }],
   },
   'aws.request.id': {
     brief: 'The AWS request ID as returned in the response headers.',
@@ -18784,7 +18928,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: '79b9da39-b7ae-508a-a6bc-864b2829c622',
-    changelog: [{ version: 'next', prs: [480], description: 'Added aws.request.id attribute' }],
+    deprecation: {
+      replacement: 'aws.request_id',
+      reason: 'This attribute is being deprecated in favor of aws.request_id, which is the OTel-aligned replacement.',
+    },
+    aliases: ['aws.request_id'],
+    changelog: [
+      {
+        version: 'next',
+        prs: [480],
+        description: 'Added aws.request.id attribute, deprecated in favor of aws.request_id',
+      },
+    ],
   },
   'aws.s3.bucket': {
     brief: 'The S3 bucket name the request refers to.',
@@ -26852,7 +27007,9 @@ export type Attributes = {
   [AWS_DYNAMODB_TABLE_COUNT]?: AWS_DYNAMODB_TABLE_COUNT_TYPE;
   [AWS_DYNAMODB_TABLE_NAMES]?: AWS_DYNAMODB_TABLE_NAMES_TYPE;
   [AWS_DYNAMODB_TOTAL_SEGMENTS]?: AWS_DYNAMODB_TOTAL_SEGMENTS_TYPE;
+  [AWS_EXTENDED_REQUEST_ID]?: AWS_EXTENDED_REQUEST_ID_TYPE;
   [AWS_KINESIS_STREAM_NAME]?: AWS_KINESIS_STREAM_NAME_TYPE;
+  [_AWS_KINESIS_STREAM_NAME]?: _AWS_KINESIS_STREAM_NAME_TYPE;
   [AWS_LAMBDA_AWS_REQUEST_ID]?: AWS_LAMBDA_AWS_REQUEST_ID_TYPE;
   [AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS]?: AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS_TYPE;
   [AWS_LAMBDA_FUNCTION_NAME]?: AWS_LAMBDA_FUNCTION_NAME_TYPE;
@@ -26864,6 +27021,7 @@ export type Attributes = {
   [AWS_LOG_STREAM_NAMES]?: AWS_LOG_STREAM_NAMES_TYPE;
   [AWS_REQUEST_EXTENDED_ID]?: AWS_REQUEST_EXTENDED_ID_TYPE;
   [AWS_REQUEST_ID]?: AWS_REQUEST_ID_TYPE;
+  [_AWS_REQUEST_ID]?: _AWS_REQUEST_ID_TYPE;
   [AWS_S3_BUCKET]?: AWS_S3_BUCKET_TYPE;
   [AWS_SECRETSMANAGER_SECRET_ARN]?: AWS_SECRETSMANAGER_SECRET_ARN_TYPE;
   [AWS_SNS_TOPIC_ARN]?: AWS_SNS_TOPIC_ARN_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2120,6 +2120,27 @@ export const AWS_DYNAMODB_TOTAL_SEGMENTS = 'aws.dynamodb.total_segments';
  */
 export type AWS_DYNAMODB_TOTAL_SEGMENTS_TYPE = number;
 
+// Path: model/attributes/aws/aws__kinesis__stream__name.json
+
+/**
+ * The name of the AWS Kinesis stream the request refers to. `aws.kinesis.stream.name`
+ *
+ * Attribute Value Type: `string` {@link AWS_KINESIS_STREAM_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "some-stream-name"
+ */
+export const AWS_KINESIS_STREAM_NAME = 'aws.kinesis.stream.name';
+
+/**
+ * Type for {@link AWS_KINESIS_STREAM_NAME} aws.kinesis.stream.name
+ */
+export type AWS_KINESIS_STREAM_NAME_TYPE = string;
+
 // Path: model/attributes/aws/aws__lambda__aws_request_id.json
 
 /**
@@ -2322,6 +2343,153 @@ export const AWS_LOG_STREAM_NAMES = 'aws.log.stream.names';
  * Type for {@link AWS_LOG_STREAM_NAMES} aws.log.stream.names
  */
 export type AWS_LOG_STREAM_NAMES_TYPE = Array<string>;
+
+// Path: model/attributes/aws/aws__request__extended_id.json
+
+/**
+ * The AWS extended request ID as returned in the response headers. `aws.request.extended_id`
+ *
+ * Attribute Value Type: `string` {@link AWS_REQUEST_EXTENDED_ID_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ="
+ */
+export const AWS_REQUEST_EXTENDED_ID = 'aws.request.extended_id';
+
+/**
+ * Type for {@link AWS_REQUEST_EXTENDED_ID} aws.request.extended_id
+ */
+export type AWS_REQUEST_EXTENDED_ID_TYPE = string;
+
+// Path: model/attributes/aws/aws__request__id.json
+
+/**
+ * The AWS request ID as returned in the response headers. `aws.request.id`
+ *
+ * Attribute Value Type: `string` {@link AWS_REQUEST_ID_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "79b9da39-b7ae-508a-a6bc-864b2829c622"
+ */
+export const AWS_REQUEST_ID = 'aws.request.id';
+
+/**
+ * Type for {@link AWS_REQUEST_ID} aws.request.id
+ */
+export type AWS_REQUEST_ID_TYPE = string;
+
+// Path: model/attributes/aws/aws__s3__bucket.json
+
+/**
+ * The S3 bucket name the request refers to. `aws.s3.bucket`
+ *
+ * Attribute Value Type: `string` {@link AWS_S3_BUCKET_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "ot-demo-test"
+ */
+export const AWS_S3_BUCKET = 'aws.s3.bucket';
+
+/**
+ * Type for {@link AWS_S3_BUCKET} aws.s3.bucket
+ */
+export type AWS_S3_BUCKET_TYPE = string;
+
+// Path: model/attributes/aws/aws__secretsmanager__secret__arn.json
+
+/**
+ * The ARN of the Secret stored in Secrets Manager. `aws.secretsmanager.secret.arn`
+ *
+ * Attribute Value Type: `string` {@link AWS_SECRETSMANAGER_SECRET_ARN_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "arn:aws:secretsmanager:us-east-1:123456789012:secret:SecretName-6RandomCharacters"
+ */
+export const AWS_SECRETSMANAGER_SECRET_ARN = 'aws.secretsmanager.secret.arn';
+
+/**
+ * Type for {@link AWS_SECRETSMANAGER_SECRET_ARN} aws.secretsmanager.secret.arn
+ */
+export type AWS_SECRETSMANAGER_SECRET_ARN_TYPE = string;
+
+// Path: model/attributes/aws/aws__sns__topic__arn.json
+
+/**
+ * The ARN of the AWS SNS Topic. An Amazon SNS topic is a logical access point that acts as a communication channel. `aws.sns.topic.arn`
+ *
+ * Attribute Value Type: `string` {@link AWS_SNS_TOPIC_ARN_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE"
+ */
+export const AWS_SNS_TOPIC_ARN = 'aws.sns.topic.arn';
+
+/**
+ * Type for {@link AWS_SNS_TOPIC_ARN} aws.sns.topic.arn
+ */
+export type AWS_SNS_TOPIC_ARN_TYPE = string;
+
+// Path: model/attributes/aws/aws__step_functions__activity__arn.json
+
+/**
+ * The ARN of the AWS Step Functions Activity. `aws.step_functions.activity.arn`
+ *
+ * Attribute Value Type: `string` {@link AWS_STEP_FUNCTIONS_ACTIVITY_ARN_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "arn:aws:states:us-east-1:123456789012:activity:get-greeting"
+ */
+export const AWS_STEP_FUNCTIONS_ACTIVITY_ARN = 'aws.step_functions.activity.arn';
+
+/**
+ * Type for {@link AWS_STEP_FUNCTIONS_ACTIVITY_ARN} aws.step_functions.activity.arn
+ */
+export type AWS_STEP_FUNCTIONS_ACTIVITY_ARN_TYPE = string;
+
+// Path: model/attributes/aws/aws__step_functions__state_machine__arn.json
+
+/**
+ * The ARN of the AWS Step Functions State Machine. `aws.step_functions.state_machine.arn`
+ *
+ * Attribute Value Type: `string` {@link AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine:1"
+ */
+export const AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN = 'aws.step_functions.state_machine.arn';
+
+/**
+ * Type for {@link AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN} aws.step_functions.state_machine.arn
+ */
+export type AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN_TYPE = string;
 
 // Path: model/attributes/blocked_main_thread.json
 
@@ -15781,6 +15949,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'aws.dynamodb.table_count': 'integer',
   'aws.dynamodb.table_names': 'string[]',
   'aws.dynamodb.total_segments': 'integer',
+  'aws.kinesis.stream.name': 'string',
   'aws.lambda.aws_request_id': 'string',
   'aws.lambda.execution_duration_in_millis': 'double',
   'aws.lambda.function_name': 'string',
@@ -15790,6 +15959,13 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'aws.lambda.remaining_time_in_millis': 'double',
   'aws.log.group.names': 'string[]',
   'aws.log.stream.names': 'string[]',
+  'aws.request.extended_id': 'string',
+  'aws.request.id': 'string',
+  'aws.s3.bucket': 'string',
+  'aws.secretsmanager.secret.arn': 'string',
+  'aws.sns.topic.arn': 'string',
+  'aws.step_functions.activity.arn': 'string',
+  'aws.step_functions.state_machine.arn': 'string',
   blocked_main_thread: 'boolean',
   'browser.name': 'string',
   'browser.performance.navigation.activation_start': 'double',
@@ -16491,6 +16667,7 @@ export type AttributeName =
   | typeof AWS_DYNAMODB_TABLE_COUNT
   | typeof AWS_DYNAMODB_TABLE_NAMES
   | typeof AWS_DYNAMODB_TOTAL_SEGMENTS
+  | typeof AWS_KINESIS_STREAM_NAME
   | typeof AWS_LAMBDA_AWS_REQUEST_ID
   | typeof AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS
   | typeof AWS_LAMBDA_FUNCTION_NAME
@@ -16500,6 +16677,13 @@ export type AttributeName =
   | typeof AWS_LAMBDA_REMAINING_TIME_IN_MILLIS
   | typeof AWS_LOG_GROUP_NAMES
   | typeof AWS_LOG_STREAM_NAMES
+  | typeof AWS_REQUEST_EXTENDED_ID
+  | typeof AWS_REQUEST_ID
+  | typeof AWS_S3_BUCKET
+  | typeof AWS_SECRETSMANAGER_SECRET_ARN
+  | typeof AWS_SNS_TOPIC_ARN
+  | typeof AWS_STEP_FUNCTIONS_ACTIVITY_ARN
+  | typeof AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN
   | typeof BLOCKED_MAIN_THREAD
   | typeof BROWSER_NAME
   | typeof BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START
@@ -18422,6 +18606,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 100,
     changelog: [{ version: 'next', prs: [479], description: 'Added aws.dynamodb.total_segments attribute' }],
   },
+  'aws.kinesis.stream.name': {
+    brief: 'The name of the AWS Kinesis stream the request refers to.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'some-stream-name',
+    changelog: [{ version: 'next', prs: [480], description: 'Added aws.kinesis.stream.name attribute' }],
+  },
   'aws.lambda.aws_request_id': {
     brief: 'The AWS request ID as received by the Lambda function runtime',
     type: 'string',
@@ -18568,6 +18763,84 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: ['logs/main/10838bed-421f-43ef-870a-f43feacbbb5b'],
     changelog: [{ version: '0.11.1', prs: [414] }],
+  },
+  'aws.request.extended_id': {
+    brief: 'The AWS extended request ID as returned in the response headers.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=',
+    changelog: [{ version: 'next', prs: [480], description: 'Added aws.request.extended_id attribute' }],
+  },
+  'aws.request.id': {
+    brief: 'The AWS request ID as returned in the response headers.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '79b9da39-b7ae-508a-a6bc-864b2829c622',
+    changelog: [{ version: 'next', prs: [480], description: 'Added aws.request.id attribute' }],
+  },
+  'aws.s3.bucket': {
+    brief: 'The S3 bucket name the request refers to.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'ot-demo-test',
+    changelog: [{ version: 'next', prs: [480], description: 'Added aws.s3.bucket attribute' }],
+  },
+  'aws.secretsmanager.secret.arn': {
+    brief: 'The ARN of the Secret stored in Secrets Manager.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:SecretName-6RandomCharacters',
+    changelog: [{ version: 'next', prs: [480], description: 'Added aws.secretsmanager.secret.arn attribute' }],
+  },
+  'aws.sns.topic.arn': {
+    brief:
+      'The ARN of the AWS SNS Topic. An Amazon SNS topic is a logical access point that acts as a communication channel.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE',
+    changelog: [{ version: 'next', prs: [480], description: 'Added aws.sns.topic.arn attribute' }],
+  },
+  'aws.step_functions.activity.arn': {
+    brief: 'The ARN of the AWS Step Functions Activity.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'arn:aws:states:us-east-1:123456789012:activity:get-greeting',
+    changelog: [{ version: 'next', prs: [480], description: 'Added aws.step_functions.activity.arn attribute' }],
+  },
+  'aws.step_functions.state_machine.arn': {
+    brief: 'The ARN of the AWS Step Functions State Machine.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine:1',
+    changelog: [{ version: 'next', prs: [480], description: 'Added aws.step_functions.state_machine.arn attribute' }],
   },
   blocked_main_thread: {
     brief: 'Whether the main thread was blocked by the span.',
@@ -26579,6 +26852,7 @@ export type Attributes = {
   [AWS_DYNAMODB_TABLE_COUNT]?: AWS_DYNAMODB_TABLE_COUNT_TYPE;
   [AWS_DYNAMODB_TABLE_NAMES]?: AWS_DYNAMODB_TABLE_NAMES_TYPE;
   [AWS_DYNAMODB_TOTAL_SEGMENTS]?: AWS_DYNAMODB_TOTAL_SEGMENTS_TYPE;
+  [AWS_KINESIS_STREAM_NAME]?: AWS_KINESIS_STREAM_NAME_TYPE;
   [AWS_LAMBDA_AWS_REQUEST_ID]?: AWS_LAMBDA_AWS_REQUEST_ID_TYPE;
   [AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS]?: AWS_LAMBDA_EXECUTION_DURATION_IN_MILLIS_TYPE;
   [AWS_LAMBDA_FUNCTION_NAME]?: AWS_LAMBDA_FUNCTION_NAME_TYPE;
@@ -26588,6 +26862,13 @@ export type Attributes = {
   [AWS_LAMBDA_REMAINING_TIME_IN_MILLIS]?: AWS_LAMBDA_REMAINING_TIME_IN_MILLIS_TYPE;
   [AWS_LOG_GROUP_NAMES]?: AWS_LOG_GROUP_NAMES_TYPE;
   [AWS_LOG_STREAM_NAMES]?: AWS_LOG_STREAM_NAMES_TYPE;
+  [AWS_REQUEST_EXTENDED_ID]?: AWS_REQUEST_EXTENDED_ID_TYPE;
+  [AWS_REQUEST_ID]?: AWS_REQUEST_ID_TYPE;
+  [AWS_S3_BUCKET]?: AWS_S3_BUCKET_TYPE;
+  [AWS_SECRETSMANAGER_SECRET_ARN]?: AWS_SECRETSMANAGER_SECRET_ARN_TYPE;
+  [AWS_SNS_TOPIC_ARN]?: AWS_SNS_TOPIC_ARN_TYPE;
+  [AWS_STEP_FUNCTIONS_ACTIVITY_ARN]?: AWS_STEP_FUNCTIONS_ACTIVITY_ARN_TYPE;
+  [AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN]?: AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN_TYPE;
   [BLOCKED_MAIN_THREAD]?: BLOCKED_MAIN_THREAD_TYPE;
   [BROWSER_NAME]?: BROWSER_NAME_TYPE;
   [BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START]?: BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START_TYPE;

--- a/model/attributes/aws/aws__extended_request_id.json
+++ b/model/attributes/aws/aws__extended_request_id.json
@@ -1,0 +1,19 @@
+{
+  "key": "aws.extended_request_id",
+  "brief": "The AWS extended request ID as returned in the response headers.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=",
+  "alias": ["aws.request.extended_id"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [480],
+      "description": "Added aws.extended_request_id attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__kinesis__stream__name.json
+++ b/model/attributes/aws/aws__kinesis__stream__name.json
@@ -7,12 +7,18 @@
   },
   "is_in_otel": false,
   "example": "some-stream-name",
+  "alias": ["aws.kinesis.stream_name"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "aws.kinesis.stream_name",
+    "reason": "This attribute is being deprecated in favor of aws.kinesis.stream_name, which is the OTel-aligned replacement."
+  },
   "visibility": "public",
   "changelog": [
     {
       "version": "next",
       "prs": [480],
-      "description": "Added aws.kinesis.stream.name attribute"
+      "description": "Added aws.kinesis.stream.name attribute, deprecated in favor of aws.kinesis.stream_name"
     }
   ]
 }

--- a/model/attributes/aws/aws__kinesis__stream__name.json
+++ b/model/attributes/aws/aws__kinesis__stream__name.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.kinesis.stream.name",
+  "brief": "The name of the AWS Kinesis stream the request refers to.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": "some-stream-name",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [480],
+      "description": "Added aws.kinesis.stream.name attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__kinesis__stream_name.json
+++ b/model/attributes/aws/aws__kinesis__stream_name.json
@@ -1,0 +1,19 @@
+{
+  "key": "aws.kinesis.stream_name",
+  "brief": "The name of the AWS Kinesis stream the request refers to.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "some-stream-name",
+  "alias": ["aws.kinesis.stream.name"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [480],
+      "description": "Added aws.kinesis.stream_name attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__request__extended_id.json
+++ b/model/attributes/aws/aws__request__extended_id.json
@@ -7,12 +7,18 @@
   },
   "is_in_otel": false,
   "example": "wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=",
+  "alias": ["aws.extended_request_id"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "aws.extended_request_id",
+    "reason": "This attribute is being deprecated in favor of aws.extended_request_id, which is the OTel-aligned replacement."
+  },
   "visibility": "public",
   "changelog": [
     {
       "version": "next",
       "prs": [480],
-      "description": "Added aws.request.extended_id attribute"
+      "description": "Added aws.request.extended_id attribute, deprecated in favor of aws.extended_request_id"
     }
   ]
 }

--- a/model/attributes/aws/aws__request__extended_id.json
+++ b/model/attributes/aws/aws__request__extended_id.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.request.extended_id",
+  "brief": "The AWS extended request ID as returned in the response headers.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": "wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [480],
+      "description": "Added aws.request.extended_id attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__request__id.json
+++ b/model/attributes/aws/aws__request__id.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.request.id",
+  "brief": "The AWS request ID as returned in the response headers.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": "79b9da39-b7ae-508a-a6bc-864b2829c622",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [480],
+      "description": "Added aws.request.id attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__request__id.json
+++ b/model/attributes/aws/aws__request__id.json
@@ -7,12 +7,18 @@
   },
   "is_in_otel": false,
   "example": "79b9da39-b7ae-508a-a6bc-864b2829c622",
+  "alias": ["aws.request_id"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "aws.request_id",
+    "reason": "This attribute is being deprecated in favor of aws.request_id, which is the OTel-aligned replacement."
+  },
   "visibility": "public",
   "changelog": [
     {
       "version": "next",
       "prs": [480],
-      "description": "Added aws.request.id attribute"
+      "description": "Added aws.request.id attribute, deprecated in favor of aws.request_id"
     }
   ]
 }

--- a/model/attributes/aws/aws__request_id.json
+++ b/model/attributes/aws/aws__request_id.json
@@ -1,0 +1,19 @@
+{
+  "key": "aws.request_id",
+  "brief": "The AWS request ID as returned in the response headers.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "79b9da39-b7ae-508a-a6bc-864b2829c622",
+  "alias": ["aws.request.id"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [480],
+      "description": "Added aws.request_id attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__s3__bucket.json
+++ b/model/attributes/aws/aws__s3__bucket.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.s3.bucket",
+  "brief": "The S3 bucket name the request refers to.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "ot-demo-test",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [480],
+      "description": "Added aws.s3.bucket attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__secretsmanager__secret__arn.json
+++ b/model/attributes/aws/aws__secretsmanager__secret__arn.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.secretsmanager.secret.arn",
+  "brief": "The ARN of the Secret stored in Secrets Manager.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "arn:aws:secretsmanager:us-east-1:123456789012:secret:SecretName-6RandomCharacters",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [480],
+      "description": "Added aws.secretsmanager.secret.arn attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__sns__topic__arn.json
+++ b/model/attributes/aws/aws__sns__topic__arn.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.sns.topic.arn",
+  "brief": "The ARN of the AWS SNS Topic. An Amazon SNS topic is a logical access point that acts as a communication channel.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [480],
+      "description": "Added aws.sns.topic.arn attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__step_functions__activity__arn.json
+++ b/model/attributes/aws/aws__step_functions__activity__arn.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.step_functions.activity.arn",
+  "brief": "The ARN of the AWS Step Functions Activity.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "arn:aws:states:us-east-1:123456789012:activity:get-greeting",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [480],
+      "description": "Added aws.step_functions.activity.arn attribute"
+    }
+  ]
+}

--- a/model/attributes/aws/aws__step_functions__state_machine__arn.json
+++ b/model/attributes/aws/aws__step_functions__state_machine__arn.json
@@ -1,0 +1,18 @@
+{
+  "key": "aws.step_functions.state_machine.arn",
+  "brief": "The ARN of the AWS Step Functions State Machine.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine:1",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [480],
+      "description": "Added aws.step_functions.state_machine.arn attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -152,10 +152,13 @@ class _AttributeNamesMeta(type):
         "APP_START_COLD",
         "APP_START_TYPE",
         "APP_START_WARM",
+        "_AWS_KINESIS_STREAM_NAME",
         "AWS_LAMBDA_AWS_REQUEST_ID",
         "AWS_LAMBDA_FUNCTION_NAME",
         "AWS_LAMBDA_FUNCTION_VERSION",
         "AWS_LAMBDA_INVOKED_FUNCTION_ARN",
+        "AWS_REQUEST_EXTENDED_ID",
+        "_AWS_REQUEST_ID",
         "CLOUDFLARE_D1_QUERY_TYPE",
         "CLS_SOURCE_KEY",
         "CLS",
@@ -1491,8 +1494,22 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 100
     """
 
+    # Path: model/attributes/aws/aws__extended_request_id.json
+    AWS_EXTENDED_REQUEST_ID: Literal["aws.extended_request_id"] = (
+        "aws.extended_request_id"
+    )
+    """The AWS extended request ID as returned in the response headers.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Aliases: aws.request.extended_id
+    Example: "wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ="
+    """
+
     # Path: model/attributes/aws/aws__kinesis__stream__name.json
-    AWS_KINESIS_STREAM_NAME: Literal["aws.kinesis.stream.name"] = (
+    _AWS_KINESIS_STREAM_NAME: Literal["aws.kinesis.stream.name"] = (
         "aws.kinesis.stream.name"
     )
     """The name of the AWS Kinesis stream the request refers to.
@@ -1501,6 +1518,22 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
+    Aliases: aws.kinesis.stream_name
+    DEPRECATED: Use aws.kinesis.stream_name instead - This attribute is being deprecated in favor of aws.kinesis.stream_name, which is the OTel-aligned replacement.
+    Example: "some-stream-name"
+    """
+
+    # Path: model/attributes/aws/aws__kinesis__stream_name.json
+    AWS_KINESIS_STREAM_NAME: Literal["aws.kinesis.stream_name"] = (
+        "aws.kinesis.stream_name"
+    )
+    """The name of the AWS Kinesis stream the request refers to.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Aliases: aws.kinesis.stream.name
     Example: "some-stream-name"
     """
 
@@ -1634,17 +1667,33 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
+    Aliases: aws.extended_request_id
+    DEPRECATED: Use aws.extended_request_id instead - This attribute is being deprecated in favor of aws.extended_request_id, which is the OTel-aligned replacement.
     Example: "wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ="
     """
 
     # Path: model/attributes/aws/aws__request__id.json
-    AWS_REQUEST_ID: Literal["aws.request.id"] = "aws.request.id"
+    _AWS_REQUEST_ID: Literal["aws.request.id"] = "aws.request.id"
     """The AWS request ID as returned in the response headers.
 
     Type: str
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
+    Aliases: aws.request_id
+    DEPRECATED: Use aws.request_id instead - This attribute is being deprecated in favor of aws.request_id, which is the OTel-aligned replacement.
+    Example: "79b9da39-b7ae-508a-a6bc-864b2829c622"
+    """
+
+    # Path: model/attributes/aws/aws__request_id.json
+    AWS_REQUEST_ID: Literal["aws.request_id"] = "aws.request_id"
+    """The AWS request ID as returned in the response headers.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Aliases: aws.request.id
     Example: "79b9da39-b7ae-508a-a6bc-864b2829c622"
     """
 
@@ -10550,6 +10599,22 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "aws.extended_request_id": AttributeMetadata(
+        brief="The AWS extended request ID as returned in the response headers.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=",
+        aliases=["aws.request.extended_id"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[480],
+                description="Added aws.extended_request_id attribute",
+            ),
+        ],
+    ),
     "aws.kinesis.stream.name": AttributeMetadata(
         brief="The name of the AWS Kinesis stream the request refers to.",
         type=AttributeType.STRING,
@@ -10557,11 +10622,33 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="some-stream-name",
+        deprecation=DeprecationInfo(
+            replacement="aws.kinesis.stream_name",
+            reason="This attribute is being deprecated in favor of aws.kinesis.stream_name, which is the OTel-aligned replacement.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["aws.kinesis.stream_name"],
         changelog=[
             ChangelogEntry(
                 version="next",
                 prs=[480],
-                description="Added aws.kinesis.stream.name attribute",
+                description="Added aws.kinesis.stream.name attribute, deprecated in favor of aws.kinesis.stream_name",
+            ),
+        ],
+    ),
+    "aws.kinesis.stream_name": AttributeMetadata(
+        brief="The name of the AWS Kinesis stream the request refers to.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="some-stream-name",
+        aliases=["aws.kinesis.stream.name"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[480],
+                description="Added aws.kinesis.stream_name attribute",
             ),
         ],
     ),
@@ -10745,11 +10832,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=",
+        deprecation=DeprecationInfo(
+            replacement="aws.extended_request_id",
+            reason="This attribute is being deprecated in favor of aws.extended_request_id, which is the OTel-aligned replacement.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["aws.extended_request_id"],
         changelog=[
             ChangelogEntry(
                 version="next",
                 prs=[480],
-                description="Added aws.request.extended_id attribute",
+                description="Added aws.request.extended_id attribute, deprecated in favor of aws.extended_request_id",
             ),
         ],
     ),
@@ -10760,9 +10853,31 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="79b9da39-b7ae-508a-a6bc-864b2829c622",
+        deprecation=DeprecationInfo(
+            replacement="aws.request_id",
+            reason="This attribute is being deprecated in favor of aws.request_id, which is the OTel-aligned replacement.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["aws.request_id"],
         changelog=[
             ChangelogEntry(
-                version="next", prs=[480], description="Added aws.request.id attribute"
+                version="next",
+                prs=[480],
+                description="Added aws.request.id attribute, deprecated in favor of aws.request_id",
+            ),
+        ],
+    ),
+    "aws.request_id": AttributeMetadata(
+        brief="The AWS request ID as returned in the response headers.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="79b9da39-b7ae-508a-a6bc-864b2829c622",
+        aliases=["aws.request.id"],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[480], description="Added aws.request_id attribute"
             ),
         ],
     ),
@@ -19350,7 +19465,9 @@ Attributes = TypedDict(
         "aws.dynamodb.table_count": int,
         "aws.dynamodb.table_names": List[str],
         "aws.dynamodb.total_segments": int,
+        "aws.extended_request_id": str,
         "aws.kinesis.stream.name": str,
+        "aws.kinesis.stream_name": str,
         "aws.lambda.aws_request_id": str,
         "aws.lambda.execution_duration_in_millis": float,
         "aws.lambda.function_name": str,
@@ -19362,6 +19479,7 @@ Attributes = TypedDict(
         "aws.log.stream.names": List[str],
         "aws.request.extended_id": str,
         "aws.request.id": str,
+        "aws.request_id": str,
         "aws.s3.bucket": str,
         "aws.secretsmanager.secret.arn": str,
         "aws.sns.topic.arn": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1491,6 +1491,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 100
     """
 
+    # Path: model/attributes/aws/aws__kinesis__stream__name.json
+    AWS_KINESIS_STREAM_NAME: Literal["aws.kinesis.stream.name"] = (
+        "aws.kinesis.stream.name"
+    )
+    """The name of the AWS Kinesis stream the request refers to.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "some-stream-name"
+    """
+
     # Path: model/attributes/aws/aws__lambda__aws_request_id.json
     AWS_LAMBDA_AWS_REQUEST_ID: Literal["aws.lambda.aws_request_id"] = (
         "aws.lambda.aws_request_id"
@@ -1609,6 +1622,91 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Example: ["logs/main/10838bed-421f-43ef-870a-f43feacbbb5b"]
+    """
+
+    # Path: model/attributes/aws/aws__request__extended_id.json
+    AWS_REQUEST_EXTENDED_ID: Literal["aws.request.extended_id"] = (
+        "aws.request.extended_id"
+    )
+    """The AWS extended request ID as returned in the response headers.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ="
+    """
+
+    # Path: model/attributes/aws/aws__request__id.json
+    AWS_REQUEST_ID: Literal["aws.request.id"] = "aws.request.id"
+    """The AWS request ID as returned in the response headers.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "79b9da39-b7ae-508a-a6bc-864b2829c622"
+    """
+
+    # Path: model/attributes/aws/aws__s3__bucket.json
+    AWS_S3_BUCKET: Literal["aws.s3.bucket"] = "aws.s3.bucket"
+    """The S3 bucket name the request refers to.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "ot-demo-test"
+    """
+
+    # Path: model/attributes/aws/aws__secretsmanager__secret__arn.json
+    AWS_SECRETSMANAGER_SECRET_ARN: Literal["aws.secretsmanager.secret.arn"] = (
+        "aws.secretsmanager.secret.arn"
+    )
+    """The ARN of the Secret stored in Secrets Manager.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "arn:aws:secretsmanager:us-east-1:123456789012:secret:SecretName-6RandomCharacters"
+    """
+
+    # Path: model/attributes/aws/aws__sns__topic__arn.json
+    AWS_SNS_TOPIC_ARN: Literal["aws.sns.topic.arn"] = "aws.sns.topic.arn"
+    """The ARN of the AWS SNS Topic. An Amazon SNS topic is a logical access point that acts as a communication channel.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE"
+    """
+
+    # Path: model/attributes/aws/aws__step_functions__activity__arn.json
+    AWS_STEP_FUNCTIONS_ACTIVITY_ARN: Literal["aws.step_functions.activity.arn"] = (
+        "aws.step_functions.activity.arn"
+    )
+    """The ARN of the AWS Step Functions Activity.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "arn:aws:states:us-east-1:123456789012:activity:get-greeting"
+    """
+
+    # Path: model/attributes/aws/aws__step_functions__state_machine__arn.json
+    AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN: Literal[
+        "aws.step_functions.state_machine.arn"
+    ] = "aws.step_functions.state_machine.arn"
+    """The ARN of the AWS Step Functions State Machine.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine:1"
     """
 
     # Path: model/attributes/blocked_main_thread.json
@@ -10452,6 +10550,21 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "aws.kinesis.stream.name": AttributeMetadata(
+        brief="The name of the AWS Kinesis stream the request refers to.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="some-stream-name",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[480],
+                description="Added aws.kinesis.stream.name attribute",
+            ),
+        ],
+    ),
     "aws.lambda.aws_request_id": AttributeMetadata(
         brief="The AWS request ID as received by the Lambda function runtime",
         type=AttributeType.STRING,
@@ -10623,6 +10736,107 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=["logs/main/10838bed-421f-43ef-870a-f43feacbbb5b"],
         changelog=[
             ChangelogEntry(version="0.11.1", prs=[414]),
+        ],
+    ),
+    "aws.request.extended_id": AttributeMetadata(
+        brief="The AWS extended request ID as returned in the response headers.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="wzHcyEWfmOGDIE5QOhTAqFDoDWP3y8IUvpNINCwL9N4TEHbUw0/gZJ+VZTmCNCWR7fezEN3eCiQ=",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[480],
+                description="Added aws.request.extended_id attribute",
+            ),
+        ],
+    ),
+    "aws.request.id": AttributeMetadata(
+        brief="The AWS request ID as returned in the response headers.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="79b9da39-b7ae-508a-a6bc-864b2829c622",
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[480], description="Added aws.request.id attribute"
+            ),
+        ],
+    ),
+    "aws.s3.bucket": AttributeMetadata(
+        brief="The S3 bucket name the request refers to.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="ot-demo-test",
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[480], description="Added aws.s3.bucket attribute"
+            ),
+        ],
+    ),
+    "aws.secretsmanager.secret.arn": AttributeMetadata(
+        brief="The ARN of the Secret stored in Secrets Manager.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="arn:aws:secretsmanager:us-east-1:123456789012:secret:SecretName-6RandomCharacters",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[480],
+                description="Added aws.secretsmanager.secret.arn attribute",
+            ),
+        ],
+    ),
+    "aws.sns.topic.arn": AttributeMetadata(
+        brief="The ARN of the AWS SNS Topic. An Amazon SNS topic is a logical access point that acts as a communication channel.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[480],
+                description="Added aws.sns.topic.arn attribute",
+            ),
+        ],
+    ),
+    "aws.step_functions.activity.arn": AttributeMetadata(
+        brief="The ARN of the AWS Step Functions Activity.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="arn:aws:states:us-east-1:123456789012:activity:get-greeting",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[480],
+                description="Added aws.step_functions.activity.arn attribute",
+            ),
+        ],
+    ),
+    "aws.step_functions.state_machine.arn": AttributeMetadata(
+        brief="The ARN of the AWS Step Functions State Machine.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine:1",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[480],
+                description="Added aws.step_functions.state_machine.arn attribute",
+            ),
         ],
     ),
     "blocked_main_thread": AttributeMetadata(
@@ -19136,6 +19350,7 @@ Attributes = TypedDict(
         "aws.dynamodb.table_count": int,
         "aws.dynamodb.table_names": List[str],
         "aws.dynamodb.total_segments": int,
+        "aws.kinesis.stream.name": str,
         "aws.lambda.aws_request_id": str,
         "aws.lambda.execution_duration_in_millis": float,
         "aws.lambda.function_name": str,
@@ -19145,6 +19360,13 @@ Attributes = TypedDict(
         "aws.lambda.remaining_time_in_millis": float,
         "aws.log.group.names": List[str],
         "aws.log.stream.names": List[str],
+        "aws.request.extended_id": str,
+        "aws.request.id": str,
+        "aws.s3.bucket": str,
+        "aws.secretsmanager.secret.arn": str,
+        "aws.sns.topic.arn": str,
+        "aws.step_functions.activity.arn": str,
+        "aws.step_functions.state_machine.arn": str,
         "blocked_main_thread": bool,
         "browser.name": str,
         "browser.performance.navigation.activation_start": float,


### PR DESCRIPTION
Adds AWS SDK service attributes: `aws.kinesis.stream.name`, `aws.request.id`, `aws.request.extended_id`, `aws.s3.bucket`, `aws.secretsmanager.secret.arn`, `aws.sns.topic.arn`, `aws.step_functions.activity.arn`, `aws.step_functions.state_machine.arn`.


OTel aws sem convs can be found at: https://opentelemetry.io/docs/specs/semconv/registry/attributes/aws/