### PR TITLE
feat(descriptions): Add `http.route` description template for `http.server` span description inference

### DIFF
--- a/model/description/http.json
+++ b/model/description/http.json
@@ -13,6 +13,7 @@
       "brief": "Operations that represent processing incoming HTTP requests in a web server.",
       "ops": ["http.server"],
       "templates": [
+        "{{http.request.method}} {{http.route}}",
         "{{http.request.method}} {{url.template}}",
         "{{http.request.method}} {{url.path}}",
         "{{http.request.method}} {{url.full}}"


### PR DESCRIPTION
[`http.route`](https://getsentry.github.io/sentry-conventions/attributes/http/#http-route) and [`url.template`](https://getsentry.github.io/sentry-conventions/attributes/url/#url-template) alias each other but neither is deprecated. Hence, for spans only having `http.route`, our description inference doesn't work as expected. Therefore, this PR adds the same rule for `http.route` as for `url.template`.