### PR TITLE
feat(attributes): Add dist (deprecated)

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4798,6 +4798,30 @@ export const DEVICE_USABLE_MEMORY = 'device.usable_memory';
  */
 export type DEVICE_USABLE_MEMORY_TYPE = number;
 
+// Path: model/attributes/dist.json
+
+/**
+ * The sentry dist. `dist`
+ *
+ * Attribute Value Type: `string` {@link DIST_TYPE}
+ *
+ * Apply Scrubbing: never
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link SENTRY_DIST} `sentry.dist`
+ *
+ * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead - This attribute is being deprecated in favor of sentry.dist.
+ * @example "1.0"
+ */
+export const DIST = 'dist';
+
+/**
+ * Type for {@link DIST} dist
+ */
+export type DIST_TYPE = string;
+
 // Path: model/attributes/effectiveConnectionType.json
 
 /**
@@ -15304,6 +15328,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'device.thermal_state': 'string',
   'device.timezone': 'string',
   'device.usable_memory': 'integer',
+  dist: 'string',
   effectiveConnectionType: 'string',
   environment: 'string',
   'error.type': 'string',
@@ -15986,6 +16011,7 @@ export type AttributeName =
   | typeof DEVICE_THERMAL_STATE
   | typeof DEVICE_TIMEZONE
   | typeof DEVICE_USABLE_MEMORY
+  | typeof DIST
   | typeof EFFECTIVECONNECTIONTYPE
   | typeof ENVIRONMENT
   | typeof ERROR_TYPE
@@ -19307,6 +19333,22 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 2147483648,
     changelog: [{ version: '0.5.0', prs: [303], description: 'Added device.usable_memory attribute' }],
+  },
+  dist: {
+    brief: 'The sentry dist.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'never',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '1.0',
+    deprecation: {
+      replacement: 'server.address',
+      reason: 'This attribute is being deprecated in favor of sentry.dist.',
+    },
+    aliases: ['sentry.dist'],
+    changelog: [{ version: 'next', prs: [489], description: 'Added dist attribute' }],
   },
   effectiveConnectionType: {
     brief: 'Specifies the estimated effective type of the current connection (e.g. slow-2g, 2g, 3g, 4g).',
@@ -25696,6 +25738,7 @@ export type Attributes = {
   [DEVICE_THERMAL_STATE]?: DEVICE_THERMAL_STATE_TYPE;
   [DEVICE_TIMEZONE]?: DEVICE_TIMEZONE_TYPE;
   [DEVICE_USABLE_MEMORY]?: DEVICE_USABLE_MEMORY_TYPE;
+  [DIST]?: DIST_TYPE;
   [EFFECTIVECONNECTIONTYPE]?: EFFECTIVECONNECTIONTYPE_TYPE;
   [ENVIRONMENT]?: ENVIRONMENT_TYPE;
   [ERROR_TYPE]?: ERROR_TYPE_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4812,7 +4812,7 @@ export type DEVICE_USABLE_MEMORY_TYPE = number;
  *
  * Aliases: {@link SENTRY_DIST} `sentry.dist`
  *
- * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead - This attribute is being deprecated in favor of sentry.dist.
+ * @deprecated Use {@link SERVER_DIST} (server.dist) instead - This attribute is being deprecated in favor of sentry.dist.
  * @example "1.0"
  */
 export const DIST = 'dist';
@@ -19344,7 +19344,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: '1.0',
     deprecation: {
-      replacement: 'server.address',
+      replacement: 'server.dist',
       reason: 'This attribute is being deprecated in favor of sentry.dist.',
     },
     aliases: ['sentry.dist'],

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4812,7 +4812,7 @@ export type DEVICE_USABLE_MEMORY_TYPE = number;
  *
  * Aliases: {@link SENTRY_DIST} `sentry.dist`
  *
- * @deprecated Use {@link SERVER_DIST} (server.dist) instead - This attribute is being deprecated in favor of sentry.dist.
+ * @deprecated Use {@link SENTRY_DIST} (sentry.dist) instead - This attribute is being deprecated in favor of sentry.dist.
  * @example "1.0"
  */
 export const DIST = 'dist';
@@ -11707,6 +11707,8 @@ export type SENTRY_DESCRIPTION_TYPE = string;
  *
  * Attribute defined in OTEL: No
  * Visibility: public
+ *
+ * Aliases: {@link DIST} `dist`
  *
  * @example "1.0"
  */
@@ -19344,7 +19346,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: '1.0',
     deprecation: {
-      replacement: 'server.dist',
+      replacement: 'sentry.dist',
       reason: 'This attribute is being deprecated in favor of sentry.dist.',
     },
     aliases: ['sentry.dist'],
@@ -23649,7 +23651,8 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: '1.0',
-    changelog: [{ version: '0.0.0' }],
+    aliases: ['dist'],
+    changelog: [{ version: 'next', description: 'Added dist as an alias' }, { version: '0.0.0' }],
   },
   'sentry.domain': {
     brief:

--- a/model/attributes/dist.json
+++ b/model/attributes/dist.json
@@ -1,0 +1,24 @@
+{
+  "key": "dist",
+  "brief": "The sentry dist.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "never"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "example": "1.0",
+  "alias": ["sentry.dist"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "server.address",
+    "reason": "This attribute is being deprecated in favor of sentry.dist."
+  },
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [489],
+      "description": "Added dist attribute"
+    }
+  ]
+}

