### PR TITLE
ref(attributes): Deprecate `sentry.span.source` and change backfill status of `sentry.source`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -14380,7 +14380,7 @@ export type SENTRY_SERVER_SAMPLE_RATE_TYPE = number;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * @deprecated Use {@link SENTRY_SPAN_SOURCE} (sentry.span.source) instead - This attribute is being deprecated in favor of sentry.span.source
+ * @deprecated  - This attribute is superseded by sentry.segment.name.source, which only needs to be set on segment spans.
  * @example "route"
  */
 export const SENTRY_SOURCE = 'sentry.source';
@@ -14402,6 +14402,7 @@ export type SENTRY_SOURCE_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * @deprecated  - This attribute is superseded by sentry.segment.name.source, which only needs to be set on segment spans.
  * @example "route"
  */
 export const SENTRY_SPAN_SOURCE = 'sentry.span.source';
@@ -27330,11 +27331,10 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'route',
     deprecation: {
-      replacement: 'sentry.span.source',
-      reason: 'This attribute is being deprecated in favor of sentry.span.source',
-      status: 'backfill',
+      reason:
+        'This attribute is superseded by sentry.segment.name.source, which only needs to be set on segment spans.',
     },
-    changelog: [{ version: '0.5.0' }],
+    changelog: [{ version: 'next', description: 'Removed the sentry.span.source replacement' }, { version: '0.5.0' }],
   },
   'sentry.span.source': {
     brief:
@@ -27346,7 +27346,15 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'route',
-    changelog: [{ version: '0.4.0', prs: [214] }, { version: '0.0.0' }],
+    deprecation: {
+      reason:
+        'This attribute is superseded by sentry.segment.name.source, which only needs to be set on segment spans.',
+    },
+    changelog: [
+      { version: 'next', description: 'Deprecated; superseded by sentry.segment.name.source on segment spans' },
+      { version: '0.4.0', prs: [214] },
+      { version: '0.0.0' },
+    ],
   },
   'sentry.status': {
     brief:

--- a/model/attributes/sentry/sentry__source.json
+++ b/model/attributes/sentry/sentry__source.json
@@ -8,12 +8,15 @@
   "is_in_otel": false,
   "example": "route",
   "deprecation": {
-    "_status": "backfill",
-    "replacement": "sentry.span.source",
-    "reason": "This attribute is being deprecated in favor of sentry.span.source"
+    "_status": null,
+    "reason": "This attribute is superseded by sentry.segment.name.source, which only needs to be set on segment spans."
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Removed the sentry.span.source replacement"
+    },
     {
       "version": "0.5.0"
     }

--- a/model/attributes/sentry/sentry__span__source.json
+++ b/model/attributes/sentry/sentry__span__source.json
@@ -7,8 +7,16 @@
   },
   "is_in_otel": false,
   "example": "route",
+  "deprecation": {
+    "_status": null,
+    "reason": "This attribute is superseded by sentry.segment.name.source, which only needs to be set on segment spans."
+  },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Deprecated; superseded by sentry.segment.name.source on segment spans"
+    },
     {
       "version": "0.4.0",
       "prs": [214]

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -283,6 +283,7 @@ class _AttributeNamesMeta(type):
         "SENTRY_REPORT_EVENT",
         "_SENTRY_SEGMENT_ID",
         "SENTRY_SOURCE",
+        "SENTRY_SPAN_SOURCE",
         "SENTRY_SVELTEKIT_NAVIGATION_FROM",
         "SENTRY_SVELTEKIT_NAVIGATION_TO",
         "SENTRY_SVELTEKIT_NAVIGATION_TYPE",
@@ -8365,7 +8366,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: never
     Defined in OTEL: No
     Visibility: public
-    DEPRECATED: Use sentry.span.source instead - This attribute is being deprecated in favor of sentry.span.source
+    DEPRECATED: No replacement at this time - This attribute is superseded by sentry.segment.name.source, which only needs to be set on segment spans.
     Example: "route"
     """
 
@@ -8377,6 +8378,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: never
     Defined in OTEL: No
     Visibility: public
+    DEPRECATED: No replacement at this time - This attribute is superseded by sentry.segment.name.source, which only needs to be set on segment spans.
     Example: "route"
     """
 
@@ -19303,11 +19305,12 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="route",
         deprecation=DeprecationInfo(
-            replacement="sentry.span.source",
-            reason="This attribute is being deprecated in favor of sentry.span.source",
-            status=DeprecationStatus.BACKFILL,
+            reason="This attribute is superseded by sentry.segment.name.source, which only needs to be set on segment spans."
         ),
         changelog=[
+            ChangelogEntry(
+                version="next", description="Removed the sentry.span.source replacement"
+            ),
             ChangelogEntry(version="0.5.0"),
         ],
     ),
@@ -19318,7 +19321,14 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="route",
+        deprecation=DeprecationInfo(
+            reason="This attribute is superseded by sentry.segment.name.source, which only needs to be set on segment spans."
+        ),
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Deprecated; superseded by sentry.segment.name.source on segment spans",
+            ),
             ChangelogEntry(version="0.4.0", prs=[214]),
             ChangelogEntry(version="0.0.0"),
         ],


### PR DESCRIPTION
This PR deprecates `sentry.span.source` without a direct replacement. We added `sentry.segment.name.source` before but the expectation here is that this attribute must only ever be set on segment spans. Therefore, we don't want to normalize or backfill it from `sentry.span.source`. 

Also required to change the `sentry.source` backfilling status, since its replacement no longer gets backfilled.

Side-note/context, this _does not_ concern setting `transaction_info.source` on transaction events. This we'll leave as-is for transactions. We intended `sentry.span.source` to be the replacement but then reconsidered the approach. Since the naming was less than ideal and the JS SDK also set it on non-segment spans, we decided on hopefully the final attribute now. 