### PR TITLE
feat(attributes): Add `starlite.middleware_name` (deprecated) in favor of `middleware.name`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -15180,6 +15180,7 @@ export type STALL_TOTAL_TIME_TYPE = number;
  *
  * Aliases: {@link MIDDLEWARE_NAME} `middleware.name`
  *
+ * @deprecated Use {@link MIDDLEWARE_NAME} (middleware.name) instead - This attribute is being deprecated in favor of middleware.name, which is the framework-agnostic replacement.
  * @example "AuthenticationMiddleware"
  */
 export const STARLITE_MIDDLEWARE_NAME = 'starlite.middleware_name';
@@ -28049,6 +28050,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'AuthenticationMiddleware',
     examples: ['AuthenticationMiddleware'],
+    deprecation: {
+      replacement: 'middleware.name',
+      reason:
+        'This attribute is being deprecated in favor of middleware.name, which is the framework-agnostic replacement.',
+      status: 'backfill',
+    },
     aliases: ['middleware.name'],
     changelog: [{ version: 'next', prs: [519], description: 'Added starlite.middleware_name attribute' }],
   },

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -11234,6 +11234,8 @@ export type METHOD_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link STARLITE_MIDDLEWARE_NAME} `starlite.middleware_name`
+ *
  * @example "AuthenticationMiddleware"
  */
 export const MIDDLEWARE_NAME = 'middleware.name';
@@ -15164,6 +15166,29 @@ export const STALL_TOTAL_TIME = 'stall_total_time';
  */
 export type STALL_TOTAL_TIME_TYPE = number;
 
