### PR TITLE
feat(attributes): Add React Native TurboModule call attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -15998,6 +15998,489 @@ export const TTFB_REQUESTTIME = 'ttfb.requestTime';
  */
 export type TTFB_REQUESTTIME_TYPE = number;
 
+// Path: model/attributes/turbo_modules/turbo_modules__total_call_count.json
+
+/**
+ * The number of native module calls in the flushed call aggregate. Only applies to React Native. `turbo_modules.total_call_count`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULES_TOTAL_CALL_COUNT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_CALL_COUNT} `turbo_module.call.count`, {@link TURBO_MODULE_TOTAL_CALL_COUNT} `turbo_module.total_call_count`
+ *
+ * @deprecated Use {@link TURBO_MODULE_CALL_COUNT} (turbo_module.call.count) instead - Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix
+ * @example 42
+ */
+export const TURBO_MODULES_TOTAL_CALL_COUNT = 'turbo_modules.total_call_count';
+
+/**
+ * Type for {@link TURBO_MODULES_TOTAL_CALL_COUNT} turbo_modules.total_call_count
+ */
+export type TURBO_MODULES_TOTAL_CALL_COUNT_TYPE = number;
+
+// Path: model/attributes/turbo_modules/turbo_modules__total_duration_ms.json
+
+/**
+ * The combined duration of all native module calls in the flushed call aggregate, in milliseconds. Only applies to React Native. `turbo_modules.total_duration_ms`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULES_TOTAL_DURATION_MS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_DURATION_TOTAL} `turbo_module.duration.total`, {@link TURBO_MODULE_TOTAL_DURATION_MS} `turbo_module.total_duration_ms`
+ *
+ * @deprecated Use {@link TURBO_MODULE_DURATION_TOTAL} (turbo_module.duration.total) instead - Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix
+ * @example 128.45
+ */
+export const TURBO_MODULES_TOTAL_DURATION_MS = 'turbo_modules.total_duration_ms';
+
+/**
+ * Type for {@link TURBO_MODULES_TOTAL_DURATION_MS} turbo_modules.total_duration_ms
+ */
+export type TURBO_MODULES_TOTAL_DURATION_MS_TYPE = number;
+
+// Path: model/attributes/turbo_modules/turbo_modules__total_error_count.json
+
+/**
+ * The number of failed native module calls in the flushed call aggregate. Only applies to React Native. `turbo_modules.total_error_count`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULES_TOTAL_ERROR_COUNT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_ERROR_COUNT} `turbo_module.error.count`, {@link TURBO_MODULE_TOTAL_ERROR_COUNT} `turbo_module.total_error_count`
+ *
+ * @deprecated Use {@link TURBO_MODULE_ERROR_COUNT} (turbo_module.error.count) instead - Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix
+ * @example 2
+ */
+export const TURBO_MODULES_TOTAL_ERROR_COUNT = 'turbo_modules.total_error_count';
+
+/**
+ * Type for {@link TURBO_MODULES_TOTAL_ERROR_COUNT} turbo_modules.total_error_count
+ */
+export type TURBO_MODULES_TOTAL_ERROR_COUNT_TYPE = number;
+
+// Path: model/attributes/turbo_modules/turbo_modules__unique_methods.json
+
+/**
+ * The number of distinct native module and method pairs in the flushed call aggregate. Only applies to React Native. `turbo_modules.unique_methods`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULES_UNIQUE_METHODS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_CALL_DISTINCT_COUNT} `turbo_module.call.distinct_count`, {@link TURBO_MODULE_UNIQUE_METHODS} `turbo_module.unique_methods`
+ *
+ * @deprecated Use {@link TURBO_MODULE_CALL_DISTINCT_COUNT} (turbo_module.call.distinct_count) instead - Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix
+ * @example 7
+ */
+export const TURBO_MODULES_UNIQUE_METHODS = 'turbo_modules.unique_methods';
+
+/**
+ * Type for {@link TURBO_MODULES_UNIQUE_METHODS} turbo_modules.unique_methods
+ */
+export type TURBO_MODULES_UNIQUE_METHODS_TYPE = number;
+
+// Path: model/attributes/turbo_module/turbo_module__arch.json
+
+/**
+ * The React Native architecture the call was observed on. `new` for a TurboModule resolved through `TurboModuleRegistry`, `legacy` for a module reached over the Old Architecture bridge. Only applies to React Native. `turbo_module.arch`
+ *
+ * Attribute Value Type: `string` {@link TURBO_MODULE_ARCH_TYPE}
+ *
+ * Apply Scrubbing: manual - Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "new"
+ */
+export const TURBO_MODULE_ARCH = 'turbo_module.arch';
+
+/**
+ * Type for {@link TURBO_MODULE_ARCH} turbo_module.arch
+ */
+export type TURBO_MODULE_ARCH_TYPE = string;
+
+// Path: model/attributes/turbo_module/turbo_module__call__count.json
+
+/**
+ * The number of native module calls observed during the lifetime of the span. Only applies to React Native. `turbo_module.call.count`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULE_CALL_COUNT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_TOTAL_CALL_COUNT} `turbo_module.total_call_count`, {@link TURBO_MODULES_TOTAL_CALL_COUNT} `turbo_modules.total_call_count`
+ *
+ * @example 42
+ */
+export const TURBO_MODULE_CALL_COUNT = 'turbo_module.call.count';
+
+/**
+ * Type for {@link TURBO_MODULE_CALL_COUNT} turbo_module.call.count
+ */
+export type TURBO_MODULE_CALL_COUNT_TYPE = number;
+
+// Path: model/attributes/turbo_module/turbo_module__call__distinct_count.json
+
+/**
+ * The number of distinct native module and method pairs called during the lifetime of the span. Useful as a cardinality signal when the per-method breakdown has been truncated. Only applies to React Native. `turbo_module.call.distinct_count`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULE_CALL_DISTINCT_COUNT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_UNIQUE_METHODS} `turbo_module.unique_methods`, {@link TURBO_MODULES_UNIQUE_METHODS} `turbo_modules.unique_methods`
+ *
+ * @example 7
+ */
+export const TURBO_MODULE_CALL_DISTINCT_COUNT = 'turbo_module.call.distinct_count';
+
+/**
+ * Type for {@link TURBO_MODULE_CALL_DISTINCT_COUNT} turbo_module.call.distinct_count
+ */
+export type TURBO_MODULE_CALL_DISTINCT_COUNT_TYPE = number;
+
+// Path: model/attributes/turbo_module/turbo_module__duration__max.json
+
+/**
+ * The duration of the slowest single native module call observed during the lifetime of the span, in milliseconds. Only applies to React Native. `turbo_module.duration.max`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULE_DURATION_MAX_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example 512.5
+ */
+export const TURBO_MODULE_DURATION_MAX = 'turbo_module.duration.max';
+
+/**
+ * Type for {@link TURBO_MODULE_DURATION_MAX} turbo_module.duration.max
+ */
+export type TURBO_MODULE_DURATION_MAX_TYPE = number;
+
+// Path: model/attributes/turbo_module/turbo_module__duration__total.json
+
+/**
+ * The combined wall-clock duration of all native module calls observed during the lifetime of the span, in milliseconds. Calls overlap, so this can exceed the span duration. Only applies to React Native. `turbo_module.duration.total`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULE_DURATION_TOTAL_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_TOTAL_DURATION_MS} `turbo_module.total_duration_ms`, {@link TURBO_MODULES_TOTAL_DURATION_MS} `turbo_modules.total_duration_ms`
+ *
+ * @example 128.45
+ */
+export const TURBO_MODULE_DURATION_TOTAL = 'turbo_module.duration.total';
+
+/**
+ * Type for {@link TURBO_MODULE_DURATION_TOTAL} turbo_module.duration.total
+ */
+export type TURBO_MODULE_DURATION_TOTAL_TYPE = number;
+
+// Path: model/attributes/turbo_module/turbo_module__error__count.json
+
+/**
+ * The number of native module calls that failed during the lifetime of the span. A call counts as failed when it threw, rejected, or — on the Old Architecture bridge only — invoked its failure callback. Only applies to React Native. `turbo_module.error.count`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULE_ERROR_COUNT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_TOTAL_ERROR_COUNT} `turbo_module.total_error_count`, {@link TURBO_MODULES_TOTAL_ERROR_COUNT} `turbo_modules.total_error_count`
+ *
+ * @example 2
+ */
+export const TURBO_MODULE_ERROR_COUNT = 'turbo_module.error.count';
+
+/**
+ * Type for {@link TURBO_MODULE_ERROR_COUNT} turbo_module.error.count
+ */
+export type TURBO_MODULE_ERROR_COUNT_TYPE = number;
+
+// Path: model/attributes/turbo_module/turbo_module__kind.json
+
+/**
+ * Whether the native module call completed synchronously or reported completion later through a Promise or a callback. One of `sync` or `async`. Only applies to React Native. `turbo_module.kind`
+ *
+ * Attribute Value Type: `string` {@link TURBO_MODULE_KIND_TYPE}
+ *
+ * Apply Scrubbing: manual - Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "async"
+ */
+export const TURBO_MODULE_KIND = 'turbo_module.kind';
+
+/**
+ * Type for {@link TURBO_MODULE_KIND} turbo_module.kind
+ */
+export type TURBO_MODULE_KIND_TYPE = string;
+
+// Path: model/attributes/turbo_module/turbo_module__method.json
+
+/**
+ * The name of the native module method that was called. Only applies to React Native. `turbo_module.method`
+ *
+ * Attribute Value Type: `string` {@link TURBO_MODULE_METHOD_TYPE}
+ *
+ * Apply Scrubbing: manual - Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "getUniqueId"
+ */
+export const TURBO_MODULE_METHOD = 'turbo_module.method';
+
+/**
+ * Type for {@link TURBO_MODULE_METHOD} turbo_module.method
+ */
+export type TURBO_MODULE_METHOD_TYPE = string;
+
+// Path: model/attributes/turbo_module/turbo_module__name.json
+
+/**
+ * The name of the native module the call was dispatched to. On the New Architecture this is the TurboModule name, on the Old Architecture the `NativeModules` key. Only applies to React Native. `turbo_module.name`
+ *
+ * Attribute Value Type: `string` {@link TURBO_MODULE_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual - Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "RNDeviceInfo"
+ */
+export const TURBO_MODULE_NAME = 'turbo_module.name';
+
+/**
+ * Type for {@link TURBO_MODULE_NAME} turbo_module.name
+ */
+export type TURBO_MODULE_NAME_TYPE = string;
+
+// Path: model/attributes/turbo_module/turbo_module__top__duration.json
+
+/**
+ * The total duration attributed to `turbo_module.top.name`, in milliseconds. Only applies to React Native. `turbo_module.top.duration`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULE_TOP_DURATION_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_TOP_MODULE_DURATION_MS} `turbo_module.top_module_duration_ms`
+ *
+ * @example 87.25
+ */
+export const TURBO_MODULE_TOP_DURATION = 'turbo_module.top.duration';
+
+/**
+ * Type for {@link TURBO_MODULE_TOP_DURATION} turbo_module.top.duration
+ */
+export type TURBO_MODULE_TOP_DURATION_TYPE = number;
+
+// Path: model/attributes/turbo_module/turbo_module__top_module.json
+
+/**
+ * The native module and method that accounted for the most total duration during the lifetime of the span. Only applies to React Native. `turbo_module.top_module`
+ *
+ * Attribute Value Type: `string` {@link TURBO_MODULE_TOP_MODULE_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_TOP_NAME} `turbo_module.top.name`
+ *
+ * @deprecated Use {@link TURBO_MODULE_TOP_NAME} (turbo_module.top.name) instead - Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping
+ * @example "RNDeviceInfo.getUniqueId"
+ */
+export const TURBO_MODULE_TOP_MODULE = 'turbo_module.top_module';
+
+/**
+ * Type for {@link TURBO_MODULE_TOP_MODULE} turbo_module.top_module
+ */
+export type TURBO_MODULE_TOP_MODULE_TYPE = string;
+
+// Path: model/attributes/turbo_module/turbo_module__top_module_duration_ms.json
+
+/**
+ * The total duration attributed to the top native module method, in milliseconds. Only applies to React Native. `turbo_module.top_module_duration_ms`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULE_TOP_MODULE_DURATION_MS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_TOP_DURATION} `turbo_module.top.duration`
+ *
+ * @deprecated Use {@link TURBO_MODULE_TOP_DURATION} (turbo_module.top.duration) instead - Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping
+ * @example 87.25
+ */
+export const TURBO_MODULE_TOP_MODULE_DURATION_MS = 'turbo_module.top_module_duration_ms';
+
+/**
+ * Type for {@link TURBO_MODULE_TOP_MODULE_DURATION_MS} turbo_module.top_module_duration_ms
+ */
+export type TURBO_MODULE_TOP_MODULE_DURATION_MS_TYPE = number;
+
+// Path: model/attributes/turbo_module/turbo_module__top__name.json
+
+/**
+ * The native module and method that accounted for the most total duration during the lifetime of the span, formatted as `<module>.<method>`. Only applies to React Native. `turbo_module.top.name`
+ *
+ * Attribute Value Type: `string` {@link TURBO_MODULE_TOP_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual - Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_TOP_MODULE} `turbo_module.top_module`
+ *
+ * @example "RNDeviceInfo.getUniqueId"
+ */
+export const TURBO_MODULE_TOP_NAME = 'turbo_module.top.name';
+
+/**
+ * Type for {@link TURBO_MODULE_TOP_NAME} turbo_module.top.name
+ */
+export type TURBO_MODULE_TOP_NAME_TYPE = string;
+
+// Path: model/attributes/turbo_module/turbo_module__total_call_count.json
+
+/**
+ * The number of native module calls observed during the lifetime of the span. Only applies to React Native. `turbo_module.total_call_count`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULE_TOTAL_CALL_COUNT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_CALL_COUNT} `turbo_module.call.count`, {@link TURBO_MODULES_TOTAL_CALL_COUNT} `turbo_modules.total_call_count`
+ *
+ * @deprecated Use {@link TURBO_MODULE_CALL_COUNT} (turbo_module.call.count) instead - Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping
+ * @example 42
+ */
+export const TURBO_MODULE_TOTAL_CALL_COUNT = 'turbo_module.total_call_count';
+
+/**
+ * Type for {@link TURBO_MODULE_TOTAL_CALL_COUNT} turbo_module.total_call_count
+ */
+export type TURBO_MODULE_TOTAL_CALL_COUNT_TYPE = number;
+
+// Path: model/attributes/turbo_module/turbo_module__total_duration_ms.json
+
+/**
+ * The combined duration of all native module calls observed during the lifetime of the span, in milliseconds. Only applies to React Native. `turbo_module.total_duration_ms`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULE_TOTAL_DURATION_MS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_DURATION_TOTAL} `turbo_module.duration.total`, {@link TURBO_MODULES_TOTAL_DURATION_MS} `turbo_modules.total_duration_ms`
+ *
+ * @deprecated Use {@link TURBO_MODULE_DURATION_TOTAL} (turbo_module.duration.total) instead - Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping
+ * @example 128.45
+ */
+export const TURBO_MODULE_TOTAL_DURATION_MS = 'turbo_module.total_duration_ms';
+
+/**
+ * Type for {@link TURBO_MODULE_TOTAL_DURATION_MS} turbo_module.total_duration_ms
+ */
+export type TURBO_MODULE_TOTAL_DURATION_MS_TYPE = number;
+
+// Path: model/attributes/turbo_module/turbo_module__total_error_count.json
+
+/**
+ * The number of native module calls that failed during the lifetime of the span. Only applies to React Native. `turbo_module.total_error_count`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULE_TOTAL_ERROR_COUNT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_ERROR_COUNT} `turbo_module.error.count`, {@link TURBO_MODULES_TOTAL_ERROR_COUNT} `turbo_modules.total_error_count`
+ *
+ * @deprecated Use {@link TURBO_MODULE_ERROR_COUNT} (turbo_module.error.count) instead - Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping
+ * @example 2
+ */
+export const TURBO_MODULE_TOTAL_ERROR_COUNT = 'turbo_module.total_error_count';
+
+/**
+ * Type for {@link TURBO_MODULE_TOTAL_ERROR_COUNT} turbo_module.total_error_count
+ */
+export type TURBO_MODULE_TOTAL_ERROR_COUNT_TYPE = number;
+
+// Path: model/attributes/turbo_module/turbo_module__unique_methods.json
+
+/**
+ * The number of distinct native module and method pairs called during the lifetime of the span. Only applies to React Native. `turbo_module.unique_methods`
+ *
+ * Attribute Value Type: `number` {@link TURBO_MODULE_UNIQUE_METHODS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link TURBO_MODULE_CALL_DISTINCT_COUNT} `turbo_module.call.distinct_count`, {@link TURBO_MODULES_UNIQUE_METHODS} `turbo_modules.unique_methods`
+ *
+ * @deprecated Use {@link TURBO_MODULE_CALL_DISTINCT_COUNT} (turbo_module.call.distinct_count) instead - Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping
+ * @example 7
+ */
+export const TURBO_MODULE_UNIQUE_METHODS = 'turbo_module.unique_methods';
+
+/**
+ * Type for {@link TURBO_MODULE_UNIQUE_METHODS} turbo_module.unique_methods
+ */
+export type TURBO_MODULE_UNIQUE_METHODS_TYPE = number;
+
 // Path: model/attributes/type.json
 
 /**
@@ -18339,6 +18822,27 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'trpc.procedure_type': 'string',
   ttfb: 'double',
   'ttfb.requestTime': 'double',
+  'turbo_modules.total_call_count': 'integer',
+  'turbo_modules.total_duration_ms': 'double',
+  'turbo_modules.total_error_count': 'integer',
+  'turbo_modules.unique_methods': 'integer',
+  'turbo_module.arch': 'string',
+  'turbo_module.call.count': 'integer',
+  'turbo_module.call.distinct_count': 'integer',
+  'turbo_module.duration.max': 'double',
+  'turbo_module.duration.total': 'double',
+  'turbo_module.error.count': 'integer',
+  'turbo_module.kind': 'string',
+  'turbo_module.method': 'string',
+  'turbo_module.name': 'string',
+  'turbo_module.top.duration': 'double',
+  'turbo_module.top_module': 'string',
+  'turbo_module.top_module_duration_ms': 'double',
+  'turbo_module.top.name': 'string',
+  'turbo_module.total_call_count': 'integer',
+  'turbo_module.total_duration_ms': 'double',
+  'turbo_module.total_error_count': 'integer',
+  'turbo_module.unique_methods': 'integer',
   type: 'string',
   'ui.component_name': 'string',
   'ui.contributes_to_ttfd': 'boolean',
@@ -19132,6 +19636,27 @@ export type AttributeName =
   | typeof TRPC_PROCEDURE_TYPE
   | typeof TTFB
   | typeof TTFB_REQUESTTIME
+  | typeof TURBO_MODULES_TOTAL_CALL_COUNT
+  | typeof TURBO_MODULES_TOTAL_DURATION_MS
+  | typeof TURBO_MODULES_TOTAL_ERROR_COUNT
+  | typeof TURBO_MODULES_UNIQUE_METHODS
+  | typeof TURBO_MODULE_ARCH
+  | typeof TURBO_MODULE_CALL_COUNT
+  | typeof TURBO_MODULE_CALL_DISTINCT_COUNT
+  | typeof TURBO_MODULE_DURATION_MAX
+  | typeof TURBO_MODULE_DURATION_TOTAL
+  | typeof TURBO_MODULE_ERROR_COUNT
+  | typeof TURBO_MODULE_KIND
+  | typeof TURBO_MODULE_METHOD
+  | typeof TURBO_MODULE_NAME
+  | typeof TURBO_MODULE_TOP_DURATION
+  | typeof TURBO_MODULE_TOP_MODULE
+  | typeof TURBO_MODULE_TOP_MODULE_DURATION_MS
+  | typeof TURBO_MODULE_TOP_NAME
+  | typeof TURBO_MODULE_TOTAL_CALL_COUNT
+  | typeof TURBO_MODULE_TOTAL_DURATION_MS
+  | typeof TURBO_MODULE_TOTAL_ERROR_COUNT
+  | typeof TURBO_MODULE_UNIQUE_METHODS
   | typeof TYPE
   | typeof UI_COMPONENT_NAME
   | typeof UI_CONTRIBUTES_TO_TTFD
@@ -29357,6 +29882,390 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: ['browser.web_vital.ttfb.request_time'],
     changelog: [{ version: '0.5.0', prs: [235] }],
   },
+  'turbo_modules.total_call_count': {
+    brief: 'The number of native module calls in the flushed call aggregate. Only applies to React Native.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 42,
+    deprecation: {
+      replacement: 'turbo_module.call.count',
+      reason:
+        'Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix',
+      status: 'backfill',
+    },
+    aliases: ['turbo_module.call.count', 'turbo_module.total_call_count'],
+    changelog: [
+      {
+        version: 'next',
+        description: 'Added turbo_modules.total_call_count and deprecated it in favor of turbo_module.call.count',
+      },
+    ],
+  },
+  'turbo_modules.total_duration_ms': {
+    brief:
+      'The combined duration of all native module calls in the flushed call aggregate, in milliseconds. Only applies to React Native.',
+    type: 'double',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 128.45,
+    deprecation: {
+      replacement: 'turbo_module.duration.total',
+      reason:
+        'Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix',
+      status: 'backfill',
+    },
+    aliases: ['turbo_module.duration.total', 'turbo_module.total_duration_ms'],
+    changelog: [
+      {
+        version: 'next',
+        description: 'Added turbo_modules.total_duration_ms and deprecated it in favor of turbo_module.duration.total',
+      },
+    ],
+  },
+  'turbo_modules.total_error_count': {
+    brief: 'The number of failed native module calls in the flushed call aggregate. Only applies to React Native.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 2,
+    deprecation: {
+      replacement: 'turbo_module.error.count',
+      reason:
+        'Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix',
+      status: 'backfill',
+    },
+    aliases: ['turbo_module.error.count', 'turbo_module.total_error_count'],
+    changelog: [
+      {
+        version: 'next',
+        description: 'Added turbo_modules.total_error_count and deprecated it in favor of turbo_module.error.count',
+      },
+    ],
+  },
+  'turbo_modules.unique_methods': {
+    brief:
+      'The number of distinct native module and method pairs in the flushed call aggregate. Only applies to React Native.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 7,
+    deprecation: {
+      replacement: 'turbo_module.call.distinct_count',
+      reason:
+        'Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix',
+      status: 'backfill',
+    },
+    aliases: ['turbo_module.call.distinct_count', 'turbo_module.unique_methods'],
+    changelog: [
+      {
+        version: 'next',
+        description:
+          'Added turbo_modules.unique_methods and deprecated it in favor of turbo_module.call.distinct_count',
+      },
+    ],
+  },
+  'turbo_module.arch': {
+    brief:
+      'The React Native architecture the call was observed on. `new` for a TurboModule resolved through `TurboModuleRegistry`, `legacy` for a module reached over the Old Architecture bridge. Only applies to React Native.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+      reason:
+        'Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'new',
+    changelog: [{ version: 'next', description: 'Added turbo_module.arch attribute' }],
+  },
+  'turbo_module.call.count': {
+    brief: 'The number of native module calls observed during the lifetime of the span. Only applies to React Native.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 42,
+    aliases: ['turbo_module.total_call_count', 'turbo_modules.total_call_count'],
+    changelog: [{ version: 'next', description: 'Added turbo_module.call.count attribute' }],
+  },
+  'turbo_module.call.distinct_count': {
+    brief:
+      'The number of distinct native module and method pairs called during the lifetime of the span. Useful as a cardinality signal when the per-method breakdown has been truncated. Only applies to React Native.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 7,
+    aliases: ['turbo_module.unique_methods', 'turbo_modules.unique_methods'],
+    changelog: [{ version: 'next', description: 'Added turbo_module.call.distinct_count attribute' }],
+  },
+  'turbo_module.duration.max': {
+    brief:
+      'The duration of the slowest single native module call observed during the lifetime of the span, in milliseconds. Only applies to React Native.',
+    type: 'double',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 512.5,
+    changelog: [{ version: 'next', description: 'Added turbo_module.duration.max attribute' }],
+  },
+  'turbo_module.duration.total': {
+    brief:
+      'The combined wall-clock duration of all native module calls observed during the lifetime of the span, in milliseconds. Calls overlap, so this can exceed the span duration. Only applies to React Native.',
+    type: 'double',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 128.45,
+    aliases: ['turbo_module.total_duration_ms', 'turbo_modules.total_duration_ms'],
+    changelog: [{ version: 'next', description: 'Added turbo_module.duration.total attribute' }],
+  },
+  'turbo_module.error.count': {
+    brief:
+      'The number of native module calls that failed during the lifetime of the span. A call counts as failed when it threw, rejected, or — on the Old Architecture bridge only — invoked its failure callback. Only applies to React Native.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 2,
+    aliases: ['turbo_module.total_error_count', 'turbo_modules.total_error_count'],
+    changelog: [{ version: 'next', description: 'Added turbo_module.error.count attribute' }],
+  },
+  'turbo_module.kind': {
+    brief:
+      'Whether the native module call completed synchronously or reported completion later through a Promise or a callback. One of `sync` or `async`. Only applies to React Native.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+      reason:
+        'Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'async',
+    changelog: [{ version: 'next', description: 'Added turbo_module.kind attribute' }],
+  },
+  'turbo_module.method': {
+    brief: 'The name of the native module method that was called. Only applies to React Native.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+      reason:
+        'Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'getUniqueId',
+    changelog: [{ version: 'next', description: 'Added turbo_module.method attribute' }],
+  },
+  'turbo_module.name': {
+    brief:
+      'The name of the native module the call was dispatched to. On the New Architecture this is the TurboModule name, on the Old Architecture the `NativeModules` key. Only applies to React Native.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+      reason:
+        'Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'RNDeviceInfo',
+    changelog: [{ version: 'next', description: 'Added turbo_module.name attribute' }],
+  },
+  'turbo_module.top.duration': {
+    brief: 'The total duration attributed to `turbo_module.top.name`, in milliseconds. Only applies to React Native.',
+    type: 'double',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 87.25,
+    aliases: ['turbo_module.top_module_duration_ms'],
+    changelog: [{ version: 'next', description: 'Added turbo_module.top.duration attribute' }],
+  },
+  'turbo_module.top_module': {
+    brief:
+      'The native module and method that accounted for the most total duration during the lifetime of the span. Only applies to React Native.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'RNDeviceInfo.getUniqueId',
+    deprecation: {
+      replacement: 'turbo_module.top.name',
+      reason:
+        'Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping',
+      status: 'backfill',
+    },
+    aliases: ['turbo_module.top.name'],
+    changelog: [
+      {
+        version: 'next',
+        description: 'Added turbo_module.top_module and deprecated it in favor of turbo_module.top.name',
+      },
+    ],
+  },
+  'turbo_module.top_module_duration_ms': {
+    brief:
+      'The total duration attributed to the top native module method, in milliseconds. Only applies to React Native.',
+    type: 'double',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 87.25,
+    deprecation: {
+      replacement: 'turbo_module.top.duration',
+      reason:
+        'Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping',
+      status: 'backfill',
+    },
+    aliases: ['turbo_module.top.duration'],
+    changelog: [
+      {
+        version: 'next',
+        description:
+          'Added turbo_module.top_module_duration_ms and deprecated it in favor of turbo_module.top.duration',
+      },
+    ],
+  },
+  'turbo_module.top.name': {
+    brief:
+      'The native module and method that accounted for the most total duration during the lifetime of the span, formatted as `<module>.<method>`. Only applies to React Native.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'manual',
+      reason:
+        'Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'RNDeviceInfo.getUniqueId',
+    aliases: ['turbo_module.top_module'],
+    changelog: [{ version: 'next', description: 'Added turbo_module.top.name attribute' }],
+  },
+  'turbo_module.total_call_count': {
+    brief: 'The number of native module calls observed during the lifetime of the span. Only applies to React Native.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 42,
+    deprecation: {
+      replacement: 'turbo_module.call.count',
+      reason:
+        'Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping',
+      status: 'backfill',
+    },
+    aliases: ['turbo_module.call.count', 'turbo_modules.total_call_count'],
+    changelog: [
+      {
+        version: 'next',
+        description: 'Added turbo_module.total_call_count and deprecated it in favor of turbo_module.call.count',
+      },
+    ],
+  },
+  'turbo_module.total_duration_ms': {
+    brief:
+      'The combined duration of all native module calls observed during the lifetime of the span, in milliseconds. Only applies to React Native.',
+    type: 'double',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 128.45,
+    deprecation: {
+      replacement: 'turbo_module.duration.total',
+      reason:
+        'Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping',
+      status: 'backfill',
+    },
+    aliases: ['turbo_module.duration.total', 'turbo_modules.total_duration_ms'],
+    changelog: [
+      {
+        version: 'next',
+        description: 'Added turbo_module.total_duration_ms and deprecated it in favor of turbo_module.duration.total',
+      },
+    ],
+  },
+  'turbo_module.total_error_count': {
+    brief:
+      'The number of native module calls that failed during the lifetime of the span. Only applies to React Native.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 2,
+    deprecation: {
+      replacement: 'turbo_module.error.count',
+      reason:
+        'Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping',
+      status: 'backfill',
+    },
+    aliases: ['turbo_module.error.count', 'turbo_modules.total_error_count'],
+    changelog: [
+      {
+        version: 'next',
+        description: 'Added turbo_module.total_error_count and deprecated it in favor of turbo_module.error.count',
+      },
+    ],
+  },
+  'turbo_module.unique_methods': {
+    brief:
+      'The number of distinct native module and method pairs called during the lifetime of the span. Only applies to React Native.',
+    type: 'integer',
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 7,
+    deprecation: {
+      replacement: 'turbo_module.call.distinct_count',
+      reason:
+        'Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping',
+      status: 'backfill',
+    },
+    aliases: ['turbo_module.call.distinct_count', 'turbo_modules.unique_methods'],
+    changelog: [
+      {
+        version: 'next',
+        description: 'Added turbo_module.unique_methods and deprecated it in favor of turbo_module.call.distinct_count',
+      },
+    ],
+  },
   type: {
     brief: 'More granular type of the operation happening.',
     type: 'string',
@@ -30937,6 +31846,27 @@ export type Attributes = {
   [TRPC_PROCEDURE_TYPE]?: TRPC_PROCEDURE_TYPE_TYPE;
   [TTFB]?: TTFB_TYPE;
   [TTFB_REQUESTTIME]?: TTFB_REQUESTTIME_TYPE;
+  [TURBO_MODULES_TOTAL_CALL_COUNT]?: TURBO_MODULES_TOTAL_CALL_COUNT_TYPE;
+  [TURBO_MODULES_TOTAL_DURATION_MS]?: TURBO_MODULES_TOTAL_DURATION_MS_TYPE;
+  [TURBO_MODULES_TOTAL_ERROR_COUNT]?: TURBO_MODULES_TOTAL_ERROR_COUNT_TYPE;
+  [TURBO_MODULES_UNIQUE_METHODS]?: TURBO_MODULES_UNIQUE_METHODS_TYPE;
+  [TURBO_MODULE_ARCH]?: TURBO_MODULE_ARCH_TYPE;
+  [TURBO_MODULE_CALL_COUNT]?: TURBO_MODULE_CALL_COUNT_TYPE;
+  [TURBO_MODULE_CALL_DISTINCT_COUNT]?: TURBO_MODULE_CALL_DISTINCT_COUNT_TYPE;
+  [TURBO_MODULE_DURATION_MAX]?: TURBO_MODULE_DURATION_MAX_TYPE;
+  [TURBO_MODULE_DURATION_TOTAL]?: TURBO_MODULE_DURATION_TOTAL_TYPE;
+  [TURBO_MODULE_ERROR_COUNT]?: TURBO_MODULE_ERROR_COUNT_TYPE;
+  [TURBO_MODULE_KIND]?: TURBO_MODULE_KIND_TYPE;
+  [TURBO_MODULE_METHOD]?: TURBO_MODULE_METHOD_TYPE;
+  [TURBO_MODULE_NAME]?: TURBO_MODULE_NAME_TYPE;
+  [TURBO_MODULE_TOP_DURATION]?: TURBO_MODULE_TOP_DURATION_TYPE;
+  [TURBO_MODULE_TOP_MODULE]?: TURBO_MODULE_TOP_MODULE_TYPE;
+  [TURBO_MODULE_TOP_MODULE_DURATION_MS]?: TURBO_MODULE_TOP_MODULE_DURATION_MS_TYPE;
+  [TURBO_MODULE_TOP_NAME]?: TURBO_MODULE_TOP_NAME_TYPE;
+  [TURBO_MODULE_TOTAL_CALL_COUNT]?: TURBO_MODULE_TOTAL_CALL_COUNT_TYPE;
+  [TURBO_MODULE_TOTAL_DURATION_MS]?: TURBO_MODULE_TOTAL_DURATION_MS_TYPE;
+  [TURBO_MODULE_TOTAL_ERROR_COUNT]?: TURBO_MODULE_TOTAL_ERROR_COUNT_TYPE;
+  [TURBO_MODULE_UNIQUE_METHODS]?: TURBO_MODULE_UNIQUE_METHODS_TYPE;
   [TYPE]?: TYPE_TYPE;
   [UI_COMPONENT_NAME]?: UI_COMPONENT_NAME_TYPE;
   [UI_CONTRIBUTES_TO_TTFD]?: UI_CONTRIBUTES_TO_TTFD_TYPE;

--- a/javascript/sentry-conventions/src/op.ts
+++ b/javascript/sentry-conventions/src/op.ts
@@ -395,6 +395,11 @@ export const MOBILE_SERIALIZE_SPAN_OP = 'serialize';
 
 export const MOBILE_HTTP_SPAN_OP = 'http';
 
+/**
+ * A call from JavaScript into a React Native native module, or an aggregate of such calls.
+ */
+export const MOBILE_TURBO_MODULE_SPAN_OP = 'turbo_module';
+
 // Path: model/op/object.json
 // Name: object
 

