### PR TITLE
feat(op): Add `router` span operation

### DIFF
--- a/javascript/sentry-conventions/src/op.ts
+++ b/javascript/sentry-conventions/src/op.ts
@@ -445,6 +445,16 @@ export const OBJECT_OBJECT_MULTIPART_UPLOAD_CREATE_SPAN_OP = 'object.multipart_u
  */
 export const OBJECT_OBJECT_MULTIPART_UPLOAD_COMPLETE_SPAN_OP = 'object.multipart_upload.complete';
 
+// Path: model/op/routing.json
+// Name: routing
+
+// Description: Routing related spans represent work performed by frontend and backend application routers.
+
+/**
+ * A framework-neutral operation for work performed by an application router.
+ */
+export const ROUTING_ROUTER_SPAN_OP = 'router';
+
 // Path: model/op/web_server.json
 // Name: web_server
 

--- a/model/description/routing.json
+++ b/model/description/routing.json
@@ -1,0 +1,12 @@
+{
+  "brief": "Routing",
+  "operations": [
+    {
+      "name": "Router",
+      "brief": "Operations that match and dispatch requests or navigations through an application router.",
+      "ops": ["router"],
+      "templates": ["{{navigation.route.id}}", "{{http.route}}", "{{url.template}}", "{{url.path}}"],
+      "examples": ["UserProfile", "/users/:id", "/users/{id}", "/users/123"]
+    }
+  ]
+}

--- a/model/name/routing.json
+++ b/model/name/routing.json
@@ -1,0 +1,13 @@
+{
+  "brief": "Routing",
+  "operations": [
+    {
+      "name": "Router",
+      "brief": "Operations that match and dispatch requests or navigations through an application router.",
+      "is_in_otel": false,
+      "ops": ["router"],
+      "templates": ["{{navigation.route.id}}", "{{http.route}}", "{{url.template}}", "Router"],
+      "examples": ["UserProfile", "/users/:id", "/users/{id}", "Router"]
+    }
+  ]
+}

--- a/model/op/routing.json
+++ b/model/op/routing.json
@@ -1,0 +1,10 @@
+{
+  "name": "routing",
+  "description": "Routing related spans represent work performed by frontend and backend application routers.",
+  "fields": [
+    {
+      "name": "router",
+      "description": "A framework-neutral operation for work performed by an application router."
+    }
+  ]
+}

--- a/rust/src/op.rs
+++ b/rust/src/op.rs
@@ -306,6 +306,13 @@ pub const OBJECT_OBJECT_MULTIPART_UPLOAD_CREATE_SPAN_OP: &str = "object.multipar
 /// Completing a multipart upload to an object store.
 pub const OBJECT_OBJECT_MULTIPART_UPLOAD_COMPLETE_SPAN_OP: &str = "object.multipart_upload.complete";
 
+// Path: model/op/routing.json
+// Name: routing
+
+// Description: Routing related spans represent work performed by frontend and backend application routers.
+/// A framework-neutral operation for work performed by an application router.
+pub const ROUTING_ROUTER_SPAN_OP: &str = "router";
+
 // Path: model/op/web_server.json
 // Name: web_server
 


### PR DESCRIPTION
## Description
Register the `router` operation and a new `routing` category for work performed by an application router, along with its span name inference rules.
<!-- Describe your changes -->

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
