### PR TITLE
feat(op): Add browser resource, timing phase, and UI span operations

### DIFF
--- a/javascript/sentry-conventions/src/op.ts
+++ b/javascript/sentry-conventions/src/op.ts
@@ -35,11 +35,91 @@ export const BROWSER_RESOURCE_IFRAME_SPAN_OP = 'resource.iframe';
 export const BROWSER_RESOURCE_OTHER_SPAN_OP = 'resource.other';
 
 /**
+ * Loading of a resource initiated by a worker (e.g. Web Worker or Service Worker).
+ */
+export const BROWSER_RESOURCE_WORKER_SPAN_OP = 'resource.worker';
+
+/**
+ * Loading of an icon resource.
+ */
+export const BROWSER_RESOURCE_ICON_SPAN_OP = 'resource.icon';
+
+/**
+ * Loading of a resource initiated by a frame.
+ */
+export const BROWSER_RESOURCE_FRAME_SPAN_OP = 'resource.frame';
+
+/**
+ * Loading of a resource initiated by an `<object>` element.
+ */
+export const BROWSER_RESOURCE_OBJECT_SPAN_OP = 'resource.object';
+
+/**
+ * A hyperlink auditing ping request.
+ */
+export const BROWSER_RESOURCE_PING_SPAN_OP = 'resource.ping';
+
+/**
+ * Loading of a `<track>` element resource (e.g. subtitles or captions).
+ */
+export const BROWSER_RESOURCE_TRACK_SPAN_OP = 'resource.track';
+
+/**
  * Usage of browser APIs or functionality
  */
 export const BROWSER_BROWSER_SPAN_OP = 'browser';
 
 export const BROWSER_BROWSER_PAINT_SPAN_OP = 'browser.paint';
+
+/**
+ * The unload event phase of a browser navigation.
+ */
+export const BROWSER_BROWSER_UNLOAD_EVENT_SPAN_OP = 'browser.unload_event';
+
+/**
+ * The redirect phase of a browser navigation.
+ */
+export const BROWSER_BROWSER_REDIRECT_SPAN_OP = 'browser.redirect';
+
+/**
+ * The DOMContentLoaded event phase of a browser navigation.
+ */
+export const BROWSER_BROWSER_DOM_CONTENT_LOADED_EVENT_SPAN_OP = 'browser.dom_content_loaded_event';
+
+/**
+ * The load event phase of a browser navigation.
+ */
+export const BROWSER_BROWSER_LOAD_EVENT_SPAN_OP = 'browser.load_event';
+
+/**
+ * The connection phase of a browser navigation.
+ */
+export const BROWSER_BROWSER_CONNECT_SPAN_OP = 'browser.connect';
+
+/**
+ * The secure connection (TLS/SSL) phase of a browser navigation.
+ */
+export const BROWSER_BROWSER_TLS_SSL_SPAN_OP = 'browser.tls_ssl';
+
+/**
+ * The cache lookup / fetch start phase of a browser navigation.
+ */
+export const BROWSER_BROWSER_CACHE_SPAN_OP = 'browser.cache';
+
+/**
+ * The DNS domain lookup phase of a browser navigation.
+ */
+export const BROWSER_BROWSER_DNS_SPAN_OP = 'browser.dns';
+
+/**
+ * The request phase of a browser navigation.
+ */
+export const BROWSER_BROWSER_REQUEST_SPAN_OP = 'browser.request';
+
+/**
+ * The response phase of a browser navigation.
+ */
+export const BROWSER_BROWSER_RESPONSE_SPAN_OP = 'browser.response';
 
 /**
  * Operations related to browser UI
@@ -52,6 +132,61 @@ export const BROWSER_UI_SPAN_OP = 'ui';
 export const BROWSER_UI_TASK_SPAN_OP = 'ui.task';
 
 export const BROWSER_UI_RENDER_SPAN_OP = 'ui.render';
+
+/**
+ * Mounting of a UI component or application (e.g. initial render/bootstrap).
+ */
+export const BROWSER_UI_MOUNT_SPAN_OP = 'ui.mount';
+
+/**
+ * Updating of an already-mounted UI component.
+ */
+export const BROWSER_UI_UPDATE_SPAN_OP = 'ui.update';
+
+/**
+ * Unmounting/teardown of a UI component.
+ */
+export const BROWSER_UI_UNMOUNT_SPAN_OP = 'ui.unmount';
+
+/**
+ * A long task on the main UI thread, as reported by the Long Tasks API.
+ */
+export const BROWSER_UI_LONG_TASK_SPAN_OP = 'ui.long_task';
+
+/**
+ * A long animation frame, as reported by the Long Animation Frames API.
+ */
+export const BROWSER_UI_LONG_ANIMATION_FRAME_SPAN_OP = 'ui.long_animation_frame';
+
+/**
+ * A click interaction measured via Interaction to Next Paint (INP).
+ */
+export const BROWSER_UI_INTERACTION_CLICK_SPAN_OP = 'ui.interaction.click';
+
+/**
+ * A hover interaction measured via Interaction to Next Paint (INP).
+ */
+export const BROWSER_UI_INTERACTION_HOVER_SPAN_OP = 'ui.interaction.hover';
+
+/**
+ * A drag interaction measured via Interaction to Next Paint (INP).
+ */
+export const BROWSER_UI_INTERACTION_DRAG_SPAN_OP = 'ui.interaction.drag';
+
+/**
+ * A key press interaction measured via Interaction to Next Paint (INP).
+ */
+export const BROWSER_UI_INTERACTION_PRESS_SPAN_OP = 'ui.interaction.press';
+
+/**
+ * A Largest Contentful Paint (LCP) web vital measurement.
+ */
+export const BROWSER_UI_WEBVITAL_LCP_SPAN_OP = 'ui.webvital.lcp';
+
+/**
+ * A Cumulative Layout Shift (CLS) web vital measurement.
+ */
+export const BROWSER_UI_WEBVITAL_CLS_SPAN_OP = 'ui.webvital.cls';
 
 export const BROWSER_UI_ACTION_SPAN_OP = 'ui.action';
 

