### PR TITLE
feat(attributes): Add `address`, deprecated in favor of `server.address`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -18828,7 +18828,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       status: 'backfill',
     },
     aliases: ['server.address', 'http.server_name', 'net.host.name', 'http.host', 'server_name'],
-    changelog: [{ version: 'next', prs: [529], description: 'Added address attribute' }],
+    changelog: [{ version: 'next', prs: [534], description: 'Added address attribute' }],
   },
   'ai.citations': {
     brief: 'References or sources cited by the AI model in its response.',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -1,5 +1,29 @@
 // This is an auto-generated file. Do not edit!
 
+// Path: model/attributes/address.json
+
+/**
+ * The destination hostname or IP address for a TCP connection. `address`
+ *
+ * Attribute Value Type: `string` {@link ADDRESS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`
+ *
+ * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead - Old namespace-less attribute, to be replaced with server.address for span-first future
+ * @example "example.com"
+ */
+export const ADDRESS = 'address';
+
+/**
+ * Type for {@link ADDRESS} address
+ */
+export type ADDRESS_TYPE = string;
+
 // Path: model/attributes/ai/ai__citations.json
 
 /**
@@ -8744,7 +8768,7 @@ export type HTTP_FRAGMENT_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link SERVER_ADDRESS} `server.address`, {@link CLIENT_ADDRESS} `client.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link SERVER_NAME} `server_name`
+ * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link CLIENT_ADDRESS} `client.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link SERVER_NAME} `server_name`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead - Deprecated, use one of `server.address` or `client.address`, depending on the usage
  * @example "example.com"
@@ -9443,7 +9467,7 @@ export type HTTP_SCHEME_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link SERVER_ADDRESS} `server.address`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`
+ * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead
  * @example "example.com"
@@ -11802,7 +11826,7 @@ export type NET_HOST_IP_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`
+ * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead
  * @example "example.com"
@@ -15123,7 +15147,7 @@ export type SENTRY_USER_USERNAME_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`
+ * Aliases: {@link ADDRESS} `address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`
  *
  * @example "example.com"
  */
@@ -15146,7 +15170,7 @@ export type SERVER_ADDRESS_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`
+ * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead - This attribute is being deprecated in favor of server.address, which is the OTel-aligned replacement.
  * @example "example.com"
@@ -17235,6 +17259,7 @@ export interface AttributeMetadata {
 }
 
 export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
+  address: 'string',
   'ai.citations': 'string[]',
   'ai.completion_tokens.used': 'integer',
   'ai.documents': 'string[]',
@@ -18011,6 +18036,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
 };
 
 export type AttributeName =
+  | typeof ADDRESS
   | typeof AI_CITATIONS
   | typeof AI_COMPLETION_TOKENS_USED
   | typeof AI_DOCUMENTS
@@ -18786,6 +18812,24 @@ export type AttributeName =
   | typeof VERCEL_STATUS_CODE;
 
 export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
+  address: {
+    brief: 'The destination hostname or IP address for a TCP connection.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'example.com',
+    examples: ['example.com'],
+    deprecation: {
+      replacement: 'server.address',
+      reason: 'Old namespace-less attribute, to be replaced with server.address for span-first future',
+      status: 'backfill',
+    },
+    aliases: ['server.address', 'http.server_name', 'net.host.name', 'http.host', 'server_name'],
+    changelog: [{ version: 'next', prs: [529], description: 'Added address attribute' }],
+  },
   'ai.citations': {
     brief: 'References or sources cited by the AI model in its response.',
     type: 'string[]',
@@ -24335,8 +24379,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'server.address',
       reason: 'Deprecated, use one of `server.address` or `client.address`, depending on the usage',
     },
-    aliases: ['server.address', 'client.address', 'http.server_name', 'net.host.name', 'server_name'],
-    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+    aliases: ['address', 'server.address', 'client.address', 'http.server_name', 'net.host.name', 'server_name'],
+    changelog: [
+      { version: 'next', description: 'Added address as an alias' },
+      { version: '0.1.0', prs: [61, 108, 127] },
+      { version: '0.0.0' },
+    ],
   },
   'http.method': {
     brief: 'The HTTP method used.',
@@ -24749,8 +24797,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'server.address',
     },
-    aliases: ['server.address', 'net.host.name', 'http.host', 'server_name'],
-    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+    aliases: ['address', 'server.address', 'net.host.name', 'http.host', 'server_name'],
+    changelog: [
+      { version: 'next', description: 'Added address as an alias' },
+      { version: '0.1.0', prs: [61, 108, 127] },
+      { version: '0.0.0' },
+    ],
   },
   'http.server.request.time_in_queue': {
     brief:
@@ -26236,8 +26288,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'server.address',
     },
-    aliases: ['server.address', 'http.server_name', 'http.host', 'server_name'],
-    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+    aliases: ['address', 'server.address', 'http.server_name', 'http.host', 'server_name'],
+    changelog: [
+      { version: 'next', description: 'Added address as an alias' },
+      { version: '0.1.0', prs: [61, 108, 127] },
+      { version: '0.0.0' },
+    ],
   },
   'net.host.port': {
     brief: 'Server port number.',
@@ -28236,8 +28292,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'example.com',
-    aliases: ['http.server_name', 'net.host.name', 'http.host', 'server_name'],
-    changelog: [{ version: '0.1.0', prs: [108, 127] }, { version: '0.0.0' }],
+    aliases: ['address', 'http.server_name', 'net.host.name', 'http.host', 'server_name'],
+    changelog: [
+      { version: 'next', description: 'Added address as an alias' },
+      { version: '0.1.0', prs: [108, 127] },
+      { version: '0.0.0' },
+    ],
   },
   server_name: {
     brief:
@@ -28254,8 +28314,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'This attribute is being deprecated in favor of server.address, which is the OTel-aligned replacement.',
       status: 'backfill',
     },
-    aliases: ['server.address', 'http.server_name', 'net.host.name', 'http.host'],
+    aliases: ['address', 'server.address', 'http.server_name', 'net.host.name', 'http.host'],
     changelog: [
+      { version: 'next', description: 'Added address as an alias' },
       {
         version: '0.16.0',
         prs: [477],
@@ -29430,6 +29491,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
 export type AttributeValue = string | number | boolean | Array<string> | Array<number> | Array<boolean>;
 
 export type Attributes = {
+  [ADDRESS]?: ADDRESS_TYPE;
   [AI_CITATIONS]?: AI_CITATIONS_TYPE;
   [AI_COMPLETION_TOKENS_USED]?: AI_COMPLETION_TOKENS_USED_TYPE;
   [AI_DOCUMENTS]?: AI_DOCUMENTS_TYPE;

--- a/model/attributes/address.json
+++ b/model/attributes/address.json
@@ -17,7 +17,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [529],
+      "prs": [534],
       "description": "Added address attribute"
     }
   ]

--- a/model/attributes/address.json
+++ b/model/attributes/address.json
@@ -1,0 +1,24 @@
+{
+  "key": "address",
+  "brief": "The destination hostname or IP address for a TCP connection.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["example.com"],
+  "alias": ["server.address", "http.server_name", "net.host.name", "http.host", "server_name"],
+  "deprecation": {
+    "replacement": "server.address",
+    "reason": "Old namespace-less attribute, to be replaced with server.address for span-first future",
+    "_status": "backfill"
+  },
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [529],
+      "description": "Added address attribute"
+    }
+  ]
+}

--- a/model/attributes/http/http__host.json
+++ b/model/attributes/http/http__host.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "example.com",
-  "alias": ["server.address", "client.address", "http.server_name", "net.host.name", "server_name"],
+  "alias": ["address", "server.address", "client.address", "http.server_name", "net.host.name", "server_name"],
   "deprecation": {
     "_status": null,
     "replacement": "server.address",
@@ -15,6 +15,10 @@
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added address as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [61, 108, 127]

--- a/model/attributes/http/http__server_name.json
+++ b/model/attributes/http/http__server_name.json
@@ -7,13 +7,17 @@
   },
   "is_in_otel": true,
   "example": "example.com",
-  "alias": ["server.address", "net.host.name", "http.host", "server_name"],
+  "alias": ["address", "server.address", "net.host.name", "http.host", "server_name"],
   "deprecation": {
     "_status": null,
     "replacement": "server.address"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added address as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [61, 108, 127]

--- a/model/attributes/net/net__host__name.json
+++ b/model/attributes/net/net__host__name.json
@@ -7,13 +7,17 @@
   },
   "is_in_otel": true,
   "example": "example.com",
-  "alias": ["server.address", "http.server_name", "http.host", "server_name"],
+  "alias": ["address", "server.address", "http.server_name", "http.host", "server_name"],
   "deprecation": {
     "_status": null,
     "replacement": "server.address"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added address as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [61, 108, 127]

--- a/model/attributes/server/server__address.json
+++ b/model/attributes/server/server__address.json
@@ -7,9 +7,13 @@
   },
   "is_in_otel": true,
   "example": "example.com",
-  "alias": ["http.server_name", "net.host.name", "http.host", "server_name"],
+  "alias": ["address", "http.server_name", "net.host.name", "http.host", "server_name"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added address as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [108, 127]

--- a/model/attributes/server_name.json
+++ b/model/attributes/server_name.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": false,
   "example": "example.com",
-  "alias": ["server.address", "http.server_name", "net.host.name", "http.host"],
+  "alias": ["address", "server.address", "http.server_name", "net.host.name", "http.host"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "server.address",
@@ -15,6 +15,10 @@
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added address as an alias"
+    },
     {
       "version": "0.16.0",
       "prs": [477],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -116,6 +116,7 @@ class AttributeMetadata:
 
 class _AttributeNamesMeta(type):
     _deprecated_names = {
+        "ADDRESS",
         "AI_CITATIONS",
         "AI_COMPLETION_TOKENS_USED",
         "AI_DOCUMENTS",
@@ -337,6 +338,19 @@ class _AttributeNamesMeta(type):
 
 class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """Contains all attribute names as class attributes with their documentation."""
+
+    # Path: model/attributes/address.json
+    ADDRESS: Literal["address"] = "address"
+    """The destination hostname or IP address for a TCP connection.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: server.address, http.server_name, net.host.name, http.host, server_name
+    DEPRECATED: Use server.address instead - Old namespace-less attribute, to be replaced with server.address for span-first future
+    Example: "example.com"
+    """
 
     # Path: model/attributes/ai/ai__citations.json
     AI_CITATIONS: Literal["ai.citations"] = "ai.citations"
@@ -5271,7 +5285,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: server.address, client.address, http.server_name, net.host.name, server_name
+    Aliases: address, server.address, client.address, http.server_name, net.host.name, server_name
     DEPRECATED: Use server.address instead - Deprecated, use one of `server.address` or `client.address`, depending on the usage
     Example: "example.com"
     """
@@ -5692,7 +5706,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: server.address, net.host.name, http.host, server_name
+    Aliases: address, server.address, net.host.name, http.host, server_name
     DEPRECATED: Use server.address instead
     Example: "example.com"
     """
@@ -6850,7 +6864,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: server.address, http.server_name, http.host, server_name
+    Aliases: address, server.address, http.server_name, http.host, server_name
     DEPRECATED: Use server.address instead
     Example: "example.com"
     """
@@ -8804,7 +8818,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: http.server_name, net.host.name, http.host, server_name
+    Aliases: address, http.server_name, net.host.name, http.host, server_name
     Example: "example.com"
     """
 
@@ -8828,7 +8842,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: server.address, http.server_name, net.host.name, http.host
+    Aliases: address, server.address, http.server_name, net.host.name, http.host
     DEPRECATED: Use server.address instead - This attribute is being deprecated in favor of server.address, which is the OTel-aligned replacement.
     Example: "example.com"
     """
@@ -9901,6 +9915,32 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
 
 ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
+    "address": AttributeMetadata(
+        brief="The destination hostname or IP address for a TCP connection.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="example.com",
+        examples=["example.com"],
+        deprecation=DeprecationInfo(
+            replacement="server.address",
+            reason="Old namespace-less attribute, to be replaced with server.address for span-first future",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=[
+            "server.address",
+            "http.server_name",
+            "net.host.name",
+            "http.host",
+            "server_name",
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[529], description="Added address attribute"
+            ),
+        ],
+    ),
     "ai.citations": AttributeMetadata(
         brief="References or sources cited by the AI model in its response.",
         type=AttributeType.STRING_ARRAY,
@@ -15992,6 +16032,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             reason="Deprecated, use one of `server.address` or `client.address`, depending on the usage",
         ),
         aliases=[
+            "address",
             "server.address",
             "client.address",
             "http.server_name",
@@ -15999,6 +16040,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "server_name",
         ],
         changelog=[
+            ChangelogEntry(version="next", description="Added address as an alias"),
             ChangelogEntry(version="0.1.0", prs=[61, 108, 127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -16437,8 +16479,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="example.com",
         deprecation=DeprecationInfo(replacement="server.address"),
-        aliases=["server.address", "net.host.name", "http.host", "server_name"],
+        aliases=[
+            "address",
+            "server.address",
+            "net.host.name",
+            "http.host",
+            "server_name",
+        ],
         changelog=[
+            ChangelogEntry(version="next", description="Added address as an alias"),
             ChangelogEntry(version="0.1.0", prs=[61, 108, 127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -17839,8 +17888,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="example.com",
         deprecation=DeprecationInfo(replacement="server.address"),
-        aliases=["server.address", "http.server_name", "http.host", "server_name"],
+        aliases=[
+            "address",
+            "server.address",
+            "http.server_name",
+            "http.host",
+            "server_name",
+        ],
         changelog=[
+            ChangelogEntry(version="next", description="Added address as an alias"),
             ChangelogEntry(version="0.1.0", prs=[61, 108, 127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -20070,8 +20126,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="example.com",
-        aliases=["http.server_name", "net.host.name", "http.host", "server_name"],
+        aliases=[
+            "address",
+            "http.server_name",
+            "net.host.name",
+            "http.host",
+            "server_name",
+        ],
         changelog=[
+            ChangelogEntry(version="next", description="Added address as an alias"),
             ChangelogEntry(version="0.1.0", prs=[108, 127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -20101,8 +20164,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             reason="This attribute is being deprecated in favor of server.address, which is the OTel-aligned replacement.",
             status=DeprecationStatus.BACKFILL,
         ),
-        aliases=["server.address", "http.server_name", "net.host.name", "http.host"],
+        aliases=[
+            "address",
+            "server.address",
+            "http.server_name",
+            "net.host.name",
+            "http.host",
+        ],
         changelog=[
+            ChangelogEntry(version="next", description="Added address as an alias"),
             ChangelogEntry(
                 version="0.16.0",
                 prs=[477],
@@ -21323,6 +21393,7 @@ If a key is not present in this dictionary, it means that attribute is not defin
 Attributes = TypedDict(
     "Attributes",
     {
+        "address": str,
         "ai.citations": List[str],
         "ai.completion_tokens.used": int,
         "ai.documents": List[str],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -9937,7 +9937,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
         changelog=[
             ChangelogEntry(
-                version="next", prs=[529], description="Added address attribute"
+                version="next", prs=[534], description="Added address attribute"
             ),
         ],
     ),


### PR DESCRIPTION
## Description

Set in the transaction-based mode in Python's `socket` integration:

https://github.com/getsentry/sentry-python/blob/5204ffa36063c4dc85dd1be1f0b64c72e8fe0390/sentry_sdk/integrations/socket.py#L83

<!-- Describe your changes -->

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [ ] I have run `yarn test` and verified that the tests pass.
- [ ] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
