### PR TITLE
ref(attribute): Improve `db.statement` example and add deprecation reason

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4769,8 +4769,8 @@ export type DB_SQL_BINDINGS_TYPE = Array<string>;
  *
  * Aliases: {@link DB_QUERY_TEXT} `db.query.text`
  *
- * @deprecated Use {@link DB_QUERY_TEXT} (db.query.text) instead
- * @example "SELECT * FROM users"
+ * @deprecated Use {@link DB_QUERY_TEXT} (db.query.text) instead - While this attribute never specifically required parameterization, the replacement, db.query.text, does.
+ * @example "SELECT * FROM users WHERE id = $1"
  */
 export const DB_STATEMENT = 'db.statement';
 
@@ -21378,13 +21378,20 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: true,
     visibility: 'public',
-    example: 'SELECT * FROM users',
+    example: 'SELECT * FROM users WHERE id = $1',
     deprecation: {
       replacement: 'db.query.text',
+      reason:
+        'While this attribute never specifically required parameterization, the replacement, db.query.text, does.',
       status: 'normalize',
     },
     aliases: ['db.query.text'],
-    changelog: [{ version: '0.4.0', prs: [199] }, { version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: 'next', description: 'Improved example and added deprecation reason' },
+      { version: '0.4.0', prs: [199] },
+      { version: '0.1.0', prs: [61, 127] },
+      { version: '0.0.0' },
+    ],
   },
   'db.stored_procedure.name': {
     brief: 'The name of a stored procedure being called.',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -21387,7 +21387,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     aliases: ['db.query.text'],
     changelog: [
-      { version: 'next', description: 'Improved example and added deprecation reason' },
+      { version: 'next', prs: [501], description: 'Improved example and added deprecation reason' },
       { version: '0.4.0', prs: [199] },
       { version: '0.1.0', prs: [61, 127] },
       { version: '0.0.0' },

--- a/model/attributes/db/db__statement.json
+++ b/model/attributes/db/db__statement.json
@@ -17,7 +17,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [],
+      "prs": [501],
       "description": "Improved example and added deprecation reason"
     },
     {

--- a/model/attributes/db/db__statement.json
+++ b/model/attributes/db/db__statement.json
@@ -6,14 +6,20 @@
     "key": "auto"
   },
   "is_in_otel": true,
-  "example": "SELECT * FROM users",
+  "example": "SELECT * FROM users WHERE id = $1",
   "alias": ["db.query.text"],
   "deprecation": {
     "_status": "normalize",
-    "replacement": "db.query.text"
+    "replacement": "db.query.text",
+    "reason": "While this attribute never specifically required parameterization, the replacement, db.query.text, does."
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [],
+      "description": "Improved example and added deprecation reason"
+    },
     {
       "version": "0.4.0",
       "prs": [199]

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3023,8 +3023,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Aliases: db.query.text
-    DEPRECATED: Use db.query.text instead
-    Example: "SELECT * FROM users"
+    DEPRECATED: Use db.query.text instead - While this attribute never specifically required parameterization, the replacement, db.query.text, does.
+    Example: "SELECT * FROM users WHERE id = $1"
     """
 
     # Path: model/attributes/db/db__stored_procedure__name.json
@@ -12950,12 +12950,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
-        example="SELECT * FROM users",
+        example="SELECT * FROM users WHERE id = $1",
         deprecation=DeprecationInfo(
-            replacement="db.query.text", status=DeprecationStatus.NORMALIZE
+            replacement="db.query.text",
+            reason="While this attribute never specifically required parameterization, the replacement, db.query.text, does.",
+            status=DeprecationStatus.NORMALIZE,
         ),
         aliases=["db.query.text"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Improved example and added deprecation reason",
+            ),
             ChangelogEntry(version="0.4.0", prs=[199]),
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
             ChangelogEntry(version="0.0.0"),

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -12960,6 +12960,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
+                prs=[501],
                 description="Improved example and added deprecation reason",
             ),
             ChangelogEntry(version="0.4.0", prs=[199]),


### PR DESCRIPTION
The example was too minimal and the difference to `db.query.text` wasn't mentioned explicilty. Came up offline today, so figured we should adjust it.