### PR TITLE
feat(attributes): Deprecate `http.query` and `http.fragment` in favour of `url.query` and `url.fragment`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8725,7 +8725,7 @@ export type HTTP_FLAVOR_TYPE = string;
  *
  * Aliases: {@link URL_FRAGMENT} `url.fragment`
  *
- * @deprecated Use {@link URL_FRAGMENT} (url.fragment) instead
+ * @deprecated Use {@link URL_FRAGMENT} (url.fragment) instead - `url.fragment` is supported by OTel and conceptually more fitting.
  * @example "#details"
  */
 export const HTTP_FRAGMENT = 'http.fragment';
@@ -8797,7 +8797,7 @@ export type HTTP_METHOD_TYPE = string;
  *
  * Aliases: {@link URL_QUERY} `url.query`
  *
- * @deprecated Use {@link URL_QUERY} (url.query) instead
+ * @deprecated Use {@link URL_QUERY} (url.query) instead - `url.query` is supported by OTel and conceptually more fitting.
  * @example "?foo=bar&bar=baz"
  */
 export const HTTP_QUERY = 'http.query';
@@ -24332,6 +24332,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '#details',
     deprecation: {
       replacement: 'url.fragment',
+      reason: '`url.fragment` is supported by OTel and conceptually more fitting.',
       status: 'backfill',
     },
     aliases: ['url.fragment'],
@@ -24383,6 +24384,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '?foo=bar&bar=baz',
     deprecation: {
       replacement: 'url.query',
+      reason: '`url.query` is supported by OTel and conceptually more fitting.',
       status: 'backfill',
     },
     aliases: ['url.query'],

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8723,6 +8723,9 @@ export type HTTP_FLAVOR_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link URL_FRAGMENT} `url.fragment`
+ *
+ * @deprecated Use {@link URL_FRAGMENT} (url.fragment) instead
  * @example "#details"
  */
 export const HTTP_FRAGMENT = 'http.fragment';
@@ -8792,6 +8795,9 @@ export type HTTP_METHOD_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link URL_QUERY} `url.query`
+ *
+ * @deprecated Use {@link URL_QUERY} (url.query) instead
  * @example "?foo=bar&bar=baz"
  */
 export const HTTP_QUERY = 'http.query';
@@ -15940,6 +15946,8 @@ export type URL_DOMAIN_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
+ * Aliases: {@link HTTP_FRAGMENT} `http.fragment`
+ *
  * @example "details"
  */
 export const URL_FRAGMENT = 'url.fragment';
@@ -16055,6 +16063,8 @@ export type URL_PORT_TYPE = number;
  *
  * Attribute defined in OTEL: Yes
  * Visibility: public
+ *
+ * Aliases: {@link HTTP_QUERY} `http.query`
  *
  * @example "foo=bar&bar=baz"
  */
@@ -24320,6 +24330,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: '#details',
+    deprecation: {
+      replacement: 'url.fragment',
+      status: 'backfill',
+    },
+    aliases: ['url.fragment'],
     changelog: [{ version: '0.0.0' }],
   },
   'http.host': {
@@ -24366,6 +24381,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: '?foo=bar&bar=baz',
+    deprecation: {
+      replacement: 'url.query',
+      status: 'backfill',
+    },
+    aliases: ['url.query'],
     changelog: [{ version: '0.0.0' }],
   },
   'http.request.body.data': {
@@ -28755,6 +28775,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'details',
+    aliases: ['http.fragment'],
     changelog: [{ version: '0.0.0' }],
   },
   'url.full': {
@@ -28821,6 +28842,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'foo=bar&bar=baz',
+    aliases: ['http.query'],
     changelog: [{ version: '0.0.0' }],
   },
   'url.same_origin': {

--- a/model/attributes/http/http__fragment.json
+++ b/model/attributes/http/http__fragment.json
@@ -7,7 +7,8 @@
   },
   "deprecation": {
     "_status": "backfill",
-    "replacement": "url.fragment"
+    "replacement": "url.fragment",
+    "reason": "`url.fragment` is supported by OTel and conceptually more fitting."
   },
   "alias": ["url.fragment"],
   "is_in_otel": false,

--- a/model/attributes/http/http__fragment.json
+++ b/model/attributes/http/http__fragment.json
@@ -5,6 +5,11 @@
   "apply_scrubbing": {
     "key": "auto"
   },
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "url.fragment"
+  },
+  "alias": ["url.fragment"],
   "is_in_otel": false,
   "example": "#details",
   "visibility": "public",

--- a/model/attributes/http/http__query.json
+++ b/model/attributes/http/http__query.json
@@ -6,6 +6,11 @@
     "key": "auto",
     "reason": "Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information."
   },
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "url.query"
+  },
+  "alias": ["url.query"],
   "is_in_otel": false,
   "example": "?foo=bar&bar=baz",
   "visibility": "public",

