### PR TITLE
feat(attributes): deprecate gen AI reasoning effort

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -7092,6 +7092,9 @@ export type GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE = number;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link GEN_AI_REQUEST_REASONING_LEVEL} `gen_ai.request.reasoning.level`
+ *
+ * @deprecated Use {@link GEN_AI_REQUEST_REASONING_LEVEL} (gen_ai.request.reasoning.level) instead
  * @example "high"
  */
 export const GEN_AI_REQUEST_REASONING_EFFORT = 'gen_ai.request.reasoning_effort';
@@ -7100,6 +7103,29 @@ export const GEN_AI_REQUEST_REASONING_EFFORT = 'gen_ai.request.reasoning_effort'
  * Type for {@link GEN_AI_REQUEST_REASONING_EFFORT} gen_ai.request.reasoning_effort
  */
 export type GEN_AI_REQUEST_REASONING_EFFORT_TYPE = string;
+
+// Path: model/attributes/gen_ai/gen_ai__request__reasoning__level.json
+
+/**
+ * The reasoning or thinking effort level requested for a GenAI model. `gen_ai.request.reasoning.level`
+ *
+ * Attribute Value Type: `string` {@link GEN_AI_REQUEST_REASONING_LEVEL_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * Aliases: {@link GEN_AI_REQUEST_REASONING_EFFORT} `gen_ai.request.reasoning_effort`
+ *
+ * @example "high"
+ */
+export const GEN_AI_REQUEST_REASONING_LEVEL = 'gen_ai.request.reasoning.level';
+
+/**
+ * Type for {@link GEN_AI_REQUEST_REASONING_LEVEL} gen_ai.request.reasoning.level
+ */
+export type GEN_AI_REQUEST_REASONING_LEVEL_TYPE = string;
 
 // Path: model/attributes/gen_ai/gen_ai__request__seed.json
 
@@ -16848,6 +16874,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'gen_ai.request.model': 'string',
   'gen_ai.request.presence_penalty': 'double',
   'gen_ai.request.reasoning_effort': 'string',
+  'gen_ai.request.reasoning.level': 'string',
   'gen_ai.request.seed': 'string',
   'gen_ai.request.stop_sequences': 'string[]',
   'gen_ai.request.temperature': 'double',
@@ -17596,6 +17623,7 @@ export type AttributeName =
   | typeof GEN_AI_REQUEST_MODEL
   | typeof GEN_AI_REQUEST_PRESENCE_PENALTY
   | typeof GEN_AI_REQUEST_REASONING_EFFORT
+  | typeof GEN_AI_REQUEST_REASONING_LEVEL
   | typeof GEN_AI_REQUEST_SEED
   | typeof GEN_AI_REQUEST_STOP_SEQUENCES
   | typeof GEN_AI_REQUEST_TEMPERATURE
