### PR TITLE
feat(attributes): Add messaging, rpc and gen_ai attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -11378,9 +11378,12 @@ export type RPC_SERVICE_TYPE = string;
  *
  * Apply Scrubbing: manual
  *
- * Attribute defined in OTEL: Yes
+ * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link RPC_SYSTEM_NAME} `rpc.system.name`
+ *
+ * @deprecated Use {@link RPC_SYSTEM_NAME} (rpc.system.name) instead - This attribute is being deprecated in favor of rpc.system.name, which is the OTel-aligned replacement.
  * @example "aws-api"
  */
 export const RPC_SYSTEM = 'rpc.system';
@@ -11389,6 +11392,29 @@ export const RPC_SYSTEM = 'rpc.system';
  * Type for {@link RPC_SYSTEM} rpc.system
  */
 export type RPC_SYSTEM_TYPE = string;
+
+// Path: model/attributes/rpc/rpc__system__name.json
+
+/**
+ * A string identifying the remoting system. `rpc.system.name`
+ *
+ * Attribute Value Type: `string` {@link RPC_SYSTEM_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * Aliases: {@link RPC_SYSTEM} `rpc.system`
+ *
+ * @example "aws-api"
+ */
+export const RPC_SYSTEM_NAME = 'rpc.system.name';
+
+/**
+ * Type for {@link RPC_SYSTEM_NAME} rpc.system.name
+ */
+export type RPC_SYSTEM_NAME_TYPE = string;
 
 // Path: model/attributes/runtime/runtime__build.json
 
@@ -15668,6 +15694,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'rpc.response.status_code': 'string',
   'rpc.service': 'string',
   'rpc.system': 'string',
+  'rpc.system.name': 'string',
   'runtime.build': 'string',
   'runtime.name': 'string',
   'runtime.raw_description': 'string',
@@ -16353,6 +16380,7 @@ export type AttributeName =
   | typeof RPC_RESPONSE_STATUS_CODE
   | typeof RPC_SERVICE
   | typeof RPC_SYSTEM
+  | typeof RPC_SYSTEM_NAME
   | typeof RUNTIME_BUILD
   | typeof RUNTIME_NAME
   | typeof RUNTIME_RAW_DESCRIPTION
@@ -23500,10 +23528,33 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     applyScrubbing: {
       key: 'manual',
     },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'aws-api',
