### PR TITLE
feat(attributes): Add `redis.command`, deprecated in favor of `db.operation.name`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4571,7 +4571,7 @@ export type DB_NAMESPACE_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link DB_OPERATION_NAME} `db.operation.name`, {@link CLOUDFLARE_D1_QUERY_TYPE} `cloudflare.d1.query_type`
+ * Aliases: {@link DB_OPERATION_NAME} `db.operation.name`, {@link CLOUDFLARE_D1_QUERY_TYPE} `cloudflare.d1.query_type`, {@link REDIS_COMMAND} `redis.command`
  *
  * @deprecated Use {@link DB_OPERATION_NAME} (db.operation.name) instead
  * @example "SELECT"
@@ -4616,7 +4616,7 @@ export type DB_OPERATION_BATCH_SIZE_TYPE = number;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link DB_OPERATION} `db.operation`, {@link CLOUDFLARE_D1_QUERY_TYPE} `cloudflare.d1.query_type`
+ * Aliases: {@link DB_OPERATION} `db.operation`, {@link CLOUDFLARE_D1_QUERY_TYPE} `cloudflare.d1.query_type`, {@link REDIS_COMMAND} `redis.command`
  *
  * @example "SELECT"
  */
@@ -12790,6 +12790,30 @@ export const REACT_VERSION = 'react.version';
  */
 export type REACT_VERSION_TYPE = string;
 
