### PR TITLE
chore(codeowners): Assign telemetry-experience to gen_ai/ai attributes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,10 +2,10 @@
 * @Lms24 @cleptric @getsentry/ingest @mjq @nsdeschenes
 
 # Gen AI / AI attributes
-/model/attributes/gen_ai/ @getsentry/telemetry-experience
-/model/attributes/ai/ @getsentry/telemetry-experience
+/model/attributes/gen_ai/ @getsentry/telemetry-experience @Lms24 @cleptric @getsentry/ingest @mjq @nsdeschenes
+/model/attributes/ai/ @getsentry/telemetry-experience @Lms24 @cleptric @getsentry/ingest @mjq @nsdeschenes
 
 # Generated files that aggregate every attribute namespace; left unowned so
 # individual namespace owners aren't required reviewers on unrelated diffs
-javascript/sentry-conventions/src/attributes.ts
-python/src/sentry_conventions/attributes.py
+javascript/sentry-conventions/
+python/src/sentry_conventions/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
 # Global ownership
 * @Lms24 @cleptric @getsentry/ingest @mjq @nsdeschenes
+
+# Gen AI / AI attributes
+/model/attributes/gen_ai/ @getsentry/telemetry-experience
+/model/attributes/ai/ @getsentry/telemetry-experience

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,8 @@
 # Gen AI / AI attributes
 /model/attributes/gen_ai/ @getsentry/telemetry-experience
 /model/attributes/ai/ @getsentry/telemetry-experience
+
+# Generated files that aggregate every attribute namespace; left unowned so
+# individual namespace owners aren't required reviewers on unrelated diffs
+javascript/sentry-conventions/src/attributes.ts
+python/src/sentry_conventions/attributes.py

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
 # Global ownership
 * @Lms24 @cleptric @getsentry/ingest @mjq @nsdeschenes
 
-# Gen AI / AI attributes
-/model/attributes/gen_ai/ @getsentry/telemetry-experience @Lms24 @cleptric @getsentry/ingest @mjq @nsdeschenes
-/model/attributes/ai/ @getsentry/telemetry-experience @Lms24 @cleptric @getsentry/ingest @mjq @nsdeschenes
-
 # Generated files that aggregate every attribute namespace; left unowned so
 # individual namespace owners aren't required reviewers on unrelated diffs
 javascript/sentry-conventions/
 python/src/sentry_conventions/
+
+# Gen AI / AI attributes
+/model/attributes/gen_ai/ @getsentry/telemetry-experience @Lms24 @cleptric @getsentry/ingest @mjq @nsdeschenes
+/model/attributes/ai/ @getsentry/telemetry-experience @Lms24 @cleptric @getsentry/ingest @mjq @nsdeschenes


### PR DESCRIPTION
The `model/attributes/gen_ai/` and `model/attributes/ai/` directories are now owned by `@getsentry/telemetry-experience` in CODEOWNERS, so PRs touching those attribute definitions route to that team for review.

`javascript/sentry-conventions/src/attributes.ts` and `python/src/sentry_conventions/attributes.py` are generated from every namespace under `model/attributes/`, not just gen_ai/ai, so they're left unowned rather than assigned to any single namespace's team — matching the pattern used for generated files in [ops' CODEOWNERS](https://github.com/getsentry/ops/blob/master/CODEOWNERS#L4-L13). Otherwise every namespace-specific rule added here would pull its team into reviewing unrelated diffs whenever these combined files regenerate.