### PR TITLE
feat(op): Add object storage span operations

### DIFF
--- a/javascript/sentry-conventions/src/op.ts
+++ b/javascript/sentry-conventions/src/op.ts
@@ -235,6 +235,56 @@ export const MOBILE_SERIALIZE_SPAN_OP = 'serialize';
 
 export const MOBILE_HTTP_SPAN_OP = 'http';
 
+// Path: model/op/object.json
+// Name: object
+
+// Description: Object storage related spans represent operations on object storage systems such as Cloudflare R2, Amazon S3, and compatible services.
+
+/**
+ * Retrieving an object from an object store.
+ */
+export const OBJECT_OBJECT_GET_SPAN_OP = 'object.get';
+
+/**
+ * Retrieving the metadata of an object from an object store.
+ */
+export const OBJECT_OBJECT_HEAD_SPAN_OP = 'object.head';
+
+/**
+ * Storing an object in an object store.
+ */
+export const OBJECT_OBJECT_PUT_SPAN_OP = 'object.put';
+
+/**
+ * Deleting an object from an object store.
+ */
+export const OBJECT_OBJECT_DELETE_SPAN_OP = 'object.delete';
+
+/**
+ * Listing objects in an object store.
+ */
+export const OBJECT_OBJECT_LIST_SPAN_OP = 'object.list';
+
+/**
+ * Uploading a single part of a multipart upload to an object store.
+ */
+export const OBJECT_OBJECT_UPLOAD_PART_SPAN_OP = 'object.upload_part';
+
+/**
+ * Aborting a multipart upload to an object store.
+ */
+export const OBJECT_OBJECT_MULTIPART_UPLOAD_ABORT_SPAN_OP = 'object.multipart_upload.abort';
+
+/**
+ * Creating a multipart upload to an object store.
+ */
+export const OBJECT_OBJECT_MULTIPART_UPLOAD_CREATE_SPAN_OP = 'object.multipart_upload.create';
+
+/**
+ * Completing a multipart upload to an object store.
+ */
+export const OBJECT_OBJECT_MULTIPART_UPLOAD_COMPLETE_SPAN_OP = 'object.multipart_upload.complete';
+
 // Path: model/op/web_server.json
 // Name: web_server
 

--- a/model/op/object.json
+++ b/model/op/object.json
@@ -1,0 +1,42 @@
+{
+  "name": "object",
+  "description": "Object storage related spans represent operations on object storage systems such as Cloudflare R2, Amazon S3, and compatible services.",
+  "fields": [
+    {
+      "name": "object.get",
+      "description": "Retrieving an object from an object store."
+    },
+    {
+      "name": "object.head",
+      "description": "Retrieving the metadata of an object from an object store."
+    },
+    {
+      "name": "object.put",
+      "description": "Storing an object in an object store."
+    },
+    {
+      "name": "object.delete",
+      "description": "Deleting an object from an object store."
+    },
+    {
+      "name": "object.list",
+      "description": "Listing objects in an object store."
+    },
+    {
+      "name": "object.upload_part",
+      "description": "Uploading a single part of a multipart upload to an object store."
+    },
+    {
+      "name": "object.multipart_upload.abort",
+      "description": "Aborting a multipart upload to an object store."
+    },
+    {
+      "name": "object.multipart_upload.create",
+      "description": "Creating a multipart upload to an object store."
+    },
+    {
+      "name": "object.multipart_upload.complete",
+      "description": "Completing a multipart upload to an object store."
+    }
+  ]
+}

--- a/rust/src/op.rs
+++ b/rust/src/op.rs
@@ -179,6 +179,37 @@ pub const MOBILE_SERIALIZE_SPAN_OP: &str = "serialize";
 
 pub const MOBILE_HTTP_SPAN_OP: &str = "http";
 
+// Path: model/op/object.json
+// Name: object
+
+// Description: Object storage related spans represent operations on object storage systems such as Cloudflare R2, Amazon S3, and compatible services.
+/// Retrieving an object from an object store.
+pub const OBJECT_OBJECT_GET_SPAN_OP: &str = "object.get";
+
+/// Retrieving the metadata of an object from an object store.
+pub const OBJECT_OBJECT_HEAD_SPAN_OP: &str = "object.head";
+
+/// Storing an object in an object store.
+pub const OBJECT_OBJECT_PUT_SPAN_OP: &str = "object.put";
+
+/// Deleting an object from an object store.
+pub const OBJECT_OBJECT_DELETE_SPAN_OP: &str = "object.delete";
+
+/// Listing objects in an object store.
+pub const OBJECT_OBJECT_LIST_SPAN_OP: &str = "object.list";
+
+/// Uploading a single part of a multipart upload to an object store.
+pub const OBJECT_OBJECT_UPLOAD_PART_SPAN_OP: &str = "object.upload_part";
+
+/// Aborting a multipart upload to an object store.
+pub const OBJECT_OBJECT_MULTIPART_UPLOAD_ABORT_SPAN_OP: &str = "object.multipart_upload.abort";
+
+/// Creating a multipart upload to an object store.
+pub const OBJECT_OBJECT_MULTIPART_UPLOAD_CREATE_SPAN_OP: &str = "object.multipart_upload.create";
+
+/// Completing a multipart upload to an object store.
+pub const OBJECT_OBJECT_MULTIPART_UPLOAD_COMPLETE_SPAN_OP: &str = "object.multipart_upload.complete";
+
 // Path: model/op/web_server.json
 // Name: web_server
 


### PR DESCRIPTION
## Description

Adds a new `object` op category with the following object storage related ops:
- `object.get`
- `object.head`
- `object.put`
- `object.delete`
- `object.list`
- `object.upload_part`
- `object.multipart_upload.abort`
- `object.multipart_upload.create`
- `object.multipart_upload.complete`

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
