### PR TITLE
feat(attributes): Add `aws_region`, deprecated in favor of `cloud.region`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -20515,7 +20515,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       status: 'backfill',
     },
     aliases: ['cloud.region'],
-    changelog: [{ version: 'next', prs: [529], description: 'Added aws_region attribute' }],
+    changelog: [{ version: 'next', prs: [537], description: 'Added aws_region attribute' }],
   },
   'aws.request.extended_id': {
     brief: 'The AWS extended request ID as returned in the response headers.',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2605,6 +2605,30 @@ export const AWS_LOG_STREAM_NAMES = 'aws.log.stream.names';
  */
 export type AWS_LOG_STREAM_NAMES_TYPE = Array<string>;
 
+// Path: model/attributes/aws_region.json
+
+/**
+ * The geographical region the AWS resource is running `aws_region`
+ *
+ * Attribute Value Type: `string` {@link AWS_REGION_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link CLOUD_REGION} `cloud.region`
+ *
+ * @deprecated Use {@link CLOUD_REGION} (cloud.region) instead
+ * @example "us-east-1"
+ */
+export const AWS_REGION = 'aws_region';
+
+/**
+ * Type for {@link AWS_REGION} aws_region
+ */
+export type AWS_REGION_TYPE = string;
+
 // Path: model/attributes/aws/aws__request__extended_id.json
 
 /**
@@ -4040,6 +4064,8 @@ export type CLOUD_PROVIDER_TYPE = string;
  *
  * Attribute defined in OTEL: Yes
  * Visibility: public
+ *
+ * Aliases: {@link AWS_REGION} `aws_region`
  *
  * @example "us-east-1"
  */
@@ -17351,6 +17377,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'aws.lambda.remaining_time_in_millis': 'double',
   'aws.log.group.names': 'string[]',
   'aws.log.stream.names': 'string[]',
+  aws_region: 'string',
   'aws.request.extended_id': 'string',
   'aws.request_id': 'string',
   'aws.request.id': 'string',
@@ -18127,6 +18154,7 @@ export type AttributeName =
   | typeof AWS_LAMBDA_REMAINING_TIME_IN_MILLIS
   | typeof AWS_LOG_GROUP_NAMES
   | typeof AWS_LOG_STREAM_NAMES
+  | typeof AWS_REGION
   | typeof AWS_REQUEST_EXTENDED_ID
   | typeof AWS_REQUEST_ID
   | typeof _AWS_REQUEST_ID
@@ -20472,6 +20500,23 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: ['logs/main/10838bed-421f-43ef-870a-f43feacbbb5b'],
     changelog: [{ version: '0.11.1', prs: [414] }],
   },
+  aws_region: {
+    brief: 'The geographical region the AWS resource is running',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'us-east-1',
+    examples: ['us-east-1'],
+    deprecation: {
+      replacement: 'cloud.region',
+      status: 'backfill',
+    },
+    aliases: ['cloud.region'],
+    changelog: [{ version: 'next', prs: [529], description: 'Added aws_region attribute' }],
+  },
   'aws.request.extended_id': {
     brief: 'The AWS extended request ID as returned in the response headers.',
     type: 'string',
@@ -21266,7 +21311,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'us-east-1',
-    changelog: [{ version: '0.7.0', prs: [364], description: 'Added cloud.region attribute' }],
+    aliases: ['aws_region'],
+    changelog: [
+      { version: 'next', description: 'Added aws_region as an alias' },
+      { version: '0.7.0', prs: [364], description: 'Added cloud.region attribute' },
+    ],
   },
   'cloud.resource_id': {
     brief: 'Cloud provider-specific native identifier of the monitored cloud resource',
@@ -29546,6 +29595,7 @@ export type Attributes = {
   [AWS_LAMBDA_REMAINING_TIME_IN_MILLIS]?: AWS_LAMBDA_REMAINING_TIME_IN_MILLIS_TYPE;
   [AWS_LOG_GROUP_NAMES]?: AWS_LOG_GROUP_NAMES_TYPE;
   [AWS_LOG_STREAM_NAMES]?: AWS_LOG_STREAM_NAMES_TYPE;
+  [AWS_REGION]?: AWS_REGION_TYPE;
   [AWS_REQUEST_EXTENDED_ID]?: AWS_REQUEST_EXTENDED_ID_TYPE;
   [AWS_REQUEST_ID]?: AWS_REQUEST_ID_TYPE;
   [_AWS_REQUEST_ID]?: _AWS_REQUEST_ID_TYPE;

--- a/model/attributes/aws_region.json
+++ b/model/attributes/aws_region.json
@@ -1,0 +1,23 @@
+{
+  "key": "aws_region",
+  "brief": "The geographical region the AWS resource is running",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["us-east-1"],
+  "alias": ["cloud.region"],
+  "deprecation": {
+    "replacement": "cloud.region",
+    "_status": "backfill"
+  },
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [529],
+      "description": "Added aws_region attribute"
+    }
+  ]
+}

