### PR TITLE
feat(ops): Add MCP ops

### DIFF
--- a/javascript/sentry-conventions/src/op.ts
+++ b/javascript/sentry-conventions/src/op.ts
@@ -305,6 +305,26 @@ export const GENERAL_FUNCTION_SPAN_OP = 'function';
  */
 export const GENERAL_MEASURE_SPAN_OP = 'measure';
 
+// Path: model/op/mcp.json
+// Name: mcp
+
+// Description: Operations related to Model Context Protocol (MCP) interactions
+
+/**
+ * A request handled by an MCP server (e.g. a tool call, resource read, or prompt request).
+ */
+export const MCP_MCP_SERVER_SPAN_OP = 'mcp.server';
+
+/**
+ * A notification sent from an MCP client to an MCP server.
+ */
+export const MCP_MCP_NOTIFICATION_CLIENT_TO_SERVER_SPAN_OP = 'mcp.notification.client_to_server';
+
+/**
+ * A notification sent from an MCP server to an MCP client.
+ */
+export const MCP_MCP_NOTIFICATION_SERVER_TO_CLIENT_SPAN_OP = 'mcp.notification.server_to_client';
+
 // Path: model/op/messaging.json
 // Name: messaging
 

--- a/javascript/sentry-conventions/src/op.ts
+++ b/javascript/sentry-conventions/src/op.ts
@@ -303,6 +303,26 @@ export const FUNCTION = 'function';
  */
 export const MEASURE = 'measure';
 
+// Path: model/op/mcp.json
+// Name: mcp
+
+// Description: Operations related to Model Context Protocol (MCP) interactions
+
+/**
+ * A request handled by an MCP server (e.g. a tool call, resource read, or prompt request).
+ */
+export const MCP_SERVER = 'mcp.server';
+
+/**
+ * A notification sent from an MCP client to an MCP server.
+ */
+export const MCP_NOTIFICATION_CLIENT_TO_SERVER = 'mcp.notification.client_to_server';
+
+/**
+ * A notification sent from an MCP server to an MCP client.
+ */
+export const MCP_NOTIFICATION_SERVER_TO_CLIENT = 'mcp.notification.server_to_client';
+
 // Path: model/op/messaging.json
 // Name: messaging
 

--- a/model/description/mcp.json
+++ b/model/description/mcp.json
@@ -1,0 +1,29 @@
+{
+  "brief": "Model Context Protocol (MCP)",
+  "operations": [
+    {
+      "name": "Server",
+      "brief": "MCP server-side operations. Processing of incoming MCP requests initiated by a client, such as tool calls, prompt requests, and resource reads.",
+      "ops": ["mcp.server"],
+      "templates": [
+        "{{mcp.method.name}} {{gen_ai.tool.name}}",
+        "{{mcp.method.name}} {{gen_ai.prompt.name}}",
+        "{{mcp.method.name}} {{mcp.resource.uri}}",
+        "{{mcp.method.name}}"
+      ],
+      "examples": [
+        "tools/call get-weather",
+        "prompts/get analyze-code",
+        "resources/read postgres://database/customers/schema",
+        "initialize"
+      ]
+    },
+    {
+      "name": "Notification",
+      "brief": "MCP notifications. One-way messages exchanged between an MCP client and server that do not expect a response.",
+      "ops": ["mcp.notification.client_to_server", "mcp.notification.server_to_client"],
+      "templates": ["{{mcp.method.name}}"],
+      "examples": ["notifications/initialized", "notifications/cancelled", "notifications/progress"]
+    }
+  ]
+}

--- a/model/name/mcp.json
+++ b/model/name/mcp.json
@@ -14,6 +14,15 @@
         "MCP server operation"
       ],
       "examples": ["tools/call get-weather", "prompts/get analyze-code", "resources/read", "initialize"]
+    },
+    {
+      "name": "Notification",
+      "brief": "MCP notifications. One-way messages exchanged between an MCP client and server that do not expect a response.",
+      "is_in_otel": true,
+      "otel_notes": "OpenTelemetry does not model notifications as distinct operations; they are covered by the MCP Client and Server spans.",
+      "ops": ["mcp.notification.client_to_server", "mcp.notification.server_to_client"],
+      "templates": ["{{mcp.method.name}}", "MCP notification"],
+      "examples": ["notifications/initialized", "notifications/cancelled", "notifications/progress"]
     }
   ]
 }

--- a/model/op/mcp.json
+++ b/model/op/mcp.json
@@ -1,0 +1,18 @@
+{
+  "name": "mcp",
+  "description": "Operations related to Model Context Protocol (MCP) interactions",
+  "fields": [
+    {
+      "name": "mcp.server",
+      "description": "A request handled by an MCP server (e.g. a tool call, resource read, or prompt request)."
+    },
+    {
+      "name": "mcp.notification.client_to_server",
+      "description": "A notification sent from an MCP client to an MCP server."
+    },
+    {
+      "name": "mcp.notification.server_to_client",
+      "description": "A notification sent from an MCP server to an MCP client."
+    }
+  ]
+}

--- a/rust/src/op.rs
+++ b/rust/src/op.rs
@@ -212,6 +212,19 @@ pub const FUNCTION: &str = "function";
 /// A user-defined measurement of the duration between two points in time
 pub const MEASURE: &str = "measure";
 
+// Path: model/op/mcp.json
+// Name: mcp
+
+// Description: Operations related to Model Context Protocol (MCP) interactions
+/// A request handled by an MCP server (e.g. a tool call, resource read, or prompt request).
+pub const MCP_SERVER: &str = "mcp.server";
+
+/// A notification sent from an MCP client to an MCP server.
+pub const MCP_NOTIFICATION_CLIENT_TO_SERVER: &str = "mcp.notification.client_to_server";
+
+/// A notification sent from an MCP server to an MCP client.
+pub const MCP_NOTIFICATION_SERVER_TO_CLIENT: &str = "mcp.notification.server_to_client";
+
 // Path: model/op/messaging.json
 // Name: messaging
 

--- a/rust/src/op.rs
+++ b/rust/src/op.rs
@@ -214,6 +214,19 @@ pub const GENERAL_FUNCTION_SPAN_OP: &str = "function";
 /// A user-defined measurement of the duration between two points in time
 pub const GENERAL_MEASURE_SPAN_OP: &str = "measure";
 
+// Path: model/op/mcp.json
+// Name: mcp
+
+// Description: Operations related to Model Context Protocol (MCP) interactions
+/// A request handled by an MCP server (e.g. a tool call, resource read, or prompt request).
+pub const MCP_MCP_SERVER_SPAN_OP: &str = "mcp.server";
+
+/// A notification sent from an MCP client to an MCP server.
+pub const MCP_MCP_NOTIFICATION_CLIENT_TO_SERVER_SPAN_OP: &str = "mcp.notification.client_to_server";
+
+/// A notification sent from an MCP server to an MCP client.
+pub const MCP_MCP_NOTIFICATION_SERVER_TO_CLIENT_SPAN_OP: &str = "mcp.notification.server_to_client";
+
 // Path: model/op/messaging.json
 // Name: messaging
 


### PR DESCRIPTION
## Description

Adds ops and description/name rules for `mcp.server`, `mcp.notification.client_to_server`, and `mcp.notification.server_to_client`, as already used by the JS SDK.

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
