### PR TITLE
feat(attributes): Add `gcp_region`, deprecated in favor of `cloud.region`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -23032,7 +23032,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       status: 'backfill',
     },
     aliases: ['cloud.region'],
-    changelog: [{ version: 'next', prs: [529], description: 'Added gcp_region attribute' }],
+    changelog: [{ version: 'next', prs: [535], description: 'Added gcp_region attribute' }],
   },
   'gen_ai.agent.name': {
     brief: 'The name of the agent being used.',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4041,6 +4041,8 @@ export type CLOUD_PROVIDER_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
+ * Aliases: {@link GCP_REGION} `gcp_region`
+ *
  * @example "us-east-1"
  */
 export const CLOUD_REGION = 'cloud.region';
@@ -6811,6 +6813,30 @@ export const GCP_PROJECT_ID = 'gcp.project.id';
  * Type for {@link GCP_PROJECT_ID} gcp.project.id
  */
 export type GCP_PROJECT_ID_TYPE = string;
+
+// Path: model/attributes/gcp_region.json
+
+/**
+ * The geographical region the GCP resource is running `gcp_region`
+ *
+ * Attribute Value Type: `string` {@link GCP_REGION_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link CLOUD_REGION} `cloud.region`
+ *
+ * @deprecated Use {@link CLOUD_REGION} (cloud.region) instead
+ * @example "us-east-1"
+ */
+export const GCP_REGION = 'gcp_region';
+
+/**
+ * Type for {@link GCP_REGION} gcp_region
+ */
+export type GCP_REGION_TYPE = string;
 
 // Path: model/attributes/gen_ai/gen_ai__agent__name.json
 
@@ -17542,6 +17568,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'gcp.function.context.timestamp': 'string',
   'gcp.function.context.type': 'string',
   'gcp.project.id': 'string',
+  gcp_region: 'string',
   'gen_ai.agent.name': 'string',
   'gen_ai.context.utilization': 'double',
   'gen_ai.context.window_size': 'integer',
@@ -18318,6 +18345,7 @@ export type AttributeName =
   | typeof GCP_FUNCTION_CONTEXT_TIMESTAMP
   | typeof GCP_FUNCTION_CONTEXT_TYPE
   | typeof GCP_PROJECT_ID
+  | typeof GCP_REGION
   | typeof GEN_AI_AGENT_NAME
   | typeof GEN_AI_CONTEXT_UTILIZATION
   | typeof GEN_AI_CONTEXT_WINDOW_SIZE
@@ -21266,7 +21294,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'us-east-1',
-    changelog: [{ version: '0.7.0', prs: [364], description: 'Added cloud.region attribute' }],
+    aliases: ['gcp_region'],
+    changelog: [
+      { version: 'next', description: 'Added gcp_region as an alias' },
+      { version: '0.7.0', prs: [364], description: 'Added cloud.region attribute' },
+    ],
   },
   'cloud.resource_id': {
     brief: 'Cloud provider-specific native identifier of the monitored cloud resource',
@@ -22984,6 +23016,23 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'my-project-123',
     changelog: [{ version: '0.11.0', prs: [403] }],
+  },
+  gcp_region: {
+    brief: 'The geographical region the GCP resource is running',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'us-east-1',
+    examples: ['us-east-1'],
+    deprecation: {
+      replacement: 'cloud.region',
+      status: 'backfill',
+    },
+    aliases: ['cloud.region'],
+    changelog: [{ version: 'next', prs: [529], description: 'Added gcp_region attribute' }],
   },
   'gen_ai.agent.name': {
     brief: 'The name of the agent being used.',
@@ -29737,6 +29786,7 @@ export type Attributes = {
   [GCP_FUNCTION_CONTEXT_TIMESTAMP]?: GCP_FUNCTION_CONTEXT_TIMESTAMP_TYPE;
   [GCP_FUNCTION_CONTEXT_TYPE]?: GCP_FUNCTION_CONTEXT_TYPE_TYPE;
   [GCP_PROJECT_ID]?: GCP_PROJECT_ID_TYPE;
+  [GCP_REGION]?: GCP_REGION_TYPE;
   [GEN_AI_AGENT_NAME]?: GEN_AI_AGENT_NAME_TYPE;
   [GEN_AI_CONTEXT_UTILIZATION]?: GEN_AI_CONTEXT_UTILIZATION_TYPE;
   [GEN_AI_CONTEXT_WINDOW_SIZE]?: GEN_AI_CONTEXT_WINDOW_SIZE_TYPE;

--- a/model/attributes/cloud/cloud__region.json
+++ b/model/attributes/cloud/cloud__region.json
@@ -8,7 +8,12 @@
   "is_in_otel": true,
   "example": "us-east-1",
   "visibility": "public",
+  "alias": ["gcp_region"],
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added gcp_region as an alias"
+    },
     {
       "version": "0.7.0",
       "prs": [364],

--- a/model/attributes/gcp_region.json
+++ b/model/attributes/gcp_region.json
@@ -16,7 +16,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [529],
+      "prs": [535],
       "description": "Added gcp_region attribute"
     }
   ]

