### PR TITLE
feat(op): Add `http.client.stream` op

### DIFF
--- a/javascript/sentry-conventions/src/op.ts
+++ b/javascript/sentry-conventions/src/op.ts
@@ -245,6 +245,11 @@ export const WEB_SERVER_HTTP_SPAN_OP = 'http';
 
 export const WEB_SERVER_HTTP_CLIENT_SPAN_OP = 'http.client';
 
+/**
+ * Consumption of a streaming HTTP client response body
+ */
+export const WEB_SERVER_HTTP_CLIENT_STREAM_SPAN_OP = 'http.client.stream';
+
 export const WEB_SERVER_HTTP_SERVER_SPAN_OP = 'http.server';
 
 export const WEB_SERVER_WEBSOCKET_SPAN_OP = 'websocket';

--- a/model/op/web_server.json
+++ b/model/op/web_server.json
@@ -10,6 +10,10 @@
       "name": "http.client"
     },
     {
+      "name": "http.client.stream",
+      "description": "Consumption of a streaming HTTP client response body"
+    },
+    {
       "name": "http.server"
     },
     {

--- a/rust/src/op.rs
+++ b/rust/src/op.rs
@@ -187,6 +187,9 @@ pub const WEB_SERVER_HTTP_SPAN_OP: &str = "http";
 
 pub const WEB_SERVER_HTTP_CLIENT_SPAN_OP: &str = "http.client";
 
+/// Consumption of a streaming HTTP client response body
+pub const WEB_SERVER_HTTP_CLIENT_STREAM_SPAN_OP: &str = "http.client.stream";
+
 pub const WEB_SERVER_HTTP_SERVER_SPAN_OP: &str = "http.server";
 
 pub const WEB_SERVER_WEBSOCKET_SPAN_OP: &str = "websocket";


### PR DESCRIPTION
## Description

Add `http.client.stream` for spans covering consumption of a streaming HTTP client response body

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
