### PR TITLE
feat(attributes): Add browser.bfcache.* attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2901,7 +2901,7 @@ export type BLOCKED_MAIN_THREAD_TYPE = boolean;
 // Path: model/attributes/browser/browser__bfcache__frame.json
 
 /**
- * Which frame a back/forward cache not-restored reason originated from. 'masked' indicates a cross-origin subframe whose specific reason is hidden by the browser. `browser.bfcache.frame`
+ * Which frame in the page's frame tree a back/forward cache not-restored reason originated from: the top document or a child frame. `browser.bfcache.frame`
  *
  * Attribute Value Type: `string` {@link BROWSER_BFCACHE_FRAME_TYPE}
  *
@@ -2912,8 +2912,6 @@ export type BLOCKED_MAIN_THREAD_TYPE = boolean;
  *
  * @example "top"
  * @example "child"
- * @example "masked"
- * @example "unknown"
  */
 export const BROWSER_BFCACHE_FRAME = 'browser.bfcache.frame';
 
@@ -21029,7 +21027,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   },
   'browser.bfcache.frame': {
     brief:
-      "Which frame a back/forward cache not-restored reason originated from. 'masked' indicates a cross-origin subframe whose specific reason is hidden by the browser.",
+      "Which frame in the page's frame tree a back/forward cache not-restored reason originated from: the top document or a child frame.",
     type: 'string',
     applyScrubbing: {
       key: 'never',
@@ -21037,7 +21035,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'top',
-    examples: ['top', 'child', 'masked', 'unknown'],
+    examples: ['top', 'child'],
     changelog: [{ version: 'next', prs: [513], description: 'Added browser.bfcache.frame attribute' }],
   },
   'browser.bfcache.not_restored_reason_count': {

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2905,7 +2905,7 @@ export type BLOCKED_MAIN_THREAD_TYPE = boolean;
  *
  * Attribute Value Type: `string` {@link BROWSER_BFCACHE_FRAME_TYPE}
  *
- * Apply Scrubbing: never
+ * Apply Scrubbing: manual
  *
  * Attribute defined in OTEL: No
  * Visibility: public
@@ -2927,7 +2927,7 @@ export type BROWSER_BFCACHE_FRAME_TYPE = string;
  *
  * Attribute Value Type: `number` {@link BROWSER_BFCACHE_NOT_RESTORED_REASON_COUNT_TYPE}
  *
- * Apply Scrubbing: never
+ * Apply Scrubbing: manual
  *
  * Attribute defined in OTEL: No
  * Visibility: public
@@ -2948,7 +2948,7 @@ export type BROWSER_BFCACHE_NOT_RESTORED_REASON_COUNT_TYPE = number;
  *
  * Attribute Value Type: `string` {@link BROWSER_BFCACHE_OUTCOME_TYPE}
  *
- * Apply Scrubbing: never
+ * Apply Scrubbing: manual
  *
  * Attribute defined in OTEL: No
  * Visibility: public
@@ -2970,7 +2970,7 @@ export type BROWSER_BFCACHE_OUTCOME_TYPE = string;
  *
  * Attribute Value Type: `string` {@link BROWSER_BFCACHE_REASON_TYPE}
  *
- * Apply Scrubbing: never
+ * Apply Scrubbing: manual
  *
  * Attribute defined in OTEL: No
  * Visibility: public
@@ -21030,7 +21030,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       "Which frame in the page's frame tree a back/forward cache not-restored reason originated from: the top document or a child frame.",
     type: 'string',
     applyScrubbing: {
-      key: 'never',
+      key: 'manual',
     },
     isInOtel: false,
     visibility: 'public',
@@ -21043,7 +21043,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       'The number of reported reasons a page was not restored from the back/forward cache on a back/forward navigation. 0 when the browser reported no reasons (e.g. non-Chromium browsers).',
     type: 'integer',
     applyScrubbing: {
-      key: 'never',
+      key: 'manual',
     },
     isInOtel: false,
     visibility: 'public',
@@ -21058,7 +21058,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       "Whether a back/forward navigation was restored from the browser's back/forward cache (bfcache). 'hit' means the page was restored; 'miss' means it was reloaded.",
     type: 'string',
     applyScrubbing: {
-      key: 'never',
+      key: 'manual',
     },
     isInOtel: false,
     visibility: 'public',
@@ -21071,7 +21071,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       'A browser-reported reason a page was not restored from the back/forward cache on a back/forward navigation, taken from the notRestoredReasons API. Reported per reason (a single miss can have several). Currently Chromium-only.',
     type: 'string',
     applyScrubbing: {
-      key: 'never',
+      key: 'manual',
     },
     isInOtel: false,
     visibility: 'public',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2898,6 +2898,97 @@ export const BLOCKED_MAIN_THREAD = 'blocked_main_thread';
  */
 export type BLOCKED_MAIN_THREAD_TYPE = boolean;
 
+// Path: model/attributes/browser/browser__bfcache__frame.json
+
+/**
+ * Which frame a back/forward cache not-restored reason originated from. 'masked' indicates a cross-origin subframe whose specific reason is hidden by the browser. `browser.bfcache.frame`
+ *
+ * Attribute Value Type: `string` {@link BROWSER_BFCACHE_FRAME_TYPE}
+ *
+ * Apply Scrubbing: never
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "top"
+ * @example "child"
+ * @example "masked"
+ * @example "unknown"
+ */
+export const BROWSER_BFCACHE_FRAME = 'browser.bfcache.frame';
+
+/**
+ * Type for {@link BROWSER_BFCACHE_FRAME} browser.bfcache.frame
+ */
+export type BROWSER_BFCACHE_FRAME_TYPE = string;
+
+// Path: model/attributes/browser/browser__bfcache__not_restored_reason_count.json
+
+/**
+ * The number of reported reasons a page was not restored from the back/forward cache on a back/forward navigation. 0 when the browser reported no reasons (e.g. non-Chromium browsers). `browser.bfcache.not_restored_reason_count`
+ *
+ * Attribute Value Type: `number` {@link BROWSER_BFCACHE_NOT_RESTORED_REASON_COUNT_TYPE}
+ *
+ * Apply Scrubbing: never
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example 2
+ */
+export const BROWSER_BFCACHE_NOT_RESTORED_REASON_COUNT = 'browser.bfcache.not_restored_reason_count';
+
+/**
+ * Type for {@link BROWSER_BFCACHE_NOT_RESTORED_REASON_COUNT} browser.bfcache.not_restored_reason_count
+ */
+export type BROWSER_BFCACHE_NOT_RESTORED_REASON_COUNT_TYPE = number;
+
+// Path: model/attributes/browser/browser__bfcache__outcome.json
+
+/**
+ * Whether a back/forward navigation was restored from the browser's back/forward cache (bfcache). 'hit' means the page was restored; 'miss' means it was reloaded. `browser.bfcache.outcome`
+ *
+ * Attribute Value Type: `string` {@link BROWSER_BFCACHE_OUTCOME_TYPE}
+ *
+ * Apply Scrubbing: never
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "hit"
+ * @example "miss"
+ */
+export const BROWSER_BFCACHE_OUTCOME = 'browser.bfcache.outcome';
+
+/**
+ * Type for {@link BROWSER_BFCACHE_OUTCOME} browser.bfcache.outcome
+ */
+export type BROWSER_BFCACHE_OUTCOME_TYPE = string;
+
+// Path: model/attributes/browser/browser__bfcache__reason.json
+
+/**
+ * A browser-reported reason a page was not restored from the back/forward cache on a back/forward navigation, taken from the notRestoredReasons API. Reported per reason (a single miss can have several). Currently Chromium-only. `browser.bfcache.reason`
+ *
+ * Attribute Value Type: `string` {@link BROWSER_BFCACHE_REASON_TYPE}
+ *
+ * Apply Scrubbing: never
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "unload-listener"
+ * @example "websocket"
+ * @example "idbversionchangeevent"
+ * @example "response-cache-control-no-store"
+ */
+export const BROWSER_BFCACHE_REASON = 'browser.bfcache.reason';
+
+/**
+ * Type for {@link BROWSER_BFCACHE_REASON} browser.bfcache.reason
+ */
+export type BROWSER_BFCACHE_REASON_TYPE = string;
+
 // Path: model/attributes/browser/browser__name.json
 
 /**
@@ -17604,6 +17695,10 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'aws.step_functions.activity.arn': 'string',
   'aws.step_functions.state_machine.arn': 'string',
   blocked_main_thread: 'boolean',
+  'browser.bfcache.frame': 'string',
+  'browser.bfcache.not_restored_reason_count': 'integer',
+  'browser.bfcache.outcome': 'string',
+  'browser.bfcache.reason': 'string',
   'browser.name': 'string',
   'browser.performance.navigation.activation_start': 'double',
   'browser.performance.time_origin': 'double',
@@ -18390,6 +18485,10 @@ export type AttributeName =
   | typeof AWS_STEP_FUNCTIONS_ACTIVITY_ARN
   | typeof AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN
   | typeof BLOCKED_MAIN_THREAD
+  | typeof BROWSER_BFCACHE_FRAME
+  | typeof BROWSER_BFCACHE_NOT_RESTORED_REASON_COUNT
+  | typeof BROWSER_BFCACHE_OUTCOME
+  | typeof BROWSER_BFCACHE_REASON
   | typeof BROWSER_NAME
   | typeof BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START
   | typeof BROWSER_PERFORMANCE_TIME_ORIGIN
@@ -20927,6 +21026,60 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: true,
     changelog: [{ version: '0.0.0' }],
+  },
+  'browser.bfcache.frame': {
+    brief:
+      "Which frame a back/forward cache not-restored reason originated from. 'masked' indicates a cross-origin subframe whose specific reason is hidden by the browser.",
+    type: 'string',
+    applyScrubbing: {
+      key: 'never',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'top',
+    examples: ['top', 'child', 'masked', 'unknown'],
+    changelog: [{ version: 'next', prs: [513], description: 'Added browser.bfcache.frame attribute' }],
+  },
+  'browser.bfcache.not_restored_reason_count': {
+    brief:
+      'The number of reported reasons a page was not restored from the back/forward cache on a back/forward navigation. 0 when the browser reported no reasons (e.g. non-Chromium browsers).',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'never',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 2,
+    examples: [2],
+    changelog: [
+      { version: 'next', prs: [513], description: 'Added browser.bfcache.not_restored_reason_count attribute' },
+    ],
+  },
+  'browser.bfcache.outcome': {
+    brief:
+      "Whether a back/forward navigation was restored from the browser's back/forward cache (bfcache). 'hit' means the page was restored; 'miss' means it was reloaded.",
+    type: 'string',
+    applyScrubbing: {
+      key: 'never',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'hit',
+    examples: ['hit', 'miss'],
+    changelog: [{ version: 'next', prs: [513], description: 'Added browser.bfcache.outcome attribute' }],
+  },
+  'browser.bfcache.reason': {
+    brief:
+      'A browser-reported reason a page was not restored from the back/forward cache on a back/forward navigation, taken from the notRestoredReasons API. Reported per reason (a single miss can have several). Currently Chromium-only.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'never',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'unload-listener',
+    examples: ['unload-listener', 'websocket', 'idbversionchangeevent', 'response-cache-control-no-store'],
+    changelog: [{ version: 'next', prs: [513], description: 'Added browser.bfcache.reason attribute' }],
   },
   'browser.name': {
     brief: 'The name of the browser.',
@@ -30074,6 +30227,10 @@ export type Attributes = {
   [AWS_STEP_FUNCTIONS_ACTIVITY_ARN]?: AWS_STEP_FUNCTIONS_ACTIVITY_ARN_TYPE;
   [AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN]?: AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN_TYPE;
   [BLOCKED_MAIN_THREAD]?: BLOCKED_MAIN_THREAD_TYPE;
+  [BROWSER_BFCACHE_FRAME]?: BROWSER_BFCACHE_FRAME_TYPE;
+  [BROWSER_BFCACHE_NOT_RESTORED_REASON_COUNT]?: BROWSER_BFCACHE_NOT_RESTORED_REASON_COUNT_TYPE;
+  [BROWSER_BFCACHE_OUTCOME]?: BROWSER_BFCACHE_OUTCOME_TYPE;
+  [BROWSER_BFCACHE_REASON]?: BROWSER_BFCACHE_REASON_TYPE;
   [BROWSER_NAME]?: BROWSER_NAME_TYPE;
   [BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START]?: BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START_TYPE;
   [BROWSER_PERFORMANCE_TIME_ORIGIN]?: BROWSER_PERFORMANCE_TIME_ORIGIN_TYPE;

--- a/model/attributes/browser/browser__bfcache__frame.json
+++ b/model/attributes/browser/browser__bfcache__frame.json
@@ -1,0 +1,18 @@
+{
+  "key": "browser.bfcache.frame",
+  "brief": "Which frame a back/forward cache not-restored reason originated from. 'masked' indicates a cross-origin subframe whose specific reason is hidden by the browser.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "never"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["top", "child", "masked", "unknown"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [513],
+      "description": "Added browser.bfcache.frame attribute"
+    }
+  ]
+}

--- a/model/attributes/browser/browser__bfcache__frame.json
+++ b/model/attributes/browser/browser__bfcache__frame.json
@@ -1,13 +1,13 @@
 {
   "key": "browser.bfcache.frame",
-  "brief": "Which frame a back/forward cache not-restored reason originated from. 'masked' indicates a cross-origin subframe whose specific reason is hidden by the browser.",
+  "brief": "Which frame in the page's frame tree a back/forward cache not-restored reason originated from: the top document or a child frame.",
   "type": "string",
   "apply_scrubbing": {
     "key": "never"
   },
   "is_in_otel": false,
   "visibility": "public",
-  "examples": ["top", "child", "masked", "unknown"],
+  "examples": ["top", "child"],
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/browser/browser__bfcache__frame.json
+++ b/model/attributes/browser/browser__bfcache__frame.json
@@ -3,7 +3,7 @@
   "brief": "Which frame in the page's frame tree a back/forward cache not-restored reason originated from: the top document or a child frame.",
   "type": "string",
   "apply_scrubbing": {
-    "key": "never"
+    "key": "manual"
   },
   "is_in_otel": false,
   "visibility": "public",

--- a/model/attributes/browser/browser__bfcache__not_restored_reason_count.json
+++ b/model/attributes/browser/browser__bfcache__not_restored_reason_count.json
@@ -1,0 +1,18 @@
+{
+  "key": "browser.bfcache.not_restored_reason_count",
+  "brief": "The number of reported reasons a page was not restored from the back/forward cache on a back/forward navigation. 0 when the browser reported no reasons (e.g. non-Chromium browsers).",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "never"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": [2],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [513],
+      "description": "Added browser.bfcache.not_restored_reason_count attribute"
+    }
+  ]
+}

--- a/model/attributes/browser/browser__bfcache__not_restored_reason_count.json
+++ b/model/attributes/browser/browser__bfcache__not_restored_reason_count.json
@@ -3,7 +3,7 @@
   "brief": "The number of reported reasons a page was not restored from the back/forward cache on a back/forward navigation. 0 when the browser reported no reasons (e.g. non-Chromium browsers).",
   "type": "integer",
   "apply_scrubbing": {
-    "key": "never"
+    "key": "manual"
   },
   "is_in_otel": false,
   "visibility": "public",

--- a/model/attributes/browser/browser__bfcache__outcome.json
+++ b/model/attributes/browser/browser__bfcache__outcome.json
@@ -1,0 +1,18 @@
+{
+  "key": "browser.bfcache.outcome",
+  "brief": "Whether a back/forward navigation was restored from the browser's back/forward cache (bfcache). 'hit' means the page was restored; 'miss' means it was reloaded.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "never"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["hit", "miss"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [513],
+      "description": "Added browser.bfcache.outcome attribute"
+    }
+  ]
+}

--- a/model/attributes/browser/browser__bfcache__outcome.json
+++ b/model/attributes/browser/browser__bfcache__outcome.json
@@ -3,7 +3,7 @@
   "brief": "Whether a back/forward navigation was restored from the browser's back/forward cache (bfcache). 'hit' means the page was restored; 'miss' means it was reloaded.",
   "type": "string",
   "apply_scrubbing": {
-    "key": "never"
+    "key": "manual"
   },
   "is_in_otel": false,
   "visibility": "public",

--- a/model/attributes/browser/browser__bfcache__reason.json
+++ b/model/attributes/browser/browser__bfcache__reason.json
@@ -1,0 +1,18 @@
+{
+  "key": "browser.bfcache.reason",
+  "brief": "A browser-reported reason a page was not restored from the back/forward cache on a back/forward navigation, taken from the notRestoredReasons API. Reported per reason (a single miss can have several). Currently Chromium-only.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "never"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["unload-listener", "websocket", "idbversionchangeevent", "response-cache-control-no-store"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [513],
+      "description": "Added browser.bfcache.reason attribute"
+    }
+  ]
+}

--- a/model/attributes/browser/browser__bfcache__reason.json
+++ b/model/attributes/browser/browser__bfcache__reason.json
@@ -3,7 +3,7 @@
   "brief": "A browser-reported reason a page was not restored from the back/forward cache on a back/forward navigation, taken from the notRestoredReasons API. Reported per reason (a single miss can have several). Currently Chromium-only.",
   "type": "string",
   "apply_scrubbing": {
-    "key": "never"
+    "key": "manual"
   },
   "is_in_otel": false,
   "visibility": "public",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1990,7 +1990,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/browser/browser__bfcache__frame.json
     BROWSER_BFCACHE_FRAME: Literal["browser.bfcache.frame"] = "browser.bfcache.frame"
-    """Which frame a back/forward cache not-restored reason originated from. 'masked' indicates a cross-origin subframe whose specific reason is hidden by the browser.
+    """Which frame in the page's frame tree a back/forward cache not-restored reason originated from: the top document or a child frame.
 
     Type: str
     Apply Scrubbing: never
@@ -1998,8 +1998,6 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Visibility: public
     Example: "top"
     Example: "child"
-    Example: "masked"
-    Example: "unknown"
     """
 
     # Path: model/attributes/browser/browser__bfcache__not_restored_reason_count.json
@@ -12211,13 +12209,13 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "browser.bfcache.frame": AttributeMetadata(
-        brief="Which frame a back/forward cache not-restored reason originated from. 'masked' indicates a cross-origin subframe whose specific reason is hidden by the browser.",
+        brief="Which frame in the page's frame tree a back/forward cache not-restored reason originated from: the top document or a child frame.",
         type=AttributeType.STRING,
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="top",
-        examples=["top", "child", "masked", "unknown"],
+        examples=["top", "child"],
         changelog=[
             ChangelogEntry(
                 version="next",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1988,6 +1988,61 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: true
     """
 
+    # Path: model/attributes/browser/browser__bfcache__frame.json
+    BROWSER_BFCACHE_FRAME: Literal["browser.bfcache.frame"] = "browser.bfcache.frame"
+    """Which frame a back/forward cache not-restored reason originated from. 'masked' indicates a cross-origin subframe whose specific reason is hidden by the browser.
+
+    Type: str
+    Apply Scrubbing: never
+    Defined in OTEL: No
+    Visibility: public
+    Example: "top"
+    Example: "child"
+    Example: "masked"
+    Example: "unknown"
+    """
+
+    # Path: model/attributes/browser/browser__bfcache__not_restored_reason_count.json
+    BROWSER_BFCACHE_NOT_RESTORED_REASON_COUNT: Literal[
+        "browser.bfcache.not_restored_reason_count"
+    ] = "browser.bfcache.not_restored_reason_count"
+    """The number of reported reasons a page was not restored from the back/forward cache on a back/forward navigation. 0 when the browser reported no reasons (e.g. non-Chromium browsers).
+
+    Type: int
+    Apply Scrubbing: never
+    Defined in OTEL: No
+    Visibility: public
+    Example: 2
+    """
+
+    # Path: model/attributes/browser/browser__bfcache__outcome.json
+    BROWSER_BFCACHE_OUTCOME: Literal["browser.bfcache.outcome"] = (
+        "browser.bfcache.outcome"
+    )
+    """Whether a back/forward navigation was restored from the browser's back/forward cache (bfcache). 'hit' means the page was restored; 'miss' means it was reloaded.
+
+    Type: str
+    Apply Scrubbing: never
+    Defined in OTEL: No
+    Visibility: public
+    Example: "hit"
+    Example: "miss"
+    """
+
+    # Path: model/attributes/browser/browser__bfcache__reason.json
+    BROWSER_BFCACHE_REASON: Literal["browser.bfcache.reason"] = "browser.bfcache.reason"
+    """A browser-reported reason a page was not restored from the back/forward cache on a back/forward navigation, taken from the notRestoredReasons API. Reported per reason (a single miss can have several). Currently Chromium-only.
+
+    Type: str
+    Apply Scrubbing: never
+    Defined in OTEL: No
+    Visibility: public
+    Example: "unload-listener"
+    Example: "websocket"
+    Example: "idbversionchangeevent"
+    Example: "response-cache-control-no-store"
+    """
+
     # Path: model/attributes/browser/browser__name.json
     BROWSER_NAME: Literal["browser.name"] = "browser.name"
     """The name of the browser.
@@ -12155,6 +12210,75 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "browser.bfcache.frame": AttributeMetadata(
+        brief="Which frame a back/forward cache not-restored reason originated from. 'masked' indicates a cross-origin subframe whose specific reason is hidden by the browser.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="top",
+        examples=["top", "child", "masked", "unknown"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[513],
+                description="Added browser.bfcache.frame attribute",
+            ),
+        ],
+    ),
+    "browser.bfcache.not_restored_reason_count": AttributeMetadata(
+        brief="The number of reported reasons a page was not restored from the back/forward cache on a back/forward navigation. 0 when the browser reported no reasons (e.g. non-Chromium browsers).",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=2,
+        examples=[2],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[513],
+                description="Added browser.bfcache.not_restored_reason_count attribute",
+            ),
+        ],
+    ),
+    "browser.bfcache.outcome": AttributeMetadata(
+        brief="Whether a back/forward navigation was restored from the browser's back/forward cache (bfcache). 'hit' means the page was restored; 'miss' means it was reloaded.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="hit",
+        examples=["hit", "miss"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[513],
+                description="Added browser.bfcache.outcome attribute",
+            ),
+        ],
+    ),
+    "browser.bfcache.reason": AttributeMetadata(
+        brief="A browser-reported reason a page was not restored from the back/forward cache on a back/forward navigation, taken from the notRestoredReasons API. Reported per reason (a single miss can have several). Currently Chromium-only.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="unload-listener",
+        examples=[
+            "unload-listener",
+            "websocket",
+            "idbversionchangeevent",
+            "response-cache-control-no-store",
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[513],
+                description="Added browser.bfcache.reason attribute",
+            ),
+        ],
+    ),
     "browser.name": AttributeMetadata(
         brief="The name of the browser.",
         type=AttributeType.STRING,
@@ -21860,6 +21984,10 @@ Attributes = TypedDict(
         "aws.step_functions.state_machine.arn": str,
         "aws_region": str,
         "blocked_main_thread": bool,
+        "browser.bfcache.frame": str,
+        "browser.bfcache.not_restored_reason_count": int,
+        "browser.bfcache.outcome": str,
+        "browser.bfcache.reason": str,
         "browser.name": str,
         "browser.performance.navigation.activation_start": float,
         "browser.performance.time_origin": float,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -1993,7 +1993,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """Which frame in the page's frame tree a back/forward cache not-restored reason originated from: the top document or a child frame.
 
     Type: str
-    Apply Scrubbing: never
+    Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
     Example: "top"
@@ -2007,7 +2007,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The number of reported reasons a page was not restored from the back/forward cache on a back/forward navigation. 0 when the browser reported no reasons (e.g. non-Chromium browsers).
 
     Type: int
-    Apply Scrubbing: never
+    Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
     Example: 2
@@ -2020,7 +2020,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """Whether a back/forward navigation was restored from the browser's back/forward cache (bfcache). 'hit' means the page was restored; 'miss' means it was reloaded.
 
     Type: str
-    Apply Scrubbing: never
+    Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
     Example: "hit"
@@ -2032,7 +2032,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """A browser-reported reason a page was not restored from the back/forward cache on a back/forward navigation, taken from the notRestoredReasons API. Reported per reason (a single miss can have several). Currently Chromium-only.
 
     Type: str
-    Apply Scrubbing: never
+    Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
     Example: "unload-listener"
@@ -12211,7 +12211,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "browser.bfcache.frame": AttributeMetadata(
         brief="Which frame in the page's frame tree a back/forward cache not-restored reason originated from: the top document or a child frame.",
         type=AttributeType.STRING,
-        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="top",
@@ -12227,7 +12227,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "browser.bfcache.not_restored_reason_count": AttributeMetadata(
         brief="The number of reported reasons a page was not restored from the back/forward cache on a back/forward navigation. 0 when the browser reported no reasons (e.g. non-Chromium browsers).",
         type=AttributeType.INTEGER,
-        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=2,
@@ -12243,7 +12243,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "browser.bfcache.outcome": AttributeMetadata(
         brief="Whether a back/forward navigation was restored from the browser's back/forward cache (bfcache). 'hit' means the page was restored; 'miss' means it was reloaded.",
         type=AttributeType.STRING,
-        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="hit",
@@ -12259,7 +12259,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "browser.bfcache.reason": AttributeMetadata(
         brief="A browser-reported reason a page was not restored from the back/forward cache on a back/forward navigation, taken from the notRestoredReasons API. Reported per reason (a single miss can have several). Currently Chromium-only.",
         type=AttributeType.STRING,
-        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="unload-listener",


### PR DESCRIPTION
Registers the four `browser.bfcache.*` attributes emitted by the new `bfcacheMetricsIntegration` in the JS SDK (getsentry/sentry-javascript#22397).

They describe browser back/forward-cache health metrics.

| Attribute | Description |
| --- | --- |
| `browser.bfcache.outcome` | `hit`/`miss` of a back/forward navigation. |
| `browser.bfcache.reason` | A browser-reported not-restored reason (one per reason; a single miss can have several; Chromium-only via `notRestoredReasons`). |
| `browser.bfcache.frame` | Which frame the reason came from (`top`/`child`). |
| `browser.bfcache.not_restored_reason_count` | Number of reported reasons (`0` when the browser reported none, e.g. non-Chromium). |


All are Sentry-specific, so `is_in_otel: false` and PII is not applicable here.
