### PR TITLE
feat(attributes): Add `sentry.pageload.span_id` attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -13632,6 +13632,27 @@ export const SENTRY_ORIGIN = 'sentry.origin';
  */
 export type SENTRY_ORIGIN_TYPE = string;
 
+// Path: model/attributes/sentry/sentry__pageload__span_id.json
+
+/**
+ * The id of the pageload span, set by web vital spans and metrics `sentry.pageload.span_id`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_PAGELOAD_SPAN_ID_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "bf2c8d3df84524de"
+ */
+export const SENTRY_PAGELOAD_SPAN_ID = 'sentry.pageload.span_id';
+
+/**
+ * Type for {@link SENTRY_PAGELOAD_SPAN_ID} sentry.pageload.span_id
+ */
+export type SENTRY_PAGELOAD_SPAN_ID_TYPE = string;
+
 // Path: model/attributes/sentry/sentry__platform.json
 
 /**
@@ -17078,6 +17099,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'sentry.observed_timestamp_nanos': 'string',
   'sentry.op': 'string',
   'sentry.origin': 'string',
+  'sentry.pageload.span_id': 'string',
   'sentry.platform': 'string',
   'sentry.profiler_id': 'string',
   'sentry.profile_id': 'string',
@@ -17823,6 +17845,7 @@ export type AttributeName =
   | typeof SENTRY_OBSERVED_TIMESTAMP_NANOS
   | typeof SENTRY_OP
   | typeof SENTRY_ORIGIN
+  | typeof SENTRY_PAGELOAD_SPAN_ID
   | typeof SENTRY_PLATFORM
   | typeof SENTRY_PROFILER_ID
   | typeof SENTRY_PROFILE_ID
@@ -26241,6 +26264,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'auto.http.otel.fastify',
     changelog: [{ version: '0.1.0', prs: [68] }, { version: '0.0.0' }],
   },
+  'sentry.pageload.span_id': {
+    brief: 'The id of the pageload span, set by web vital spans and metrics',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'bf2c8d3df84524de',
+    changelog: [{ version: 'next', prs: [495], description: 'Added sentry.pageload.span_id attribute' }],
+  },
   'sentry.platform': {
     brief: 'The sdk platform that generated the event.',
     type: 'string',
@@ -28442,6 +28476,7 @@ export type Attributes = {
   [SENTRY_OBSERVED_TIMESTAMP_NANOS]?: SENTRY_OBSERVED_TIMESTAMP_NANOS_TYPE;
   [SENTRY_OP]?: SENTRY_OP_TYPE;
   [SENTRY_ORIGIN]?: SENTRY_ORIGIN_TYPE;
+  [SENTRY_PAGELOAD_SPAN_ID]?: SENTRY_PAGELOAD_SPAN_ID_TYPE;
   [SENTRY_PLATFORM]?: SENTRY_PLATFORM_TYPE;
   [SENTRY_PROFILER_ID]?: SENTRY_PROFILER_ID_TYPE;
   [SENTRY_PROFILE_ID]?: SENTRY_PROFILE_ID_TYPE;

--- a/model/attributes/sentry/sentry__pageload__span_id.json
+++ b/model/attributes/sentry/sentry__pageload__span_id.json
@@ -1,0 +1,18 @@
+{
+  "key": "sentry.pageload.span_id",
+  "brief": "The id of the pageload span, set by web vital spans and metrics",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "example": "bf2c8d3df84524de",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [495],
+      "description": "Added sentry.pageload.span_id attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -7931,6 +7931,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "auto.http.otel.fastify"
     """
 
+    # Path: model/attributes/sentry/sentry__pageload__span_id.json
+    SENTRY_PAGELOAD_SPAN_ID: Literal["sentry.pageload.span_id"] = (
+        "sentry.pageload.span_id"
+    )
+    """The id of the pageload span, set by web vital spans and metrics
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "bf2c8d3df84524de"
+    """
+
     # Path: model/attributes/sentry/sentry__platform.json
     SENTRY_PLATFORM: Literal["sentry.platform"] = "sentry.platform"
     """The sdk platform that generated the event.
@@ -18441,6 +18454,21 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "sentry.pageload.span_id": AttributeMetadata(
+        brief="The id of the pageload span, set by web vital spans and metrics",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="bf2c8d3df84524de",
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[495],
+                description="Added sentry.pageload.span_id attribute",
+            ),
+        ],
+    ),
     "sentry.platform": AttributeMetadata(
         brief="The sdk platform that generated the event.",
         type=AttributeType.STRING,
@@ -20712,6 +20740,7 @@ Attributes = TypedDict(
         "sentry.observed_timestamp_nanos": str,
         "sentry.op": str,
         "sentry.origin": str,
+        "sentry.pageload.span_id": str,
         "sentry.platform": str,
         "sentry.profile_id": str,
         "sentry.profiler_id": str,


### PR DESCRIPTION
## Description

Already sent by the browser SDK on v1 and v2 web vital spans. Also helpful for web vitals as metrics

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