--- a/model/op/browser.json
+++ b/model/op/browser.json
@@ -39,11 +39,75 @@
       "name": "resource.other"
     },
     {
+      "name": "resource.worker",
+      "description": "Loading of a resource initiated by a worker (e.g. Web Worker or Service Worker)."
+    },
+    {
+      "name": "resource.icon",
+      "description": "Loading of an icon resource."
+    },
+    {
+      "name": "resource.frame",
+      "description": "Loading of a resource initiated by a frame."
+    },
+    {
+      "name": "resource.object",
+      "description": "Loading of a resource initiated by an `<object>` element."
+    },
+    {
+      "name": "resource.ping",
+      "description": "A hyperlink auditing ping request."
+    },
+    {
+      "name": "resource.track",
+      "description": "Loading of a `<track>` element resource (e.g. subtitles or captions)."
+    },
+    {
       "name": "browser",
       "description": "Usage of browser APIs or functionality"
     },
     {
       "name": "browser.paint"
+    },
+    {
+      "name": "browser.unload_event",
+      "description": "The unload event phase of a browser navigation."
+    },
+    {
+      "name": "browser.redirect",
+      "description": "The redirect phase of a browser navigation."
+    },
+    {
+      "name": "browser.dom_content_loaded_event",
+      "description": "The DOMContentLoaded event phase of a browser navigation."
+    },
+    {
+      "name": "browser.load_event",
+      "description": "The load event phase of a browser navigation."
+    },
+    {
+      "name": "browser.connect",
+      "description": "The connection phase of a browser navigation."
+    },
+    {
+      "name": "browser.tls_ssl",
+      "description": "The secure connection (TLS/SSL) phase of a browser navigation."
+    },
+    {
+      "name": "browser.cache",
+      "description": "The cache lookup / fetch start phase of a browser navigation."
+    },
+    {
+      "name": "browser.dns",
+      "description": "The DNS domain lookup phase of a browser navigation."
+    },
+    {
+      "name": "browser.request",
+      "description": "The request phase of a browser navigation."
+    },
+    {
+      "name": "browser.response",
+      "description": "The response phase of a browser navigation."
     },
     {
       "name": "ui",
@@ -55,6 +119,50 @@
     },
     {
       "name": "ui.render"
+    },
+    {
+      "name": "ui.mount",
+      "description": "Mounting of a UI component or application (e.g. initial render/bootstrap)."
+    },
+    {
+      "name": "ui.update",
+      "description": "Updating of an already-mounted UI component."
+    },
+    {
+      "name": "ui.unmount",
+      "description": "Unmounting/teardown of a UI component."
+    },
+    {
+      "name": "ui.long_task",
+      "description": "A long task on the main UI thread, as reported by the Long Tasks API."
+    },
+    {
+      "name": "ui.long_animation_frame",
+      "description": "A long animation frame, as reported by the Long Animation Frames API."
+    },
+    {
+      "name": "ui.interaction.click",
+      "description": "A click interaction measured via Interaction to Next Paint (INP)."
+    },
+    {
+      "name": "ui.interaction.hover",
+      "description": "A hover interaction measured via Interaction to Next Paint (INP)."
+    },
+    {
+      "name": "ui.interaction.drag",
+      "description": "A drag interaction measured via Interaction to Next Paint (INP)."
+    },
+    {
+      "name": "ui.interaction.press",
+      "description": "A key press interaction measured via Interaction to Next Paint (INP)."
+    },
+    {
+      "name": "ui.webvital.lcp",
+      "description": "A Largest Contentful Paint (LCP) web vital measurement."
+    },
+    {
+      "name": "ui.webvital.cls",
+      "description": "A Cumulative Layout Shift (CLS) web vital measurement."
     },
     {
       "name": "ui.action"

--- a/rust/src/op.rs
+++ b/rust/src/op.rs
@@ -28,10 +28,58 @@ pub const BROWSER_RESOURCE_IFRAME_SPAN_OP: &str = "resource.iframe";
 
 pub const BROWSER_RESOURCE_OTHER_SPAN_OP: &str = "resource.other";
 
+/// Loading of a resource initiated by a worker (e.g. Web Worker or Service Worker).
+pub const BROWSER_RESOURCE_WORKER_SPAN_OP: &str = "resource.worker";
+
+/// Loading of an icon resource.
+pub const BROWSER_RESOURCE_ICON_SPAN_OP: &str = "resource.icon";
+
+/// Loading of a resource initiated by a frame.
+pub const BROWSER_RESOURCE_FRAME_SPAN_OP: &str = "resource.frame";
+
+/// Loading of a resource initiated by an `<object>` element.
+pub const BROWSER_RESOURCE_OBJECT_SPAN_OP: &str = "resource.object";
+
+/// A hyperlink auditing ping request.
+pub const BROWSER_RESOURCE_PING_SPAN_OP: &str = "resource.ping";
+
+/// Loading of a `<track>` element resource (e.g. subtitles or captions).
+pub const BROWSER_RESOURCE_TRACK_SPAN_OP: &str = "resource.track";
+
 /// Usage of browser APIs or functionality
 pub const BROWSER_BROWSER_SPAN_OP: &str = "browser";
 
 pub const BROWSER_BROWSER_PAINT_SPAN_OP: &str = "browser.paint";
+
+/// The unload event phase of a browser navigation.
+pub const BROWSER_BROWSER_UNLOAD_EVENT_SPAN_OP: &str = "browser.unload_event";
+
+/// The redirect phase of a browser navigation.
+pub const BROWSER_BROWSER_REDIRECT_SPAN_OP: &str = "browser.redirect";
+
+/// The DOMContentLoaded event phase of a browser navigation.
+pub const BROWSER_BROWSER_DOM_CONTENT_LOADED_EVENT_SPAN_OP: &str = "browser.dom_content_loaded_event";
+
+/// The load event phase of a browser navigation.
+pub const BROWSER_BROWSER_LOAD_EVENT_SPAN_OP: &str = "browser.load_event";
+
+/// The connection phase of a browser navigation.
+pub const BROWSER_BROWSER_CONNECT_SPAN_OP: &str = "browser.connect";
+
+/// The secure connection (TLS/SSL) phase of a browser navigation.
+pub const BROWSER_BROWSER_TLS_SSL_SPAN_OP: &str = "browser.tls_ssl";
+
+/// The cache lookup / fetch start phase of a browser navigation.
+pub const BROWSER_BROWSER_CACHE_SPAN_OP: &str = "browser.cache";
+
+/// The DNS domain lookup phase of a browser navigation.
+pub const BROWSER_BROWSER_DNS_SPAN_OP: &str = "browser.dns";
+
+/// The request phase of a browser navigation.
+pub const BROWSER_BROWSER_REQUEST_SPAN_OP: &str = "browser.request";
+
+/// The response phase of a browser navigation.
+pub const BROWSER_BROWSER_RESPONSE_SPAN_OP: &str = "browser.response";
 
 /// Operations related to browser UI
 pub const BROWSER_UI_SPAN_OP: &str = "ui";
@@ -40,6 +88,39 @@ pub const BROWSER_UI_SPAN_OP: &str = "ui";
 pub const BROWSER_UI_TASK_SPAN_OP: &str = "ui.task";
 
 pub const BROWSER_UI_RENDER_SPAN_OP: &str = "ui.render";
+
+/// Mounting of a UI component or application (e.g. initial render/bootstrap).
+pub const BROWSER_UI_MOUNT_SPAN_OP: &str = "ui.mount";
+
+/// Updating of an already-mounted UI component.
+pub const BROWSER_UI_UPDATE_SPAN_OP: &str = "ui.update";
+
+/// Unmounting/teardown of a UI component.
+pub const BROWSER_UI_UNMOUNT_SPAN_OP: &str = "ui.unmount";
+
+/// A long task on the main UI thread, as reported by the Long Tasks API.
+pub const BROWSER_UI_LONG_TASK_SPAN_OP: &str = "ui.long_task";
+
+/// A long animation frame, as reported by the Long Animation Frames API.
+pub const BROWSER_UI_LONG_ANIMATION_FRAME_SPAN_OP: &str = "ui.long_animation_frame";
+
+/// A click interaction measured via Interaction to Next Paint (INP).
+pub const BROWSER_UI_INTERACTION_CLICK_SPAN_OP: &str = "ui.interaction.click";
+
+/// A hover interaction measured via Interaction to Next Paint (INP).
+pub const BROWSER_UI_INTERACTION_HOVER_SPAN_OP: &str = "ui.interaction.hover";
+
+/// A drag interaction measured via Interaction to Next Paint (INP).
+pub const BROWSER_UI_INTERACTION_DRAG_SPAN_OP: &str = "ui.interaction.drag";
+
+/// A key press interaction measured via Interaction to Next Paint (INP).
+pub const BROWSER_UI_INTERACTION_PRESS_SPAN_OP: &str = "ui.interaction.press";
+
+/// A Largest Contentful Paint (LCP) web vital measurement.
+pub const BROWSER_UI_WEBVITAL_LCP_SPAN_OP: &str = "ui.webvital.lcp";
+
+/// A Cumulative Layout Shift (CLS) web vital measurement.
+pub const BROWSER_UI_WEBVITAL_CLS_SPAN_OP: &str = "ui.webvital.cls";
 
 pub const BROWSER_UI_ACTION_SPAN_OP: &str = "ui.action";
 


### PR DESCRIPTION
## Description

Add new browser ops:
- Resource initiator types: resource.worker, resource.icon, resource.frame, resource.object, resource.ping, resource.track.
- Navigation timing phases: browser.unload_event, browser.redirect, browser.dom_content_loaded_event, browser.load_event, browser.connect, browser.tls_ssl, browser.cache, browser.dns, browser.request, browser.response.
- UI operations: ui.mount, ui.update, ui.unmount, ui.long_task, ui.long_animation_frame, ui.interaction.click/hover/drag/press, ui.webvital.lcp, ui.webvital.cls.

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
