### PR TITLE
feat(op)!: Add `gen_ai` prefix to existing ops and add `embeddings`, `generate_content`, and `rerank` ops

### DIFF
--- a/javascript/sentry-conventions/src/op.ts
+++ b/javascript/sentry-conventions/src/op.ts
@@ -115,22 +115,37 @@ export const FAAS_FUNCTION_AZURE_SPAN_OP = 'function.azure';
 /**
  * A chat interaction with a generative AI model
  */
-export const GEN_AI_CHAT_SPAN_OP = 'chat';
+export const GEN_AI_GEN_AI_CHAT_SPAN_OP = 'gen_ai.chat';
 
 /**
  * Execution of a tool or function by a generative AI model
  */
-export const GEN_AI_EXECUTE_TOOL_SPAN_OP = 'execute_tool';
+export const GEN_AI_GEN_AI_EXECUTE_TOOL_SPAN_OP = 'gen_ai.execute_tool';
 
 /**
  * Handoff of control between different AI agents or components
  */
-export const GEN_AI_HANDOFF_SPAN_OP = 'handoff';
+export const GEN_AI_GEN_AI_HANDOFF_SPAN_OP = 'gen_ai.handoff';
 
 /**
  * Invocation of an AI agent to perform a task
  */
-export const GEN_AI_INVOKE_AGENT_SPAN_OP = 'invoke_agent';
+export const GEN_AI_GEN_AI_INVOKE_AGENT_SPAN_OP = 'gen_ai.invoke_agent';
+
+/**
+ * Generation of embeddings by a generative AI model
+ */
+export const GEN_AI_GEN_AI_EMBEDDINGS_SPAN_OP = 'gen_ai.embeddings';
+
+/**
+ * Content generation by a generative AI model
+ */
+export const GEN_AI_GEN_AI_GENERATE_CONTENT_SPAN_OP = 'gen_ai.generate_content';
+
+/**
+ * Reranking of documents or results by a generative AI model
+ */
+export const GEN_AI_GEN_AI_RERANK_SPAN_OP = 'gen_ai.rerank';
 
 // Path: model/op/general.json
 // Name: general

--- a/model/op/gen_ai.json
+++ b/model/op/gen_ai.json
@@ -3,20 +3,32 @@
   "description": "Operations related to Generative AI interactions",
   "fields": [
     {
-      "name": "chat",
+      "name": "gen_ai.chat",
       "description": "A chat interaction with a generative AI model"
     },
     {
-      "name": "execute_tool",
+      "name": "gen_ai.execute_tool",
       "description": "Execution of a tool or function by a generative AI model"
     },
     {
-      "name": "handoff",
+      "name": "gen_ai.handoff",
       "description": "Handoff of control between different AI agents or components"
     },
     {
-      "name": "invoke_agent",
+      "name": "gen_ai.invoke_agent",
       "description": "Invocation of an AI agent to perform a task"
+    },
+    {
+      "name": "gen_ai.embeddings",
+      "description": "Generation of embeddings by a generative AI model"
+    },
+    {
+      "name": "gen_ai.generate_content",
+      "description": "Content generation by a generative AI model"
+    },
+    {
+      "name": "gen_ai.rerank",
+      "description": "Reranking of documents or results by a generative AI model"
     }
   ]
 }

--- a/rust/src/op.rs
+++ b/rust/src/op.rs
@@ -98,16 +98,25 @@ pub const FAAS_FUNCTION_AZURE_SPAN_OP: &str = "function.azure";
 
 // Description: Operations related to Generative AI interactions
 /// A chat interaction with a generative AI model
-pub const GEN_AI_CHAT_SPAN_OP: &str = "chat";
+pub const GEN_AI_GEN_AI_CHAT_SPAN_OP: &str = "gen_ai.chat";
 
 /// Execution of a tool or function by a generative AI model
-pub const GEN_AI_EXECUTE_TOOL_SPAN_OP: &str = "execute_tool";
+pub const GEN_AI_GEN_AI_EXECUTE_TOOL_SPAN_OP: &str = "gen_ai.execute_tool";
 
 /// Handoff of control between different AI agents or components
-pub const GEN_AI_HANDOFF_SPAN_OP: &str = "handoff";
+pub const GEN_AI_GEN_AI_HANDOFF_SPAN_OP: &str = "gen_ai.handoff";
 
 /// Invocation of an AI agent to perform a task
-pub const GEN_AI_INVOKE_AGENT_SPAN_OP: &str = "invoke_agent";
+pub const GEN_AI_GEN_AI_INVOKE_AGENT_SPAN_OP: &str = "gen_ai.invoke_agent";
+
+/// Generation of embeddings by a generative AI model
+pub const GEN_AI_GEN_AI_EMBEDDINGS_SPAN_OP: &str = "gen_ai.embeddings";
+
+/// Content generation by a generative AI model
+pub const GEN_AI_GEN_AI_GENERATE_CONTENT_SPAN_OP: &str = "gen_ai.generate_content";
+
+/// Reranking of documents or results by a generative AI model
+pub const GEN_AI_GEN_AI_RERANK_SPAN_OP: &str = "gen_ai.rerank";
 
 // Path: model/op/general.json
 // Name: general


### PR DESCRIPTION
## Description

Adds `gen_ai.embeddings`, `gen_ai.generate_content` and `gen_ai.rerank` to gen ai ops and adds the `gen_ai.` prefix to existing ops to align with [the docs](https://develop.sentry.dev/sdk/telemetry/traces/modules/ai-agents/#invoke-agent-span) and SDKs.

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