--- a/model/attributes/gcp_region.json
+++ b/model/attributes/gcp_region.json
@@ -1,0 +1,23 @@
+{
+  "key": "gcp_region",
+  "brief": "The geographical region the GCP resource is running",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["us-east-1"],
+  "alias": ["cloud.region"],
+  "deprecation": {
+    "replacement": "cloud.region",
+    "_status": "backfill"
+  },
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [529],
+      "description": "Added gcp_region attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -14627,7 +14627,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         aliases=["cloud.region"],
         changelog=[
             ChangelogEntry(
-                version="next", prs=[529], description="Added gcp_region attribute"
+                version="next", prs=[535], description="Added gcp_region attribute"
             ),
         ],
     ),

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -200,6 +200,7 @@ class _AttributeNamesMeta(type):
         "FRAMES_FROZEN_RATE",
         "FRAMES_SLOW_RATE",
         "FS_ERROR",
+        "GCP_REGION",
         "GEN_AI_PROMPT",
         "GEN_AI_REQUEST_AVAILABLE_TOOLS",
         "GEN_AI_REQUEST_MESSAGES",
@@ -2416,6 +2417,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: gcp_region
     Example: "us-east-1"
     """
 
@@ -4142,6 +4144,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Visibility: public
     Example: "my-project-123"
+    """
+
+    # Path: model/attributes/gcp_region.json
+    GCP_REGION: Literal["gcp_region"] = "gcp_region"
+    """The geographical region the GCP resource is running
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: cloud.region
+    DEPRECATED: Use cloud.region instead
+    Example: "us-east-1"
     """
 
     # Path: model/attributes/gen_ai/gen_ai__agent__name.json
@@ -12433,7 +12448,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="us-east-1",
+        aliases=["gcp_region"],
         changelog=[
+            ChangelogEntry(version="next", description="Added gcp_region as an alias"),
             ChangelogEntry(
                 version="0.7.0", prs=[364], description="Added cloud.region attribute"
             ),
@@ -14594,6 +14611,24 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="my-project-123",
         changelog=[
             ChangelogEntry(version="0.11.0", prs=[403]),
+        ],
+    ),
+    "gcp_region": AttributeMetadata(
+        brief="The geographical region the GCP resource is running",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="us-east-1",
+        examples=["us-east-1"],
+        deprecation=DeprecationInfo(
+            replacement="cloud.region", status=DeprecationStatus.BACKFILL
+        ),
+        aliases=["cloud.region"],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[529], description="Added gcp_region attribute"
+            ),
         ],
     ),
     "gen_ai.agent.name": AttributeMetadata(
@@ -21630,6 +21665,7 @@ Attributes = TypedDict(
         "gcp.function.context.timestamp": str,
         "gcp.function.context.type": str,
         "gcp.project.id": str,
+        "gcp_region": str,
         "gen_ai.agent.name": str,
         "gen_ai.context.utilization": float,
         "gen_ai.context.window_size": int,


### PR DESCRIPTION
## Description

Document an attribute set in the transaction-based Python SDK world:

https://github.com/getsentry/sentry-python/blob/5204ffa36063c4dc85dd1be1f0b64c72e8fe0390/sentry_sdk/integrations/gcp.py#L71

<!-- Describe your changes -->

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [ ] I have run `yarn test` and verified that the tests pass.
- [ ] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
