### PR TITLE
ref(attributes): Improve description of `sentry.segment.name.source`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -14359,7 +14359,7 @@ export type SENTRY_SEGMENT_NAME_TYPE = string;
 // Path: model/attributes/sentry/sentry__segment__name__source.json
 
 /**
- * The name source of the segment span. Should only be set on segment spans. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`. `sentry.segment.name.source`
+ * The source of the segment span name. Should only be set on segment spans. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`. `sentry.segment.name.source`
  *
  * Attribute Value Type: `string` {@link SENTRY_SEGMENT_NAME_SOURCE_TYPE}
  *
@@ -27388,7 +27388,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   },
   'sentry.segment.name.source': {
     brief:
-      "The name source of the segment span. Should only be set on segment spans. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`.",
+      "The source of the segment span name. Should only be set on segment spans. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`.",
     type: 'string',
     applyScrubbing: {
       key: 'manual',
@@ -27397,6 +27397,10 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'internal',
     example: "'route'",
     changelog: [{ version: 'next', prs: [466], description: 'Added sentry.segment.name.source' }],
+    additionalContext: [
+      'This attribute is the replacement for `transaction_info.source` on transactions.',
+      'Should we bring back clustering for segment names (like we do for transaction names), this attribute will be used to determine if a segment name should be clustered.',
+    ],
   },
   'sentry.server_sample_rate': {
     brief: 'Rate at which a span was sampled in Relay.',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -14368,7 +14368,12 @@ export type SENTRY_SEGMENT_NAME_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: internal
  *
- * @example "'route'"
+ * @example "route"
+ * @example "component"
+ * @example "view"
+ * @example "task"
+ * @example "custom"
+ * @example "url"
  */
 export const SENTRY_SEGMENT_NAME_SOURCE = 'sentry.segment.name.source';
 
@@ -27395,7 +27400,8 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     isInOtel: false,
     visibility: 'internal',
-    example: "'route'",
+    example: 'route',
+    examples: ['route', 'component', 'view', 'task', 'custom', 'url'],
     changelog: [{ version: 'next', prs: [466], description: 'Added sentry.segment.name.source' }],
     additionalContext: [
       'This attribute is the replacement for `transaction_info.source` on transactions.',

--- a/model/attributes/sentry/sentry__segment__name__source.json
+++ b/model/attributes/sentry/sentry__segment__name__source.json
@@ -11,7 +11,7 @@
   },
   "is_in_otel": false,
   "visibility": "internal",
-  "example": "'route'",
+  "examples": ["route", "component", "view", "task", "custom", "url"],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/sentry/sentry__segment__name__source.json
+++ b/model/attributes/sentry/sentry__segment__name__source.json
@@ -1,6 +1,10 @@
 {
   "key": "sentry.segment.name.source",
-  "brief": "The name source of the segment span. Should only be set on segment spans. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`.",
+  "brief": "The source of the segment span name. Should only be set on segment spans. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`.",
+  "additional_context": [
+    "This attribute is the replacement for `transaction_info.source` on transactions.",
+    "Should we bring back clustering for segment names (like we do for transaction names), this attribute will be used to determine if a segment name should be clustered."
+  ],
   "type": "string",
   "apply_scrubbing": {
     "key": "manual"

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -8348,7 +8348,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     SENTRY_SEGMENT_NAME_SOURCE: Literal["sentry.segment.name.source"] = (
         "sentry.segment.name.source"
     )
-    """The name source of the segment span. Should only be set on segment spans. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`.
+    """The source of the segment span name. Should only be set on segment spans. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`.
 
     Type: str
     Apply Scrubbing: manual
@@ -19329,7 +19329,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "sentry.segment.name.source": AttributeMetadata(
-        brief="The name source of the segment span. Should only be set on segment spans. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`.",
+        brief="The source of the segment span name. Should only be set on segment spans. Known values are:  `'custom'`, `'url'`, `'route'`, `'component'`, `'view'`, `'task'`.",
         type=AttributeType.STRING,
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
@@ -19341,6 +19341,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
                 prs=[466],
                 description="Added sentry.segment.name.source",
             ),
+        ],
+        additional_context=[
+            "This attribute is the replacement for `transaction_info.source` on transactions.",
+            "Should we bring back clustering for segment names (like we do for transaction names), this attribute will be used to determine if a segment name should be clustered.",
         ],
     ),
     "sentry.segment_id": AttributeMetadata(

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -8354,7 +8354,12 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: internal
-    Example: "'route'"
+    Example: "route"
+    Example: "component"
+    Example: "view"
+    Example: "task"
+    Example: "custom"
+    Example: "url"
     """
 
     # Path: model/attributes/sentry/sentry__segment_id.json
@@ -19334,7 +19339,8 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.INTERNAL,
-        example="'route'",
+        example="route",
+        examples=["route", "component", "view", "task", "custom", "url"],
         changelog=[
             ChangelogEntry(
                 version="next",


### PR DESCRIPTION
h/t @ericapisani for pointing out that the previous description was not ideal. This PR (hopefully) improves the brief description and adds some additional context. ~We can also leave this open for a bit and add more examples once #505 lands.~ Update: Added multiple examples