### PR TITLE
feat(attributes): Deprecate `code.function` in favour of `code.function.name`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4191,6 +4191,7 @@ export type CODE_FILE_PATH_TYPE = string;
  *
  * Aliases: {@link CODE_FUNCTION_NAME} `code.function.name`
  *
+ * @deprecated Use {@link CODE_FUNCTION_NAME} (code.function.name) instead - `code.function` was deprecated by OTel in favor of `code.function.name`.
  * @example "server_request"
  */
 export const CODE_FUNCTION = 'code.function';
@@ -21365,8 +21366,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'server_request',
+    deprecation: {
+      replacement: 'code.function.name',
+      reason: '`code.function` was deprecated by OTel in favor of `code.function.name`.',
+      status: 'backfill',
+    },
     aliases: ['code.function.name'],
-    changelog: [{ version: '0.1.0', prs: [61, 74] }, { version: '0.0.0' }],
+    changelog: [
+      { version: 'next', prs: [542], description: 'Deprecated code.function in favor of code.function.name' },
+      { version: '0.1.0', prs: [61, 74] },
+      { version: '0.0.0' },
+    ],
   },
   'code.function.name': {
     brief: 'The method or function fully-qualified name without arguments.',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4204,7 +4204,7 @@ export type CODE_FUNCTION_TYPE = string;
 // Path: model/attributes/code/code__function__name.json
 
 /**
- * The method or function fully-qualified name without arguments. `code.function.name`
+ * The method or function name without arguments. The name may be fully-qualified or just list the simple function name. See examples. `code.function.name`
  *
  * Attribute Value Type: `string` {@link CODE_FUNCTION_NAME_TYPE}
  *
@@ -4215,7 +4215,11 @@ export type CODE_FUNCTION_TYPE = string;
  *
  * Aliases: {@link CODE_FUNCTION} `code.function`
  *
+ * @example "com.example.MyHttpService.serveRequest"
  * @example "server_request"
+ * @example "getAllUsers"
+ * @example "UserService.getAllUsers"
+ * @example "GuzzleHttp\\Client::transfer"
  */
 export const CODE_FUNCTION_NAME = 'code.function.name';
 
@@ -21379,16 +21383,32 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     ],
   },
   'code.function.name': {
-    brief: 'The method or function fully-qualified name without arguments.',
+    brief:
+      'The method or function name without arguments. The name may be fully-qualified or just list the simple function name. See examples.',
     type: 'string',
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: true,
     visibility: 'public',
-    example: 'server_request',
+    example: 'com.example.MyHttpService.serveRequest',
+    examples: [
+      'com.example.MyHttpService.serveRequest',
+      'server_request',
+      'getAllUsers',
+      'UserService.getAllUsers',
+      'GuzzleHttp\\Client::transfer',
+    ],
     aliases: ['code.function'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    changelog: [
+      {
+        version: 'next',
+        prs: [542],
+        description: 'Loosened specification around fully qualified to also accept a simple function name.',
+      },
+      { version: '0.1.0', prs: [127] },
+      { version: '0.0.0' },
+    ],
   },
   'code.lineno': {
     brief:

--- a/model/attributes/code/code__function.json
+++ b/model/attributes/code/code__function.json
@@ -8,8 +8,18 @@
   "is_in_otel": true,
   "example": "server_request",
   "alias": ["code.function.name"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "code.function.name",
+    "reason": "`code.function` was deprecated by OTel in favor of `code.function.name`."
+  },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [542],
+      "description": "Deprecated code.function in favor of code.function.name"
+    },
     {
       "version": "0.1.0",
       "prs": [61, 74]

--- a/model/attributes/code/code__function__name.json
+++ b/model/attributes/code/code__function__name.json
@@ -1,15 +1,26 @@
 {
   "key": "code.function.name",
-  "brief": "The method or function fully-qualified name without arguments.",
+  "brief": "The method or function name without arguments. The name may be fully-qualified or just list the simple function name. See examples.",
   "type": "string",
   "apply_scrubbing": {
     "key": "manual"
   },
   "is_in_otel": true,
-  "example": "server_request",
+  "examples": [
+    "com.example.MyHttpService.serveRequest",
+    "server_request",
+    "getAllUsers",
+    "UserService.getAllUsers",
+    "GuzzleHttp\\Client::transfer"
+  ],
   "alias": ["code.function"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [542],
+      "description": "Loosened specification around fully qualified to also accept a simple function name."
+    },
     {
       "version": "0.1.0",
       "prs": [127]

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -174,6 +174,7 @@ class _AttributeNamesMeta(type):
         "CLS_SOURCE_KEY",
         "CLS",
         "CODE_FILEPATH",
+        "CODE_FUNCTION",
         "CODE_LINENO",
         "CONNECTION_RTT",
         "CONNECTIONTYPE",
@@ -2724,6 +2725,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Aliases: code.function.name
+    DEPRECATED: Use code.function.name instead - `code.function` was deprecated by OTel in favor of `code.function.name`.
     Example: "server_request"
     """
 
@@ -12794,8 +12796,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="server_request",
+        deprecation=DeprecationInfo(
+            replacement="code.function.name",
+            reason="`code.function` was deprecated by OTel in favor of `code.function.name`.",
+            status=DeprecationStatus.BACKFILL,
+        ),
         aliases=["code.function.name"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[542],
+                description="Deprecated code.function in favor of code.function.name",
+            ),
             ChangelogEntry(version="0.1.0", prs=[61, 74]),
             ChangelogEntry(version="0.0.0"),
         ],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2731,14 +2731,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/code/code__function__name.json
     CODE_FUNCTION_NAME: Literal["code.function.name"] = "code.function.name"
-    """The method or function fully-qualified name without arguments.
+    """The method or function name without arguments. The name may be fully-qualified or just list the simple function name. See examples.
 
     Type: str
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
     Aliases: code.function
+    Example: "com.example.MyHttpService.serveRequest"
     Example: "server_request"
+    Example: "getAllUsers"
+    Example: "UserService.getAllUsers"
+    Example: "GuzzleHttp\\Client::transfer"
     """
 
     # Path: model/attributes/code/code__line__number.json
@@ -12813,14 +12817,26 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "code.function.name": AttributeMetadata(
-        brief="The method or function fully-qualified name without arguments.",
+        brief="The method or function name without arguments. The name may be fully-qualified or just list the simple function name. See examples.",
         type=AttributeType.STRING,
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
-        example="server_request",
+        example="com.example.MyHttpService.serveRequest",
+        examples=[
+            "com.example.MyHttpService.serveRequest",
+            "server_request",
+            "getAllUsers",
+            "UserService.getAllUsers",
+            "GuzzleHttp\\Client::transfer",
+        ],
         aliases=["code.function"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[542],
+                description="Loosened specification around fully qualified to also accept a simple function name.",
+            ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
         ],


### PR DESCRIPTION
OTel [deprecated](https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/#code-function) `code.function` , we didn't yet. This PR now deprecates it on our conventions. Problem is, there's a slight semantic difference. The deprecated version would make no specification what the name should include. The `code.function.name` version [specifies](https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/#code-function-name) a fully-qualified name (e.g. com.example.MyHttpService.serveRequest for Java). This is a bit cumbersome and in languages like JS we likely won't be able to produce a correct, fully qualified name in a lot of cases.

Therefore, this PR deprecates `code.function` but loosens the specification of `code.function.name` so that it may also allow simple function names. This would also allow to backfill/coerce the attribute without transformations. 