+// Path: model/attributes/starlite/starlite__middleware_name.json
+
+/**
+ * The name of the Starlite middleware. `starlite.middleware_name`
+ *
+ * Attribute Value Type: `string` {@link STARLITE_MIDDLEWARE_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link MIDDLEWARE_NAME} `middleware.name`
+ *
+ * @example "AuthenticationMiddleware"
+ */
+export const STARLITE_MIDDLEWARE_NAME = 'starlite.middleware_name';
+
+/**
+ * Type for {@link STARLITE_MIDDLEWARE_NAME} starlite.middleware_name
+ */
+export type STARLITE_MIDDLEWARE_NAME_TYPE = string;
+
 // Path: model/attributes/state/state__type.json
 
 /**
@@ -17717,6 +17742,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'session.id': 'string',
   stall_percentage: 'double',
   stall_total_time: 'double',
+  'starlite.middleware_name': 'string',
   'state.type': 'string',
   'thread.id': 'integer',
   'thread.name': 'string',
@@ -18485,6 +18511,7 @@ export type AttributeName =
   | typeof SESSION_ID
   | typeof STALL_PERCENTAGE
   | typeof STALL_TOTAL_TIME
+  | typeof STARLITE_MIDDLEWARE_NAME
   | typeof STATE_TYPE
   | typeof THREAD_ID
   | typeof THREAD_NAME
@@ -25635,7 +25662,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'AuthenticationMiddleware',
-    changelog: [{ version: '0.6.0', prs: [336], description: 'Added middleware.name attribute' }],
+    aliases: ['starlite.middleware_name'],
+    changelog: [
+      { version: 'next', description: 'Added starlite.middleware_name as an alias' },
+      { version: '0.6.0', prs: [336], description: 'Added middleware.name attribute' },
+    ],
   },
   'navigation.origin': {
     brief:
@@ -28008,6 +28039,19 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: '0.7.0', prs: [362], description: 'Added stall_total_time attribute' },
     ],
   },
+  'starlite.middleware_name': {
+    brief: 'The name of the Starlite middleware.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'AuthenticationMiddleware',
+    examples: ['AuthenticationMiddleware'],
+    aliases: ['middleware.name'],
+    changelog: [{ version: 'next', prs: [519], description: 'Added starlite.middleware_name attribute' }],
+  },
   'state.type': {
     brief: 'The type of state management library',
     type: 'string',
@@ -29707,6 +29751,7 @@ export type Attributes = {
   [SESSION_ID]?: SESSION_ID_TYPE;
   [STALL_PERCENTAGE]?: STALL_PERCENTAGE_TYPE;
   [STALL_TOTAL_TIME]?: STALL_TOTAL_TIME_TYPE;
+  [STARLITE_MIDDLEWARE_NAME]?: STARLITE_MIDDLEWARE_NAME_TYPE;
   [STATE_TYPE]?: STATE_TYPE_TYPE;
   [THREAD_ID]?: THREAD_ID_TYPE;
   [THREAD_NAME]?: THREAD_NAME_TYPE;

--- a/model/attributes/middleware/middleware__name.json
+++ b/model/attributes/middleware/middleware__name.json
@@ -7,8 +7,13 @@
   },
   "is_in_otel": false,
   "example": "AuthenticationMiddleware",
+  "alias": ["starlite.middleware_name"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added starlite.middleware_name as an alias"
+    },
     {
       "version": "0.6.0",
       "prs": [336],

--- a/model/attributes/starlite/starlite__middleware_name.json
+++ b/model/attributes/starlite/starlite__middleware_name.json
@@ -9,6 +9,11 @@
   "visibility": "public",
   "examples": ["AuthenticationMiddleware"],
   "alias": ["middleware.name"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "middleware.name",
+    "reason": "This attribute is being deprecated in favor of middleware.name, which is the framework-agnostic replacement."
+  },
   "changelog": [
     {
       "version": "next",

--- a/model/attributes/starlite/starlite__middleware_name.json
+++ b/model/attributes/starlite/starlite__middleware_name.json
@@ -1,0 +1,19 @@
+{
+  "key": "starlite.middleware_name",
+  "brief": "The name of the Starlite middleware.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["AuthenticationMiddleware"],
+  "alias": ["middleware.name"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [519],
+      "description": "Added starlite.middleware_name attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -6671,6 +6671,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
+    Aliases: starlite.middleware_name
     Example: "AuthenticationMiddleware"
     """
 
@@ -8810,6 +8811,20 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Visibility: public
     Aliases: app.vitals.stall.duration
     DEPRECATED: Use app.vitals.stall.duration instead - Replaced by app.vitals.stall.duration to align with the app.vitals.* namespace for mobile performance attributes
+    """
+
+    # Path: model/attributes/starlite/starlite__middleware_name.json
+    STARLITE_MIDDLEWARE_NAME: Literal["starlite.middleware_name"] = (
+        "starlite.middleware_name"
+    )
+    """The name of the Starlite middleware.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: middleware.name
+    Example: "AuthenticationMiddleware"
     """
 
     # Path: model/attributes/state/state__type.json
@@ -17485,7 +17500,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="AuthenticationMiddleware",
+        aliases=["starlite.middleware_name"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added starlite.middleware_name as an alias"
+            ),
             ChangelogEntry(
                 version="0.6.0",
                 prs=[336],
@@ -19954,6 +19973,23 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "starlite.middleware_name": AttributeMetadata(
+        brief="The name of the Starlite middleware.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="AuthenticationMiddleware",
+        examples=["AuthenticationMiddleware"],
+        aliases=["middleware.name"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[519],
+                description="Added starlite.middleware_name attribute",
+            ),
+        ],
+    ),
     "state.type": AttributeMetadata(
         brief="The type of state management library",
         type=AttributeType.STRING,
@@ -21696,6 +21732,7 @@ Attributes = TypedDict(
         "session.id": str,
         "stall_percentage": float,
         "stall_total_time": float,
+        "starlite.middleware_name": str,
         "state.type": str,
         "thread.id": int,
         "thread.name": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -306,6 +306,7 @@ class _AttributeNamesMeta(type):
         "SERVER_NAME",
         "STALL_PERCENTAGE",
         "STALL_TOTAL_TIME",
+        "STARLITE_MIDDLEWARE_NAME",
         "TIME_TO_FULL_DISPLAY",
         "TIME_TO_INITIAL_DISPLAY",
         "TRANSACTION",
@@ -8824,6 +8825,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Visibility: public
     Aliases: middleware.name
+    DEPRECATED: Use middleware.name instead - This attribute is being deprecated in favor of middleware.name, which is the framework-agnostic replacement.
     Example: "AuthenticationMiddleware"
     """
 
@@ -19981,6 +19983,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="AuthenticationMiddleware",
         examples=["AuthenticationMiddleware"],
+        deprecation=DeprecationInfo(
+            replacement="middleware.name",
+            reason="This attribute is being deprecated in favor of middleware.name, which is the framework-agnostic replacement.",
+            status=DeprecationStatus.BACKFILL,
+        ),
         aliases=["middleware.name"],
         changelog=[
             ChangelogEntry(


### PR DESCRIPTION
## Description

<!-- Describe your changes -->

- Adds `starlite.middleware_name` as a deprecated attribute with `middleware.name` as its replacement
- Adds `starlite.middleware_name` as an alias on `middleware.name`

I've just replicated https://github.com/getsentry/sentry-conventions/pull/486 for starlite.
I'll resolve conflicts depending on merge order.

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