+    deprecation: {
+      replacement: 'rpc.system.name',
+      reason: 'This attribute is being deprecated in favor of rpc.system.name, which is the OTel-aligned replacement.',
+    },
+    aliases: ['rpc.system.name'],
+    changelog: [
+      {
+        version: 'next',
+        prs: [482],
+        description: 'Added rpc.system attribute, deprecated in favor of rpc.system.name',
+      },
+    ],
+  },
+  'rpc.system.name': {
+    brief: 'A string identifying the remoting system.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
     isInOtel: true,
     visibility: 'public',
     example: 'aws-api',
-    changelog: [{ version: 'next', prs: [482], description: 'Added rpc.system attribute' }],
+    aliases: ['rpc.system'],
+    changelog: [{ version: 'next', prs: [482], description: 'Added rpc.system.name attribute' }],
   },
   'runtime.build': {
     brief: 'The application build string, when it is separate from the version.',
@@ -26116,6 +26167,7 @@ export type Attributes = {
   [RPC_RESPONSE_STATUS_CODE]?: RPC_RESPONSE_STATUS_CODE_TYPE;
   [RPC_SERVICE]?: RPC_SERVICE_TYPE;
   [RPC_SYSTEM]?: RPC_SYSTEM_TYPE;
+  [RPC_SYSTEM_NAME]?: RPC_SYSTEM_NAME_TYPE;
   [RUNTIME_BUILD]?: RUNTIME_BUILD_TYPE;
   [RUNTIME_NAME]?: RUNTIME_NAME_TYPE;
   [RUNTIME_RAW_DESCRIPTION]?: RUNTIME_RAW_DESCRIPTION_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -11378,7 +11378,7 @@ export type RPC_SERVICE_TYPE = string;
  *
  * Apply Scrubbing: manual
  *
- * Attribute defined in OTEL: No
+ * Attribute defined in OTEL: Yes
  * Visibility: public
  *
  * Aliases: {@link RPC_SYSTEM_NAME} `rpc.system.name`
@@ -23528,7 +23528,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     applyScrubbing: {
       key: 'manual',
     },
-    isInOtel: false,
+    isInOtel: true,
     visibility: 'public',
     example: 'aws-api',
     deprecation: {

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -6308,6 +6308,27 @@ export const GEN_AI_REQUEST_SEED = 'gen_ai.request.seed';
  */
 export type GEN_AI_REQUEST_SEED_TYPE = string;
 
+// Path: model/attributes/gen_ai/gen_ai__request__stop_sequences.json
+
+/**
+ * List of sequences that the model will use to stop generating further tokens. `gen_ai.request.stop_sequences`
+ *
+ * Attribute Value Type: `Array<string>` {@link GEN_AI_REQUEST_STOP_SEQUENCES_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example ["forest","lived"]
+ */
+export const GEN_AI_REQUEST_STOP_SEQUENCES = 'gen_ai.request.stop_sequences';
+
+/**
+ * Type for {@link GEN_AI_REQUEST_STOP_SEQUENCES} gen_ai.request.stop_sequences
+ */
+export type GEN_AI_REQUEST_STOP_SEQUENCES_TYPE = Array<string>;
+
 // Path: model/attributes/gen_ai/gen_ai__request__temperature.json
 
 /**
@@ -9403,6 +9424,30 @@ export const MESSAGING_BATCH_MESSAGE_COUNT = 'messaging.batch.message_count';
  */
 export type MESSAGING_BATCH_MESSAGE_COUNT_TYPE = number;
 
+// Path: model/attributes/messaging/messaging__destination.json
+
+/**
+ * The message destination name. `messaging.destination`
+ *
+ * Attribute Value Type: `string` {@link MESSAGING_DESTINATION_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link MESSAGING_DESTINATION_NAME} `messaging.destination.name`
+ *
+ * @deprecated Use {@link MESSAGING_DESTINATION_NAME} (messaging.destination.name) instead - This attribute is being deprecated in favor of messaging.destination.name, which is the OTel-aligned replacement.
+ * @example "BestTopic"
+ */
+export const MESSAGING_DESTINATION = 'messaging.destination';
+
+/**
+ * Type for {@link MESSAGING_DESTINATION} messaging.destination
+ */
+export type MESSAGING_DESTINATION_TYPE = string;
+
 // Path: model/attributes/messaging/messaging__destination__connection.json
 
 /**
@@ -9435,6 +9480,8 @@ export type MESSAGING_DESTINATION_CONNECTION_TYPE = string;
  *
  * Attribute defined in OTEL: Yes
  * Visibility: public
+ *
+ * Aliases: {@link MESSAGING_DESTINATION} `messaging.destination`
  *
  * @example "BestTopic"
  */
@@ -11321,6 +11368,27 @@ export const RPC_SERVICE = 'rpc.service';
  * Type for {@link RPC_SERVICE} rpc.service
  */
 export type RPC_SERVICE_TYPE = string;
+
+// Path: model/attributes/rpc/rpc__system.json
+
+/**
+ * A string identifying the remoting system. `rpc.system`
+ *
+ * Attribute Value Type: `string` {@link RPC_SYSTEM_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "aws-api"
+ */
+export const RPC_SYSTEM = 'rpc.system';
+
+/**
+ * Type for {@link RPC_SYSTEM} rpc.system
+ */
+export type RPC_SYSTEM_TYPE = string;
 
 // Path: model/attributes/runtime/runtime__build.json
 
@@ -15373,6 +15441,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'gen_ai.request.presence_penalty': 'double',
   'gen_ai.request.reasoning_effort': 'string',
   'gen_ai.request.seed': 'string',
+  'gen_ai.request.stop_sequences': 'string[]',
   'gen_ai.request.temperature': 'double',
   'gen_ai.request.top_k': 'integer',
   'gen_ai.request.top_p': 'double',
@@ -15511,6 +15580,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'mcp.transport': 'string',
   'mdc.<key>': 'string',
   'messaging.batch.message_count': 'integer',
+  'messaging.destination': 'string',
   'messaging.destination.connection': 'string',
   'messaging.destination.name': 'string',
   'messaging.message.body.size': 'integer',
@@ -15597,6 +15667,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'rpc.method': 'string',
   'rpc.response.status_code': 'string',
   'rpc.service': 'string',
+  'rpc.system': 'string',
   'runtime.build': 'string',
   'runtime.name': 'string',
   'runtime.raw_description': 'string',
@@ -16055,6 +16126,7 @@ export type AttributeName =
   | typeof GEN_AI_REQUEST_PRESENCE_PENALTY
   | typeof GEN_AI_REQUEST_REASONING_EFFORT
   | typeof GEN_AI_REQUEST_SEED
+  | typeof GEN_AI_REQUEST_STOP_SEQUENCES
   | typeof GEN_AI_REQUEST_TEMPERATURE
   | typeof GEN_AI_REQUEST_TOP_K
   | typeof GEN_AI_REQUEST_TOP_P
@@ -16193,6 +16265,7 @@ export type AttributeName =
   | typeof MCP_TRANSPORT
   | typeof MDC_KEY
   | typeof MESSAGING_BATCH_MESSAGE_COUNT
+  | typeof MESSAGING_DESTINATION
   | typeof MESSAGING_DESTINATION_CONNECTION
   | typeof MESSAGING_DESTINATION_NAME
   | typeof MESSAGING_MESSAGE_BODY_SIZE
@@ -16279,6 +16352,7 @@ export type AttributeName =
   | typeof RPC_METHOD
   | typeof RPC_RESPONSE_STATUS_CODE
   | typeof RPC_SERVICE
+  | typeof RPC_SYSTEM
   | typeof RUNTIME_BUILD
   | typeof RUNTIME_NAME
   | typeof RUNTIME_RAW_DESCRIPTION
@@ -20270,6 +20344,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: ['ai.seed'],
     changelog: [{ version: '0.1.0', prs: [57, 127] }],
   },
+  'gen_ai.request.stop_sequences': {
+    brief: 'List of sequences that the model will use to stop generating further tokens.',
+    type: 'string[]',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: ['forest', 'lived'],
+    changelog: [{ version: 'next', prs: [482], description: 'Added gen_ai.request.stop_sequences attribute' }],
+  },
   'gen_ai.request.temperature': {
     brief:
       'For an AI model call, the temperature parameter. Temperature essentially means how random the output will be.',
@@ -22272,6 +22357,29 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 10,
     changelog: [{ version: '0.6.0', prs: [341], description: 'Added messaging.batch.message_count attribute' }],
   },
+  'messaging.destination': {
+    brief: 'The message destination name.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'BestTopic',
+    deprecation: {
+      replacement: 'messaging.destination.name',
+      reason:
+        'This attribute is being deprecated in favor of messaging.destination.name, which is the OTel-aligned replacement.',
+    },
+    aliases: ['messaging.destination.name'],
+    changelog: [
+      {
+        version: 'next',
+        prs: [482],
+        description: 'Added messaging.destination attribute, deprecated in favor of messaging.destination.name',
+      },
+    ],
+  },
   'messaging.destination.connection': {
     brief: 'The message destination connection.',
     type: 'string',
@@ -22292,7 +22400,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'BestTopic',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    aliases: ['messaging.destination'],
+    changelog: [
+      { version: 'next', prs: [482], description: 'Added messaging.destination as an alias' },
+      { version: '0.1.0', prs: [127] },
+      { version: '0.0.0' },
+    ],
   },
   'messaging.message.body.size': {
     brief: 'The size of the message body in bytes.',
@@ -23380,6 +23493,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'myService.BestService',
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+  },
+  'rpc.system': {
+    brief: 'A string identifying the remoting system.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'aws-api',
+    changelog: [{ version: 'next', prs: [482], description: 'Added rpc.system attribute' }],
   },
   'runtime.build': {
     brief: 'The application build string, when it is separate from the version.',
@@ -25765,6 +25889,7 @@ export type Attributes = {
   [GEN_AI_REQUEST_PRESENCE_PENALTY]?: GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE;
   [GEN_AI_REQUEST_REASONING_EFFORT]?: GEN_AI_REQUEST_REASONING_EFFORT_TYPE;
   [GEN_AI_REQUEST_SEED]?: GEN_AI_REQUEST_SEED_TYPE;
+  [GEN_AI_REQUEST_STOP_SEQUENCES]?: GEN_AI_REQUEST_STOP_SEQUENCES_TYPE;
   [GEN_AI_REQUEST_TEMPERATURE]?: GEN_AI_REQUEST_TEMPERATURE_TYPE;
   [GEN_AI_REQUEST_TOP_K]?: GEN_AI_REQUEST_TOP_K_TYPE;
   [GEN_AI_REQUEST_TOP_P]?: GEN_AI_REQUEST_TOP_P_TYPE;
@@ -25903,6 +26028,7 @@ export type Attributes = {
   [MCP_TRANSPORT]?: MCP_TRANSPORT_TYPE;
   [MDC_KEY]?: MDC_KEY_TYPE;
   [MESSAGING_BATCH_MESSAGE_COUNT]?: MESSAGING_BATCH_MESSAGE_COUNT_TYPE;
+  [MESSAGING_DESTINATION]?: MESSAGING_DESTINATION_TYPE;
   [MESSAGING_DESTINATION_CONNECTION]?: MESSAGING_DESTINATION_CONNECTION_TYPE;
   [MESSAGING_DESTINATION_NAME]?: MESSAGING_DESTINATION_NAME_TYPE;
   [MESSAGING_MESSAGE_BODY_SIZE]?: MESSAGING_MESSAGE_BODY_SIZE_TYPE;
@@ -25989,6 +26115,7 @@ export type Attributes = {
   [RPC_METHOD]?: RPC_METHOD_TYPE;
   [RPC_RESPONSE_STATUS_CODE]?: RPC_RESPONSE_STATUS_CODE_TYPE;
   [RPC_SERVICE]?: RPC_SERVICE_TYPE;
+  [RPC_SYSTEM]?: RPC_SYSTEM_TYPE;
   [RUNTIME_BUILD]?: RUNTIME_BUILD_TYPE;
   [RUNTIME_NAME]?: RUNTIME_NAME_TYPE;
   [RUNTIME_RAW_DESCRIPTION]?: RUNTIME_RAW_DESCRIPTION_TYPE;

--- a/model/attributes/gen_ai/gen_ai__request__stop_sequences.json
+++ b/model/attributes/gen_ai/gen_ai__request__stop_sequences.json
@@ -1,0 +1,18 @@
+{
+  "key": "gen_ai.request.stop_sequences",
+  "brief": "List of sequences that the model will use to stop generating further tokens.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": ["forest", "lived"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [482],
+      "description": "Added gen_ai.request.stop_sequences attribute"
+    }
+  ]
+}

--- a/model/attributes/messaging/messaging__destination.json
+++ b/model/attributes/messaging/messaging__destination.json
@@ -1,0 +1,24 @@
+{
+  "key": "messaging.destination",
+  "brief": "The message destination name.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": "BestTopic",
+  "alias": ["messaging.destination.name"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "messaging.destination.name",
+    "reason": "This attribute is being deprecated in favor of messaging.destination.name, which is the OTel-aligned replacement."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [482],
+      "description": "Added messaging.destination attribute, deprecated in favor of messaging.destination.name"
+    }
+  ]
+}

--- a/model/attributes/messaging/messaging__destination__name.json
+++ b/model/attributes/messaging/messaging__destination__name.json
@@ -7,8 +7,14 @@
   },
   "is_in_otel": true,
   "example": "BestTopic",
+  "alias": ["messaging.destination"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [482],
+      "description": "Added messaging.destination as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [127]

--- a/model/attributes/rpc/rpc__system.json
+++ b/model/attributes/rpc/rpc__system.json
@@ -5,7 +5,7 @@
   "apply_scrubbing": {
     "key": "manual"
   },
-  "is_in_otel": false,
+  "is_in_otel": true,
   "example": "aws-api",
   "alias": ["rpc.system.name"],
   "deprecation": {

--- a/model/attributes/rpc/rpc__system.json
+++ b/model/attributes/rpc/rpc__system.json
@@ -5,14 +5,20 @@
   "apply_scrubbing": {
     "key": "manual"
   },
-  "is_in_otel": true,
+  "is_in_otel": false,
   "example": "aws-api",
+  "alias": ["rpc.system.name"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "rpc.system.name",
+    "reason": "This attribute is being deprecated in favor of rpc.system.name, which is the OTel-aligned replacement."
+  },
   "visibility": "public",
   "changelog": [
     {
       "version": "next",
       "prs": [482],
-      "description": "Added rpc.system attribute"
+      "description": "Added rpc.system attribute, deprecated in favor of rpc.system.name"
     }
   ]
 }

--- a/model/attributes/rpc/rpc__system.json
+++ b/model/attributes/rpc/rpc__system.json
@@ -1,0 +1,18 @@
+{
+  "key": "rpc.system",
+  "brief": "A string identifying the remoting system.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "aws-api",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [482],
+      "description": "Added rpc.system attribute"
+    }
+  ]
+}

--- a/model/attributes/rpc/rpc__system__name.json
+++ b/model/attributes/rpc/rpc__system__name.json
@@ -1,0 +1,19 @@
+{
+  "key": "rpc.system.name",
+  "brief": "A string identifying the remoting system.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": "aws-api",
+  "alias": ["rpc.system"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [482],
+      "description": "Added rpc.system.name attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -254,6 +254,7 @@ class _AttributeNamesMeta(type):
         "RESOURCE_DEPLOYMENT_ENVIRONMENT",
         "RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME",
         "ROUTE",
+        "RPC_SYSTEM",
         "RUNTIME_BUILD",
         "RUNTIME_NAME",
         "RUNTIME_RAW_DESCRIPTION",
@@ -6650,8 +6651,22 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     Type: str
     Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: rpc.system.name
+    DEPRECATED: Use rpc.system.name instead - This attribute is being deprecated in favor of rpc.system.name, which is the OTel-aligned replacement.
+    Example: "aws-api"
+    """
+
+    # Path: model/attributes/rpc/rpc__system__name.json
+    RPC_SYSTEM_NAME: Literal["rpc.system.name"] = "rpc.system.name"
+    """A string identifying the remoting system.
+
+    Type: str
+    Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: rpc.system
     Example: "aws-api"
     """
 
@@ -16174,12 +16189,34 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="A string identifying the remoting system.",
         type=AttributeType.STRING,
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="aws-api",
+        deprecation=DeprecationInfo(
+            replacement="rpc.system.name",
+            reason="This attribute is being deprecated in favor of rpc.system.name, which is the OTel-aligned replacement.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["rpc.system.name"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[482],
+                description="Added rpc.system attribute, deprecated in favor of rpc.system.name",
+            ),
+        ],
+    ),
+    "rpc.system.name": AttributeMetadata(
+        brief="A string identifying the remoting system.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="aws-api",
+        aliases=["rpc.system"],
         changelog=[
             ChangelogEntry(
-                version="next", prs=[482], description="Added rpc.system attribute"
+                version="next", prs=[482], description="Added rpc.system.name attribute"
             ),
         ],
     ),
@@ -18850,6 +18887,7 @@ Attributes = TypedDict(
         "rpc.response.status_code": str,
         "rpc.service": str,
         "rpc.system": str,
+        "rpc.system.name": str,
         "runtime.build": str,
         "runtime.name": str,
         "runtime.raw_description": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -6651,7 +6651,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     Type: str
     Apply Scrubbing: manual
-    Defined in OTEL: No
+    Defined in OTEL: Yes
     Visibility: public
     Aliases: rpc.system.name
     DEPRECATED: Use rpc.system.name instead - This attribute is being deprecated in favor of rpc.system.name, which is the OTel-aligned replacement.
@@ -16189,7 +16189,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="A string identifying the remoting system.",
         type=AttributeType.STRING,
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
-        is_in_otel=False,
+        is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="aws-api",
         deprecation=DeprecationInfo(

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -227,6 +227,7 @@ class _AttributeNamesMeta(type):
         "MCP_TOOL_RESULT_CONTENT",
         "MCP_TOOL_RESULT_IS_ERROR",
         "MCP_TRANSPORT",
+        "MESSAGING_DESTINATION",
         "METHOD",
         "NET_HOST_IP",
         "NET_HOST_NAME",
@@ -3809,6 +3810,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "1234567890"
     """
 
+    # Path: model/attributes/gen_ai/gen_ai__request__stop_sequences.json
+    GEN_AI_REQUEST_STOP_SEQUENCES: Literal["gen_ai.request.stop_sequences"] = (
+        "gen_ai.request.stop_sequences"
+    )
+    """List of sequences that the model will use to stop generating further tokens.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: ["forest","lived"]
+    """
+
     # Path: model/attributes/gen_ai/gen_ai__request__temperature.json
     GEN_AI_REQUEST_TEMPERATURE: Literal["gen_ai.request.temperature"] = (
         "gen_ai.request.temperature"
@@ -5559,6 +5573,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 10
     """
 
+    # Path: model/attributes/messaging/messaging__destination.json
+    MESSAGING_DESTINATION: Literal["messaging.destination"] = "messaging.destination"
+    """The message destination name.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: messaging.destination.name
+    DEPRECATED: Use messaging.destination.name instead - This attribute is being deprecated in favor of messaging.destination.name, which is the OTel-aligned replacement.
+    Example: "BestTopic"
+    """
+
     # Path: model/attributes/messaging/messaging__destination__connection.json
     MESSAGING_DESTINATION_CONNECTION: Literal["messaging.destination.connection"] = (
         "messaging.destination.connection"
@@ -5582,6 +5609,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: messaging.destination
     Example: "BestTopic"
     """
 
@@ -6614,6 +6642,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Example: "myService.BestService"
+    """
+
+    # Path: model/attributes/rpc/rpc__system.json
+    RPC_SYSTEM: Literal["rpc.system"] = "rpc.system"
+    """A string identifying the remoting system.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "aws-api"
     """
 
     # Path: model/attributes/runtime/runtime__build.json
@@ -12823,6 +12862,21 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[57, 127]),
         ],
     ),
+    "gen_ai.request.stop_sequences": AttributeMetadata(
+        brief="List of sequences that the model will use to stop generating further tokens.",
+        type=AttributeType.STRING_ARRAY,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=["forest", "lived"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[482],
+                description="Added gen_ai.request.stop_sequences attribute",
+            ),
+        ],
+    ),
     "gen_ai.request.temperature": AttributeMetadata(
         brief="For an AI model call, the temperature parameter. Temperature essentially means how random the output will be.",
         type=AttributeType.DOUBLE,
@@ -14921,6 +14975,27 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "messaging.destination": AttributeMetadata(
+        brief="The message destination name.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="BestTopic",
+        deprecation=DeprecationInfo(
+            replacement="messaging.destination.name",
+            reason="This attribute is being deprecated in favor of messaging.destination.name, which is the OTel-aligned replacement.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["messaging.destination.name"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[482],
+                description="Added messaging.destination attribute, deprecated in favor of messaging.destination.name",
+            ),
+        ],
+    ),
     "messaging.destination.connection": AttributeMetadata(
         brief="The message destination connection.",
         type=AttributeType.STRING,
@@ -14940,7 +15015,13 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="BestTopic",
+        aliases=["messaging.destination"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[482],
+                description="Added messaging.destination as an alias",
+            ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -16087,6 +16168,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "rpc.system": AttributeMetadata(
+        brief="A string identifying the remoting system.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="aws-api",
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[482], description="Added rpc.system attribute"
+            ),
         ],
     ),
     "runtime.build": AttributeMetadata(
@@ -18529,6 +18623,7 @@ Attributes = TypedDict(
         "gen_ai.request.presence_penalty": float,
         "gen_ai.request.reasoning_effort": str,
         "gen_ai.request.seed": str,
+        "gen_ai.request.stop_sequences": List[str],
         "gen_ai.request.temperature": float,
         "gen_ai.request.top_k": int,
         "gen_ai.request.top_p": float,
@@ -18667,6 +18762,7 @@ Attributes = TypedDict(
         "mcp.transport": str,
         "mdc.<key>": str,
         "messaging.batch.message_count": int,
+        "messaging.destination": str,
         "messaging.destination.connection": str,
         "messaging.destination.name": str,
         "messaging.message.body.size": int,
@@ -18753,6 +18849,7 @@ Attributes = TypedDict(
         "rpc.method": str,
         "rpc.response.status_code": str,
         "rpc.service": str,
+        "rpc.system": str,
         "runtime.build": str,
         "runtime.name": str,
         "runtime.raw_description": str,


### PR DESCRIPTION
Adds generic OTel semantic-convention attributes: `gen_ai.request.stop_sequences`, `rpc.system`, and `messaging.destination` (deprecated in favor of `messaging.destination.name`).

OTel sem conv sources used:
- https://github.com/open-telemetry/semantic-conventions-genai/blob/63f8200eee093730ce845d26ce2aafb621b0807e/docs/gen-ai/gen-ai-spans.md
- https://opentelemetry.io/docs/specs/semconv/registry/attributes/rpc/
- https://opentelemetry.io/docs/specs/semconv/registry/attributes/messaging/