@@ -22310,7 +22338,26 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'high',
-    changelog: [{ version: '0.13.0', prs: [334], description: 'Added gen_ai.request.reasoning_effort attribute' }],
+    deprecation: {
+      replacement: 'gen_ai.request.reasoning.level',
+    },
+    aliases: ['gen_ai.request.reasoning.level'],
+    changelog: [
+      { version: 'next', prs: [502], description: 'Deprecated in favor of gen_ai.request.reasoning.level' },
+      { version: '0.13.0', prs: [334], description: 'Added gen_ai.request.reasoning_effort attribute' },
+    ],
+  },
+  'gen_ai.request.reasoning.level': {
+    brief: 'The reasoning or thinking effort level requested for a GenAI model.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'high',
+    aliases: ['gen_ai.request.reasoning_effort'],
+    changelog: [{ version: 'next', prs: [502], description: 'Added gen_ai.request.reasoning.level attribute' }],
   },
   'gen_ai.request.seed': {
     brief: 'The seed, ideally models given the same seed and same other parameters will produce the exact same output.',
@@ -28251,6 +28298,7 @@ export type Attributes = {
   [GEN_AI_REQUEST_MODEL]?: GEN_AI_REQUEST_MODEL_TYPE;
   [GEN_AI_REQUEST_PRESENCE_PENALTY]?: GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE;
   [GEN_AI_REQUEST_REASONING_EFFORT]?: GEN_AI_REQUEST_REASONING_EFFORT_TYPE;
+  [GEN_AI_REQUEST_REASONING_LEVEL]?: GEN_AI_REQUEST_REASONING_LEVEL_TYPE;
   [GEN_AI_REQUEST_SEED]?: GEN_AI_REQUEST_SEED_TYPE;
   [GEN_AI_REQUEST_STOP_SEQUENCES]?: GEN_AI_REQUEST_STOP_SEQUENCES_TYPE;
   [GEN_AI_REQUEST_TEMPERATURE]?: GEN_AI_REQUEST_TEMPERATURE_TYPE;

--- a/model/attributes/gen_ai/gen_ai__request__reasoning__level.json
+++ b/model/attributes/gen_ai/gen_ai__request__reasoning__level.json
@@ -1,0 +1,19 @@
+{
+  "key": "gen_ai.request.reasoning.level",
+  "brief": "The reasoning or thinking effort level requested for a GenAI model.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "visibility": "public",
+  "example": "high",
+  "alias": ["gen_ai.request.reasoning_effort"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [502],
+      "description": "Added gen_ai.request.reasoning.level attribute"
+    }
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__request__reasoning_effort.json
+++ b/model/attributes/gen_ai/gen_ai__request__reasoning_effort.json
@@ -8,7 +8,17 @@
   "is_in_otel": false,
   "visibility": "public",
   "example": "high",
+  "alias": ["gen_ai.request.reasoning.level"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "gen_ai.request.reasoning.level"
+  },
   "changelog": [
+    {
+      "version": "next",
+      "prs": [502],
+      "description": "Deprecated in favor of gen_ai.request.reasoning.level"
+    },
     {
       "version": "0.13.0",
       "prs": [334],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -188,6 +188,7 @@ class _AttributeNamesMeta(type):
         "GEN_AI_PROMPT",
         "GEN_AI_REQUEST_AVAILABLE_TOOLS",
         "GEN_AI_REQUEST_MESSAGES",
+        "GEN_AI_REQUEST_REASONING_EFFORT",
         "GEN_AI_RESPONSE_TEXT",
         "GEN_AI_RESPONSE_TIME_TO_FIRST_TOKEN",
         "GEN_AI_RESPONSE_TOOL_CALLS",
@@ -4272,6 +4273,20 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 0.5
     """
 
+    # Path: model/attributes/gen_ai/gen_ai__request__reasoning__level.json
+    GEN_AI_REQUEST_REASONING_LEVEL: Literal["gen_ai.request.reasoning.level"] = (
+        "gen_ai.request.reasoning.level"
+    )
+    """The reasoning or thinking effort level requested for a GenAI model.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Aliases: gen_ai.request.reasoning_effort
+    Example: "high"
+    """
+
     # Path: model/attributes/gen_ai/gen_ai__request__reasoning_effort.json
     GEN_AI_REQUEST_REASONING_EFFORT: Literal["gen_ai.request.reasoning_effort"] = (
         "gen_ai.request.reasoning_effort"
@@ -4282,6 +4297,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
+    Aliases: gen_ai.request.reasoning.level
+    DEPRECATED: Use gen_ai.request.reasoning.level instead
     Example: "high"
     """
 
@@ -14246,6 +14263,22 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[57]),
         ],
     ),
+    "gen_ai.request.reasoning.level": AttributeMetadata(
+        brief="The reasoning or thinking effort level requested for a GenAI model.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="high",
+        aliases=["gen_ai.request.reasoning_effort"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[502],
+                description="Added gen_ai.request.reasoning.level attribute",
+            ),
+        ],
+    ),
     "gen_ai.request.reasoning_effort": AttributeMetadata(
         brief="Constrains the effort on reasoning for reasoning models. Supported values vary by provider.",
         type=AttributeType.STRING,
@@ -14253,7 +14286,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="high",
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.request.reasoning.level",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["gen_ai.request.reasoning.level"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[502],
+                description="Deprecated in favor of gen_ai.request.reasoning.level",
+            ),
             ChangelogEntry(
                 version="0.13.0",
                 prs=[334],
@@ -20498,6 +20541,7 @@ Attributes = TypedDict(
         "gen_ai.request.messages": str,
         "gen_ai.request.model": str,
         "gen_ai.request.presence_penalty": float,
+        "gen_ai.request.reasoning.level": str,
         "gen_ai.request.reasoning_effort": str,
         "gen_ai.request.seed": str,
         "gen_ai.request.stop_sequences": List[str],


### PR DESCRIPTION
## Description

Adds the OpenTelemetry-aligned `gen_ai.request.reasoning.level` attribute and deprecates `gen_ai.request.reasoning_effort` in favor of it.

The deprecated attribute uses `_status: "backfill"` so downstream ingestion can copy existing values to the replacement during the transition, and both attributes list each other as aliases.

Contributes to TET-2603.

## PR Checklist

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)

## Validation

- `yarn generate`
- `yarn test`
