### PR TITLE
feat(attributes): Add `django.middleware_name` (deprecated) in favor of `middleware.name`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -5722,6 +5722,30 @@ export const DIST = 'dist';
  */
 export type DIST_TYPE = string;
 
+// Path: model/attributes/django/django__middleware_name.json
+
+/**
+ * The name of the Django middleware. `django.middleware_name`
+ *
+ * Attribute Value Type: `string` {@link DJANGO_MIDDLEWARE_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link MIDDLEWARE_NAME} `middleware.name`
+ *
+ * @deprecated Use {@link MIDDLEWARE_NAME} (middleware.name) instead - This attribute is being deprecated in favor of middleware.name, which is the framework-agnostic replacement.
+ * @example "AuthenticationMiddleware"
+ */
+export const DJANGO_MIDDLEWARE_NAME = 'django.middleware_name';
+
+/**
+ * Type for {@link DJANGO_MIDDLEWARE_NAME} django.middleware_name
+ */
+export type DJANGO_MIDDLEWARE_NAME_TYPE = string;
+
 // Path: model/attributes/effectiveConnectionType.json
 
 /**
@@ -11233,6 +11257,8 @@ export type METHOD_TYPE = string;
  *
  * Attribute defined in OTEL: No
  * Visibility: public
+ *
+ * Aliases: {@link DJANGO_MIDDLEWARE_NAME} `django.middleware_name`
  *
  * @example "AuthenticationMiddleware"
  */
@@ -17293,6 +17319,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'device.timezone': 'string',
   'device.usable_memory': 'integer',
   dist: 'string',
+  'django.middleware_name': 'string',
   effectiveConnectionType: 'string',
   environment: 'string',
   'error.type': 'string',
@@ -18061,6 +18088,7 @@ export type AttributeName =
   | typeof DEVICE_TIMEZONE
   | typeof DEVICE_USABLE_MEMORY
   | typeof DIST
+  | typeof DJANGO_MIDDLEWARE_NAME
   | typeof EFFECTIVECONNECTIONTYPE
   | typeof ENVIRONMENT
   | typeof ERROR_TYPE
@@ -22048,6 +22076,25 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: ['sentry.dist'],
     changelog: [{ version: '0.16.0', prs: [489], description: 'Added dist attribute' }],
   },
+  'django.middleware_name': {
+    brief: 'The name of the Django middleware.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'AuthenticationMiddleware',
+    examples: ['AuthenticationMiddleware'],
+    deprecation: {
+      replacement: 'middleware.name',
+      reason:
+        'This attribute is being deprecated in favor of middleware.name, which is the framework-agnostic replacement.',
+      status: 'backfill',
+    },
+    aliases: ['middleware.name'],
+    changelog: [{ version: 'next', prs: [520], description: 'Added django.middleware_name attribute' }],
+  },
   effectiveConnectionType: {
     brief: 'Specifies the estimated effective type of the current connection (e.g. slow-2g, 2g, 3g, 4g).',
     type: 'string',
@@ -25635,7 +25682,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'AuthenticationMiddleware',
-    changelog: [{ version: '0.6.0', prs: [336], description: 'Added middleware.name attribute' }],
+    aliases: ['django.middleware_name'],
+    changelog: [
+      { version: 'next', description: 'Added django.middleware_name as an alias' },
+      { version: '0.6.0', prs: [336], description: 'Added middleware.name attribute' },
+    ],
   },
   'navigation.origin': {
     brief:
@@ -29283,6 +29334,7 @@ export type Attributes = {
   [DEVICE_TIMEZONE]?: DEVICE_TIMEZONE_TYPE;
   [DEVICE_USABLE_MEMORY]?: DEVICE_USABLE_MEMORY_TYPE;
   [DIST]?: DIST_TYPE;
+  [DJANGO_MIDDLEWARE_NAME]?: DJANGO_MIDDLEWARE_NAME_TYPE;
   [EFFECTIVECONNECTIONTYPE]?: EFFECTIVECONNECTIONTYPE_TYPE;
   [ENVIRONMENT]?: ENVIRONMENT_TYPE;
   [ERROR_TYPE]?: ERROR_TYPE_TYPE;

--- a/model/attributes/django/django__middleware_name.json
+++ b/model/attributes/django/django__middleware_name.json
@@ -1,0 +1,24 @@
+{
+  "key": "django.middleware_name",
+  "brief": "The name of the Django middleware.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["AuthenticationMiddleware"],
+  "alias": ["middleware.name"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "middleware.name",
+    "reason": "This attribute is being deprecated in favor of middleware.name, which is the framework-agnostic replacement."
+  },
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [520],
+      "description": "Added django.middleware_name attribute"
+    }
+  ]
+}