+// Path: model/attributes/redis/redis__command.json
+
+/**
+ * The name of the Redis operation being executed. `redis.command`
+ *
+ * Attribute Value Type: `string` {@link REDIS_COMMAND_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link DB_OPERATION_NAME} `db.operation.name`, {@link DB_OPERATION} `db.operation`
+ *
+ * @deprecated Use {@link DB_OPERATION_NAME} (db.operation.name) instead
+ * @example "SELECT"
+ */
+export const REDIS_COMMAND = 'redis.command';
+
+/**
+ * Type for {@link REDIS_COMMAND} redis.command
+ */
+export type REDIS_COMMAND_TYPE = string;
+
 // Path: model/attributes/redis/redis__key.json
 
 /**
@@ -17810,6 +17834,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   profile_id: 'string',
   'query.<key>': 'string',
   'react.version': 'string',
+  'redis.command': 'string',
   'redis.key': 'string',
   release: 'string',
   'remix.action_form_data.<key>': 'string',
@@ -18586,6 +18611,7 @@ export type AttributeName =
   | typeof PROFILE_ID
   | typeof QUERY_KEY
   | typeof REACT_VERSION
+  | typeof REDIS_COMMAND
   | typeof REDIS_KEY
   | typeof RELEASE
   | typeof REMIX_ACTION_FORM_DATA_KEY
@@ -21613,7 +21639,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'db.operation.name',
       status: 'normalize',
     },
-    aliases: ['db.operation.name', 'cloudflare.d1.query_type'],
+    aliases: ['db.operation.name', 'cloudflare.d1.query_type', 'redis.command'],
     changelog: [{ version: '0.4.0', prs: [199] }, { version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
   },
   'db.operation.batch.size': {
@@ -21637,7 +21663,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'SELECT',
-    aliases: ['db.operation', 'cloudflare.d1.query_type'],
+    aliases: ['db.operation', 'cloudflare.d1.query_type', 'redis.command'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   'db.query.parameter.<key>': {
@@ -26820,6 +26846,23 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '18.2.0',
     changelog: [{ version: '0.7.0', prs: [368], description: 'Added react.version attribute' }],
   },
+  'redis.command': {
+    brief: 'The name of the Redis operation being executed.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'SELECT',
+    examples: ['SELECT'],
+    deprecation: {
+      replacement: 'db.operation.name',
+      status: 'normalize',
+    },
+    aliases: ['db.operation.name', 'db.operation'],
+    changelog: [{ version: 'next', prs: [529], description: 'Added redis.command attribute' }],
+  },
   'redis.key': {
     brief: 'The key the Redis command is operating on.',
     type: 'string',
@@ -30005,6 +30048,7 @@ export type Attributes = {
   [PROFILE_ID]?: PROFILE_ID_TYPE;
   [QUERY_KEY]?: QUERY_KEY_TYPE;
   [REACT_VERSION]?: REACT_VERSION_TYPE;
+  [REDIS_COMMAND]?: REDIS_COMMAND_TYPE;
   [REDIS_KEY]?: REDIS_KEY_TYPE;
   [RELEASE]?: RELEASE_TYPE;
   [REMIX_ACTION_FORM_DATA_KEY]?: REMIX_ACTION_FORM_DATA_KEY_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -26858,7 +26858,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     examples: ['SELECT'],
     deprecation: {
       replacement: 'db.operation.name',
-      status: 'normalize',
+      status: 'backfill',
     },
     aliases: ['db.operation.name', 'db.operation'],
     changelog: [{ version: 'next', prs: [529], description: 'Added redis.command attribute' }],

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -21640,7 +21640,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       status: 'normalize',
     },
     aliases: ['db.operation.name', 'cloudflare.d1.query_type', 'redis.command'],
-    changelog: [{ version: '0.4.0', prs: [199] }, { version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: 'next', description: 'Added redis.command as an alias' },
+      { version: '0.4.0', prs: [199] },
+      { version: '0.1.0', prs: [61, 127] },
+      { version: '0.0.0' },
+    ],
   },
   'db.operation.batch.size': {
     brief:
@@ -21664,7 +21669,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'SELECT',
     aliases: ['db.operation', 'cloudflare.d1.query_type', 'redis.command'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      { version: 'next', description: 'Added redis.command as an alias' },
+      { version: '0.1.0', prs: [127] },
+      { version: '0.0.0' },
+    ],
   },
   'db.query.parameter.<key>': {
     brief:

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3645,7 +3645,7 @@ export type CLOUDFLARE_D1_DURATION_TYPE = number;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link DB_OPERATION_NAME} `db.operation.name`, {@link DB_OPERATION} `db.operation`
+ * Aliases: {@link DB_OPERATION_NAME} `db.operation.name`, {@link DB_OPERATION} `db.operation`, {@link REDIS_COMMAND} `redis.command`
  *
  * @deprecated Use {@link DB_OPERATION_NAME} (db.operation.name) instead
  * @example "run"
@@ -12876,7 +12876,7 @@ export type REACT_VERSION_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link DB_OPERATION_NAME} `db.operation.name`, {@link DB_OPERATION} `db.operation`
+ * Aliases: {@link CLOUDFLARE_D1_QUERY_TYPE} `cloudflare.d1.query_type`, {@link DB_OPERATION_NAME} `db.operation.name`, {@link DB_OPERATION} `db.operation`
  *
  * @deprecated Use {@link DB_OPERATION_NAME} (db.operation.name) instead
  * @example "SELECT"
@@ -21167,8 +21167,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'db.operation.name',
       status: 'backfill',
     },
-    aliases: ['db.operation.name', 'db.operation'],
-    changelog: [{ version: '0.11.0', prs: [392], description: 'Added cloudflare.d1.query_type attribute' }],
+    aliases: ['db.operation.name', 'db.operation', 'redis.command'],
+    changelog: [
+      { version: 'next', description: 'Added redis.command as an alias' },
+      { version: '0.11.0', prs: [392], description: 'Added cloudflare.d1.query_type attribute' },
+    ],
   },
   'cloudflare.d1.rows_read': {
     brief: 'The number of rows read in a Cloudflare D1 operation.',
@@ -27023,7 +27026,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'db.operation.name',
       status: 'backfill',
     },
-    aliases: ['db.operation.name', 'db.operation'],
+    aliases: ['cloudflare.d1.query_type', 'db.operation.name', 'db.operation'],
     changelog: [{ version: 'next', prs: [531], description: 'Added redis.command attribute' }],
   },
   'redis.key': {

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -26870,7 +26870,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       status: 'backfill',
     },
     aliases: ['db.operation.name', 'db.operation'],
-    changelog: [{ version: 'next', prs: [529], description: 'Added redis.command attribute' }],
+    changelog: [{ version: 'next', prs: [531], description: 'Added redis.command attribute' }],
   },
   'redis.key': {
     brief: 'The key the Redis command is operating on.',

--- a/model/attributes/cloudflare/cloudflare__d1__query_type.json
+++ b/model/attributes/cloudflare/cloudflare__d1__query_type.json
@@ -7,13 +7,17 @@
   },
   "is_in_otel": false,
   "example": "run",
-  "alias": ["db.operation.name", "db.operation"],
+  "alias": ["db.operation.name", "db.operation", "redis.command"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "db.operation.name"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added redis.command as an alias"
+    },
     {
       "version": "0.11.0",
       "prs": [392],

--- a/model/attributes/db/db__operation.json
+++ b/model/attributes/db/db__operation.json
@@ -15,6 +15,10 @@
   "visibility": "public",
   "changelog": [
     {
+      "version": "next",
+      "description": "Added redis.command as an alias"
+    },
+    {
       "version": "0.4.0",
       "prs": [199]
     },

--- a/model/attributes/db/db__operation.json
+++ b/model/attributes/db/db__operation.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "SELECT",
-  "alias": ["db.operation.name", "cloudflare.d1.query_type"],
+  "alias": ["db.operation.name", "cloudflare.d1.query_type", "redis.command"],
   "deprecation": {
     "_status": "normalize",
     "replacement": "db.operation.name"

--- a/model/attributes/db/db__operation__name.json
+++ b/model/attributes/db/db__operation__name.json
@@ -11,6 +11,10 @@
   "visibility": "public",
   "changelog": [
     {
+      "version": "next",
+      "description": "Added redis.command as an alias"
+    },
+    {
       "version": "0.1.0",
       "prs": [127]
     },

--- a/model/attributes/db/db__operation__name.json
+++ b/model/attributes/db/db__operation__name.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "SELECT",
-  "alias": ["db.operation", "cloudflare.d1.query_type"],
+  "alias": ["db.operation", "cloudflare.d1.query_type", "redis.command"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/redis/redis__command.json
+++ b/model/attributes/redis/redis__command.json
@@ -16,7 +16,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [529],
+      "prs": [531],
       "description": "Added redis.command attribute"
     }
   ]

--- a/model/attributes/redis/redis__command.json
+++ b/model/attributes/redis/redis__command.json
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "visibility": "public",
   "examples": ["SELECT"],
-  "alias": ["db.operation.name", "db.operation"],
+  "alias": ["cloudflare.d1.query_type", "db.operation.name", "db.operation"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "db.operation.name"

--- a/model/attributes/redis/redis__command.json
+++ b/model/attributes/redis/redis__command.json
@@ -10,7 +10,7 @@
   "examples": ["SELECT"],
   "alias": ["db.operation.name", "db.operation"],
   "deprecation": {
-    "_status": "normalize",
+    "_status": "backfill",
     "replacement": "db.operation.name"
   },
   "changelog": [

--- a/model/attributes/redis/redis__command.json
+++ b/model/attributes/redis/redis__command.json
@@ -1,0 +1,23 @@
+{
+  "key": "redis.command",
+  "brief": "The name of the Redis operation being executed.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["SELECT"],
+  "alias": ["db.operation.name", "db.operation"],
+  "deprecation": {
+    "_status": "normalize",
+    "replacement": "db.operation.name"
+  },
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [529],
+      "description": "Added redis.command attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -18644,7 +18644,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         aliases=["db.operation.name", "db.operation"],
         changelog=[
             ChangelogEntry(
-                version="next", prs=[529], description="Added redis.command attribute"
+                version="next", prs=[531], description="Added redis.command attribute"
             ),
         ],
     ),

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -13052,6 +13052,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ),
         aliases=["db.operation.name", "cloudflare.d1.query_type", "redis.command"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added redis.command as an alias"
+            ),
             ChangelogEntry(version="0.4.0", prs=[199]),
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
             ChangelogEntry(version="0.0.0"),
@@ -13081,6 +13084,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="SELECT",
         aliases=["db.operation", "cloudflare.d1.query_type", "redis.command"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added redis.command as an alias"
+            ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
         ],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -273,6 +273,7 @@ class _AttributeNamesMeta(type):
         "PERFORMANCE_TIMEORIGIN",
         "PROFILE_ID",
         "QUERY_KEY",
+        "REDIS_COMMAND",
         "REDIS_KEY",
         "RELEASE",
         "REPLAY_ID",
@@ -2927,7 +2928,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: db.operation.name, cloudflare.d1.query_type
+    Aliases: db.operation.name, cloudflare.d1.query_type, redis.command
     DEPRECATED: Use db.operation.name instead
     Example: "SELECT"
     """
@@ -2953,7 +2954,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: db.operation, cloudflare.d1.query_type
+    Aliases: db.operation, cloudflare.d1.query_type, redis.command
     Example: "SELECT"
     """
 
@@ -7516,6 +7517,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Visibility: public
     Example: "18.2.0"
+    """
+
+    # Path: model/attributes/redis/redis__command.json
+    REDIS_COMMAND: Literal["redis.command"] = "redis.command"
+    """The name of the Redis operation being executed.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: db.operation.name, db.operation
+    DEPRECATED: Use db.operation.name instead
+    Example: "SELECT"
     """
 
     # Path: model/attributes/redis/redis__key.json
@@ -13036,7 +13050,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="db.operation.name", status=DeprecationStatus.NORMALIZE
         ),
-        aliases=["db.operation.name", "cloudflare.d1.query_type"],
+        aliases=["db.operation.name", "cloudflare.d1.query_type", "redis.command"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[199]),
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
@@ -13065,7 +13079,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="SELECT",
-        aliases=["db.operation", "cloudflare.d1.query_type"],
+        aliases=["db.operation", "cloudflare.d1.query_type", "redis.command"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
@@ -18610,6 +18624,24 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "redis.command": AttributeMetadata(
+        brief="The name of the Redis operation being executed.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="SELECT",
+        examples=["SELECT"],
+        deprecation=DeprecationInfo(
+            replacement="db.operation.name", status=DeprecationStatus.NORMALIZE
+        ),
+        aliases=["db.operation.name", "db.operation"],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[529], description="Added redis.command attribute"
+            ),
+        ],
+    ),
     "redis.key": AttributeMetadata(
         brief="The key the Redis command is operating on.",
         type=AttributeType.STRING,
@@ -21898,6 +21930,7 @@ Attributes = TypedDict(
         "profile_id": str,
         "query.<key>": str,
         "react.version": str,
+        "redis.command": str,
         "redis.key": str,
         "release": str,
         "remix.action_form_data.<key>": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -18633,7 +18633,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="SELECT",
         examples=["SELECT"],
         deprecation=DeprecationInfo(
-            replacement="db.operation.name", status=DeprecationStatus.NORMALIZE
+            replacement="db.operation.name", status=DeprecationStatus.BACKFILL
         ),
         aliases=["db.operation.name", "db.operation"],
         changelog=[

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2483,7 +2483,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: db.operation.name, db.operation
+    Aliases: db.operation.name, db.operation, redis.command
     DEPRECATED: Use db.operation.name instead
     Example: "run"
     """
@@ -7570,7 +7570,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: db.operation.name, db.operation
+    Aliases: cloudflare.d1.query_type, db.operation.name, db.operation
     DEPRECATED: Use db.operation.name instead
     Example: "SELECT"
     """
@@ -12583,8 +12583,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="db.operation.name", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["db.operation.name", "db.operation"],
+        aliases=["db.operation.name", "db.operation", "redis.command"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added redis.command as an alias"
+            ),
             ChangelogEntry(
                 version="0.11.0",
                 prs=[392],
@@ -18771,7 +18774,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="db.operation.name", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["db.operation.name", "db.operation"],
+        aliases=["cloudflare.d1.query_type", "db.operation.name", "db.operation"],
         changelog=[
             ChangelogEntry(
                 version="next", prs=[531], description="Added redis.command attribute"


### PR DESCRIPTION
## Description

<!-- Describe your changes -->

Document `redis.command`, set here:

https://github.com/getsentry/sentry-python/blob/2ab75a505df1d19ea7a85749709f9323edb89053/sentry_sdk/integrations/redis/utils.py#L148

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [ ] I have run `yarn test` and verified that the tests pass.
- [ ] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