--- a/model/attributes/turbo_module/turbo_module__arch.json
+++ b/model/attributes/turbo_module/turbo_module__arch.json
@@ -1,0 +1,18 @@
+{
+  "key": "turbo_module.arch",
+  "brief": "The React Native architecture the call was observed on. `new` for a TurboModule resolved through `TurboModuleRegistry`, `legacy` for a module reached over the Old Architecture bridge. Only applies to React Native.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual",
+    "reason": "Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable"
+  },
+  "is_in_otel": false,
+  "example": "new",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.arch attribute"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__call__count.json
+++ b/model/attributes/turbo_module/turbo_module__call__count.json
@@ -1,0 +1,18 @@
+{
+  "key": "turbo_module.call.count",
+  "brief": "The number of native module calls observed during the lifetime of the span. Only applies to React Native.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 42,
+  "alias": ["turbo_module.total_call_count", "turbo_modules.total_call_count"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.call.count attribute"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__call__distinct_count.json
+++ b/model/attributes/turbo_module/turbo_module__call__distinct_count.json
@@ -1,0 +1,18 @@
+{
+  "key": "turbo_module.call.distinct_count",
+  "brief": "The number of distinct native module and method pairs called during the lifetime of the span. Useful as a cardinality signal when the per-method breakdown has been truncated. Only applies to React Native.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 7,
+  "alias": ["turbo_module.unique_methods", "turbo_modules.unique_methods"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.call.distinct_count attribute"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__duration__max.json
+++ b/model/attributes/turbo_module/turbo_module__duration__max.json
@@ -1,0 +1,17 @@
+{
+  "key": "turbo_module.duration.max",
+  "brief": "The duration of the slowest single native module call observed during the lifetime of the span, in milliseconds. Only applies to React Native.",
+  "type": "double",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 512.5,
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.duration.max attribute"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__duration__total.json
+++ b/model/attributes/turbo_module/turbo_module__duration__total.json
@@ -1,0 +1,18 @@
+{
+  "key": "turbo_module.duration.total",
+  "brief": "The combined wall-clock duration of all native module calls observed during the lifetime of the span, in milliseconds. Calls overlap, so this can exceed the span duration. Only applies to React Native.",
+  "type": "double",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 128.45,
+  "alias": ["turbo_module.total_duration_ms", "turbo_modules.total_duration_ms"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.duration.total attribute"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__error__count.json
+++ b/model/attributes/turbo_module/turbo_module__error__count.json
@@ -1,0 +1,18 @@
+{
+  "key": "turbo_module.error.count",
+  "brief": "The number of native module calls that failed during the lifetime of the span. A call counts as failed when it threw, rejected, or — on the Old Architecture bridge only — invoked its failure callback. Only applies to React Native.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 2,
+  "alias": ["turbo_module.total_error_count", "turbo_modules.total_error_count"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.error.count attribute"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__kind.json
+++ b/model/attributes/turbo_module/turbo_module__kind.json
@@ -1,0 +1,18 @@
+{
+  "key": "turbo_module.kind",
+  "brief": "Whether the native module call completed synchronously or reported completion later through a Promise or a callback. One of `sync` or `async`. Only applies to React Native.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual",
+    "reason": "Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable"
+  },
+  "is_in_otel": false,
+  "example": "async",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.kind attribute"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__method.json
+++ b/model/attributes/turbo_module/turbo_module__method.json
@@ -1,0 +1,18 @@
+{
+  "key": "turbo_module.method",
+  "brief": "The name of the native module method that was called. Only applies to React Native.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual",
+    "reason": "Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable"
+  },
+  "is_in_otel": false,
+  "example": "getUniqueId",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.method attribute"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__name.json
+++ b/model/attributes/turbo_module/turbo_module__name.json
@@ -1,0 +1,18 @@
+{
+  "key": "turbo_module.name",
+  "brief": "The name of the native module the call was dispatched to. On the New Architecture this is the TurboModule name, on the Old Architecture the `NativeModules` key. Only applies to React Native.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual",
+    "reason": "Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable"
+  },
+  "is_in_otel": false,
+  "example": "RNDeviceInfo",
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.name attribute"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__top__duration.json
+++ b/model/attributes/turbo_module/turbo_module__top__duration.json
@@ -1,0 +1,18 @@
+{
+  "key": "turbo_module.top.duration",
+  "brief": "The total duration attributed to `turbo_module.top.name`, in milliseconds. Only applies to React Native.",
+  "type": "double",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 87.25,
+  "alias": ["turbo_module.top_module_duration_ms"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.top.duration attribute"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__top__name.json
+++ b/model/attributes/turbo_module/turbo_module__top__name.json
@@ -1,0 +1,19 @@
+{
+  "key": "turbo_module.top.name",
+  "brief": "The native module and method that accounted for the most total duration during the lifetime of the span, formatted as `<module>.<method>`. Only applies to React Native.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual",
+    "reason": "Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable"
+  },
+  "is_in_otel": false,
+  "example": "RNDeviceInfo.getUniqueId",
+  "alias": ["turbo_module.top_module"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.top.name attribute"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__top_module.json
+++ b/model/attributes/turbo_module/turbo_module__top_module.json
@@ -1,0 +1,23 @@
+{
+  "key": "turbo_module.top_module",
+  "brief": "The native module and method that accounted for the most total duration during the lifetime of the span. Only applies to React Native.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": "RNDeviceInfo.getUniqueId",
+  "alias": ["turbo_module.top.name"],
+  "deprecation": {
+    "replacement": "turbo_module.top.name",
+    "reason": "Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping",
+    "_status": "backfill"
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.top_module and deprecated it in favor of turbo_module.top.name"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__top_module_duration_ms.json
+++ b/model/attributes/turbo_module/turbo_module__top_module_duration_ms.json
@@ -1,0 +1,23 @@
+{
+  "key": "turbo_module.top_module_duration_ms",
+  "brief": "The total duration attributed to the top native module method, in milliseconds. Only applies to React Native.",
+  "type": "double",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 87.25,
+  "alias": ["turbo_module.top.duration"],
+  "deprecation": {
+    "replacement": "turbo_module.top.duration",
+    "reason": "Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping",
+    "_status": "backfill"
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.top_module_duration_ms and deprecated it in favor of turbo_module.top.duration"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__total_call_count.json
+++ b/model/attributes/turbo_module/turbo_module__total_call_count.json
@@ -1,0 +1,23 @@
+{
+  "key": "turbo_module.total_call_count",
+  "brief": "The number of native module calls observed during the lifetime of the span. Only applies to React Native.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 42,
+  "alias": ["turbo_module.call.count", "turbo_modules.total_call_count"],
+  "deprecation": {
+    "replacement": "turbo_module.call.count",
+    "reason": "Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping",
+    "_status": "backfill"
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.total_call_count and deprecated it in favor of turbo_module.call.count"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__total_duration_ms.json
+++ b/model/attributes/turbo_module/turbo_module__total_duration_ms.json
@@ -1,0 +1,23 @@
+{
+  "key": "turbo_module.total_duration_ms",
+  "brief": "The combined duration of all native module calls observed during the lifetime of the span, in milliseconds. Only applies to React Native.",
+  "type": "double",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 128.45,
+  "alias": ["turbo_module.duration.total", "turbo_modules.total_duration_ms"],
+  "deprecation": {
+    "replacement": "turbo_module.duration.total",
+    "reason": "Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping",
+    "_status": "backfill"
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.total_duration_ms and deprecated it in favor of turbo_module.duration.total"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__total_error_count.json
+++ b/model/attributes/turbo_module/turbo_module__total_error_count.json
@@ -1,0 +1,23 @@
+{
+  "key": "turbo_module.total_error_count",
+  "brief": "The number of native module calls that failed during the lifetime of the span. Only applies to React Native.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 2,
+  "alias": ["turbo_module.error.count", "turbo_modules.total_error_count"],
+  "deprecation": {
+    "replacement": "turbo_module.error.count",
+    "reason": "Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping",
+    "_status": "backfill"
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.total_error_count and deprecated it in favor of turbo_module.error.count"
+    }
+  ]
+}

--- a/model/attributes/turbo_module/turbo_module__unique_methods.json
+++ b/model/attributes/turbo_module/turbo_module__unique_methods.json
@@ -1,0 +1,23 @@
+{
+  "key": "turbo_module.unique_methods",
+  "brief": "The number of distinct native module and method pairs called during the lifetime of the span. Only applies to React Native.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 7,
+  "alias": ["turbo_module.call.distinct_count", "turbo_modules.unique_methods"],
+  "deprecation": {
+    "replacement": "turbo_module.call.distinct_count",
+    "reason": "Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping",
+    "_status": "backfill"
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_module.unique_methods and deprecated it in favor of turbo_module.call.distinct_count"
+    }
+  ]
+}

--- a/model/attributes/turbo_modules/turbo_modules__total_call_count.json
+++ b/model/attributes/turbo_modules/turbo_modules__total_call_count.json
@@ -1,0 +1,23 @@
+{
+  "key": "turbo_modules.total_call_count",
+  "brief": "The number of native module calls in the flushed call aggregate. Only applies to React Native.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 42,
+  "alias": ["turbo_module.call.count", "turbo_module.total_call_count"],
+  "deprecation": {
+    "replacement": "turbo_module.call.count",
+    "reason": "Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix",
+    "_status": "backfill"
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_modules.total_call_count and deprecated it in favor of turbo_module.call.count"
+    }
+  ]
+}

--- a/model/attributes/turbo_modules/turbo_modules__total_duration_ms.json
+++ b/model/attributes/turbo_modules/turbo_modules__total_duration_ms.json
@@ -1,0 +1,23 @@
+{
+  "key": "turbo_modules.total_duration_ms",
+  "brief": "The combined duration of all native module calls in the flushed call aggregate, in milliseconds. Only applies to React Native.",
+  "type": "double",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 128.45,
+  "alias": ["turbo_module.duration.total", "turbo_module.total_duration_ms"],
+  "deprecation": {
+    "replacement": "turbo_module.duration.total",
+    "reason": "Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix",
+    "_status": "backfill"
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_modules.total_duration_ms and deprecated it in favor of turbo_module.duration.total"
+    }
+  ]
+}

--- a/model/attributes/turbo_modules/turbo_modules__total_error_count.json
+++ b/model/attributes/turbo_modules/turbo_modules__total_error_count.json
@@ -1,0 +1,23 @@
+{
+  "key": "turbo_modules.total_error_count",
+  "brief": "The number of failed native module calls in the flushed call aggregate. Only applies to React Native.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 2,
+  "alias": ["turbo_module.error.count", "turbo_module.total_error_count"],
+  "deprecation": {
+    "replacement": "turbo_module.error.count",
+    "reason": "Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix",
+    "_status": "backfill"
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_modules.total_error_count and deprecated it in favor of turbo_module.error.count"
+    }
+  ]
+}

--- a/model/attributes/turbo_modules/turbo_modules__unique_methods.json
+++ b/model/attributes/turbo_modules/turbo_modules__unique_methods.json
@@ -1,0 +1,23 @@
+{
+  "key": "turbo_modules.unique_methods",
+  "brief": "The number of distinct native module and method pairs in the flushed call aggregate. Only applies to React Native.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 7,
+  "alias": ["turbo_module.call.distinct_count", "turbo_module.unique_methods"],
+  "deprecation": {
+    "replacement": "turbo_module.call.distinct_count",
+    "reason": "Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix",
+    "_status": "backfill"
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "description": "Added turbo_modules.unique_methods and deprecated it in favor of turbo_module.call.distinct_count"
+    }
+  ]
+}

--- a/model/op/mobile.json
+++ b/model/op/mobile.json
@@ -19,6 +19,10 @@
     },
     {
       "name": "http"
+    },
+    {
+      "name": "turbo_module",
+      "description": "A call from JavaScript into a React Native native module, or an aggregate of such calls."
     }
   ]
 }

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -329,6 +329,16 @@ class _AttributeNamesMeta(type):
         "TRANSACTION",
         "TTFB_REQUESTTIME",
         "TTFB",
+        "TURBO_MODULE_TOP_MODULE",
+        "TURBO_MODULE_TOP_MODULE_DURATION_MS",
+        "TURBO_MODULE_TOTAL_CALL_COUNT",
+        "TURBO_MODULE_TOTAL_DURATION_MS",
+        "TURBO_MODULE_TOTAL_ERROR_COUNT",
+        "TURBO_MODULE_UNIQUE_METHODS",
+        "TURBO_MODULES_TOTAL_CALL_COUNT",
+        "TURBO_MODULES_TOTAL_DURATION_MS",
+        "TURBO_MODULES_TOTAL_ERROR_COUNT",
+        "TURBO_MODULES_UNIQUE_METHODS",
         "URL_SAME_ORIGIN",
         "URL",
     }
@@ -9295,6 +9305,295 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Aliases: browser.web_vital.ttfb.value
     DEPRECATED: Use browser.web_vital.ttfb.value instead - This attribute is being deprecated in favor of browser.web_vital.ttfb.value
     Example: 194
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__arch.json
+    TURBO_MODULE_ARCH: Literal["turbo_module.arch"] = "turbo_module.arch"
+    """The React Native architecture the call was observed on. `new` for a TurboModule resolved through `TurboModuleRegistry`, `legacy` for a module reached over the Old Architecture bridge. Only applies to React Native.
+
+    Type: str
+    Apply Scrubbing: manual - Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable
+    Defined in OTEL: No
+    Visibility: public
+    Example: "new"
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__call__count.json
+    TURBO_MODULE_CALL_COUNT: Literal["turbo_module.call.count"] = (
+        "turbo_module.call.count"
+    )
+    """The number of native module calls observed during the lifetime of the span. Only applies to React Native.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.total_call_count, turbo_modules.total_call_count
+    Example: 42
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__call__distinct_count.json
+    TURBO_MODULE_CALL_DISTINCT_COUNT: Literal["turbo_module.call.distinct_count"] = (
+        "turbo_module.call.distinct_count"
+    )
+    """The number of distinct native module and method pairs called during the lifetime of the span. Useful as a cardinality signal when the per-method breakdown has been truncated. Only applies to React Native.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.unique_methods, turbo_modules.unique_methods
+    Example: 7
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__duration__max.json
+    TURBO_MODULE_DURATION_MAX: Literal["turbo_module.duration.max"] = (
+        "turbo_module.duration.max"
+    )
+    """The duration of the slowest single native module call observed during the lifetime of the span, in milliseconds. Only applies to React Native.
+
+    Type: float
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: 512.5
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__duration__total.json
+    TURBO_MODULE_DURATION_TOTAL: Literal["turbo_module.duration.total"] = (
+        "turbo_module.duration.total"
+    )
+    """The combined wall-clock duration of all native module calls observed during the lifetime of the span, in milliseconds. Calls overlap, so this can exceed the span duration. Only applies to React Native.
+
+    Type: float
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.total_duration_ms, turbo_modules.total_duration_ms
+    Example: 128.45
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__error__count.json
+    TURBO_MODULE_ERROR_COUNT: Literal["turbo_module.error.count"] = (
+        "turbo_module.error.count"
+    )
+    """The number of native module calls that failed during the lifetime of the span. A call counts as failed when it threw, rejected, or — on the Old Architecture bridge only — invoked its failure callback. Only applies to React Native.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.total_error_count, turbo_modules.total_error_count
+    Example: 2
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__kind.json
+    TURBO_MODULE_KIND: Literal["turbo_module.kind"] = "turbo_module.kind"
+    """Whether the native module call completed synchronously or reported completion later through a Promise or a callback. One of `sync` or `async`. Only applies to React Native.
+
+    Type: str
+    Apply Scrubbing: manual - Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable
+    Defined in OTEL: No
+    Visibility: public
+    Example: "async"
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__method.json
+    TURBO_MODULE_METHOD: Literal["turbo_module.method"] = "turbo_module.method"
+    """The name of the native module method that was called. Only applies to React Native.
+
+    Type: str
+    Apply Scrubbing: manual - Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable
+    Defined in OTEL: No
+    Visibility: public
+    Example: "getUniqueId"
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__name.json
+    TURBO_MODULE_NAME: Literal["turbo_module.name"] = "turbo_module.name"
+    """The name of the native module the call was dispatched to. On the New Architecture this is the TurboModule name, on the Old Architecture the `NativeModules` key. Only applies to React Native.
+
+    Type: str
+    Apply Scrubbing: manual - Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable
+    Defined in OTEL: No
+    Visibility: public
+    Example: "RNDeviceInfo"
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__top__duration.json
+    TURBO_MODULE_TOP_DURATION: Literal["turbo_module.top.duration"] = (
+        "turbo_module.top.duration"
+    )
+    """The total duration attributed to `turbo_module.top.name`, in milliseconds. Only applies to React Native.
+
+    Type: float
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.top_module_duration_ms
+    Example: 87.25
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__top__name.json
+    TURBO_MODULE_TOP_NAME: Literal["turbo_module.top.name"] = "turbo_module.top.name"
+    """The native module and method that accounted for the most total duration during the lifetime of the span, formatted as `<module>.<method>`. Only applies to React Native.
+
+    Type: str
+    Apply Scrubbing: manual - Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.top_module
+    Example: "RNDeviceInfo.getUniqueId"
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__top_module.json
+    TURBO_MODULE_TOP_MODULE: Literal["turbo_module.top_module"] = (
+        "turbo_module.top_module"
+    )
+    """The native module and method that accounted for the most total duration during the lifetime of the span. Only applies to React Native.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.top.name
+    DEPRECATED: Use turbo_module.top.name instead - Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping
+    Example: "RNDeviceInfo.getUniqueId"
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__top_module_duration_ms.json
+    TURBO_MODULE_TOP_MODULE_DURATION_MS: Literal[
+        "turbo_module.top_module_duration_ms"
+    ] = "turbo_module.top_module_duration_ms"
+    """The total duration attributed to the top native module method, in milliseconds. Only applies to React Native.
+
+    Type: float
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.top.duration
+    DEPRECATED: Use turbo_module.top.duration instead - Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping
+    Example: 87.25
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__total_call_count.json
+    TURBO_MODULE_TOTAL_CALL_COUNT: Literal["turbo_module.total_call_count"] = (
+        "turbo_module.total_call_count"
+    )
+    """The number of native module calls observed during the lifetime of the span. Only applies to React Native.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.call.count, turbo_modules.total_call_count
+    DEPRECATED: Use turbo_module.call.count instead - Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping
+    Example: 42
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__total_duration_ms.json
+    TURBO_MODULE_TOTAL_DURATION_MS: Literal["turbo_module.total_duration_ms"] = (
+        "turbo_module.total_duration_ms"
+    )
+    """The combined duration of all native module calls observed during the lifetime of the span, in milliseconds. Only applies to React Native.
+
+    Type: float
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.duration.total, turbo_modules.total_duration_ms
+    DEPRECATED: Use turbo_module.duration.total instead - Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping
+    Example: 128.45
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__total_error_count.json
+    TURBO_MODULE_TOTAL_ERROR_COUNT: Literal["turbo_module.total_error_count"] = (
+        "turbo_module.total_error_count"
+    )
+    """The number of native module calls that failed during the lifetime of the span. Only applies to React Native.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.error.count, turbo_modules.total_error_count
+    DEPRECATED: Use turbo_module.error.count instead - Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping
+    Example: 2
+    """
+
+    # Path: model/attributes/turbo_module/turbo_module__unique_methods.json
+    TURBO_MODULE_UNIQUE_METHODS: Literal["turbo_module.unique_methods"] = (
+        "turbo_module.unique_methods"
+    )
+    """The number of distinct native module and method pairs called during the lifetime of the span. Only applies to React Native.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.call.distinct_count, turbo_modules.unique_methods
+    DEPRECATED: Use turbo_module.call.distinct_count instead - Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping
+    Example: 7
+    """
+
+    # Path: model/attributes/turbo_modules/turbo_modules__total_call_count.json
+    TURBO_MODULES_TOTAL_CALL_COUNT: Literal["turbo_modules.total_call_count"] = (
+        "turbo_modules.total_call_count"
+    )
+    """The number of native module calls in the flushed call aggregate. Only applies to React Native.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.call.count, turbo_module.total_call_count
+    DEPRECATED: Use turbo_module.call.count instead - Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix
+    Example: 42
+    """
+
+    # Path: model/attributes/turbo_modules/turbo_modules__total_duration_ms.json
+    TURBO_MODULES_TOTAL_DURATION_MS: Literal["turbo_modules.total_duration_ms"] = (
+        "turbo_modules.total_duration_ms"
+    )
+    """The combined duration of all native module calls in the flushed call aggregate, in milliseconds. Only applies to React Native.
+
+    Type: float
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.duration.total, turbo_module.total_duration_ms
+    DEPRECATED: Use turbo_module.duration.total instead - Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix
+    Example: 128.45
+    """
+
+    # Path: model/attributes/turbo_modules/turbo_modules__total_error_count.json
+    TURBO_MODULES_TOTAL_ERROR_COUNT: Literal["turbo_modules.total_error_count"] = (
+        "turbo_modules.total_error_count"
+    )
+    """The number of failed native module calls in the flushed call aggregate. Only applies to React Native.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.error.count, turbo_module.total_error_count
+    DEPRECATED: Use turbo_module.error.count instead - Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix
+    Example: 2
+    """
+
+    # Path: model/attributes/turbo_modules/turbo_modules__unique_methods.json
+    TURBO_MODULES_UNIQUE_METHODS: Literal["turbo_modules.unique_methods"] = (
+        "turbo_modules.unique_methods"
+    )
+    """The number of distinct native module and method pairs in the flushed call aggregate. Only applies to React Native.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: turbo_module.call.distinct_count, turbo_module.unique_methods
+    DEPRECATED: Use turbo_module.call.distinct_count instead - Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix
+    Example: 7
     """
 
     # Path: model/attributes/type.json
@@ -21085,6 +21384,372 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.5.0", prs=[235]),
         ],
     ),
+    "turbo_module.arch": AttributeMetadata(
+        brief="The React Native architecture the call was observed on. `new` for a TurboModule resolved through `TurboModuleRegistry`, `legacy` for a module reached over the Old Architecture bridge. Only applies to React Native.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(
+            key=ApplyScrubbing.MANUAL,
+            reason="Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable",
+        ),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="new",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added turbo_module.arch attribute"
+            ),
+        ],
+    ),
+    "turbo_module.call.count": AttributeMetadata(
+        brief="The number of native module calls observed during the lifetime of the span. Only applies to React Native.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=42,
+        aliases=["turbo_module.total_call_count", "turbo_modules.total_call_count"],
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added turbo_module.call.count attribute"
+            ),
+        ],
+    ),
+    "turbo_module.call.distinct_count": AttributeMetadata(
+        brief="The number of distinct native module and method pairs called during the lifetime of the span. Useful as a cardinality signal when the per-method breakdown has been truncated. Only applies to React Native.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=7,
+        aliases=["turbo_module.unique_methods", "turbo_modules.unique_methods"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added turbo_module.call.distinct_count attribute",
+            ),
+        ],
+    ),
+    "turbo_module.duration.max": AttributeMetadata(
+        brief="The duration of the slowest single native module call observed during the lifetime of the span, in milliseconds. Only applies to React Native.",
+        type=AttributeType.DOUBLE,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=512.5,
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added turbo_module.duration.max attribute"
+            ),
+        ],
+    ),
+    "turbo_module.duration.total": AttributeMetadata(
+        brief="The combined wall-clock duration of all native module calls observed during the lifetime of the span, in milliseconds. Calls overlap, so this can exceed the span duration. Only applies to React Native.",
+        type=AttributeType.DOUBLE,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=128.45,
+        aliases=["turbo_module.total_duration_ms", "turbo_modules.total_duration_ms"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added turbo_module.duration.total attribute",
+            ),
+        ],
+    ),
+    "turbo_module.error.count": AttributeMetadata(
+        brief="The number of native module calls that failed during the lifetime of the span. A call counts as failed when it threw, rejected, or — on the Old Architecture bridge only — invoked its failure callback. Only applies to React Native.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=2,
+        aliases=["turbo_module.total_error_count", "turbo_modules.total_error_count"],
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added turbo_module.error.count attribute"
+            ),
+        ],
+    ),
+    "turbo_module.kind": AttributeMetadata(
+        brief="Whether the native module call completed synchronously or reported completion later through a Promise or a callback. One of `sync` or `async`. Only applies to React Native.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(
+            key=ApplyScrubbing.MANUAL,
+            reason="Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable",
+        ),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="async",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added turbo_module.kind attribute"
+            ),
+        ],
+    ),
+    "turbo_module.method": AttributeMetadata(
+        brief="The name of the native module method that was called. Only applies to React Native.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(
+            key=ApplyScrubbing.MANUAL,
+            reason="Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable",
+        ),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="getUniqueId",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added turbo_module.method attribute"
+            ),
+        ],
+    ),
+    "turbo_module.name": AttributeMetadata(
+        brief="The name of the native module the call was dispatched to. On the New Architecture this is the TurboModule name, on the Old Architecture the `NativeModules` key. Only applies to React Native.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(
+            key=ApplyScrubbing.MANUAL,
+            reason="Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable",
+        ),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="RNDeviceInfo",
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added turbo_module.name attribute"
+            ),
+        ],
+    ),
+    "turbo_module.top.duration": AttributeMetadata(
+        brief="The total duration attributed to `turbo_module.top.name`, in milliseconds. Only applies to React Native.",
+        type=AttributeType.DOUBLE,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=87.25,
+        aliases=["turbo_module.top_module_duration_ms"],
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added turbo_module.top.duration attribute"
+            ),
+        ],
+    ),
+    "turbo_module.top.name": AttributeMetadata(
+        brief="The native module and method that accounted for the most total duration during the lifetime of the span, formatted as `<module>.<method>`. Only applies to React Native.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(
+            key=ApplyScrubbing.MANUAL,
+            reason="Native module and method names are app-defined identifiers, but scrubbing them would make the call attribution unusable",
+        ),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="RNDeviceInfo.getUniqueId",
+        aliases=["turbo_module.top_module"],
+        changelog=[
+            ChangelogEntry(
+                version="next", description="Added turbo_module.top.name attribute"
+            ),
+        ],
+    ),
+    "turbo_module.top_module": AttributeMetadata(
+        brief="The native module and method that accounted for the most total duration during the lifetime of the span. Only applies to React Native.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="RNDeviceInfo.getUniqueId",
+        deprecation=DeprecationInfo(
+            replacement="turbo_module.top.name",
+            reason="Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["turbo_module.top.name"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added turbo_module.top_module and deprecated it in favor of turbo_module.top.name",
+            ),
+        ],
+    ),
+    "turbo_module.top_module_duration_ms": AttributeMetadata(
+        brief="The total duration attributed to the top native module method, in milliseconds. Only applies to React Native.",
+        type=AttributeType.DOUBLE,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=87.25,
+        deprecation=DeprecationInfo(
+            replacement="turbo_module.top.duration",
+            reason="Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["turbo_module.top.duration"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added turbo_module.top_module_duration_ms and deprecated it in favor of turbo_module.top.duration",
+            ),
+        ],
+    ),
+    "turbo_module.total_call_count": AttributeMetadata(
+        brief="The number of native module calls observed during the lifetime of the span. Only applies to React Native.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=42,
+        deprecation=DeprecationInfo(
+            replacement="turbo_module.call.count",
+            reason="Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["turbo_module.call.count", "turbo_modules.total_call_count"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added turbo_module.total_call_count and deprecated it in favor of turbo_module.call.count",
+            ),
+        ],
+    ),
+    "turbo_module.total_duration_ms": AttributeMetadata(
+        brief="The combined duration of all native module calls observed during the lifetime of the span, in milliseconds. Only applies to React Native.",
+        type=AttributeType.DOUBLE,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=128.45,
+        deprecation=DeprecationInfo(
+            replacement="turbo_module.duration.total",
+            reason="Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["turbo_module.duration.total", "turbo_modules.total_duration_ms"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added turbo_module.total_duration_ms and deprecated it in favor of turbo_module.duration.total",
+            ),
+        ],
+    ),
+    "turbo_module.total_error_count": AttributeMetadata(
+        brief="The number of native module calls that failed during the lifetime of the span. Only applies to React Native.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=2,
+        deprecation=DeprecationInfo(
+            replacement="turbo_module.error.count",
+            reason="Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["turbo_module.error.count", "turbo_modules.total_error_count"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added turbo_module.total_error_count and deprecated it in favor of turbo_module.error.count",
+            ),
+        ],
+    ),
+    "turbo_module.unique_methods": AttributeMetadata(
+        brief="The number of distinct native module and method pairs called during the lifetime of the span. Only applies to React Native.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=7,
+        deprecation=DeprecationInfo(
+            replacement="turbo_module.call.distinct_count",
+            reason="Replaced to consolidate the React Native TurboModule attributes under a single `turbo_module.*` namespace with dot-separated logical grouping",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["turbo_module.call.distinct_count", "turbo_modules.unique_methods"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added turbo_module.unique_methods and deprecated it in favor of turbo_module.call.distinct_count",
+            ),
+        ],
+    ),
+    "turbo_modules.total_call_count": AttributeMetadata(
+        brief="The number of native module calls in the flushed call aggregate. Only applies to React Native.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=42,
+        deprecation=DeprecationInfo(
+            replacement="turbo_module.call.count",
+            reason="Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["turbo_module.call.count", "turbo_module.total_call_count"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added turbo_modules.total_call_count and deprecated it in favor of turbo_module.call.count",
+            ),
+        ],
+    ),
+    "turbo_modules.total_duration_ms": AttributeMetadata(
+        brief="The combined duration of all native module calls in the flushed call aggregate, in milliseconds. Only applies to React Native.",
+        type=AttributeType.DOUBLE,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=128.45,
+        deprecation=DeprecationInfo(
+            replacement="turbo_module.duration.total",
+            reason="Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["turbo_module.duration.total", "turbo_module.total_duration_ms"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added turbo_modules.total_duration_ms and deprecated it in favor of turbo_module.duration.total",
+            ),
+        ],
+    ),
+    "turbo_modules.total_error_count": AttributeMetadata(
+        brief="The number of failed native module calls in the flushed call aggregate. Only applies to React Native.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=2,
+        deprecation=DeprecationInfo(
+            replacement="turbo_module.error.count",
+            reason="Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["turbo_module.error.count", "turbo_module.total_error_count"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added turbo_modules.total_error_count and deprecated it in favor of turbo_module.error.count",
+            ),
+        ],
+    ),
+    "turbo_modules.unique_methods": AttributeMetadata(
+        brief="The number of distinct native module and method pairs in the flushed call aggregate. Only applies to React Native.",
+        type=AttributeType.INTEGER,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=7,
+        deprecation=DeprecationInfo(
+            replacement="turbo_module.call.distinct_count",
+            reason="Replaced by the `turbo_module.*` namespace; the SDK emitted the same values under both a singular and a plural prefix",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["turbo_module.call.distinct_count", "turbo_module.unique_methods"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added turbo_modules.unique_methods and deprecated it in favor of turbo_module.call.distinct_count",
+            ),
+        ],
+    ),
     "type": AttributeMetadata(
         brief="More granular type of the operation happening.",
         type=AttributeType.STRING,
@@ -22694,6 +23359,27 @@ Attributes = TypedDict(
         "trpc.procedure_type": str,
         "ttfb.requestTime": float,
         "ttfb": float,
+        "turbo_module.arch": str,
+        "turbo_module.call.count": int,
+        "turbo_module.call.distinct_count": int,
+        "turbo_module.duration.max": float,
+        "turbo_module.duration.total": float,
+        "turbo_module.error.count": int,
+        "turbo_module.kind": str,
+        "turbo_module.method": str,
+        "turbo_module.name": str,
+        "turbo_module.top.duration": float,
+        "turbo_module.top.name": str,
+        "turbo_module.top_module": str,
+        "turbo_module.top_module_duration_ms": float,
+        "turbo_module.total_call_count": int,
+        "turbo_module.total_duration_ms": float,
+        "turbo_module.total_error_count": int,
+        "turbo_module.unique_methods": int,
+        "turbo_modules.total_call_count": int,
+        "turbo_modules.total_duration_ms": float,
+        "turbo_modules.total_error_count": int,
+        "turbo_modules.unique_methods": int,
         "type": str,
         "ui.component_name": str,
         "ui.contributes_to_ttfd": bool,

--- a/rust/src/op.rs
+++ b/rust/src/op.rs
@@ -275,6 +275,9 @@ pub const MOBILE_SERIALIZE_SPAN_OP: &str = "serialize";
 
 pub const MOBILE_HTTP_SPAN_OP: &str = "http";
 
+/// A call from JavaScript into a React Native native module, or an aggregate of such calls.
+pub const MOBILE_TURBO_MODULE_SPAN_OP: &str = "turbo_module";
+
 // Path: model/op/object.json
 // Name: object
 


### PR DESCRIPTION
## Description

Registers the attributes `sentry-react-native` emits for its TurboModule / native module call instrumentation, consolidated under a single `turbo_module.*` namespace. 21 attribute files — 11 canonical, 10 deprecated — plus `turbo_module` as a `mobile` span operation.

These attributes shipped before being registered here, which is backwards: they have been live since sentry-react-native 8.14.0 (`turbo_module.name` / `.method`), 8.19.0 (call aggregate) and 8.21.0 (span attribution). This PR is retroactive registration plus a cleanup of the naming that slipped through as a result. That is why 10 of the 21 files arrive already deprecated — they are the shipped names, registered so they can be aliased and backfilled rather than silently broken.

### Canonical

<!-- linear:table-colwidths:266,266,266 -->
| Key | Type | Purpose |
| -- | -- | -- |
| `turbo_module.name` | string | Native module name (TurboModule name, or `NativeModules` key on Old Arch) |
| `turbo_module.method` | string | Method name |
| `turbo_module.kind` | string | `sync` or `async` |
| `turbo_module.arch` | string | `new` or `legacy` |
| `turbo_module.call.count` | integer | Calls observed during the span |
| `turbo_module.call.distinct_count` | integer | Distinct (module, method) pairs |
| `turbo_module.error.count` | integer | Calls that failed |
| `turbo_module.duration.total` | double | Summed call duration, ms |
| `turbo_module.duration.max` | double | Slowest single call, ms |
| `turbo_module.top.name` | string | `<module>.<method>` with the highest total duration |
| `turbo_module.top.duration` | double | That total, ms |

`turbo_module.name`, `.method` and `.arch` keep their shipped names — they were already correct.

### Deprecated

All with `_status: "backfill"` and symmetric aliases.

<!-- linear:table-colwidths:400,400 -->
| Deprecated | Replacement |
| -- | -- |
| `turbo_module.total_call_count`, `turbo_modules.total_call_count` | `turbo_module.call.count` |
| `turbo_module.total_error_count`, `turbo_modules.total_error_count` | `turbo_module.error.count` |
| `turbo_module.total_duration_ms`, `turbo_modules.total_duration_ms` | `turbo_module.duration.total` |
| `turbo_module.unique_methods`, `turbo_modules.unique_methods` | `turbo_module.call.distinct_count` |
| `turbo_module.top_module` | `turbo_module.top.name` |
| `turbo_module.top_module_duration_ms` | `turbo_module.top.duration` |

Two problems fixed. The SDK emitted the same four totals as `turbo_module.*` on root spans and `turbo_modules.*` on the aggregate span — same semantics, two prefixes, which is half the deprecations. The rest drop `total_` prefixes and `_ms` suffixes in favour of dot-separated grouping, with the unit in the `brief` as `app.vitals.*` does.

### Keys removed rather than deprecated

The SDK also emits per-method breakdowns with the dynamic segment in the **middle** of the key, e.g. `turbo_module.<module>.<method>.call_count` and `turbo_modules.<module>.<method>.<kind>.count`. `has_dynamic_suffix` only models a dynamic **trailing** segment, so these are not expressible in the schema and no file is included for them; they cannot be formally deprecated.

The SDK will stop emitting them and carry the per-method breakdown as one child span per `(module, method)` using the static attributes above. That is why the identity attributes (`name`, `method`, `kind`, `arch`) are registered alongside the counters: on a per-method child span they are dimensions, not a key prefix.

### Not included

* The four `turbo_modules.*` transaction measurements. Every existing entry in `model/measurements/` is a flat unnamespaced key, and they duplicate numbers now available as span attributes, so the SDK will drop them instead.
* `native.turbo_module`, the slow-call breadcrumb category — breadcrumb categories are not modelled in this repo.
* The `event.kind: turbo_modules.aggregate` tag, an unnamespaced generic key being removed SDK-side.

The SDK-side rename is gated on this PR and tracked in getsentry/sentry-react-native#6168.

`changelog.prs` is unset on all 21 files pending this PR's number.

## PR Checklist

- [X] I have run `yarn test` and verified that the tests pass.
- [X] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [X] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [X] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [X] I've followed the policies described in [CONTRIBUTING.md](<https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md>)