### PR TITLE
feat(attributes): Add `sentry.sample_rate` attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -14415,6 +14415,27 @@ export const SENTRY_REPORT_EVENT = 'sentry.report_event';
  */
 export type SENTRY_REPORT_EVENT_TYPE = string;
 
+// Path: model/attributes/sentry/sentry__sample_rate.json
+
+/**
+ * The sample rate that was locally applied to a span by the SDK. Only set on segment span. `sentry.sample_rate`
+ *
+ * Attribute Value Type: `number` {@link SENTRY_SAMPLE_RATE_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example 0.1
+ */
+export const SENTRY_SAMPLE_RATE = 'sentry.sample_rate';
+
+/**
+ * Type for {@link SENTRY_SAMPLE_RATE} sentry.sample_rate
+ */
+export type SENTRY_SAMPLE_RATE_TYPE = number;
+
 // Path: model/attributes/sentry/sentry__sdk__integrations.json
 
 /**
@@ -17835,6 +17856,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'sentry.replay_id': 'string',
   'sentry.replay_is_buffering': 'boolean',
   'sentry.report_event': 'string',
+  'sentry.sample_rate': 'double',
   'sentry.sdk.integrations': 'string[]',
   'sentry.sdk.name': 'string',
   'sentry.sdk.version': 'string',
@@ -18609,6 +18631,7 @@ export type AttributeName =
   | typeof SENTRY_REPLAY_ID
   | typeof SENTRY_REPLAY_IS_BUFFERING
   | typeof SENTRY_REPORT_EVENT
+  | typeof SENTRY_SAMPLE_RATE
   | typeof SENTRY_SDK_INTEGRATIONS
   | typeof SENTRY_SDK_NAME
   | typeof SENTRY_SDK_VERSION
@@ -27723,6 +27746,21 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     changelog: [{ version: '0.5.0', prs: [320], description: 'Added sentry.report_event attribute' }],
   },
+  'sentry.sample_rate': {
+    brief: 'The sample rate that was locally applied to a span by the SDK. Only set on segment span.',
+    type: 'double',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 0.1,
+    examples: [0.1],
+    changelog: [{ version: 'next', prs: [528], description: 'Added sentry.sample_rate attribute' }],
+    additionalContext: [
+      'This attribute is only set on segment spans if the span was sampled locally. The attribute is not set, if a trace is continued from an upstream service.',
+    ],
+  },
   'sentry.sdk.integrations': {
     brief:
       'A list of names identifying enabled integrations. The list shouldhave all enabled integrations, including default integrations. Defaultintegrations are included because different SDK releases may contain differentdefault integrations.',
@@ -29979,6 +30017,7 @@ export type Attributes = {
   [SENTRY_REPLAY_ID]?: SENTRY_REPLAY_ID_TYPE;
   [SENTRY_REPLAY_IS_BUFFERING]?: SENTRY_REPLAY_IS_BUFFERING_TYPE;
   [SENTRY_REPORT_EVENT]?: SENTRY_REPORT_EVENT_TYPE;
+  [SENTRY_SAMPLE_RATE]?: SENTRY_SAMPLE_RATE_TYPE;
   [SENTRY_SDK_INTEGRATIONS]?: SENTRY_SDK_INTEGRATIONS_TYPE;
   [SENTRY_SDK_NAME]?: SENTRY_SDK_NAME_TYPE;
   [SENTRY_SDK_VERSION]?: SENTRY_SDK_VERSION_TYPE;

--- a/model/attributes/sentry/sentry__sample_rate.json
+++ b/model/attributes/sentry/sentry__sample_rate.json
@@ -1,0 +1,21 @@
+{
+  "key": "sentry.sample_rate",
+  "brief": "The sample rate that was locally applied to a span by the SDK. Only set on segment span.",
+  "additional_context": [
+    "This attribute is only set on segment spans if the span was sampled locally. The attribute is not set, if a trace is continued from an upstream service."
+  ],
+  "type": "double",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": [0.1],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [528],
+      "description": "Added sentry.sample_rate attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -8403,6 +8403,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "pagehide"
     """
 
+    # Path: model/attributes/sentry/sentry__sample_rate.json
+    SENTRY_SAMPLE_RATE: Literal["sentry.sample_rate"] = "sentry.sample_rate"
+    """The sample rate that was locally applied to a span by the SDK. Only set on segment span.
+
+    Type: float
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: 0.1
+    """
+
     # Path: model/attributes/sentry/sentry__sdk__integrations.json
     SENTRY_SDK_INTEGRATIONS: Literal["sentry.sdk.integrations"] = (
         "sentry.sdk.integrations"
@@ -19576,6 +19587,25 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "sentry.sample_rate": AttributeMetadata(
+        brief="The sample rate that was locally applied to a span by the SDK. Only set on segment span.",
+        type=AttributeType.DOUBLE,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=0.1,
+        examples=[0.1],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[528],
+                description="Added sentry.sample_rate attribute",
+            ),
+        ],
+        additional_context=[
+            "This attribute is only set on segment spans if the span was sampled locally. The attribute is not set, if a trace is continued from an upstream service."
+        ],
+    ),
     "sentry.sdk.integrations": AttributeMetadata(
         brief="A list of names identifying enabled integrations. The list shouldhave all enabled integrations, including default integrations. Defaultintegrations are included because different SDK releases may contain differentdefault integrations.",
         type=AttributeType.STRING_ARRAY,
@@ -21892,6 +21922,7 @@ Attributes = TypedDict(
         "sentry.replay_id": str,
         "sentry.replay_is_buffering": bool,
         "sentry.report_event": str,
+        "sentry.sample_rate": float,
         "sentry.sdk.integrations": List[str],
         "sentry.sdk.name": str,
         "sentry.sdk.version": str,


### PR DESCRIPTION
## Description

Adds a previously missing attribute sent by JS SDKs (at least): `sentry.sample_rate`. 

See slack thread in conventions for more context. TLDR: We have multiple sample rate attributes already but all of them get set by Relay. For now this PR documents that `sentry.sample_rate` is sent. If reviewers prefer SDKs not sending it, we can deprecate it and stop sending it in v11. 

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
