### PR TITLE
feat(attributes): Add `django.function_name`, deprecated in favor of `code.function.name`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4189,7 +4189,7 @@ export type CODE_FILE_PATH_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link CODE_FUNCTION_NAME} `code.function.name`
+ * Aliases: {@link CODE_FUNCTION_NAME} `code.function.name`, {@link DJANGO_FUNCTION_NAME} `django.function_name`
  *
  * @example "server_request"
  */
@@ -4212,7 +4212,7 @@ export type CODE_FUNCTION_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link CODE_FUNCTION} `code.function`
+ * Aliases: {@link CODE_FUNCTION} `code.function`, {@link DJANGO_FUNCTION_NAME} `django.function_name`
  *
  * @example "server_request"
  */
@@ -5773,6 +5773,30 @@ export const DIST = 'dist';
  * Type for {@link DIST} dist
  */
 export type DIST_TYPE = string;
+
+// Path: model/attributes/django/django__function_name.json
+
+/**
+ * The fully qualified name of a function used in a Django context. `django.function_name`
+ *
+ * Attribute Value Type: `string` {@link DJANGO_FUNCTION_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link CODE_FUNCTION_NAME} `code.function.name`, {@link CODE_FUNCTION} `code.function`
+ *
+ * @deprecated Use {@link CODE_FUNCTION_NAME} (code.function.name) instead - This attribute is being deprecated in favor of code.function.name, which is the framework-agnostic replacement.
+ * @example "django.contrib.sessions.middleware.SessionMiddleware"
+ */
+export const DJANGO_FUNCTION_NAME = 'django.function_name';
+
+/**
+ * Type for {@link DJANGO_FUNCTION_NAME} django.function_name
+ */
+export type DJANGO_FUNCTION_NAME_TYPE = string;
 
 // Path: model/attributes/django/django__middleware_name.json
 
@@ -17495,6 +17519,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'device.timezone': 'string',
   'device.usable_memory': 'integer',
   dist: 'string',
+  'django.function_name': 'string',
   'django.middleware_name': 'string',
   effectiveConnectionType: 'string',
   environment: 'string',
@@ -18271,6 +18296,7 @@ export type AttributeName =
   | typeof DEVICE_TIMEZONE
   | typeof DEVICE_USABLE_MEMORY
   | typeof DIST
+  | typeof DJANGO_FUNCTION_NAME
   | typeof DJANGO_MIDDLEWARE_NAME
   | typeof EFFECTIVECONNECTIONTYPE
   | typeof ENVIRONMENT