--- a/model/attributes/aws_region.json
+++ b/model/attributes/aws_region.json
@@ -16,7 +16,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [529],
+      "prs": [537],
       "description": "Added aws_region attribute"
     }
   ]

--- a/model/attributes/cloud/cloud__region.json
+++ b/model/attributes/cloud/cloud__region.json
@@ -8,7 +8,12 @@
   "is_in_otel": true,
   "example": "us-east-1",
   "visibility": "public",
+  "alias": ["aws_region"],
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added aws_region as an alias"
+    },
     {
       "version": "0.7.0",
       "prs": [364],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -11967,7 +11967,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         aliases=["cloud.region"],
         changelog=[
             ChangelogEntry(
-                version="next", prs=[529], description="Added aws_region attribute"
+                version="next", prs=[537], description="Added aws_region attribute"
             ),
         ],
     ),

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -170,6 +170,7 @@ class _AttributeNamesMeta(type):
         "AWS_REQUEST_EXTENDED_ID",
         "_AWS_REQUEST_ID",
         "AWS_REQUEST_URL",
+        "AWS_REGION",
         "CLOUDFLARE_D1_QUERY_TYPE",
         "CLS_SOURCE_KEY",
         "CLS",
@@ -1928,6 +1929,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "arn:aws:states:us-east-1:123456789012:stateMachine:myStateMachine:1"
     """
 
+    # Path: model/attributes/aws_region.json
+    AWS_REGION: Literal["aws_region"] = "aws_region"
+    """The geographical region the AWS resource is running
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: cloud.region
+    DEPRECATED: Use cloud.region instead
+    Example: "us-east-1"
+    """
+
     # Path: model/attributes/blocked_main_thread.json
     BLOCKED_MAIN_THREAD: Literal["blocked_main_thread"] = "blocked_main_thread"
     """Whether the main thread was blocked by the span.
@@ -2416,6 +2430,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: aws_region
     Example: "us-east-1"
     """
 
@@ -11938,6 +11953,24 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "aws_region": AttributeMetadata(
+        brief="The geographical region the AWS resource is running",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="us-east-1",
+        examples=["us-east-1"],
+        deprecation=DeprecationInfo(
+            replacement="cloud.region", status=DeprecationStatus.BACKFILL
+        ),
+        aliases=["cloud.region"],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[529], description="Added aws_region attribute"
+            ),
+        ],
+    ),
     "blocked_main_thread": AttributeMetadata(
         brief="Whether the main thread was blocked by the span.",
         type=AttributeType.BOOLEAN,
@@ -12433,7 +12466,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="us-east-1",
+        aliases=["aws_region"],
         changelog=[
+            ChangelogEntry(version="next", description="Added aws_region as an alias"),
             ChangelogEntry(
                 version="0.7.0", prs=[364], description="Added cloud.region attribute"
             ),
@@ -21448,6 +21483,7 @@ Attributes = TypedDict(
         "aws.sns.topic.arn": str,
         "aws.step_functions.activity.arn": str,
         "aws.step_functions.state_machine.arn": str,
+        "aws_region": str,
         "blocked_main_thread": bool,
         "browser.name": str,
         "browser.performance.navigation.activation_start": float,


### PR DESCRIPTION
## Description

Document an attribute set in the transaction-based Python SDK world:

https://github.com/getsentry/sentry-python/blob/5204ffa36063c4dc85dd1be1f0b64c72e8fe0390/sentry_sdk/integrations/aws_lambda.py#L124

<!-- Describe your changes -->

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [ ] I have run `yarn test` and verified that the tests pass.
- [ ] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
