### PR TITLE
feat(attributes): Add `sentry.event.serialized_*` attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -14031,6 +14031,63 @@ export const SENTRY_ENVIRONMENT = 'sentry.environment';
  */
 export type SENTRY_ENVIRONMENT_TYPE = string;
 
+// Path: model/attributes/sentry/sentry__event__serialized_breadcrumbs.json
+
+/**
+ * JSON-serialized `breadcrumbs` property from a Sentry event. `sentry.event.serialized_breadcrumbs`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_EVENT_SERIALIZED_BREADCRUMBS_TYPE}
+ *
+ * Apply Scrubbing: never
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: internal
+ */
+export const SENTRY_EVENT_SERIALIZED_BREADCRUMBS = 'sentry.event.serialized_breadcrumbs';
+
+/**
+ * Type for {@link SENTRY_EVENT_SERIALIZED_BREADCRUMBS} sentry.event.serialized_breadcrumbs
+ */
+export type SENTRY_EVENT_SERIALIZED_BREADCRUMBS_TYPE = string;
+
+// Path: model/attributes/sentry/sentry__event__serialized_contexts.json
+
+/**
+ * JSON-serialized `contexts` property from a Sentry event. `sentry.event.serialized_contexts`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_EVENT_SERIALIZED_CONTEXTS_TYPE}
+ *
+ * Apply Scrubbing: never
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: internal
+ */
+export const SENTRY_EVENT_SERIALIZED_CONTEXTS = 'sentry.event.serialized_contexts';
+
+/**
+ * Type for {@link SENTRY_EVENT_SERIALIZED_CONTEXTS} sentry.event.serialized_contexts
+ */
+export type SENTRY_EVENT_SERIALIZED_CONTEXTS_TYPE = string;
+
+// Path: model/attributes/sentry/sentry__event__serialized_extra.json
+
+/**
+ * JSON-serialized `extra` property from a Sentry event. `sentry.event.serialized_extra`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_EVENT_SERIALIZED_EXTRA_TYPE}
+ *
+ * Apply Scrubbing: never
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: internal
+ */
+export const SENTRY_EVENT_SERIALIZED_EXTRA = 'sentry.event.serialized_extra';
+
+/**
+ * Type for {@link SENTRY_EVENT_SERIALIZED_EXTRA} sentry.event.serialized_extra
+ */
+export type SENTRY_EVENT_SERIALIZED_EXTRA_TYPE = string;
+
 // Path: model/attributes/sentry/sentry__exclusive_time.json
 
 /**
@@ -18193,6 +18250,9 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'sentry.dsc.trace_id': 'string',
   'sentry.dsc.transaction': 'string',
   'sentry.environment': 'string',
+  'sentry.event.serialized_breadcrumbs': 'string',
+  'sentry.event.serialized_contexts': 'string',
+  'sentry.event.serialized_extra': 'string',
   'sentry.exclusive_time': 'double',
   'sentry.frames.frozen': 'integer',
   'sentry.frames.slow': 'integer',
@@ -18983,6 +19043,9 @@ export type AttributeName =
   | typeof SENTRY_DSC_TRACE_ID
   | typeof SENTRY_DSC_TRANSACTION
   | typeof SENTRY_ENVIRONMENT
+  | typeof SENTRY_EVENT_SERIALIZED_BREADCRUMBS
+  | typeof SENTRY_EVENT_SERIALIZED_CONTEXTS
+  | typeof SENTRY_EVENT_SERIALIZED_EXTRA
   | typeof SENTRY_EXCLUSIVE_TIME
   | typeof SENTRY_FRAMES_FROZEN
   | typeof SENTRY_FRAMES_SLOW
@@ -28031,6 +28094,36 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: ['environment'],
     changelog: [{ version: '0.0.0' }],
   },
+  'sentry.event.serialized_breadcrumbs': {
+    brief: 'JSON-serialized `breadcrumbs` property from a Sentry event.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'never',
+    },
+    isInOtel: false,
+    visibility: 'internal',
+    changelog: [{ version: 'next' }],
+  },
+  'sentry.event.serialized_contexts': {
+    brief: 'JSON-serialized `contexts` property from a Sentry event.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'never',
+    },
+    isInOtel: false,
+    visibility: 'internal',
+    changelog: [{ version: 'next' }],
+  },
+  'sentry.event.serialized_extra': {
+    brief: 'JSON-serialized `extra` property from a Sentry event.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'never',
+    },
+    isInOtel: false,
+    visibility: 'internal',
+    changelog: [{ version: 'next' }],
+  },
   'sentry.exclusive_time': {
     brief: 'The exclusive time duration of the span in milliseconds.',
     type: 'double',
@@ -30725,6 +30818,9 @@ export type Attributes = {
   [SENTRY_DSC_TRACE_ID]?: SENTRY_DSC_TRACE_ID_TYPE;
   [SENTRY_DSC_TRANSACTION]?: SENTRY_DSC_TRANSACTION_TYPE;
   [SENTRY_ENVIRONMENT]?: SENTRY_ENVIRONMENT_TYPE;
+  [SENTRY_EVENT_SERIALIZED_BREADCRUMBS]?: SENTRY_EVENT_SERIALIZED_BREADCRUMBS_TYPE;
+  [SENTRY_EVENT_SERIALIZED_CONTEXTS]?: SENTRY_EVENT_SERIALIZED_CONTEXTS_TYPE;
+  [SENTRY_EVENT_SERIALIZED_EXTRA]?: SENTRY_EVENT_SERIALIZED_EXTRA_TYPE;
   [SENTRY_EXCLUSIVE_TIME]?: SENTRY_EXCLUSIVE_TIME_TYPE;
   [SENTRY_FRAMES_FROZEN]?: SENTRY_FRAMES_FROZEN_TYPE;
   [SENTRY_FRAMES_SLOW]?: SENTRY_FRAMES_SLOW_TYPE;

--- a/model/attributes/sentry/sentry__event__serialized_breadcrumbs.json
+++ b/model/attributes/sentry/sentry__event__serialized_breadcrumbs.json
@@ -1,0 +1,15 @@
+{
+  "key": "sentry.event.serialized_breadcrumbs",
+  "brief": "JSON-serialized `breadcrumbs` property from a Sentry event.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "never"
+  },
+  "is_in_otel": false,
+  "visibility": "internal",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/sentry/sentry__event__serialized_contexts.json
+++ b/model/attributes/sentry/sentry__event__serialized_contexts.json
@@ -1,0 +1,15 @@
+{
+  "key": "sentry.event.serialized_contexts",
+  "brief": "JSON-serialized `contexts` property from a Sentry event.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "never"
+  },
+  "is_in_otel": false,
+  "visibility": "internal",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/model/attributes/sentry/sentry__event__serialized_extra.json
+++ b/model/attributes/sentry/sentry__event__serialized_extra.json
@@ -1,0 +1,15 @@
+{
+  "key": "sentry.event.serialized_extra",
+  "brief": "JSON-serialized `extra` property from a Sentry event.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "never"
+  },
+  "is_in_otel": false,
+  "visibility": "internal",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -8200,6 +8200,42 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "production"
     """
 
+    # Path: model/attributes/sentry/sentry__event__serialized_breadcrumbs.json
+    SENTRY_EVENT_SERIALIZED_BREADCRUMBS: Literal[
+        "sentry.event.serialized_breadcrumbs"
+    ] = "sentry.event.serialized_breadcrumbs"
+    """JSON-serialized `breadcrumbs` property from a Sentry event.
+
+    Type: str
+    Apply Scrubbing: never
+    Defined in OTEL: No
+    Visibility: internal
+    """
+
+    # Path: model/attributes/sentry/sentry__event__serialized_contexts.json
+    SENTRY_EVENT_SERIALIZED_CONTEXTS: Literal["sentry.event.serialized_contexts"] = (
+        "sentry.event.serialized_contexts"
+    )
+    """JSON-serialized `contexts` property from a Sentry event.
+
+    Type: str
+    Apply Scrubbing: never
+    Defined in OTEL: No
+    Visibility: internal
+    """
+
+    # Path: model/attributes/sentry/sentry__event__serialized_extra.json
+    SENTRY_EVENT_SERIALIZED_EXTRA: Literal["sentry.event.serialized_extra"] = (
+        "sentry.event.serialized_extra"
+    )
+    """JSON-serialized `extra` property from a Sentry event.
+
+    Type: str
+    Apply Scrubbing: never
+    Defined in OTEL: No
+    Visibility: internal
+    """
+
     # Path: model/attributes/sentry/sentry__exclusive_time.json
     SENTRY_EXCLUSIVE_TIME: Literal["sentry.exclusive_time"] = "sentry.exclusive_time"
     """The exclusive time duration of the span in milliseconds.
@@ -19693,6 +19729,36 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "sentry.event.serialized_breadcrumbs": AttributeMetadata(
+        brief="JSON-serialized `breadcrumbs` property from a Sentry event.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        is_in_otel=False,
+        visibility=Visibility.INTERNAL,
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
+    "sentry.event.serialized_contexts": AttributeMetadata(
+        brief="JSON-serialized `contexts` property from a Sentry event.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        is_in_otel=False,
+        visibility=Visibility.INTERNAL,
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
+    "sentry.event.serialized_extra": AttributeMetadata(
+        brief="JSON-serialized `extra` property from a Sentry event.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        is_in_otel=False,
+        visibility=Visibility.INTERNAL,
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
     "sentry.exclusive_time": AttributeMetadata(
         brief="The exclusive time duration of the span in milliseconds.",
         type=AttributeType.DOUBLE,
@@ -22482,6 +22548,9 @@ Attributes = TypedDict(
         "sentry.dsc.trace_id": str,
         "sentry.dsc.transaction": str,
         "sentry.environment": str,
+        "sentry.event.serialized_breadcrumbs": str,
+        "sentry.event.serialized_contexts": str,
+        "sentry.event.serialized_extra": str,
         "sentry.exclusive_time": float,
         "sentry.frames.frozen": int,
         "sentry.frames.slow": int,


### PR DESCRIPTION
Add:
- `sentry.event.serialized_contexts`
- `sentry.event.serialized_extra`
- `sentry.event.serialized_breadcrumbs`

as **internal** attributes for storing the JSON-serialized values from incoming Sentry transactions (and maybe later other event types).

These will be populated by Relay for incoming transaction events and displayed on the Sentry frontend so that transaction-based SDK users don't lose this data.

The `serialized_` prefix allows us to e.g. use a different attribute name in the future once we natively support object types.