### PR TITLE
feat(attributes): Add cloudflare.agent attributes to identify agents

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3564,6 +3564,50 @@ export const CLIENT_PORT = 'client.port';
  */
 export type CLIENT_PORT_TYPE = number;
 
+// Path: model/attributes/cloudflare/cloudflare__agent__class.json
+
+/**
+ * The class name of the Cloudflare agent that produced the span. `cloudflare.agent.class`
+ *
+ * Attribute Value Type: `string` {@link CLOUDFLARE_AGENT_CLASS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "MyBaseAgent"
+ * @example "AIChatAgent"
+ */
+export const CLOUDFLARE_AGENT_CLASS = 'cloudflare.agent.class';
+
+/**
+ * Type for {@link CLOUDFLARE_AGENT_CLASS} cloudflare.agent.class
+ */
+export type CLOUDFLARE_AGENT_CLASS_TYPE = string;
+
+// Path: model/attributes/cloudflare/cloudflare__agent__name.json
+
+/**
+ * The user-configured name of the Cloudflare agent instance that produced the span. `cloudflare.agent.name`
+ *
+ * Attribute Value Type: `string` {@link CLOUDFLARE_AGENT_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "user-123"
+ * @example "chat-rpc-instance"
+ */
+export const CLOUDFLARE_AGENT_NAME = 'cloudflare.agent.name';
+
+/**
+ * Type for {@link CLOUDFLARE_AGENT_NAME} cloudflare.agent.name
+ */
+export type CLOUDFLARE_AGENT_NAME_TYPE = string;
+
 // Path: model/attributes/cloudflare/cloudflare__d1__duration.json
 
 /**
@@ -17394,6 +17438,8 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   channel: 'string',
   'client.address': 'string',
   'client.port': 'integer',
+  'cloudflare.agent.class': 'string',
+  'cloudflare.agent.name': 'string',
   'cloudflare.d1.duration': 'integer',
   'cloudflare.d1.query_type': 'string',
   'cloudflare.d1.rows_read': 'integer',
@@ -18170,6 +18216,8 @@ export type AttributeName =
   | typeof CHANNEL
   | typeof CLIENT_ADDRESS
   | typeof CLIENT_PORT
+  | typeof CLOUDFLARE_AGENT_CLASS
+  | typeof CLOUDFLARE_AGENT_NAME
   | typeof CLOUDFLARE_D1_DURATION
   | typeof CLOUDFLARE_D1_QUERY_TYPE
   | typeof CLOUDFLARE_D1_ROWS_READ
@@ -21003,6 +21051,30 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 5432,
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+  },
+  'cloudflare.agent.class': {
+    brief: 'The class name of the Cloudflare agent that produced the span.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'MyBaseAgent',
+    examples: ['MyBaseAgent', 'AIChatAgent'],
+    changelog: [{ version: 'next', prs: [541], description: 'Added cloudflare.agent.class attribute' }],
+  },
+  'cloudflare.agent.name': {
+    brief: 'The user-configured name of the Cloudflare agent instance that produced the span.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'user-123',
+    examples: ['user-123', 'chat-rpc-instance'],
+    changelog: [{ version: 'next', prs: [541], description: 'Added cloudflare.agent.name attribute' }],
   },
   'cloudflare.d1.duration': {
     brief: 'The duration of a Cloudflare D1 operation.',
@@ -29589,6 +29661,8 @@ export type Attributes = {
   [CHANNEL]?: CHANNEL_TYPE;
   [CLIENT_ADDRESS]?: CLIENT_ADDRESS_TYPE;
   [CLIENT_PORT]?: CLIENT_PORT_TYPE;
+  [CLOUDFLARE_AGENT_CLASS]?: CLOUDFLARE_AGENT_CLASS_TYPE;
+  [CLOUDFLARE_AGENT_NAME]?: CLOUDFLARE_AGENT_NAME_TYPE;
   [CLOUDFLARE_D1_DURATION]?: CLOUDFLARE_D1_DURATION_TYPE;
   [CLOUDFLARE_D1_QUERY_TYPE]?: CLOUDFLARE_D1_QUERY_TYPE_TYPE;
   [CLOUDFLARE_D1_ROWS_READ]?: CLOUDFLARE_D1_ROWS_READ_TYPE;

--- a/model/attributes/cloudflare/cloudflare__agent__class.json
+++ b/model/attributes/cloudflare/cloudflare__agent__class.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.agent.class",
+  "brief": "The class name of the Cloudflare agent that produced the span.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["MyBaseAgent", "AIChatAgent"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [541],
+      "description": "Added cloudflare.agent.class attribute"
+    }
+  ]
+}

--- a/model/attributes/cloudflare/cloudflare__agent__name.json
+++ b/model/attributes/cloudflare/cloudflare__agent__name.json
@@ -1,0 +1,18 @@
+{
+  "key": "cloudflare.agent.name",
+  "brief": "The user-configured name of the Cloudflare agent instance that produced the span.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["user-123", "chat-rpc-instance"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [541],
+      "description": "Added cloudflare.agent.name attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2431,6 +2431,30 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function"
     """
 
+    # Path: model/attributes/cloudflare/cloudflare__agent__class.json
+    CLOUDFLARE_AGENT_CLASS: Literal["cloudflare.agent.class"] = "cloudflare.agent.class"
+    """The class name of the Cloudflare agent that produced the span.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "MyBaseAgent"
+    Example: "AIChatAgent"
+    """
+
+    # Path: model/attributes/cloudflare/cloudflare__agent__name.json
+    CLOUDFLARE_AGENT_NAME: Literal["cloudflare.agent.name"] = "cloudflare.agent.name"
+    """The user-configured name of the Cloudflare agent instance that produced the span.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "user-123"
+    Example: "chat-rpc-instance"
+    """
+
     # Path: model/attributes/cloudflare/cloudflare__d1__duration.json
     CLOUDFLARE_D1_DURATION: Literal["cloudflare.d1.duration"] = "cloudflare.d1.duration"
     """The duration of a Cloudflare D1 operation.
@@ -12457,6 +12481,38 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "This can be an identifier for a resource in AWS, GCP, or Azure. There may be some overlap in values found here with other attributes. For instance, an AWS lambda ARN may be found here as well as in `aws.lambda.invoked_arn`. OTEL recommends setting them alongside each other."
         ],
     ),
+    "cloudflare.agent.class": AttributeMetadata(
+        brief="The class name of the Cloudflare agent that produced the span.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="MyBaseAgent",
+        examples=["MyBaseAgent", "AIChatAgent"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[541],
+                description="Added cloudflare.agent.class attribute",
+            ),
+        ],
+    ),
+    "cloudflare.agent.name": AttributeMetadata(
+        brief="The user-configured name of the Cloudflare agent instance that produced the span.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="user-123",
+        examples=["user-123", "chat-rpc-instance"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[541],
+                description="Added cloudflare.agent.name attribute",
+            ),
+        ],
+    ),
     "cloudflare.d1.duration": AttributeMetadata(
         brief="The duration of a Cloudflare D1 operation.",
         type=AttributeType.INTEGER,
@@ -21488,6 +21544,8 @@ Attributes = TypedDict(
         "cloud.provider": str,
         "cloud.region": str,
         "cloud.resource_id": str,
+        "cloudflare.agent.class": str,
+        "cloudflare.agent.name": str,
         "cloudflare.d1.duration": int,
         "cloudflare.d1.query_type": str,
         "cloudflare.d1.rows_read": int,


### PR DESCRIPTION
## Description

This adds `cloudflare.agent.name` (name of the instance name) and `cloudflare.agent.class` (name of the class name - could be `Agent`, `AIChatAgent` or similar).

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
