### PR TITLE
feat(conventions): Support multiple examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,12 +46,14 @@ Run `yarn run create:attribute` to create a new attribute. This will prompt you 
 - Interactive mode: This will prompt you to enter information about the attribute.
 - Non-interactive mode: This will use the information provided to create the attribute. You'll need to explicitly specify all the needed information when running the command.
 
+Provide example values with the `examples` field as a non-empty JSON array. For an array-valued attribute, each example is itself an array. The legacy `example` field remains supported for existing definitions, but new and updated attributes should use `examples`.
+
 ```bash
 # Interactive mode
 yarn run create:attribute
 
 # Non-interactive mode
-yarn run create:attribute --key http.route --description "The route pattern of the request" --type string --apply_scrubbing never --is_in_otel true --visibility public --example "/users/:id" --alias "url.template"
+yarn run create:attribute --key http.route --description "The route pattern of the request" --type string --apply_scrubbing never --is_in_otel true --visibility public --examples '["/users/:id","/teams/:id"]' --alias "url.template"
 ```
 
 After you've created an attribute, the script will ask if you'd like to generate the docs. This will run `yarn run generate`. If you want to skip this step, you can run `yarn run generate` manually afterwards.

--- a/docs/src/components/AttributeCard.astro
+++ b/docs/src/components/AttributeCard.astro
@@ -20,6 +20,7 @@ const { category } = parseAttributeId(id);
 const isDeprecated = !!attribute.deprecation;
 const anchorId = attribute.key.replace(/\./g, '-').replace(/</g, '').replace(/>/g, '');
 const rawJson = JSON.stringify(attribute, null, 2);
+const examples = attribute.examples ?? (attribute.example !== undefined ? [attribute.example] : []);
 ---
 
 <article 
@@ -74,10 +75,14 @@ const rawJson = JSON.stringify(attribute, null, 2);
       </div>
     )}
     
