### PR TITLE
fix(ops): Add `http.client.stream` to `http.client` name and description rules

### DIFF
--- a/model/description/http.json
+++ b/model/description/http.json
@@ -4,7 +4,7 @@
     {
       "name": "Client",
       "brief": "Operations that represent outgoing HTTP requests.",
-      "ops": ["http.client"],
+      "ops": ["http.client", "http.client.stream"],
       "templates": ["{{http.request.method}} {{url.full}}"],
       "examples": ["GET /users/123"]
     },

--- a/model/name/http.json
+++ b/model/name/http.json
@@ -6,7 +6,7 @@
       "brief": "Operations that represent outgoing HTTP requests.",
       "is_in_otel": true,
       "otel_notes": "",
-      "ops": ["http.client"],
+      "ops": ["http.client", "http.client.stream"],
       "templates": [
         "{{http.request.method}} {{http.route}}",
         "{{http.request.method}} {{url.template}}",


### PR DESCRIPTION
## Description

Adds the new `http.client.stream` op to existing `http.client` name and description rules

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)

closes #552 