### PR TITLE
feat(op): Add `handler` op

### DIFF
--- a/javascript/sentry-conventions/src/op.ts
+++ b/javascript/sentry-conventions/src/op.ts
@@ -487,7 +487,7 @@ export const WEB_SERVER_MIDDLEWARE_SPAN_OP = 'middleware';
 /**
  * Handling of an incoming request by a web server route handler
  */
-export const WEB_SERVER_REQUEST_HANDLER_SPAN_OP = 'request_handler';
+export const WEB_SERVER_HANDLER_SPAN_OP = 'handler';
 
 export const WEB_SERVER_VIEW_SPAN_OP = 'view';
 

--- a/javascript/sentry-conventions/src/op.ts
+++ b/javascript/sentry-conventions/src/op.ts
@@ -484,6 +484,11 @@ export const WEB_SERVER_SUBPROCESS_SPAN_OP = 'subprocess';
 
 export const WEB_SERVER_MIDDLEWARE_SPAN_OP = 'middleware';
 
+/**
+ * Handling of an incoming request by a web server route handler
+ */
+export const WEB_SERVER_REQUEST_HANDLER_SPAN_OP = 'request_handler';
+
 export const WEB_SERVER_VIEW_SPAN_OP = 'view';
 
 export const WEB_SERVER_TEMPLATE_SPAN_OP = 'template';

--- a/model/description/web_server.json
+++ b/model/description/web_server.json
@@ -1,0 +1,12 @@
+{
+  "brief": "Web server",
+  "operations": [
+    {
+      "name": "Request handler",
+      "brief": "Handling of an incoming request by a web server route handler.",
+      "ops": ["handler"],
+      "templates": ["{{http.route}}", "{{url.path}}"],
+      "examples": ["/users/:id", "/users/123"]
+    }
+  ]
+}

--- a/model/name/web_server.json
+++ b/model/name/web_server.json
@@ -1,0 +1,13 @@
+{
+  "brief": "Web server",
+  "operations": [
+    {
+      "name": "Request handler",
+      "brief": "Handling of an incoming request by a web server route handler.",
+      "is_in_otel": false,
+      "ops": ["handler"],
+      "templates": ["{{http.route}}", "Request handler"],
+      "examples": ["/users/:id", "Request handler"]
+    }
+  ]
+}

--- a/model/op/web_server.json
+++ b/model/op/web_server.json
@@ -35,7 +35,7 @@
       "name": "middleware"
     },
     {
-      "name": "request_handler",
+      "name": "handler",
       "description": "Handling of an incoming request by a web server route handler"
     },
     {

--- a/model/op/web_server.json
+++ b/model/op/web_server.json
@@ -35,6 +35,10 @@
       "name": "middleware"
     },
     {
+      "name": "request_handler",
+      "description": "Handling of an incoming request by a web server route handler"
+    },
+    {
       "name": "view"
     },
     {

--- a/rust/src/op.rs
+++ b/rust/src/op.rs
@@ -339,7 +339,7 @@ pub const WEB_SERVER_SUBPROCESS_SPAN_OP: &str = "subprocess";
 pub const WEB_SERVER_MIDDLEWARE_SPAN_OP: &str = "middleware";
 
 /// Handling of an incoming request by a web server route handler
-pub const WEB_SERVER_REQUEST_HANDLER_SPAN_OP: &str = "request_handler";
+pub const WEB_SERVER_HANDLER_SPAN_OP: &str = "handler";
 
 pub const WEB_SERVER_VIEW_SPAN_OP: &str = "view";
 

--- a/rust/src/op.rs
+++ b/rust/src/op.rs
@@ -338,6 +338,9 @@ pub const WEB_SERVER_SUBPROCESS_SPAN_OP: &str = "subprocess";
 
 pub const WEB_SERVER_MIDDLEWARE_SPAN_OP: &str = "middleware";
 
+/// Handling of an incoming request by a web server route handler
+pub const WEB_SERVER_REQUEST_HANDLER_SPAN_OP: &str = "request_handler";
+
 pub const WEB_SERVER_VIEW_SPAN_OP: &str = "view";
 
 pub const WEB_SERVER_TEMPLATE_SPAN_OP: &str = "template";


### PR DESCRIPTION
## Description

Add `handler` op to the `web_server` category for spans that instrument http request handlers in server frameworks like express, fastify, etc.

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