-    {attribute.example !== undefined && (
+    {examples.length > 0 && (
       <div class="flex items-baseline gap-3 text-sm">
-        <span class="text-text-muted min-w-[100px] flex-shrink-0">Example</span>
-        <code class="text-xs mr-1">{typeof attribute.example === 'object' ? JSON.stringify(attribute.example) : String(attribute.example)}</code>
+        <span class="text-text-muted min-w-[100px] flex-shrink-0">{attribute.examples ? 'Examples' : 'Example'}</span>
+        <span class="flex flex-wrap gap-1">
+          {examples.map((example) => (
+            <code class="text-xs">{typeof example === 'object' ? JSON.stringify(example) : String(example)}</code>
+          ))}
+        </span>
       </div>
     )}
     

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -2,41 +2,53 @@ import { defineCollection } from 'astro:content';
 import { glob } from 'astro/loaders';
 import { z } from 'astro/zod';
 
+const attributeValueSchema = z.union([
+  z.string(),
+  z.boolean(),
+  z.number(),
+  z.array(z.string()),
+  z.array(z.boolean()),
+  z.array(z.number()),
+]);
+
 // Schema matching schemas/attribute.schema.json
-const attributeSchema = z.object({
-  key: z.string(),
-  brief: z.string(),
-  has_dynamic_suffix: z.boolean().optional(),
-  type: z.enum(['string', 'boolean', 'integer', 'double', 'string[]', 'boolean[]', 'integer[]', 'double[]']),
-  apply_scrubbing: z.object({
-    key: z.enum(['auto', 'manual', 'never']),
-    reason: z.string().optional(),
-  }),
-  is_in_otel: z.boolean(),
-  visibility: z.enum(['public', 'internal']),
-  example: z
-    .union([z.string(), z.boolean(), z.number(), z.array(z.string()), z.array(z.boolean()), z.array(z.number())])
-    .optional(),
-  deprecation: z
-    .object({
-      replacement: z.string().optional(),
+const attributeSchema = z
+  .object({
+    key: z.string(),
+    brief: z.string(),
+    has_dynamic_suffix: z.boolean().optional(),
+    type: z.enum(['string', 'boolean', 'integer', 'double', 'string[]', 'boolean[]', 'integer[]', 'double[]']),
+    apply_scrubbing: z.object({
+      key: z.enum(['auto', 'manual', 'never']),
       reason: z.string().optional(),
-      _status: z.enum(['backfill', 'normalize', 'transform']).nullable(),
-      transformation: z.string().optional(),
-    })
-    .optional(),
-  alias: z.array(z.string()).optional(),
-  additional_context: z.array(z.string()).optional(),
-  changelog: z
-    .array(
-      z.object({
-        version: z.string(),
-        prs: z.array(z.number().int().positive()).optional(),
-        description: z.string().optional(),
-      }),
-    )
-    .optional(),
-});
+    }),
+    is_in_otel: z.boolean(),
+    visibility: z.enum(['public', 'internal']),
+    example: attributeValueSchema.optional(),
+    examples: z.array(attributeValueSchema).min(1).optional(),
+    deprecation: z
+      .object({
+        replacement: z.string().optional(),
+        reason: z.string().optional(),
+        _status: z.enum(['backfill', 'normalize', 'transform']).nullable(),
+        transformation: z.string().optional(),
+      })
+      .optional(),
+    alias: z.array(z.string()).optional(),
+    additional_context: z.array(z.string()).optional(),
+    changelog: z
+      .array(
+        z.object({
+          version: z.string(),
+          prs: z.array(z.number().int().positive()).optional(),
+          description: z.string().optional(),
+        }),
+      )
+      .optional(),
+  })
+  .refine((attribute) => attribute.example === undefined || attribute.examples === undefined, {
+    message: 'Use either example or examples, not both',
+  });
 
 // Schema matching schemas/name.schema.json
 const spanOperationSchema = z.object({

--- a/docs/src/pages/llms-full.txt.ts
+++ b/docs/src/pages/llms-full.txt.ts
@@ -59,9 +59,15 @@ export const GET: APIRoute = async () => {
         `- Apply Scrubbing: ${data.apply_scrubbing.key}${data.apply_scrubbing.reason ? ` (${data.apply_scrubbing.reason})` : ''}`,
       );
 
-      if (data.example !== undefined) {
-        const exampleStr = Array.isArray(data.example) ? data.example.join(', ') : String(data.example);
-        lines.push(`- Example: ${exampleStr}`);
+      if (data.examples !== undefined) {
+        lines.push('- Examples:');
+        for (const example of data.examples) {
+          const exampleText = Array.isArray(example) ? JSON.stringify(example) : String(example);
+          lines.push(`  - ${exampleText}`);
+        }
+      } else if (data.example !== undefined) {
+        const exampleText = Array.isArray(data.example) ? JSON.stringify(data.example) : String(data.example);
+        lines.push(`- Example: ${exampleText}`);
       }
 
       if (data.alias && data.alias.length > 0) {

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -21299,7 +21299,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'SELECT users',
     examples: ['SELECT users', 'INSERT products; UPDATE orders'],
     changelog: [
-      { version: 'next', description: 'Added multiple examples' },
+      { version: 'next', prs: [505], description: 'Added multiple examples' },
       { version: '0.4.0', prs: [208] },
       { version: '0.1.0', prs: [127] },
       { version: '0.0.0' },

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -9320,8 +9320,9 @@ export type HTTP_RESPONSE_TRANSFER_SIZE_TYPE = number;
  *
  * Aliases: {@link URL_TEMPLATE} `url.template`
  *
- * @example "/users/:userID?"
- * @example "my-controller/my-action/{id?}"
+ * @example "/users/:id"
+ * @example "my-controller/my-action/{id}"
+ * @example "/posts"
  */
 export const HTTP_ROUTE = 'http.route';
 
@@ -15834,7 +15835,7 @@ export type URL_SCHEME_TYPE = string;
  *
  * @example "/users/{id}"
  * @example "/users/:id"
- * @example "/users?id={id}"
+ * @example "/about"
  */
 export const URL_TEMPLATE = 'url.template';
 
@@ -24327,8 +24328,8 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: true,
     visibility: 'public',
-    example: '/users/:userID?',
-    examples: ['/users/:userID?', 'my-controller/my-action/{id?}'],
+    example: '/users/:id',
+    examples: ['/users/:id', 'my-controller/my-action/{id}', '/posts'],
     aliases: ['url.template'],
     changelog: [
       { version: 'next', prs: [505], description: 'Added multiple examples' },
@@ -28304,7 +28305,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: '/users/{id}',
-    examples: ['/users/{id}', '/users/:id', '/users?id={id}'],
+    examples: ['/users/{id}', '/users/:id', '/about'],
     aliases: ['http.route'],
     changelog: [
       { version: 'next', prs: [505], description: 'Added multiple examples' },

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -9320,7 +9320,8 @@ export type HTTP_RESPONSE_TRANSFER_SIZE_TYPE = number;
  *
  * Aliases: {@link URL_TEMPLATE} `url.template`
  *
- * @example "/users/:id"
+ * @example "/users/:userID?"
+ * @example "my-controller/my-action/{id?}"
  */
 export const HTTP_ROUTE = 'http.route';
 
@@ -15831,7 +15832,9 @@ export type URL_SCHEME_TYPE = string;
  *
  * Aliases: {@link HTTP_ROUTE} `http.route`
  *
+ * @example "/users/{id}"
  * @example "/users/:id"
+ * @example "/users?id={id}"
  */
 export const URL_TEMPLATE = 'url.template';
 
@@ -24324,9 +24327,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: true,
     visibility: 'public',
-    example: '/users/:id',
+    example: '/users/:userID?',
+    examples: ['/users/:userID?', 'my-controller/my-action/{id?}'],
     aliases: ['url.template'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: 'next', prs: [505], description: 'Added multiple examples' },
+      { version: '0.1.0', prs: [127] },
+      { version: '0.0.0' },
+    ],
   },
   'http.scheme': {
     brief: 'The URI scheme component identifying the used protocol.',
@@ -28295,9 +28303,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: true,
     visibility: 'public',
-    example: '/users/:id',
+    example: '/users/{id}',
+    examples: ['/users/{id}', '/users/:id', '/users?id={id}'],
     aliases: ['http.route'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: 'next', prs: [505], description: 'Added multiple examples' },
+      { version: '0.1.0', prs: [127] },
+      { version: '0.0.0' },
+    ],
   },
   'user_agent.original': {
     brief: 'Value of the HTTP User-Agent header sent by the client.',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4618,6 +4618,7 @@ export type DB_QUERY_PARAMETER_KEY_TYPE = string;
  * Visibility: public
  *
  * @example "SELECT users"
+ * @example "INSERT products; UPDATE orders"
  */
 export const DB_QUERY_SUMMARY = 'db.query.summary';
 
@@ -16924,6 +16925,8 @@ export interface AttributeMetadata {
   hasDynamicSuffix?: boolean;
   /** An example value of the attribute */
   example?: AttributeValue;
+  /** Example values of the attribute */
+  examples?: AttributeValue[];
   /** If an attribute was deprecated, and what it was replaced with */
   deprecation?: DeprecationInfo;
   /** If there are attributes that alias to this attribute */
@@ -21294,7 +21297,13 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'SELECT users',
-    changelog: [{ version: '0.4.0', prs: [208] }, { version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    examples: ['SELECT users', 'INSERT products; UPDATE orders'],
+    changelog: [
+      { version: 'next', description: 'Added multiple examples' },
+      { version: '0.4.0', prs: [208] },
+      { version: '0.1.0', prs: [127] },
+      { version: '0.0.0' },
+    ],
   },
   'db.query.text': {
     brief:

--- a/model/attributes/db/db__query__summary.json
+++ b/model/attributes/db/db__query__summary.json
@@ -11,6 +11,7 @@
   "changelog": [
     {
       "version": "next",
+      "prs": [505],
       "description": "Added multiple examples"
     },
     {

--- a/model/attributes/db/db__query__summary.json
+++ b/model/attributes/db/db__query__summary.json
@@ -6,9 +6,13 @@
     "key": "manual"
   },
   "is_in_otel": true,
-  "example": "SELECT users",
+  "examples": ["SELECT users", "INSERT products; UPDATE orders"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added multiple examples"
+    },
     {
       "version": "0.4.0",
       "prs": [208]

--- a/model/attributes/http/http__route.json
+++ b/model/attributes/http/http__route.json
@@ -6,7 +6,7 @@
     "key": "manual"
   },
   "is_in_otel": true,
-  "examples": ["/users/:userID?", "my-controller/my-action/{id?}"],
+  "examples": ["/users/:id", "my-controller/my-action/{id}", "/posts"],
   "alias": ["url.template"],
   "visibility": "public",
   "changelog": [

--- a/model/attributes/http/http__route.json
+++ b/model/attributes/http/http__route.json
@@ -6,10 +6,15 @@
     "key": "manual"
   },
   "is_in_otel": true,
-  "example": "/users/:id",
+  "examples": ["/users/:userID?", "my-controller/my-action/{id?}"],
   "alias": ["url.template"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [505],
+      "description": "Added multiple examples"
+    },
     {
       "version": "0.1.0",
       "prs": [127]

--- a/model/attributes/url/url__template.json
+++ b/model/attributes/url/url__template.json
@@ -6,7 +6,7 @@
     "key": "manual"
   },
   "is_in_otel": true,
-  "examples": ["/users/{id}", "/users/:id", "/users?id={id}"],
+  "examples": ["/users/{id}", "/users/:id", "/about"],
   "alias": ["http.route"],
   "visibility": "public",
   "changelog": [

--- a/model/attributes/url/url__template.json
+++ b/model/attributes/url/url__template.json
@@ -6,10 +6,15 @@
     "key": "manual"
   },
   "is_in_otel": true,
-  "example": "/users/:id",
+  "examples": ["/users/{id}", "/users/:id", "/users?id={id}"],
   "alias": ["http.route"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [505],
+      "description": "Added multiple examples"
+    },
     {
       "version": "0.1.0",
       "prs": [127]

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5604,7 +5604,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Aliases: url.template
-    Example: "/users/:id"
+    Example: "/users/:userID?"
+    Example: "my-controller/my-action/{id?}"
     """
 
     # Path: model/attributes/http/http__scheme.json
@@ -9143,7 +9144,9 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Aliases: http.route
+    Example: "/users/{id}"
     Example: "/users/:id"
+    Example: "/users?id={id}"
     """
 
     # Path: model/attributes/url.json
@@ -16140,9 +16143,13 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
-        example="/users/:id",
+        example="/users/:userID?",
+        examples=["/users/:userID?", "my-controller/my-action/{id?}"],
         aliases=["url.template"],
         changelog=[
+            ChangelogEntry(
+                version="next", prs=[505], description="Added multiple examples"
+            ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -20294,9 +20301,13 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
-        example="/users/:id",
+        example="/users/{id}",
+        examples=["/users/{id}", "/users/:id", "/users?id={id}"],
         aliases=["http.route"],
         changelog=[
+            ChangelogEntry(
+                version="next", prs=[505], description="Added multiple examples"
+            ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
         ],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5604,8 +5604,9 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Aliases: url.template
-    Example: "/users/:userID?"
-    Example: "my-controller/my-action/{id?}"
+    Example: "/users/:id"
+    Example: "my-controller/my-action/{id}"
+    Example: "/posts"
     """
 
     # Path: model/attributes/http/http__scheme.json
@@ -9146,7 +9147,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Aliases: http.route
     Example: "/users/{id}"
     Example: "/users/:id"
-    Example: "/users?id={id}"
+    Example: "/about"
     """
 
     # Path: model/attributes/url.json
@@ -16143,8 +16144,8 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
-        example="/users/:userID?",
-        examples=["/users/:userID?", "my-controller/my-action/{id?}"],
+        example="/users/:id",
+        examples=["/users/:id", "my-controller/my-action/{id}", "/posts"],
         aliases=["url.template"],
         changelog=[
             ChangelogEntry(
@@ -20302,7 +20303,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="/users/{id}",
-        examples=["/users/{id}", "/users/:id", "/users?id={id}"],
+        examples=["/users/{id}", "/users/:id", "/about"],
         aliases=["http.route"],
         changelog=[
             ChangelogEntry(

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -12863,7 +12863,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="SELECT users",
         examples=["SELECT users", "INSERT products; UPDATE orders"],
         changelog=[
-            ChangelogEntry(version="next", description="Added multiple examples"),
+            ChangelogEntry(
+                version="next", prs=[505], description="Added multiple examples"
+            ),
             ChangelogEntry(version="0.4.0", prs=[208]),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -110,6 +110,9 @@ class AttributeMetadata:
     additional_context: Optional[List[str]] = None
     """A list of freeform notes providing additional context about how this attribute behaves, common pitfalls, or query-time nuances"""
 
+    examples: Optional[List[AttributeValue]] = None
+    """Example values of the attribute"""
+
 
 class _AttributeNamesMeta(type):
     _deprecated_names = {
@@ -2942,6 +2945,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Example: "SELECT users"
+    Example: "INSERT products; UPDATE orders"
     """
 
     # Path: model/attributes/db/db__query__text.json
@@ -12857,7 +12861,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="SELECT users",
+        examples=["SELECT users", "INSERT products; UPDATE orders"],
         changelog=[
+            ChangelogEntry(version="next", description="Added multiple examples"),
             ChangelogEntry(version="0.4.0", prs=[208]),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),

--- a/schemas/attribute.schema.json
+++ b/schemas/attribute.schema.json
@@ -44,7 +44,7 @@
     },
     "example": {
       "description": "An example value of the attribute",
-      "oneOf": [
+      "anyOf": [
         {
           "type": "string"
         },
@@ -73,6 +73,42 @@
           }
         }
       ]
+    },
+    "examples": {
+      "description": "Example values of the attribute",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "boolean"
+            }
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        ]
+      }
     },
     "deprecation": {
       "description": "If an attribute was deprecated, and what it was replaced with",
@@ -151,5 +187,158 @@
       }
     }
   },
+  "not": {
+    "required": ["example", "examples"]
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["has_dynamic_suffix"],
+        "properties": {
+          "has_dynamic_suffix": {
+            "const": true
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "example": {
+            "type": "string"
+          },
+          "examples": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "else": {
+        "oneOf": [
+          {
+            "properties": {
+              "type": {
+                "const": "string"
+              },
+              "example": {
+                "type": "string"
+              },
+              "examples": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "boolean"
+              },
+              "example": {
+                "type": "boolean"
+              },
+              "examples": {
+                "type": "array",
+                "items": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": ["integer", "double"]
+              },
+              "example": {
+                "type": "number"
+              },
+              "examples": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "string[]"
+              },
+              "example": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "examples": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "boolean[]"
+              },
+              "example": {
+                "type": "array",
+                "items": {
+                  "type": "boolean"
+                }
+              },
+              "examples": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": ["integer[]", "double[]"]
+              },
+              "example": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              "examples": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "any"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
   "required": ["key", "brief", "type", "apply_scrubbing", "is_in_otel", "visibility"]
 }

--- a/schemas/attribute.schema.json
+++ b/schemas/attribute.schema.json
@@ -201,6 +201,14 @@
         }
       },
       "then": {
+        "anyOf": [
+          {
+            "required": ["example"]
+          },
+          {
+            "required": ["examples"]
+          }
+        ],
         "properties": {
           "example": {
             "type": "string"

--- a/scripts/attribute_examples.ts
+++ b/scripts/attribute_examples.ts
@@ -1,0 +1,21 @@
+import type { AttributeJson, AttributeValue } from './types';
+
+export function getAttributeExamples(
+  attribute: Pick<AttributeJson, 'example' | 'examples'>,
+): AttributeValue[] | undefined {
+  if (attribute.examples !== undefined) {
+    return attribute.examples;
+  }
+  if (attribute.example !== undefined) {
+    return [attribute.example];
+  }
+  return undefined;
+}
+
+export function parseAttributeExamples(value: string): AttributeValue[] {
+  const examples = JSON.parse(value) as unknown;
+  if (!Array.isArray(examples) || examples.length === 0) {
+    throw new Error('Examples must be provided as a non-empty JSON array');
+  }
+  return examples as AttributeValue[];
+}

--- a/scripts/create_attribute.ts
+++ b/scripts/create_attribute.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { parseArgs } from 'node:util';
 import { confirm, intro, isCancel, log, outro, select, text } from '@clack/prompts';
 import Ajv from 'ajv';
+import { parseAttributeExamples, type AttributeValue } from './types';
 
 const getNextPrNumber = (): number | undefined => {
   try {
@@ -31,7 +32,8 @@ Options:
   --apply_scrubbing, -s   How PII scrubbing should be applied (auto/manual/never)
   --is_in_otel, -o    Whether the attribute is in OpenTelemetry (true/false)
   --visibility, -v   The visibility of the attribute (public/internal)
-  --example, -e       An example value (optional)
+  --examples          Example values as a non-empty JSON array (optional, preferred)
+  --example, -e       A single example value (optional, legacy)
   --alias, -a         Comma-separated list of attributes that alias to this attribute (optional)
 
 Examples:
@@ -39,7 +41,7 @@ Examples:
   yarn run create:attribute
 
   # Non-interactive mode
-  yarn run create:attribute --key http.route --description "The route pattern of the request" --type string --apply_scrubbing never --is_in_otel true --visibility public --example "/users/:id" --alias "url.template"
+  yarn run create:attribute --key http.route --description "The route pattern of the request" --type string --apply_scrubbing never --is_in_otel true --visibility public --examples '["/users/:id","/teams/:id"]' --alias "url.template"
 `;
 
 const validateSchema = (data: unknown) => {
@@ -65,6 +67,7 @@ const createAttribute = async () => {
         apply_scrubbing: { type: 'string', short: 's' },
         is_in_otel: { type: 'string', short: 'o' },
         visibility: { type: 'string', short: 'v' },
+        examples: { type: 'string' },
         example: { type: 'string', short: 'e' },
         alias: { type: 'string', short: 'a' },
       },
@@ -94,6 +97,7 @@ const createAttribute = async () => {
     let applyScrubbingKey: string | undefined;
     let isInOtel: string | undefined;
     let visibility: string | undefined;
+    let examples: string | undefined;
     let example: string | undefined;
     let alias: string | undefined;
 
@@ -104,7 +108,7 @@ const createAttribute = async () => {
       applyScrubbingKey = await askForApplyScrubbing();
       isInOtel = String(await askForAttributeIsInOtel());
       visibility = await askForAttributeVisibility();
-      example = await askForAttributeExample();
+      examples = await askForAttributeExamples();
       alias = await askForAttributeAlias();
     } else {
       key = values.key;
@@ -113,6 +117,7 @@ const createAttribute = async () => {
       applyScrubbingKey = values.apply_scrubbing;
       isInOtel = values.is_in_otel;
       visibility = values.visibility;
+      examples = values.examples;
       example = values.example;
       alias = values.alias;
     }
@@ -128,8 +133,18 @@ const createAttribute = async () => {
       process.exit(1);
     }
 
+    if (examples !== undefined && example !== undefined) {
+      console.error('Error: Use either --examples or --example, not both.');
+      process.exit(1);
+    }
+
     const hasDynamicSuffix = key.includes('.<key>');
-    let exampleValue: string | string[] | boolean | boolean[] | number | number[] | undefined;
+    let examplesValue: AttributeValue[] | undefined;
+    if (examples) {
+      examplesValue = parseAttributeExamples(examples);
+    }
+
+    let exampleValue: AttributeValue | undefined;
     if (example) {
       if (type === 'string[]' || type === 'boolean[]' || type === 'integer[]' || type === 'double[]') {
         exampleValue = JSON.parse(example);
@@ -156,6 +171,7 @@ const createAttribute = async () => {
       },
       is_in_otel: isInOtel.toLowerCase() === 'true',
       visibility,
+      ...(examplesValue && { examples: examplesValue }),
       ...(example && { example: exampleValue }),
       ...(alias && alias.trim() !== '' && { alias: alias.split(',').map((s) => s.trim()) }),
       changelog: [
@@ -297,11 +313,11 @@ async function askForAttributeVisibility() {
   );
 }
 
-async function askForAttributeExample() {
+async function askForAttributeExamples() {
   return abortIfCancelled(
     text({
-      message: 'Enter an example value (optional)',
-      placeholder: 'GET /users/:id',
+      message: 'Enter example values as a JSON array (optional)',
+      placeholder: '["GET /users/:id", "GET /teams/:id"]',
     }),
   );
 }

--- a/scripts/create_attribute.ts
+++ b/scripts/create_attribute.ts
@@ -4,7 +4,8 @@ import path from 'node:path';
 import { parseArgs } from 'node:util';
 import { confirm, intro, isCancel, log, outro, select, text } from '@clack/prompts';
 import Ajv from 'ajv';
-import { parseAttributeExamples, type AttributeValue } from './types';
+import { parseAttributeExamples } from './attribute_examples';
+import type { AttributeValue } from './types';
 
 const getNextPrNumber = (): number | undefined => {
   try {

--- a/scripts/generate_attributes.ts
+++ b/scripts/generate_attributes.ts
@@ -1,18 +1,29 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { AttributeJson } from './types';
+import { getAttributeExamples, type AttributeJson } from './types';
 
-export async function generateAttributes() {
-  const attributesDir = path.join(__dirname, '..', 'model', 'attributes');
+interface GenerateAttributesOptions {
+  attributesDir: string;
+  jsOutputFilePath: string;
+  pythonOutputFilePath: string;
+}
+
+export async function generateAttributes(options?: Partial<GenerateAttributesOptions>) {
+  const repositoryRoot = path.join(__dirname, '..');
+  const attributesDir = options?.attributesDir ?? path.join(repositoryRoot, 'model', 'attributes');
+  const jsOutputFilePath =
+    options?.jsOutputFilePath ?? path.join(repositoryRoot, 'javascript', 'sentry-conventions', 'src', 'attributes.ts');
+  const pythonOutputFilePath =
+    options?.pythonOutputFilePath ?? path.join(repositoryRoot, 'python', 'src', 'sentry_conventions', 'attributes.py');
 
   // Get all JSON files recursively
   const attributeFiles = await getAllJsonFiles(attributesDir);
 
   // Generate and write JavaScript code
-  writeToJs(attributesDir, attributeFiles);
+  writeToJs(attributesDir, attributeFiles, jsOutputFilePath);
 
   // Generate and write Python code
-  writeToPython(attributesDir, attributeFiles);
+  writeToPython(attributesDir, attributeFiles, pythonOutputFilePath);
 }
 
 async function getAllJsonFiles(dir: string): Promise<string[]> {
@@ -37,7 +48,7 @@ async function getAllJsonFiles(dir: string): Promise<string[]> {
   return allFiles;
 }
 
-function writeToJs(attributesDir: string, attributeFiles: string[]) {
+function writeToJs(attributesDir: string, attributeFiles: string[], outputFilePath: string) {
   let attributesContent = '// This is an auto-generated file. Do not edit!\n\n';
 
   // Reset memoization for fresh calculation
@@ -111,7 +122,8 @@ function writeToJs(attributesDir: string, attributeFiles: string[]) {
 
   // Generate individual attribute constants with documentation AND build the explicit type map
   for (const { file, key, constantName, attributeJson, _isDeprecated } of allAttributes) {
-    const { brief, type, apply_scrubbing, is_in_otel, example, has_dynamic_suffix, deprecation, alias } = attributeJson;
+    const { brief, type, apply_scrubbing, is_in_otel, has_dynamic_suffix, deprecation, alias } = attributeJson;
+    const examples = getAttributeExamples(attributeJson);
     const visibility = getVisibility(attributeJson);
 
     const tsType = getTsType(type);
@@ -159,12 +171,14 @@ function writeToJs(attributesDir: string, attributeFiles: string[]) {
       individualConstants += formatDeprecationJsdoc(deprecation, allAttributes, false);
     }
 
-    // Example
-    if (example !== undefined) {
+    // Examples
+    if (examples !== undefined) {
       if (!deprecation) {
         individualConstants += ' *\n';
       }
-      individualConstants += ` * @example ${JSON.stringify(example)}\n`;
+      for (const example of examples) {
+        individualConstants += ` * @example ${JSON.stringify(example)}\n`;
+      }
     }
 
     individualConstants += ' */\n';
@@ -205,7 +219,6 @@ function writeToJs(attributesDir: string, attributeFiles: string[]) {
 } & Record<string, AttributeValue | undefined>;\n\n`;
 
   // Write the generated content to the file
-  const outputFilePath = path.join(__dirname, '..', 'javascript', 'sentry-conventions', 'src', 'attributes.ts');
   fs.writeFileSync(outputFilePath, attributesContent);
 
   console.log(`Generated attributes file at: ${outputFilePath}`);
@@ -309,7 +322,7 @@ function getTsType(type: AttributeJson['type']): string {
   }
 }
 
-function writeToPython(attributesDir: string, attributeFiles: string[]) {
+function writeToPython(attributesDir: string, attributeFiles: string[], outputFilePath: string) {
   let content = `"""`;
   content +=
     "A collection of attribute names with helpers to retrieve an attribute's metadata, as defined in the Sentry Semantic Conventions registry.";
@@ -410,7 +423,10 @@ function writeToPython(attributesDir: string, attributeFiles: string[]) {
   content += '    \n';
   content += '    additional_context: Optional[List[str]] = None\n';
   content +=
-    '    """A list of freeform notes providing additional context about how this attribute behaves, common pitfalls, or query-time nuances"""\n\n';
+    '    """A list of freeform notes providing additional context about how this attribute behaves, common pitfalls, or query-time nuances"""\n';
+  content += '    \n';
+  content += '    examples: Optional[List[AttributeValue]] = None\n';
+  content += '    """Example values of the attribute"""\n\n';
 
   let attributesTypeMembers = '';
   let deprecatedAttributesTypeMembers = '';
@@ -463,8 +479,8 @@ function writeToPython(attributesDir: string, attributeFiles: string[]) {
     const attributePath = path.join(attributesDir, file);
     const attributeJson = JSON.parse(fs.readFileSync(attributePath, 'utf-8')) as AttributeJson;
 
-    const { key, brief, type, apply_scrubbing, is_in_otel, example, has_dynamic_suffix, deprecation, alias } =
-      attributeJson;
+    const { key, brief, type, apply_scrubbing, is_in_otel, has_dynamic_suffix, deprecation, alias } = attributeJson;
+    const examples = getAttributeExamples(attributeJson);
     const visibility = getVisibility(attributeJson);
 
     // Convert attribute key to a valid Python constant name
@@ -497,8 +513,10 @@ function writeToPython(attributesDir: string, attributeFiles: string[]) {
       }
     }
 
-    if (example !== undefined) {
-      content += `    Example: ${JSON.stringify(example)}\n`;
+    if (examples !== undefined) {
+      for (const example of examples) {
+        content += `    Example: ${JSON.stringify(example)}\n`;
+      }
     }
 
     content += '    """\n\n';
@@ -542,9 +560,12 @@ function writeToPython(attributesDir: string, attributeFiles: string[]) {
       metadataDict += '        has_dynamic_suffix=True,\n';
     }
 
-    if (example !== undefined) {
-      const pythonExample = convertToPythonLiteral(example);
+    if (examples !== undefined) {
+      const pythonExample = convertToPythonLiteral(examples[0]);
       metadataDict += `        example=${pythonExample},\n`;
+      if (attributeJson.examples !== undefined) {
+        metadataDict += `        examples=${convertToPythonLiteral(examples)},\n`;
+      }
     }
 
     // Build deprecation info structure if present
@@ -627,7 +648,6 @@ function writeToPython(attributesDir: string, attributeFiles: string[]) {
   content += ']\n\n';
 
   // Write the generated content to the file
-  const outputFilePath = path.join(__dirname, '..', 'python', 'src', 'sentry_conventions', 'attributes.py');
   fs.writeFileSync(outputFilePath, content);
 
   console.log(`Generated Python attributes file at: ${outputFilePath}`);
@@ -777,6 +797,8 @@ export interface AttributeMetadata {
   hasDynamicSuffix?: boolean;
   /** An example value of the attribute */
   example?: AttributeValue;
+  /** Example values of the attribute */
+  examples?: AttributeValue[];
   /** If an attribute was deprecated, and what it was replaced with */
   deprecation?: DeprecationInfo;
   /** If there are attributes that alias to this attribute */
@@ -820,7 +842,8 @@ function generateMetadataDict(
   metadataDict += 'export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {\n';
 
   for (const { key, attributeJson } of allAttributes) {
-    const { brief, type, apply_scrubbing, is_in_otel, example, has_dynamic_suffix, deprecation, alias } = attributeJson;
+    const { brief, type, apply_scrubbing, is_in_otel, has_dynamic_suffix, deprecation, alias } = attributeJson;
+    const examples = getAttributeExamples(attributeJson);
     const visibility = getVisibility(attributeJson);
 
     metadataDict += `  ${JSON.stringify(key)}: {\n`;
@@ -844,8 +867,11 @@ function generateMetadataDict(
       metadataDict += '    hasDynamicSuffix: true,\n';
     }
 
-    if (example !== undefined) {
-      metadataDict += `    example: ${JSON.stringify(example)},\n`;
+    if (examples !== undefined) {
+      metadataDict += `    example: ${JSON.stringify(examples[0])},\n`;
+      if (attributeJson.examples !== undefined) {
+        metadataDict += `    examples: ${JSON.stringify(examples)},\n`;
+      }
     }
 
     // Build deprecation info structure if present

--- a/scripts/generate_attributes.ts
+++ b/scripts/generate_attributes.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { getAttributeExamples, type AttributeJson } from './types';
+import { getAttributeExamples } from './attribute_examples';
+import type { AttributeJson } from './types';
 
 interface GenerateAttributesOptions {
   attributesDir: string;

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -1,3 +1,5 @@
+export type AttributeValue = string | boolean | number | string[] | boolean[] | number[];
+
 export interface AttributeJson {
   key: string;
   brief: string;
@@ -9,7 +11,8 @@ export interface AttributeJson {
   };
   is_in_otel: boolean;
   visibility?: 'public' | 'internal';
-  example?: string | boolean | number | string[] | boolean[] | number[];
+  example?: AttributeValue;
+  examples?: AttributeValue[];
   deprecation?: {
     replacement?: string;
     reason?: string;
@@ -19,6 +22,26 @@ export interface AttributeJson {
   alias?: string[];
   additional_context?: string[];
   changelog?: { version: string; prs?: number[]; description?: string }[];
+}
+
+export function getAttributeExamples(
+  attribute: Pick<AttributeJson, 'example' | 'examples'>,
+): AttributeValue[] | undefined {
+  if (attribute.examples !== undefined) {
+    return attribute.examples;
+  }
+  if (attribute.example !== undefined) {
+    return [attribute.example];
+  }
+  return undefined;
+}
+
+export function parseAttributeExamples(value: string): AttributeValue[] {
+  const examples = JSON.parse(value) as unknown;
+  if (!Array.isArray(examples) || examples.length === 0) {
+    throw new Error('Examples must be provided as a non-empty JSON array');
+  }
+  return examples as AttributeValue[];
 }
 
 export interface NameJson {

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -24,26 +24,6 @@ export interface AttributeJson {
   changelog?: { version: string; prs?: number[]; description?: string }[];
 }
 
-export function getAttributeExamples(
-  attribute: Pick<AttributeJson, 'example' | 'examples'>,
-): AttributeValue[] | undefined {
-  if (attribute.examples !== undefined) {
-    return attribute.examples;
-  }
-  if (attribute.example !== undefined) {
-    return [attribute.example];
-  }
-  return undefined;
-}
-
-export function parseAttributeExamples(value: string): AttributeValue[] {
-  const examples = JSON.parse(value) as unknown;
-  if (!Array.isArray(examples) || examples.length === 0) {
-    throw new Error('Examples must be provided as a non-empty JSON array');
-  }
-  return examples as AttributeValue[];
-}
-
 export interface NameJson {
   brief: string;
   operations: {

--- a/test/attributes.test.ts
+++ b/test/attributes.test.ts
@@ -5,11 +5,107 @@ import Ajv from 'ajv';
 import { describe, expect, it } from 'vitest';
 
 import schema from '../schemas/attribute.schema.json';
-import type { AttributeJson } from '../scripts/types';
 import { compareVersions } from '../scripts/generate_attribute_changelog';
+import { getAttributeExamples, parseAttributeExamples, type AttributeJson } from '../scripts/types';
 import { attributeKeyToFileName, fileNameToAttributeKey } from '../scripts/utils';
 
 const traceFolders = path.resolve(__dirname, '../model/attributes');
+
+describe('attribute examples schema', () => {
+  const baseAttribute = {
+    key: 'test.attribute',
+    brief: 'An attribute used to test the schema.',
+    type: 'string',
+    apply_scrubbing: { key: 'never' },
+    is_in_otel: false,
+    visibility: 'public',
+  };
+
+  it('accepts multiple scalar examples', () => {
+    const ajv = new Ajv();
+    const valid = ajv.validate(schema, {
+      ...baseAttribute,
+      examples: ['first', 'second'],
+    });
+
+    expect(valid).toBe(true);
+  });
+
+  it('accepts multiple array-valued examples', () => {
+    const ajv = new Ajv();
+    const valid = ajv.validate(schema, {
+      ...baseAttribute,
+      type: 'string[]',
+      examples: [
+        ['first', 'second'],
+        ['third', 'fourth'],
+      ],
+    });
+
+    expect(valid).toBe(true);
+  });
+
+  it('accepts an empty array as an array-valued example', () => {
+    const ajv = new Ajv();
+    const valid = ajv.validate(schema, {
+      ...baseAttribute,
+      type: 'string[]',
+      examples: [[]],
+    });
+
+    expect(valid).toBe(true);
+  });
+
+  it('rejects examples that do not match the attribute type', () => {
+    const ajv = new Ajv();
+    const valid = ajv.validate(schema, {
+      ...baseAttribute,
+      type: 'string[]',
+      examples: [42],
+    });
+
+    expect(valid).toBe(false);
+  });
+
+  it('rejects singular and plural examples on the same attribute', () => {
+    const ajv = new Ajv();
+    const valid = ajv.validate(schema, {
+      ...baseAttribute,
+      example: 'first',
+      examples: ['first', 'second'],
+    });
+
+    expect(valid).toBe(false);
+  });
+});
+
+describe('getAttributeExamples', () => {
+  it('wraps a legacy example in an array', () => {
+    expect(getAttributeExamples({ example: 'legacy' })).toEqual(['legacy']);
+  });
+
+  it('preserves plural array-valued examples', () => {
+    const examples = [
+      ['first', 'second'],
+      ['third', 'fourth'],
+    ];
+
+    expect(getAttributeExamples({ examples })).toEqual(examples);
+  });
+});
+
+describe('parseAttributeExamples', () => {
+  it('parses JSON example lists including array-valued examples', () => {
+    expect(parseAttributeExamples('[["first","second"],["third"]]')).toEqual([['first', 'second'], ['third']]);
+  });
+
+  it('rejects a value that is not a non-empty JSON array', () => {
+    expect(() => parseAttributeExamples('"one example"')).toThrow(
+      'Examples must be provided as a non-empty JSON array',
+    );
+    expect(() => parseAttributeExamples('[]')).toThrow('Examples must be provided as a non-empty JSON array');
+  });
+});
 
 describe('attribute json', async () => {
   const filesIterator = await fs.promises.glob(`${traceFolders}/**/*.json`);
@@ -26,43 +122,47 @@ describe('attribute json', async () => {
         expect(ajv.errors).toBe(null);
       });
 
-      it('should have an example that follows the type set unless has_dynamic_suffix is true', () => {
-        if (content.has_dynamic_suffix) {
-          expect(typeof content.example).toBe('string');
+      it('should have examples that follow the type set unless has_dynamic_suffix is true', () => {
+        const examples = getAttributeExamples(content);
+        if (!examples) {
           return;
         }
 
-        if (!content.example) {
+        if (content.has_dynamic_suffix) {
+          expect(examples.every((example) => typeof example === 'string')).toBe(true);
           return;
         }
-        switch (content.type) {
-          case 'integer':
-          case 'double':
-            expect(typeof content.example).toBe('number');
-            break;
-          case 'integer[]':
-          case 'double[]':
-            expect(Array.isArray(content.example)).toBe(true);
-            expect((content.example as number[]).every((e: number) => typeof e === 'number')).toBe(true);
-            break;
-          case 'string':
-            expect(typeof content.example).toBe('string');
-            break;
-          case 'string[]':
-            expect(Array.isArray(content.example)).toBe(true);
-            expect((content.example as string[]).every((e: string) => typeof e === 'string')).toBe(true);
-            break;
-          case 'boolean':
-            expect(typeof content.example).toBe('boolean');
-            break;
-          case 'boolean[]':
-            expect(Array.isArray(content.example)).toBe(true);
-            expect((content.example as boolean[]).every((e: boolean) => typeof e === 'boolean')).toBe(true);
-            break;
-          case 'any':
-            break;
-          default:
-            throw new Error('Invalid type');
+
+        for (const example of examples) {
+          switch (content.type) {
+            case 'integer':
+            case 'double':
+              expect(typeof example).toBe('number');
+              break;
+            case 'integer[]':
+            case 'double[]':
+              expect(Array.isArray(example)).toBe(true);
+              expect((example as number[]).every((value) => typeof value === 'number')).toBe(true);
+              break;
+            case 'string':
+              expect(typeof example).toBe('string');
+              break;
+            case 'string[]':
+              expect(Array.isArray(example)).toBe(true);
+              expect((example as string[]).every((value) => typeof value === 'string')).toBe(true);
+              break;
+            case 'boolean':
+              expect(typeof example).toBe('boolean');
+              break;
+            case 'boolean[]':
+              expect(Array.isArray(example)).toBe(true);
+              expect((example as boolean[]).every((value) => typeof value === 'boolean')).toBe(true);
+              break;
+            case 'any':
+              break;
+            default:
+              throw new Error('Invalid type');
+          }
         }
       });
 

--- a/test/attributes.test.ts
+++ b/test/attributes.test.ts
@@ -78,6 +78,17 @@ describe('attribute examples schema', () => {
 
     expect(valid).toBe(false);
   });
+
+  it('rejects a dynamic-suffix attribute without examples', () => {
+    const ajv = new Ajv();
+    const valid = ajv.validate(schema, {
+      ...baseAttribute,
+      key: 'test.<key>',
+      has_dynamic_suffix: true,
+    });
+
+    expect(valid).toBe(false);
+  });
 });
 
 describe('getAttributeExamples', () => {
@@ -125,12 +136,12 @@ describe('attribute json', async () => {
 
       it('should have examples that follow the type set unless has_dynamic_suffix is true', () => {
         const examples = getAttributeExamples(content);
-        if (!examples) {
+        if (content.has_dynamic_suffix) {
+          expect(examples?.every((example) => typeof example === 'string')).toBe(true);
           return;
         }
 
-        if (content.has_dynamic_suffix) {
-          expect(examples.every((example) => typeof example === 'string')).toBe(true);
+        if (!examples) {
           return;
         }
 

--- a/test/attributes.test.ts
+++ b/test/attributes.test.ts
@@ -5,8 +5,9 @@ import Ajv from 'ajv';
 import { describe, expect, it } from 'vitest';
 
 import schema from '../schemas/attribute.schema.json';
+import { getAttributeExamples, parseAttributeExamples } from '../scripts/attribute_examples';
 import { compareVersions } from '../scripts/generate_attribute_changelog';
-import { getAttributeExamples, parseAttributeExamples, type AttributeJson } from '../scripts/types';
+import type { AttributeJson } from '../scripts/types';
 import { attributeKeyToFileName, fileNameToAttributeKey } from '../scripts/utils';
 
 const traceFolders = path.resolve(__dirname, '../model/attributes');

--- a/test/generate_attributes.test.ts
+++ b/test/generate_attributes.test.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { generateAttributes } from '../scripts/generate_attributes';
+
+describe('generateAttributes', () => {
+  it('accepts custom paths for isolated generation', () => {
+    expect(generateAttributes).toHaveLength(1);
+  });
+
+  it('generates multiple examples while retaining the first legacy example', async () => {
+    const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'sentry-conventions-'));
+    const attributesDir = path.join(temporaryDirectory, 'attributes');
+    const jsOutputFilePath = path.join(temporaryDirectory, 'attributes.ts');
+    const pythonOutputFilePath = path.join(temporaryDirectory, 'attributes.py');
+    fs.mkdirSync(attributesDir);
+    fs.writeFileSync(
+      path.join(attributesDir, 'test__attribute.json'),
+      JSON.stringify({
+        key: 'test.attribute',
+        brief: 'An attribute used to test generation.',
+        type: 'string',
+        apply_scrubbing: { key: 'never' },
+        is_in_otel: false,
+        visibility: 'public',
+        examples: ['first', 'second'],
+      }),
+    );
+    fs.writeFileSync(
+      path.join(attributesDir, 'test__array.json'),
+      JSON.stringify({
+        key: 'test.array',
+        brief: 'An array-valued attribute used to test generation.',
+        type: 'string[]',
+        apply_scrubbing: { key: 'never' },
+        is_in_otel: false,
+        visibility: 'public',
+        examples: [['first', 'second'], ['third']],
+      }),
+    );
+
+    try {
+      await generateAttributes({ attributesDir, jsOutputFilePath, pythonOutputFilePath });
+
+      const javascript = fs.readFileSync(jsOutputFilePath, 'utf8');
+      expect(javascript).toContain('* @example "first"');
+      expect(javascript).toContain('* @example "second"');
+      expect(javascript).toContain('example: "first",');
+      expect(javascript).toContain('examples: ["first","second"],');
+      expect(javascript).toContain('example: ["first","second"],');
+      expect(javascript).toContain('examples: [["first","second"],["third"]],');
+
+      const python = fs.readFileSync(pythonOutputFilePath, 'utf8');
+      expect(python.indexOf('examples: Optional[List[AttributeValue]]')).toBeGreaterThan(
+        python.indexOf('additional_context: Optional[List[str]]'),
+      );
+      expect(python).toContain('Example: "first"');
+      expect(python).toContain('Example: "second"');
+      expect(python).toContain('example="first",');
+      expect(python).toContain('examples=["first", "second"],');
+      expect(python).toContain('example=["first", "second"],');
+      expect(python).toContain('examples=[["first", "second"], ["third"]],');
+    } finally {
+      fs.rmSync(temporaryDirectory, { recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
Add support for multiple attribute examples across validation, authoring, generated JavaScript and Python metadata, and documentation while preserving legacy `example` compatibility. This is helpful when one example alone isn't enough to illustrate the possible values.

Also added a few examples to `db.query.summary` which is such a case IMHO.

cc @mydea since we talked about this

Fixes #209