@@ -21365,8 +21391,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'server_request',
-    aliases: ['code.function.name'],
-    changelog: [{ version: '0.1.0', prs: [61, 74] }, { version: '0.0.0' }],
+    aliases: ['code.function.name', 'django.function_name'],
+    changelog: [
+      { version: 'next', description: 'Added django.function_name as an alias' },
+      { version: '0.1.0', prs: [61, 74] },
+      { version: '0.0.0' },
+    ],
   },
   'code.function.name': {
     brief: 'The method or function fully-qualified name without arguments.',
@@ -21377,8 +21407,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'server_request',
-    aliases: ['code.function'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    aliases: ['code.function', 'django.function_name'],
+    changelog: [
+      { version: 'next', description: 'Added django.function_name as an alias' },
+      { version: '0.1.0', prs: [127] },
+      { version: '0.0.0' },
+    ],
   },
   'code.lineno': {
     brief:
@@ -22312,6 +22346,25 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     aliases: ['sentry.dist'],
     changelog: [{ version: '0.16.0', prs: [489], description: 'Added dist attribute' }],
+  },
+  'django.function_name': {
+    brief: 'The fully qualified name of a function used in a Django context.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'django.contrib.sessions.middleware.SessionMiddleware',
+    examples: ['django.contrib.sessions.middleware.SessionMiddleware'],
+    deprecation: {
+      replacement: 'code.function.name',
+      reason:
+        'This attribute is being deprecated in favor of code.function.name, which is the framework-agnostic replacement.',
+      status: 'backfill',
+    },
+    aliases: ['code.function.name', 'code.function'],
+    changelog: [{ version: 'next', prs: [529], description: 'Added django.function_name attribute' }],
   },
   'django.middleware_name': {
     brief: 'The name of the Django middleware.',
@@ -29690,6 +29743,7 @@ export type Attributes = {
   [DEVICE_TIMEZONE]?: DEVICE_TIMEZONE_TYPE;
   [DEVICE_USABLE_MEMORY]?: DEVICE_USABLE_MEMORY_TYPE;
   [DIST]?: DIST_TYPE;
+  [DJANGO_FUNCTION_NAME]?: DJANGO_FUNCTION_NAME_TYPE;
   [DJANGO_MIDDLEWARE_NAME]?: DJANGO_MIDDLEWARE_NAME_TYPE;
   [EFFECTIVECONNECTIONTYPE]?: EFFECTIVECONNECTIONTYPE_TYPE;
   [ENVIRONMENT]?: ENVIRONMENT_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -22364,7 +22364,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       status: 'backfill',
     },
     aliases: ['code.function.name', 'code.function'],
-    changelog: [{ version: 'next', prs: [529], description: 'Added django.function_name attribute' }],
+    changelog: [{ version: 'next', prs: [538], description: 'Added django.function_name attribute' }],
   },
   'django.middleware_name': {
     brief: 'The name of the Django middleware.',

--- a/model/attributes/code/code__function.json
+++ b/model/attributes/code/code__function.json
@@ -7,9 +7,13 @@
   },
   "is_in_otel": true,
   "example": "server_request",
-  "alias": ["code.function.name"],
+  "alias": ["code.function.name", "django.function_name"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added django.function_name as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [61, 74]

--- a/model/attributes/code/code__function__name.json
+++ b/model/attributes/code/code__function__name.json
@@ -7,9 +7,13 @@
   },
   "is_in_otel": true,
   "example": "server_request",
-  "alias": ["code.function"],
+  "alias": ["code.function", "django.function_name"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added django.function_name as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [127]

--- a/model/attributes/django/django__function_name.json
+++ b/model/attributes/django/django__function_name.json
@@ -17,7 +17,7 @@
   "changelog": [
     {
       "version": "next",
-      "prs": [529],
+      "prs": [538],
       "description": "Added django.function_name attribute"
     }
   ]

--- a/model/attributes/django/django__function_name.json
+++ b/model/attributes/django/django__function_name.json
@@ -1,0 +1,24 @@
+{
+  "key": "django.function_name",
+  "brief": "The fully qualified name of a function used in a Django context.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["django.contrib.sessions.middleware.SessionMiddleware"],
+  "alias": ["code.function.name", "code.function"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "code.function.name",
+    "reason": "This attribute is being deprecated in favor of code.function.name, which is the framework-agnostic replacement."
+  },
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [529],
+      "description": "Added django.function_name attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -186,6 +186,7 @@ class _AttributeNamesMeta(type):
         "DEVICE_CONNECTION_TYPE",
         "DEVICEMEMORY",
         "DIST",
+        "DJANGO_FUNCTION_NAME",
         "DJANGO_MIDDLEWARE_NAME",
         "EFFECTIVECONNECTIONTYPE",
         "ENVIRONMENT",
@@ -2723,7 +2724,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: code.function.name
+    Aliases: code.function.name, django.function_name
     Example: "server_request"
     """
 
@@ -2735,7 +2736,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: code.function
+    Aliases: code.function, django.function_name
     Example: "server_request"
     """
 
@@ -3576,6 +3577,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Aliases: sentry.dist
     DEPRECATED: Use sentry.dist instead - This attribute is being deprecated in favor of sentry.dist.
     Example: "1.0"
+    """
+
+    # Path: model/attributes/django/django__function_name.json
+    DJANGO_FUNCTION_NAME: Literal["django.function_name"] = "django.function_name"
+    """The fully qualified name of a function used in a Django context.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: code.function.name, code.function
+    DEPRECATED: Use code.function.name instead - This attribute is being deprecated in favor of code.function.name, which is the framework-agnostic replacement.
+    Example: "django.contrib.sessions.middleware.SessionMiddleware"
     """
 
     # Path: model/attributes/django/django__middleware_name.json
@@ -12794,8 +12808,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="server_request",
-        aliases=["code.function.name"],
+        aliases=["code.function.name", "django.function_name"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added django.function_name as an alias"
+            ),
             ChangelogEntry(version="0.1.0", prs=[61, 74]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -12807,8 +12824,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="server_request",
-        aliases=["code.function"],
+        aliases=["code.function", "django.function_name"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added django.function_name as an alias"
+            ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -13848,6 +13868,28 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="0.16.0", prs=[489], description="Added dist attribute"
+            ),
+        ],
+    ),
+    "django.function_name": AttributeMetadata(
+        brief="The fully qualified name of a function used in a Django context.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="django.contrib.sessions.middleware.SessionMiddleware",
+        examples=["django.contrib.sessions.middleware.SessionMiddleware"],
+        deprecation=DeprecationInfo(
+            replacement="code.function.name",
+            reason="This attribute is being deprecated in favor of code.function.name, which is the framework-agnostic replacement.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["code.function.name", "code.function"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[529],
+                description="Added django.function_name attribute",
             ),
         ],
     ),
@@ -21583,6 +21625,7 @@ Attributes = TypedDict(
         "device.usable_memory": int,
         "deviceMemory": str,
         "dist": str,
+        "django.function_name": str,
         "django.middleware_name": str,
         "effectiveConnectionType": str,
         "environment": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -13888,7 +13888,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                prs=[529],
+                prs=[538],
                 description="Added django.function_name attribute",
             ),
         ],


### PR DESCRIPTION
## Description

Document another attribute set in the transaction world in Python:

https://github.com/getsentry/sentry-python/blob/5204ffa36063c4dc85dd1be1f0b64c72e8fe0390/sentry_sdk/integrations/django/middleware.py#L103

<!-- Describe your changes -->

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [ ] I have run `yarn test` and verified that the tests pass.
- [ ] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
