### PR TITLE
feat(attributes): Add faas.invoked_* attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -5169,6 +5169,69 @@ export const FAAS_INVOCATION_ID = 'faas.invocation_id';
  */
 export type FAAS_INVOCATION_ID_TYPE = string;
 
+// Path: model/attributes/faas/faas__invoked_name.json
+
+/**
+ * The name of the invoked function. `faas.invoked_name`
+ *
+ * Attribute Value Type: `string` {@link FAAS_INVOKED_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "my-function"
+ */
+export const FAAS_INVOKED_NAME = 'faas.invoked_name';
+
+/**
+ * Type for {@link FAAS_INVOKED_NAME} faas.invoked_name
+ */
+export type FAAS_INVOKED_NAME_TYPE = string;
+
+// Path: model/attributes/faas/faas__invoked_provider.json
+
+/**
+ * The cloud provider of the invoked function. `faas.invoked_provider`
+ *
+ * Attribute Value Type: `string` {@link FAAS_INVOKED_PROVIDER_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "aws"
+ */
+export const FAAS_INVOKED_PROVIDER = 'faas.invoked_provider';
+
+/**
+ * Type for {@link FAAS_INVOKED_PROVIDER} faas.invoked_provider
+ */
+export type FAAS_INVOKED_PROVIDER_TYPE = string;
+
+// Path: model/attributes/faas/faas__invoked_region.json
+
+/**
+ * The cloud region of the invoked function. `faas.invoked_region`
+ *
+ * Attribute Value Type: `string` {@link FAAS_INVOKED_REGION_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "eu-central-1"
+ */
+export const FAAS_INVOKED_REGION = 'faas.invoked_region';
+
+/**
+ * Type for {@link FAAS_INVOKED_REGION} faas.invoked_region
+ */
+export type FAAS_INVOKED_REGION_TYPE = string;
+
 // Path: model/attributes/faas/faas__name.json
 
 /**
@@ -15321,6 +15384,9 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'faas.id': 'string',
   'faas.identity': 'string',
   'faas.invocation_id': 'string',
+  'faas.invoked_name': 'string',
+  'faas.invoked_provider': 'string',
+  'faas.invoked_region': 'string',
   'faas.name': 'string',
   'faas.time': 'string',
   'faas.trigger': 'string',
@@ -16003,6 +16069,9 @@ export type AttributeName =
   | typeof FAAS_ID
   | typeof FAAS_IDENTITY
   | typeof FAAS_INVOCATION_ID
+  | typeof FAAS_INVOKED_NAME
+  | typeof FAAS_INVOKED_PROVIDER
+  | typeof FAAS_INVOKED_REGION
   | typeof FAAS_NAME
   | typeof FAAS_TIME
   | typeof FAAS_TRIGGER
@@ -19540,6 +19609,39 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: 'next', prs: [473], description: 'Added faas.execution as an alias' },
       { version: '0.11.1', prs: [414, 424] },
     ],
+  },
+  'faas.invoked_name': {
+    brief: 'The name of the invoked function.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'my-function',
+    changelog: [{ version: 'next', prs: [481], description: 'Added faas.invoked_name attribute' }],
+  },
+  'faas.invoked_provider': {
+    brief: 'The cloud provider of the invoked function.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'aws',
+    changelog: [{ version: 'next', prs: [481], description: 'Added faas.invoked_provider attribute' }],
+  },
+  'faas.invoked_region': {
+    brief: 'The cloud region of the invoked function.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'eu-central-1',
+    changelog: [{ version: 'next', prs: [481], description: 'Added faas.invoked_region attribute' }],
   },
   'faas.name': {
     brief: 'The name of the serverless function',
@@ -25713,6 +25815,9 @@ export type Attributes = {
   [FAAS_ID]?: FAAS_ID_TYPE;
   [FAAS_IDENTITY]?: FAAS_IDENTITY_TYPE;
   [FAAS_INVOCATION_ID]?: FAAS_INVOCATION_ID_TYPE;
+  [FAAS_INVOKED_NAME]?: FAAS_INVOKED_NAME_TYPE;
+  [FAAS_INVOKED_PROVIDER]?: FAAS_INVOKED_PROVIDER_TYPE;
+  [FAAS_INVOKED_REGION]?: FAAS_INVOKED_REGION_TYPE;
   [FAAS_NAME]?: FAAS_NAME_TYPE;
   [FAAS_TIME]?: FAAS_TIME_TYPE;
   [FAAS_TRIGGER]?: FAAS_TRIGGER_TYPE;

--- a/model/attributes/faas/faas__invoked_name.json
+++ b/model/attributes/faas/faas__invoked_name.json
@@ -1,0 +1,18 @@
+{
+  "key": "faas.invoked_name",
+  "brief": "The name of the invoked function.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "my-function",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [481],
+      "description": "Added faas.invoked_name attribute"
+    }
+  ]
+}

--- a/model/attributes/faas/faas__invoked_provider.json
+++ b/model/attributes/faas/faas__invoked_provider.json
@@ -1,0 +1,18 @@
+{
+  "key": "faas.invoked_provider",
+  "brief": "The cloud provider of the invoked function.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "aws",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [481],
+      "description": "Added faas.invoked_provider attribute"
+    }
+  ]
+}

--- a/model/attributes/faas/faas__invoked_region.json
+++ b/model/attributes/faas/faas__invoked_region.json
@@ -1,0 +1,18 @@
+{
+  "key": "faas.invoked_region",
+  "brief": "The cloud region of the invoked function.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "eu-central-1",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [481],
+      "description": "Added faas.invoked_region attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3163,6 +3163,39 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
     """
 
+    # Path: model/attributes/faas/faas__invoked_name.json
+    FAAS_INVOKED_NAME: Literal["faas.invoked_name"] = "faas.invoked_name"
+    """The name of the invoked function.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "my-function"
+    """
+
+    # Path: model/attributes/faas/faas__invoked_provider.json
+    FAAS_INVOKED_PROVIDER: Literal["faas.invoked_provider"] = "faas.invoked_provider"
+    """The cloud provider of the invoked function.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "aws"
+    """
+
+    # Path: model/attributes/faas/faas__invoked_region.json
+    FAAS_INVOKED_REGION: Literal["faas.invoked_region"] = "faas.invoked_region"
+    """The cloud region of the invoked function.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "eu-central-1"
+    """
+
     # Path: model/attributes/faas/faas__name.json
     FAAS_NAME: Literal["faas.name"] = "faas.name"
     """The name of the serverless function
@@ -12038,6 +12071,51 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.11.1", prs=[414, 424]),
         ],
     ),
+    "faas.invoked_name": AttributeMetadata(
+        brief="The name of the invoked function.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="my-function",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[481],
+                description="Added faas.invoked_name attribute",
+            ),
+        ],
+    ),
+    "faas.invoked_provider": AttributeMetadata(
+        brief="The cloud provider of the invoked function.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="aws",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[481],
+                description="Added faas.invoked_provider attribute",
+            ),
+        ],
+    ),
+    "faas.invoked_region": AttributeMetadata(
+        brief="The cloud region of the invoked function.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="eu-central-1",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[481],
+                description="Added faas.invoked_region attribute",
+            ),
+        ],
+    ),
     "faas.name": AttributeMetadata(
         brief="The name of the serverless function",
         type=AttributeType.STRING,
@@ -18477,6 +18555,9 @@ Attributes = TypedDict(
         "faas.id": str,
         "faas.identity": str,
         "faas.invocation_id": str,
+        "faas.invoked_name": str,
+        "faas.invoked_provider": str,
+        "faas.invoked_region": str,
         "faas.name": str,
         "faas.time": str,
         "faas.trigger": str,


### PR DESCRIPTION
Adds the `faas.*` attributes emitted by the vendored JS AWS SDK instrumentation.

- invoked_name
- invoked_provider
- invoked_region

OTel sem conv for `faas.*` can be found at: https://opentelemetry.io/docs/specs/semconv/registry/attributes/faas/