### PR TITLE
feat(op): Add general `measure` span operation

### DIFF
--- a/javascript/sentry-conventions/src/op.ts
+++ b/javascript/sentry-conventions/src/op.ts
@@ -295,6 +295,11 @@ export const GENERAL_MARK_SPAN_OP = 'mark';
  */
 export const GENERAL_FUNCTION_SPAN_OP = 'function';
 
+/**
+ * A user-defined measurement of the duration between two points in time
+ */
+export const GENERAL_MEASURE_SPAN_OP = 'measure';
+
 // Path: model/op/messaging.json
 // Name: messaging
 

--- a/model/op/general.json
+++ b/model/op/general.json
@@ -9,6 +9,10 @@
     {
       "name": "function",
       "description": "The time it took for a set of instructions to execute"
+    },
+    {
+      "name": "measure",
+      "description": "A user-defined measurement of the duration between two points in time"
     }
   ]
 }

--- a/rust/src/op.rs
+++ b/rust/src/op.rs
@@ -208,6 +208,9 @@ pub const GENERAL_MARK_SPAN_OP: &str = "mark";
 /// The time it took for a set of instructions to execute
 pub const GENERAL_FUNCTION_SPAN_OP: &str = "function";
 
+/// A user-defined measurement of the duration between two points in time
+pub const GENERAL_MEASURE_SPAN_OP: &str = "measure";
+
 // Path: model/op/messaging.json
 // Name: messaging
 


### PR DESCRIPTION
## Description

Register the general `measure` operation for a user-defined measurement of the duration between two points in time. Complements the existing point-in-time `mark` operation.

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