--- a/model/attributes/dist.json
+++ b/model/attributes/dist.json
@@ -11,7 +11,7 @@
   "alias": ["sentry.dist"],
   "deprecation": {
     "_status": "backfill",
-    "replacement": "server.dist",
+    "replacement": "sentry.dist",
     "reason": "This attribute is being deprecated in favor of sentry.dist."
   },
   "changelog": [

--- a/model/attributes/dist.json
+++ b/model/attributes/dist.json
@@ -11,7 +11,7 @@
   "alias": ["sentry.dist"],
   "deprecation": {
     "_status": "backfill",
-    "replacement": "server.address",
+    "replacement": "server.dist",
     "reason": "This attribute is being deprecated in favor of sentry.dist."
   },
   "changelog": [

--- a/model/attributes/sentry/sentry__dist.json
+++ b/model/attributes/sentry/sentry__dist.json
@@ -7,8 +7,13 @@
   },
   "is_in_otel": false,
   "example": "1.0",
+  "alias": ["dist"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added dist as an alias"
+    },
     {
       "version": "0.0.0"
     }

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2975,7 +2975,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Visibility: public
     Aliases: sentry.dist
-    DEPRECATED: Use server.dist instead - This attribute is being deprecated in favor of sentry.dist.
+    DEPRECATED: Use sentry.dist instead - This attribute is being deprecated in favor of sentry.dist.
     Example: "1.0"
     """
 
@@ -6822,6 +6822,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: never
     Defined in OTEL: No
     Visibility: public
+    Aliases: dist
     Example: "1.0"
     """
 
@@ -11829,7 +11830,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="1.0",
         deprecation=DeprecationInfo(
-            replacement="server.dist",
+            replacement="sentry.dist",
             reason="This attribute is being deprecated in favor of sentry.dist.",
             status=DeprecationStatus.BACKFILL,
         ),
@@ -16346,7 +16347,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="1.0",
+        aliases=["dist"],
         changelog=[
+            ChangelogEntry(version="next", description="Added dist as an alias"),
             ChangelogEntry(version="0.0.0"),
         ],
     ),

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2975,7 +2975,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Visibility: public
     Aliases: sentry.dist
-    DEPRECATED: Use server.address instead - This attribute is being deprecated in favor of sentry.dist.
+    DEPRECATED: Use server.dist instead - This attribute is being deprecated in favor of sentry.dist.
     Example: "1.0"
     """
 
@@ -11829,7 +11829,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="1.0",
         deprecation=DeprecationInfo(
-            replacement="server.address",
+            replacement="server.dist",
             reason="This attribute is being deprecated in favor of sentry.dist.",
             status=DeprecationStatus.BACKFILL,
         ),

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -170,6 +170,7 @@ class _AttributeNamesMeta(type):
         "DB_SYSTEM",
         "DEVICE_CONNECTION_TYPE",
         "DEVICEMEMORY",
+        "DIST",
         "EFFECTIVECONNECTIONTYPE",
         "ENVIRONMENT",
         "FAAS_EXECUTION",
@@ -2963,6 +2964,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Aliases: device.memory.estimated_capacity
     DEPRECATED: Use device.memory.estimated_capacity instead - Old namespace-less attribute, to be replaced with device.memory.estimated_capacity for span-first future
     Example: "8 GB"
+    """
+
+    # Path: model/attributes/dist.json
+    DIST: Literal["dist"] = "dist"
+    """The sentry dist.
+
+    Type: str
+    Apply Scrubbing: never
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: sentry.dist
+    DEPRECATED: Use server.address instead - This attribute is being deprecated in favor of sentry.dist.
+    Example: "1.0"
     """
 
     # Path: model/attributes/effectiveConnectionType.json
@@ -11807,6 +11821,25 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "dist": AttributeMetadata(
+        brief="The sentry dist.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="1.0",
+        deprecation=DeprecationInfo(
+            replacement="server.address",
+            reason="This attribute is being deprecated in favor of sentry.dist.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["sentry.dist"],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[489], description="Added dist attribute"
+            ),
+        ],
+    ),
     "effectiveConnectionType": AttributeMetadata(
         brief="Specifies the estimated effective type of the current connection (e.g. slow-2g, 2g, 3g, 4g).",
         type=AttributeType.STRING,
@@ -18460,6 +18493,7 @@ Attributes = TypedDict(
         "device.timezone": str,
         "device.usable_memory": int,
         "deviceMemory": str,
+        "dist": str,
         "effectiveConnectionType": str,
         "environment": str,
         "error.type": str,


### PR DESCRIPTION
## Description

<!-- Describe your changes -->

Set by the Python SDK in https://github.com/getsentry/sentry-python/blob/b9899f82d186f2f71ddaff8bcc0700bebbb7bfff/sentry_sdk/client.py#L848

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
