### PR TITLE
feat(attributes): Add deprecated messaging.destination_kind

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -10756,6 +10756,28 @@ export const MESSAGING_DESTINATION_CONNECTION = 'messaging.destination.connectio
  */
 export type MESSAGING_DESTINATION_CONNECTION_TYPE = string;
 
+// Path: model/attributes/messaging/messaging__destination_kind.json
+
+/**
+ * The kind of message destination. `messaging.destination_kind`
+ *
+ * Attribute Value Type: `string` {@link MESSAGING_DESTINATION_KIND_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @deprecated  - Deprecated from OTEL, which now models the destination kind via messaging.operation.type and messaging.destination.name.
+ * @example "topic"
+ */
+export const MESSAGING_DESTINATION_KIND = 'messaging.destination_kind';
+
+/**
+ * Type for {@link MESSAGING_DESTINATION_KIND} messaging.destination_kind
+ */
+export type MESSAGING_DESTINATION_KIND_TYPE = string;
+
 // Path: model/attributes/messaging/messaging__destination__name.json
 
 /**
@@ -17257,6 +17279,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'messaging.batch.message_count': 'integer',
   'messaging.destination': 'string',
   'messaging.destination.connection': 'string',
+  'messaging.destination_kind': 'string',
   'messaging.destination.name': 'string',
   'messaging.message.body.size': 'integer',
   'messaging.message.conversation_id': 'string',
@@ -18015,6 +18038,7 @@ export type AttributeName =
   | typeof MESSAGING_BATCH_MESSAGE_COUNT
   | typeof MESSAGING_DESTINATION
   | typeof MESSAGING_DESTINATION_CONNECTION
+  | typeof MESSAGING_DESTINATION_KIND
   | typeof MESSAGING_DESTINATION_NAME
   | typeof MESSAGING_MESSAGE_BODY_SIZE
   | typeof MESSAGING_MESSAGE_CONVERSATION_ID
@@ -24933,6 +24957,27 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'BestTopic',
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
+  'messaging.destination_kind': {
+    brief: 'The kind of message destination.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'topic',
+    deprecation: {
+      reason:
+        'Deprecated from OTEL, which now models the destination kind via messaging.operation.type and messaging.destination.name.',
+    },
+    changelog: [
+      {
+        version: 'next',
+        description:
+          'Added deprecated messaging.destination_kind attribute for parity with legacy OTel instrumentations.',
+      },
+    ],
+  },
   'messaging.destination.name': {
     brief: 'The message destination name.',
     type: 'string',
@@ -28871,6 +28916,7 @@ export type Attributes = {
   [MESSAGING_BATCH_MESSAGE_COUNT]?: MESSAGING_BATCH_MESSAGE_COUNT_TYPE;
   [MESSAGING_DESTINATION]?: MESSAGING_DESTINATION_TYPE;
   [MESSAGING_DESTINATION_CONNECTION]?: MESSAGING_DESTINATION_CONNECTION_TYPE;
+  [MESSAGING_DESTINATION_KIND]?: MESSAGING_DESTINATION_KIND_TYPE;
   [MESSAGING_DESTINATION_NAME]?: MESSAGING_DESTINATION_NAME_TYPE;
   [MESSAGING_MESSAGE_BODY_SIZE]?: MESSAGING_MESSAGE_BODY_SIZE_TYPE;
   [MESSAGING_MESSAGE_CONVERSATION_ID]?: MESSAGING_MESSAGE_CONVERSATION_ID_TYPE;

--- a/model/attributes/messaging/messaging__destination_kind.json
+++ b/model/attributes/messaging/messaging__destination_kind.json
@@ -1,0 +1,21 @@
+{
+  "key": "messaging.destination_kind",
+  "brief": "The kind of message destination.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": "topic",
+  "deprecation": {
+    "_status": null,
+    "reason": "Deprecated from OTEL, which now models the destination kind via messaging.operation.type and messaging.destination.name."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added deprecated messaging.destination_kind attribute for parity with legacy OTel instrumentations."
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -239,6 +239,7 @@ class _AttributeNamesMeta(type):
         "MCP_TOOL_RESULT_IS_ERROR",
         "MCP_TRANSPORT",
         "MESSAGING_DESTINATION",
+        "MESSAGING_DESTINATION_KIND",
         "METHOD",
         "NET_HOST_IP",
         "NET_HOST_NAME",
@@ -6383,6 +6384,20 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Visibility: public
     Aliases: messaging.destination
     Example: "BestTopic"
+    """
+
+    # Path: model/attributes/messaging/messaging__destination_kind.json
+    MESSAGING_DESTINATION_KIND: Literal["messaging.destination_kind"] = (
+        "messaging.destination_kind"
+    )
+    """The kind of message destination.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    DEPRECATED: No replacement at this time - Deprecated from OTEL, which now models the destination kind via messaging.operation.type and messaging.destination.name.
+    Example: "topic"
     """
 
     # Path: model/attributes/messaging/messaging__message__body__size.json
@@ -16976,6 +16991,23 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "messaging.destination_kind": AttributeMetadata(
+        brief="The kind of message destination.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="topic",
+        deprecation=DeprecationInfo(
+            reason="Deprecated from OTEL, which now models the destination kind via messaging.operation.type and messaging.destination.name."
+        ),
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added deprecated messaging.destination_kind attribute for parity with legacy OTel instrumentations.",
+            ),
+        ],
+    ),
     "messaging.message.body.size": AttributeMetadata(
         brief="The size of the message body in bytes.",
         type=AttributeType.INTEGER,
@@ -21069,6 +21101,7 @@ Attributes = TypedDict(
         "messaging.destination": str,
         "messaging.destination.connection": str,
         "messaging.destination.name": str,
+        "messaging.destination_kind": str,
         "messaging.message.body.size": int,
         "messaging.message.conversation_id": str,
         "messaging.message.envelope.size": int,


### PR DESCRIPTION
## What

Adds the legacy `messaging.destination_kind` attribute to the model, marked deprecated with no replacement.

- Model: `model/attributes/messaging/messaging__destination_kind.json`
- Regenerated JS (`MESSAGING_DESTINATION_KIND`) and Python exports via `yarn generate`.

## Why

Older OTel instrumentations still emit `messaging.destination_kind` (e.g. the aws-sdk SNS instrumentation the Sentry JS SDK ports for parity). OTel has since removed it in favor of `messaging.operation.type` + `messaging.destination.name`, so it's modeled here as deprecated (`_status: null`, no replacement).