### PR TITLE
feat(attributes): Add `port`, deprecated in favor of `server.port`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -26714,7 +26714,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       status: 'backfill',
     },
     aliases: ['server.port', 'net.host.port'],
-    changelog: [{ version: 'next', prs: [529], description: 'Added port attribute' }],
+    changelog: [{ version: 'next', prs: [532], description: 'Added port attribute' }],
   },
   previous_route: {
     brief: 'Also used by mobile SDKs to indicate the previous route in the application.',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -26278,7 +26278,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'server.port',
     },
     aliases: ['server.port', 'port'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      { version: 'next', description: 'Added port as an alias' },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [61] },
+      { version: '0.0.0' },
+    ],
   },
   'net.peer.ip': {
     brief: 'Peer address of the network connection - IP address or Unix domain socket name.',
@@ -28317,7 +28322,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 1337,
     aliases: ['net.host.port', 'port'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    changelog: [
+      { version: 'next', description: 'Added port as an alias' },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.0.0' },
+    ],
   },
   'service.name': {
     brief: 'Logical name of the service.',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -11826,7 +11826,7 @@ export type NET_HOST_NAME_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link SERVER_PORT} `server.port`
+ * Aliases: {@link SERVER_PORT} `server.port`, {@link PORT} `port`
  *
  * @deprecated Use {@link SERVER_PORT} (server.port) instead
  * @example 1337
@@ -12516,6 +12516,30 @@ export const PERFORMANCE_TIMEORIGIN = 'performance.timeOrigin';
  * Type for {@link PERFORMANCE_TIMEORIGIN} performance.timeOrigin
  */
 export type PERFORMANCE_TIMEORIGIN_TYPE = number;
+
+// Path: model/attributes/port.json
+
+/**
+ * The destination port for a TCP connection. `port`
+ *
+ * Attribute Value Type: `number` {@link PORT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link SERVER_PORT} `server.port`, {@link NET_HOST_PORT} `net.host.port`
+ *
+ * @deprecated Use {@link SERVER_PORT} (server.port) instead - Old namespace-less attribute, to be replaced with server.port for span-first future
+ * @example 1337
+ */
+export const PORT = 'port';
+
+/**
+ * Type for {@link PORT} port
+ */
+export type PORT_TYPE = number;
 
 // Path: model/attributes/previous_route.json
 
@@ -15170,7 +15194,7 @@ export type SERVER_NAME_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link NET_HOST_PORT} `net.host.port`
+ * Aliases: {@link NET_HOST_PORT} `net.host.port`, {@link PORT} `port`
  *
  * @example 1337
  */
@@ -17798,6 +17822,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'params.<key>': 'string',
   'performance.activationStart': 'double',
   'performance.timeOrigin': 'double',
+  port: 'integer',
   previous_route: 'string',
   'process.command_args': 'string[]',
   'process.executable.name': 'string',
@@ -18574,6 +18599,7 @@ export type AttributeName =
   | typeof PARAMS_KEY
   | typeof PERFORMANCE_ACTIVATIONSTART
   | typeof PERFORMANCE_TIMEORIGIN
+  | typeof PORT
   | typeof PREVIOUS_ROUTE
   | typeof PROCESS_COMMAND_ARGS
   | typeof PROCESS_EXECUTABLE_NAME
@@ -26251,7 +26277,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'server.port',
     },