--- a/model/attributes/middleware/middleware__name.json
+++ b/model/attributes/middleware/middleware__name.json
@@ -7,8 +7,13 @@
   },
   "is_in_otel": false,
   "example": "AuthenticationMiddleware",
+  "alias": ["django.middleware_name"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added django.middleware_name as an alias"
+    },
     {
       "version": "0.6.0",
       "prs": [336],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -184,6 +184,7 @@ class _AttributeNamesMeta(type):
         "DEVICE_CONNECTION_TYPE",
         "DEVICEMEMORY",
         "DIST",
+        "DJANGO_MIDDLEWARE_NAME",
         "EFFECTIVECONNECTIONTYPE",
         "ENVIRONMENT",
         "FAAS_EXECUTION",
@@ -3542,6 +3543,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "1.0"
     """
 
+    # Path: model/attributes/django/django__middleware_name.json
+    DJANGO_MIDDLEWARE_NAME: Literal["django.middleware_name"] = "django.middleware_name"
+    """The name of the Django middleware.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: middleware.name
+    DEPRECATED: Use middleware.name instead - This attribute is being deprecated in favor of middleware.name, which is the framework-agnostic replacement.
+    Example: "AuthenticationMiddleware"
+    """
+
     # Path: model/attributes/effectiveConnectionType.json
     EFFECTIVECONNECTIONTYPE: Literal["effectiveConnectionType"] = (
         "effectiveConnectionType"
@@ -6671,6 +6685,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
+    Aliases: django.middleware_name
     Example: "AuthenticationMiddleware"
     """
 
@@ -13683,6 +13698,28 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "django.middleware_name": AttributeMetadata(
+        brief="The name of the Django middleware.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="AuthenticationMiddleware",
+        examples=["AuthenticationMiddleware"],
+        deprecation=DeprecationInfo(
+            replacement="middleware.name",
+            reason="This attribute is being deprecated in favor of middleware.name, which is the framework-agnostic replacement.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["middleware.name"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[520],
+                description="Added django.middleware_name attribute",
+            ),
+        ],
+    ),
     "effectiveConnectionType": AttributeMetadata(
         brief="Specifies the estimated effective type of the current connection (e.g. slow-2g, 2g, 3g, 4g).",
         type=AttributeType.STRING,
@@ -17485,7 +17522,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="AuthenticationMiddleware",
+        aliases=["django.middleware_name"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added django.middleware_name as an alias"
+            ),
             ChangelogEntry(
                 version="0.6.0",
                 prs=[336],
@@ -21272,6 +21313,7 @@ Attributes = TypedDict(
         "device.usable_memory": int,
         "deviceMemory": str,
         "dist": str,
+        "django.middleware_name": str,
         "effectiveConnectionType": str,
         "environment": str,
         "error.type": str,


### PR DESCRIPTION
## Description

- Adds `django.middleware_name` as a deprecated attribute with `middleware.name` as its replacement
- Adds `django.middleware_name` as an alias on `middleware.name`

I've just replicated https://github.com/getsentry/sentry-conventions/pull/486 for Django.
I'll resolve conflicts depending on merge order.

<!-- Describe your changes -->

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [ ] I have run `yarn test` and verified that the tests pass.
- [ ] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