--- a/model/attributes/http/http__query.json
+++ b/model/attributes/http/http__query.json
@@ -8,7 +8,8 @@
   },
   "deprecation": {
     "_status": "backfill",
-    "replacement": "url.query"
+    "replacement": "url.query",
+    "reason": "`url.query` is supported by OTel and conceptually more fitting."
   },
   "alias": ["url.query"],
   "is_in_otel": false,

--- a/model/attributes/url/url__fragment.json
+++ b/model/attributes/url/url__fragment.json
@@ -5,6 +5,7 @@
   "apply_scrubbing": {
     "key": "auto"
   },
+  "alias": ["http.fragment"],
   "is_in_otel": true,
   "example": "details",
   "visibility": "public",

--- a/model/attributes/url/url__query.json
+++ b/model/attributes/url/url__query.json
@@ -6,6 +6,7 @@
     "key": "auto",
     "reason": "Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information."
   },
+  "alias": ["http.query"],
   "is_in_otel": true,
   "example": "foo=bar&bar=baz",
   "visibility": "public",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5263,7 +5263,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Visibility: public
     Aliases: url.fragment
-    DEPRECATED: Use url.fragment instead
+    DEPRECATED: Use url.fragment instead - `url.fragment` is supported by OTel and conceptually more fitting.
     Example: "#details"
     """
 
@@ -5302,7 +5302,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Visibility: public
     Aliases: url.query
-    DEPRECATED: Use url.query instead
+    DEPRECATED: Use url.query instead - `url.query` is supported by OTel and conceptually more fitting.
     Example: "?foo=bar&bar=baz"
     """
 
@@ -15985,7 +15985,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="#details",
         deprecation=DeprecationInfo(
-            replacement="url.fragment", status=DeprecationStatus.BACKFILL
+            replacement="url.fragment",
+            reason="`url.fragment` is supported by OTel and conceptually more fitting.",
+            status=DeprecationStatus.BACKFILL,
         ),
         aliases=["url.fragment"],
         changelog=[
@@ -16042,7 +16044,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="?foo=bar&bar=baz",
         deprecation=DeprecationInfo(
-            replacement="url.query", status=DeprecationStatus.BACKFILL
+            replacement="url.query",
+            reason="`url.query` is supported by OTel and conceptually more fitting.",
+            status=DeprecationStatus.BACKFILL,
         ),
         aliases=["url.query"],
         changelog=[

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -221,8 +221,10 @@ class _AttributeNamesMeta(type):
         "HARDWARECONCURRENCY",
         "HTTP_CLIENT_IP",
         "HTTP_FLAVOR",
+        "HTTP_FRAGMENT",
         "HTTP_HOST",
         "HTTP_METHOD",
+        "HTTP_QUERY",
         "_HTTP_REQUEST_METHOD",
         "HTTP_RESPONSE_CONTENT_LENGTH",
         "HTTP_RESPONSE_TRANSFER_SIZE",
@@ -5260,6 +5262,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto
     Defined in OTEL: No
     Visibility: public
+    Aliases: url.fragment
+    DEPRECATED: Use url.fragment instead
     Example: "#details"
     """
 
@@ -5297,6 +5301,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto - Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.
     Defined in OTEL: No
     Visibility: public
+    Aliases: url.query
+    DEPRECATED: Use url.query instead
     Example: "?foo=bar&bar=baz"
     """
 
@@ -9229,6 +9235,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: http.fragment
     Example: "details"
     """
 
@@ -9289,6 +9296,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto - Query string values can contain sensitive information. Clients should attempt to scrub parameters that might contain sensitive information.
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: http.query
     Example: "foo=bar&bar=baz"
     """
 
@@ -15976,6 +15984,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="#details",
+        deprecation=DeprecationInfo(
+            replacement="url.fragment", status=DeprecationStatus.BACKFILL
+        ),
+        aliases=["url.fragment"],
         changelog=[
             ChangelogEntry(version="0.0.0"),
         ],
@@ -16029,6 +16041,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="?foo=bar&bar=baz",
+        deprecation=DeprecationInfo(
+            replacement="url.query", status=DeprecationStatus.BACKFILL
+        ),
+        aliases=["url.query"],
         changelog=[
             ChangelogEntry(version="0.0.0"),
         ],
@@ -20634,6 +20650,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="details",
+        aliases=["http.fragment"],
         changelog=[
             ChangelogEntry(version="0.0.0"),
         ],
@@ -20700,6 +20717,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="foo=bar&bar=baz",
+        aliases=["http.query"],
         changelog=[
             ChangelogEntry(version="0.0.0"),
         ],


### PR DESCRIPTION
## Description

These attributes are ambiguous and have slightly different semantics:

- `http.query` and `http.fragment` require a leading `?`/`#` and are not defined by OTel
- `url.query` and `url.fragment` require no leading delimiters and are [defined by OTel](https://opentelemetry.io/docs/specs/semconv/registry/attributes/url/#url-fragment). 

This PR deprecates the `http.*` variants. 

Open to decide: Should we backfill or transform the attributes? The change in semantics makes this a bit more cumbersome. A simpler option would be to set status `null`.

closes https://github.com/getsentry/sentry-conventions/issues/311

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