-    aliases: ['server.port'],
+    aliases: ['server.port', 'port'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   'net.peer.ip': {
@@ -26666,6 +26692,24 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     aliases: ['browser.performance.time_origin'],
     changelog: [{ version: '0.5.0', prs: [321], description: 'Added performance.timeOrigin attribute' }],
+  },
+  port: {
+    brief: 'The destination port for a TCP connection.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 1337,
+    examples: [1337],
+    deprecation: {
+      replacement: 'server.port',
+      reason: 'Old namespace-less attribute, to be replaced with server.port for span-first future',
+      status: 'backfill',
+    },
+    aliases: ['server.port', 'net.host.port'],
+    changelog: [{ version: 'next', prs: [529], description: 'Added port attribute' }],
   },
   previous_route: {
     brief: 'Also used by mobile SDKs to indicate the previous route in the application.',
@@ -28272,7 +28316,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 1337,
-    aliases: ['net.host.port'],
+    aliases: ['net.host.port', 'port'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
   'service.name': {
@@ -29993,6 +30037,7 @@ export type Attributes = {
   [PARAMS_KEY]?: PARAMS_KEY_TYPE;
   [PERFORMANCE_ACTIVATIONSTART]?: PERFORMANCE_ACTIVATIONSTART_TYPE;
   [PERFORMANCE_TIMEORIGIN]?: PERFORMANCE_TIMEORIGIN_TYPE;
+  [PORT]?: PORT_TYPE;
   [PREVIOUS_ROUTE]?: PREVIOUS_ROUTE_TYPE;
   [PROCESS_COMMAND_ARGS]?: PROCESS_COMMAND_ARGS_TYPE;
   [PROCESS_EXECUTABLE_NAME]?: PROCESS_EXECUTABLE_NAME_TYPE;

--- a/model/attributes/net/net__host__port.json
+++ b/model/attributes/net/net__host__port.json
@@ -15,6 +15,10 @@
   "visibility": "public",
   "changelog": [
     {
+      "version": "next",
+      "description": "Added port as an alias"
+    },
+    {
       "version": "0.4.0",
       "prs": [228]
     },

--- a/model/attributes/net/net__host__port.json
+++ b/model/attributes/net/net__host__port.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": 1337,
-  "alias": ["server.port"],
+  "alias": ["server.port", "port"],
   "deprecation": {
     "_status": null,
     "replacement": "server.port"

--- a/model/attributes/port.json
+++ b/model/attributes/port.json
@@ -17,7 +17,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [529],
+      "prs": [532],
       "description": "Added port attribute"
     }
   ]

--- a/model/attributes/port.json
+++ b/model/attributes/port.json
@@ -1,0 +1,24 @@
+{
+  "key": "port",
+  "brief": "The destination port for a TCP connection.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": [1337],
+  "alias": ["server.port", "net.host.port"],
+  "deprecation": {
+    "replacement": "server.port",
+    "reason": "Old namespace-less attribute, to be replaced with server.port for span-first future",
+    "_status": "backfill"
+  },
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [529],
+      "description": "Added port attribute"
+    }
+  ]
+}

--- a/model/attributes/server/server__port.json
+++ b/model/attributes/server/server__port.json
@@ -11,6 +11,10 @@
   "visibility": "public",
   "changelog": [
     {
+      "version": "next",
+      "description": "Added port as an alias"
+    },
+    {
       "version": "0.4.0",
       "prs": [228]
     },

--- a/model/attributes/server/server__port.json
+++ b/model/attributes/server/server__port.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": 1337,
-  "alias": ["net.host.port"],
+  "alias": ["net.host.port", "port"],
   "visibility": "public",
   "changelog": [
     {

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -17869,6 +17869,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(replacement="server.port"),
         aliases=["server.port", "port"],
         changelog=[
+            ChangelogEntry(version="next", description="Added port as an alias"),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[61]),
             ChangelogEntry(version="0.0.0"),
@@ -20119,6 +20120,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example=1337,
         aliases=["net.host.port", "port"],
         changelog=[
+            ChangelogEntry(version="next", description="Added port as an alias"),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
         ],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -271,6 +271,7 @@ class _AttributeNamesMeta(type):
         "OTEL_KIND",
         "PERFORMANCE_ACTIVATIONSTART",
         "PERFORMANCE_TIMEORIGIN",
+        "PORT",
         "PROFILE_ID",
         "QUERY_KEY",
         "REDIS_KEY",
@@ -6863,7 +6864,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: server.port
+    Aliases: server.port, port
     DEPRECATED: Use server.port instead
     Example: 1337
     """
@@ -7366,6 +7367,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Aliases: browser.performance.time_origin
     DEPRECATED: Use browser.performance.time_origin instead - The timeOrigin is now recorded as the browser.performance.time_origin attribute.
     Example: 1776185678.886
+    """
+
+    # Path: model/attributes/port.json
+    PORT: Literal["port"] = "port"
+    """The destination port for a TCP connection.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: server.port, net.host.port
+    DEPRECATED: Use server.port instead - Old namespace-less attribute, to be replaced with server.port for span-first future
+    Example: 1337
     """
 
     # Path: model/attributes/previous_route.json
@@ -8816,7 +8830,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: net.host.port
+    Aliases: net.host.port, port
     Example: 1337
     """
 
@@ -17853,7 +17867,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=1337,
         deprecation=DeprecationInfo(replacement="server.port"),
-        aliases=["server.port"],
+        aliases=["server.port", "port"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[61]),
@@ -18445,6 +18459,26 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
                 version="0.5.0",
                 prs=[321],
                 description="Added performance.timeOrigin attribute",
+            ),
+        ],
+    ),
+    "port": AttributeMetadata(
+        brief="The destination port for a TCP connection.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=1337,
+        examples=[1337],
+        deprecation=DeprecationInfo(
+            replacement="server.port",
+            reason="Old namespace-less attribute, to be replaced with server.port for span-first future",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["server.port", "net.host.port"],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[529], description="Added port attribute"
             ),
         ],
     ),
@@ -20083,7 +20117,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example=1337,
-        aliases=["net.host.port"],
+        aliases=["net.host.port", "port"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
@@ -21886,6 +21920,7 @@ Attributes = TypedDict(
         "params.<key>": str,
         "performance.activationStart": float,
         "performance.timeOrigin": float,
+        "port": int,
         "previous_route": str,
         "process.command_args": List[str],
         "process.executable.name": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -18479,7 +18479,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         aliases=["server.port", "net.host.port"],
         changelog=[
             ChangelogEntry(
-                version="next", prs=[529], description="Added port attribute"
+                version="next", prs=[532], description="Added port attribute"
             ),
         ],
     ),


### PR DESCRIPTION
## Description

Document `port`, set by `sentry-python` in the transaction world:

https://github.com/getsentry/sentry-python/blob/2ab75a505df1d19ea7a85749709f9323edb89053/sentry_sdk/integrations/socket.py#L144

<!-- Describe your changes -->

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [ ] I have run `yarn test` and verified that the tests pass.
- [ ] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
