### PR TITLE
feat(attributes): Change `sentry.description` scrubbing policy to `manual`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -13782,7 +13782,7 @@ export type SENTRY_CLIENT_SAMPLE_RATE_TYPE = number;
  *
  * Attribute Value Type: `string` {@link SENTRY_DESCRIPTION_TYPE}
  *
- * Apply Scrubbing: auto
+ * Apply Scrubbing: manual
  *
  * Attribute defined in OTEL: No
  * Visibility: public
@@ -27899,7 +27899,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief: 'The human-readable description of a span.',
     type: 'string',
     applyScrubbing: {
-      key: 'auto',
+      key: 'manual',
     },
     isInOtel: false,
     visibility: 'public',

--- a/model/attributes/sentry/sentry__description.json
+++ b/model/attributes/sentry/sentry__description.json
@@ -3,7 +3,7 @@
   "brief": "The human-readable description of a span.",
   "type": "string",
   "apply_scrubbing": {
-    "key": "auto"
+    "key": "manual"
   },
   "is_in_otel": false,
   "example": "index view query",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -8071,7 +8071,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The human-readable description of a span.
 
     Type: str
-    Apply Scrubbing: auto
+    Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
     Example: "index view query"
@@ -19555,7 +19555,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "sentry.description": AttributeMetadata(
         brief="The human-readable description of a span.",
         type=AttributeType.STRING,
-        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="index view query",


### PR DESCRIPTION
This PR reduces the `apply_scrubbing` policy from `auto` to `manual`. We've observed span descriptions being scrubbed for example because a route name contained `"auth"` (e.g. `/(auth)/lists/:id`) or an HTML selector contained `opacity` (from a tailwind class, in this case users had `city` in their custom scrubbing fields).

Since description is inferred for v2 spans, the attributes matching the description should already get scrubbed (cc @Dav1dde or @loewenheim to confirm (UPDATE confirmed)), so it's redundant to auto-scrub again here.