### PR TITLE
ref(attributes): Disambiguate `http.route` and `url.template` attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -9370,8 +9370,6 @@ export type HTTP_RESPONSE_TRANSFER_SIZE_TYPE = number;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link URL_TEMPLATE} `url.template`
- *
  * @example "/users/:id"
  * @example "my-controller/my-action/{id}"
  * @example "/posts"
@@ -16067,7 +16065,7 @@ export type URL_SCHEME_TYPE = string;
 // Path: model/attributes/url/url__template.json
 
 /**
- * The low-cardinality template of an absolute path reference. `url.template`
+ * The low-cardinality template of an absolute URL path reference. `url.template`
  *
  * Attribute Value Type: `string` {@link URL_TEMPLATE_TYPE}
  *
@@ -16075,8 +16073,6 @@ export type URL_SCHEME_TYPE = string;
  *
  * Attribute defined in OTEL: Yes
  * Visibility: public
- *
- * Aliases: {@link HTTP_ROUTE} `http.route`
  *
  * @example "/users/{id}"
  * @example "/users/:id"
@@ -24644,11 +24640,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: '/users/:id',
     examples: ['/users/:id', 'my-controller/my-action/{id}', '/posts'],
-    aliases: ['url.template'],
     changelog: [
-      { version: 'next', prs: [505], description: 'Added multiple examples' },
+      {
+        version: 'next',
+        prs: [505, 521],
+        description: 'Added multiple examples, removed alias to `url.template`, added additional context',
+      },
       { version: '0.1.0', prs: [127] },
       { version: '0.0.0' },
+    ],
+    additionalContext: [
+      'This attribute should primarily be set by server-side instrumentation that captures the framework route of an incoming request.',
+      'For `http.client` spans and client-side routing, use `url.template` instead.',
     ],
   },
   'http.scheme': {
@@ -28760,7 +28763,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   'url.template': {
-    brief: 'The low-cardinality template of an absolute path reference.',
+    brief: 'The low-cardinality template of an absolute URL path reference.',
     type: 'string',
     applyScrubbing: {
       key: 'manual',
@@ -28769,11 +28772,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: '/users/{id}',
     examples: ['/users/{id}', '/users/:id', '/about'],
-    aliases: ['http.route'],
     changelog: [
-      { version: 'next', prs: [505], description: 'Added multiple examples' },
+      {
+        version: 'next',
+        prs: [505, 521],
+        description: 'Added multiple examples, removed alias to `http.route`, added additional context',
+      },
       { version: '0.1.0', prs: [127] },
       { version: '0.0.0' },
+    ],
+    additionalContext: [
+      'This attribute should primarily be set by client-side routing instrumentation, or `http.client` spans (if applicable).',
+      'Use `http.route` for server-side instrumentation that captures the framework route of an incoming request.',
     ],
   },
   'user_agent.original': {

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -9370,6 +9370,8 @@ export type HTTP_RESPONSE_TRANSFER_SIZE_TYPE = number;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
+ * Aliases: {@link ROUTE} `route`
+ *
  * @example "/users/:id"
  * @example "my-controller/my-action/{id}"
  * @example "/posts"
@@ -24640,6 +24642,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: '/users/:id',
     examples: ['/users/:id', 'my-controller/my-action/{id}', '/posts'],
+    aliases: ['route'],
     changelog: [
       {
         version: 'next',

--- a/model/attributes/http/http__route.json
+++ b/model/attributes/http/http__route.json
@@ -1,19 +1,22 @@
 {
   "key": "http.route",
   "brief": "The matched route, that is, the path template in the format used by the respective server framework.",
+  "additional_context": [
+    "This attribute should primarily be set by server-side instrumentation that captures the framework route of an incoming request.",
+    "For `http.client` spans and client-side routing, use `url.template` instead."
+  ],
   "type": "string",
   "apply_scrubbing": {
     "key": "manual"
   },
   "is_in_otel": true,
   "examples": ["/users/:id", "my-controller/my-action/{id}", "/posts"],
-  "alias": ["url.template"],
   "visibility": "public",
   "changelog": [
     {
       "version": "next",
-      "prs": [505],
-      "description": "Added multiple examples"
+      "prs": [505, 0],
+      "description": "Added multiple examples, removed alias to `url.template`, added additional context"
     },
     {
       "version": "0.1.0",

--- a/model/attributes/http/http__route.json
+++ b/model/attributes/http/http__route.json
@@ -15,7 +15,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [505, 0],
+      "prs": [505, 521],
       "description": "Added multiple examples, removed alias to `url.template`, added additional context"
     },
     {

--- a/model/attributes/http/http__route.json
+++ b/model/attributes/http/http__route.json
@@ -10,6 +10,7 @@
     "key": "manual"
   },
   "is_in_otel": true,
+  "alias": ["route"],
   "examples": ["/users/:id", "my-controller/my-action/{id}", "/posts"],
   "visibility": "public",
   "changelog": [

--- a/model/attributes/url/url__template.json
+++ b/model/attributes/url/url__template.json
@@ -15,7 +15,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [505],
+      "prs": [505, 521],
       "description": "Added multiple examples, removed alias to `http.route`, added additional context"
     },
     {

--- a/model/attributes/url/url__template.json
+++ b/model/attributes/url/url__template.json
@@ -1,19 +1,22 @@
 {
   "key": "url.template",
-  "brief": "The low-cardinality template of an absolute path reference.",
+  "brief": "The low-cardinality template of an absolute URL path reference.",
+  "additional_context": [
+    "This attribute should primarily be set by client-side routing instrumentation, or `http.client` spans (if applicable).",
+    "Use `http.route` for server-side instrumentation that captures the framework route of an incoming request."
+  ],
   "type": "string",
   "apply_scrubbing": {
     "key": "manual"
   },
   "is_in_otel": true,
   "examples": ["/users/{id}", "/users/:id", "/about"],
-  "alias": ["http.route"],
   "visibility": "public",
   "changelog": [
     {
       "version": "next",
       "prs": [505],
-      "description": "Added multiple examples"
+      "description": "Added multiple examples, removed alias to `http.route`, added additional context"
     },
     {
       "version": "0.1.0",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5637,7 +5637,6 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: url.template
     Example: "/users/:id"
     Example: "my-controller/my-action/{id}"
     Example: "/posts"
@@ -9289,13 +9288,12 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/url/url__template.json
     URL_TEMPLATE: Literal["url.template"] = "url.template"
-    """The low-cardinality template of an absolute path reference.
+    """The low-cardinality template of an absolute URL path reference.
 
     Type: str
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: http.route
     Example: "/users/{id}"
     Example: "/users/:id"
     Example: "/about"
@@ -16343,13 +16341,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="/users/:id",
         examples=["/users/:id", "my-controller/my-action/{id}", "/posts"],
-        aliases=["url.template"],
         changelog=[
             ChangelogEntry(
-                version="next", prs=[505], description="Added multiple examples"
+                version="next",
+                prs=[505, 521],
+                description="Added multiple examples, removed alias to `url.template`, added additional context",
             ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
+        ],
+        additional_context=[
+            "This attribute should primarily be set by server-side instrumentation that captures the framework route of an incoming request.",
+            "For `http.client` spans and client-side routing, use `url.template` instead.",
         ],
     ),
     "http.scheme": AttributeMetadata(
@@ -20660,20 +20663,25 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "url.template": AttributeMetadata(
-        brief="The low-cardinality template of an absolute path reference.",
+        brief="The low-cardinality template of an absolute URL path reference.",
         type=AttributeType.STRING,
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="/users/{id}",
         examples=["/users/{id}", "/users/:id", "/about"],
-        aliases=["http.route"],
         changelog=[
             ChangelogEntry(
-                version="next", prs=[505], description="Added multiple examples"
+                version="next",
+                prs=[505, 521],
+                description="Added multiple examples, removed alias to `http.route`, added additional context",
             ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
+        ],
+        additional_context=[
+            "This attribute should primarily be set by client-side routing instrumentation, or `http.client` spans (if applicable).",
+            "Use `http.route` for server-side instrumentation that captures the framework route of an incoming request.",
         ],
     ),
     "url": AttributeMetadata(

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5637,6 +5637,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: route
     Example: "/users/:id"
     Example: "my-controller/my-action/{id}"
     Example: "/posts"
@@ -16341,6 +16342,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="/users/:id",
         examples=["/users/:id", "my-controller/my-action/{id}", "/posts"],
+        aliases=["route"],
         changelog=[
             ChangelogEntry(
                 version="next",


### PR DESCRIPTION
Previously, `http.route` and `url.template` aliased each other. I think we should avoid treating them fully equally, since they shouldn't be used interchangeably and neither is one of them deprecated (both still active in OTel, although `url.template` still has status "development").

OTel [specifies](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name) the following:
- [http.route](https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/) for HTTP Server spans
- [url.template](https://opentelemetry.io/docs/specs/semconv/registry/attributes/url/) for HTTP Client spans if enabled and available (Development)

I'd recommend, we also additionally use `url.template` on client-side router spans (pageloads and navigations).

So this PR:
- removes the alias between the two attributes
- adds additional context when to (not) use which one

