### PR TITLE
feat(ops)!: Drop category prefix and `SPAN_OP` suffix from `op` constants

### DIFF
--- a/javascript/sentry-conventions/src/op.ts
+++ b/javascript/sentry-conventions/src/op.ts
@@ -6,246 +6,244 @@
 /**
  * A full page load of a web application.
  */
-export const BROWSER_PAGELOAD_SPAN_OP = 'pageload';
+export const PAGELOAD = 'pageload';
 
 /**
  * Client-side browser history change in a web application.
  */
-export const BROWSER_NAVIGATION_SPAN_OP = 'navigation';
+export const NAVIGATION = 'navigation';
 
 /**
  * A client-side automatic redirect navigation (e.g. from framework router redirects) triggerign a browser history change.
  */
-export const BROWSER_NAVIGATION_REDIRECT_SPAN_OP = 'navigation.redirect';
+export const NAVIGATION_REDIRECT = 'navigation.redirect';
 
 /**
  * Resource as per [Performance Resource Timing](https://w3c.github.io/resource-timing/#sec-performanceresourcetiming). Defaults to resource.other if resource cannot be indentified.
  */
-export const BROWSER_RESOURCE_SPAN_OP = 'resource';
+export const RESOURCE = 'resource';
 
-export const BROWSER_RESOURCE_SCRIPT_SPAN_OP = 'resource.script';
+export const RESOURCE_SCRIPT = 'resource.script';
 
-export const BROWSER_RESOURCE_LINK_SPAN_OP = 'resource.link';
+export const RESOURCE_LINK = 'resource.link';
 
-export const BROWSER_RESOURCE_IMG_SPAN_OP = 'resource.img';
+export const RESOURCE_IMG = 'resource.img';
 
-export const BROWSER_RESOURCE_CSS_SPAN_OP = 'resource.css';
+export const RESOURCE_CSS = 'resource.css';
 
-export const BROWSER_RESOURCE_AUDIO_SPAN_OP = 'resource.audio';
+export const RESOURCE_AUDIO = 'resource.audio';
 
-export const BROWSER_RESOURCE_VIDEO_SPAN_OP = 'resource.video';
+export const RESOURCE_VIDEO = 'resource.video';
 
-export const BROWSER_RESOURCE_IFRAME_SPAN_OP = 'resource.iframe';
+export const RESOURCE_IFRAME = 'resource.iframe';
 
-export const BROWSER_RESOURCE_OTHER_SPAN_OP = 'resource.other';
+export const RESOURCE_OTHER = 'resource.other';
 
 /**
  * Loading of a resource initiated by a worker (e.g. Web Worker or Service Worker).
  */
-export const BROWSER_RESOURCE_WORKER_SPAN_OP = 'resource.worker';
+export const RESOURCE_WORKER = 'resource.worker';
 
 /**
  * Loading of an icon resource.
  */
-export const BROWSER_RESOURCE_ICON_SPAN_OP = 'resource.icon';
+export const RESOURCE_ICON = 'resource.icon';
 
 /**
  * Loading of a resource initiated by a frame.
  */
-export const BROWSER_RESOURCE_FRAME_SPAN_OP = 'resource.frame';
+export const RESOURCE_FRAME = 'resource.frame';
 
 /**
  * Loading of a resource initiated by an `<object>` element.
  */
-export const BROWSER_RESOURCE_OBJECT_SPAN_OP = 'resource.object';
+export const RESOURCE_OBJECT = 'resource.object';
 
 /**
  * A hyperlink auditing ping request.
  */
-export const BROWSER_RESOURCE_PING_SPAN_OP = 'resource.ping';
+export const RESOURCE_PING = 'resource.ping';
 
 /**
  * Loading of a `<track>` element resource (e.g. subtitles or captions).
  */
-export const BROWSER_RESOURCE_TRACK_SPAN_OP = 'resource.track';
+export const RESOURCE_TRACK = 'resource.track';
 
 /**
  * Usage of browser APIs or functionality
  */
-export const BROWSER_BROWSER_SPAN_OP = 'browser';
+export const BROWSER = 'browser';
 
-export const BROWSER_BROWSER_PAINT_SPAN_OP = 'browser.paint';
+export const BROWSER_PAINT = 'browser.paint';
 
 /**
  * The unload event phase of a browser navigation.
  */
-export const BROWSER_BROWSER_UNLOAD_EVENT_SPAN_OP = 'browser.unload_event';
+export const BROWSER_UNLOAD_EVENT = 'browser.unload_event';
 
 /**
  * The redirect phase of a browser navigation.
  */
-export const BROWSER_BROWSER_REDIRECT_SPAN_OP = 'browser.redirect';
+export const BROWSER_REDIRECT = 'browser.redirect';
 
 /**
  * The DOMContentLoaded event phase of a browser navigation.
  */
-export const BROWSER_BROWSER_DOM_CONTENT_LOADED_EVENT_SPAN_OP = 'browser.dom_content_loaded_event';
+export const BROWSER_DOM_CONTENT_LOADED_EVENT = 'browser.dom_content_loaded_event';
 
 /**
  * The load event phase of a browser navigation.
  */
-export const BROWSER_BROWSER_LOAD_EVENT_SPAN_OP = 'browser.load_event';
+export const BROWSER_LOAD_EVENT = 'browser.load_event';
 
 /**
  * The connection phase of a browser navigation.
  */
-export const BROWSER_BROWSER_CONNECT_SPAN_OP = 'browser.connect';
+export const BROWSER_CONNECT = 'browser.connect';
 
 /**
  * The secure connection (TLS/SSL) phase of a browser navigation.
  */
-export const BROWSER_BROWSER_TLS_SSL_SPAN_OP = 'browser.tls_ssl';
+export const BROWSER_TLS_SSL = 'browser.tls_ssl';
 
 /**
  * The cache lookup / fetch start phase of a browser navigation.
  */
-export const BROWSER_BROWSER_CACHE_SPAN_OP = 'browser.cache';
+export const BROWSER_CACHE = 'browser.cache';
 
 /**
  * The DNS domain lookup phase of a browser navigation.
  */
-export const BROWSER_BROWSER_DNS_SPAN_OP = 'browser.dns';
+export const BROWSER_DNS = 'browser.dns';
 
 /**
  * The request phase of a browser navigation.
  */
-export const BROWSER_BROWSER_REQUEST_SPAN_OP = 'browser.request';
+export const BROWSER_REQUEST = 'browser.request';
 
 /**
  * The response phase of a browser navigation.
  */
-export const BROWSER_BROWSER_RESPONSE_SPAN_OP = 'browser.response';
+export const BROWSER_RESPONSE = 'browser.response';
 
 /**
  * Operations related to browser UI
  */
-export const BROWSER_UI_SPAN_OP = 'ui';
+export const UI = 'ui';
 
 /**
  * A task that is taken on the main UI thread. Typically used to indicate to users about things like the [Long Tasks API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming).
  */
-export const BROWSER_UI_TASK_SPAN_OP = 'ui.task';
+export const UI_TASK = 'ui.task';
 
-export const BROWSER_UI_RENDER_SPAN_OP = 'ui.render';
+export const UI_RENDER = 'ui.render';
 
 /**
  * Mounting of a UI component or application (e.g. initial render/bootstrap).
  */
-export const BROWSER_UI_MOUNT_SPAN_OP = 'ui.mount';
+export const UI_MOUNT = 'ui.mount';
 
 /**
  * Updating of an already-mounted UI component.
  */
-export const BROWSER_UI_UPDATE_SPAN_OP = 'ui.update';
+export const UI_UPDATE = 'ui.update';
 
 /**
  * Unmounting/teardown of a UI component.
  */
-export const BROWSER_UI_UNMOUNT_SPAN_OP = 'ui.unmount';
+export const UI_UNMOUNT = 'ui.unmount';
 
 /**
  * A long task on the main UI thread, as reported by the Long Tasks API.
  */
-export const BROWSER_UI_LONG_TASK_SPAN_OP = 'ui.long_task';
+export const UI_LONG_TASK = 'ui.long_task';
 
 /**
  * A long animation frame, as reported by the Long Animation Frames API.
  */
-export const BROWSER_UI_LONG_ANIMATION_FRAME_SPAN_OP = 'ui.long_animation_frame';
+export const UI_LONG_ANIMATION_FRAME = 'ui.long_animation_frame';
 
 /**
  * A click interaction measured via Interaction to Next Paint (INP).
  */
-export const BROWSER_UI_INTERACTION_CLICK_SPAN_OP = 'ui.interaction.click';
+export const UI_INTERACTION_CLICK = 'ui.interaction.click';
 
 /**
  * A hover interaction measured via Interaction to Next Paint (INP).
  */
-export const BROWSER_UI_INTERACTION_HOVER_SPAN_OP = 'ui.interaction.hover';
+export const UI_INTERACTION_HOVER = 'ui.interaction.hover';
 
 /**
  * A drag interaction measured via Interaction to Next Paint (INP).
  */
-export const BROWSER_UI_INTERACTION_DRAG_SPAN_OP = 'ui.interaction.drag';
+export const UI_INTERACTION_DRAG = 'ui.interaction.drag';
 
 /**
  * A key press interaction measured via Interaction to Next Paint (INP).
  */
-export const BROWSER_UI_INTERACTION_PRESS_SPAN_OP = 'ui.interaction.press';
+export const UI_INTERACTION_PRESS = 'ui.interaction.press';
 
 /**
  * A Largest Contentful Paint (LCP) web vital measurement.
  */
-export const BROWSER_UI_WEBVITAL_LCP_SPAN_OP = 'ui.webvital.lcp';
+export const UI_WEBVITAL_LCP = 'ui.webvital.lcp';
 
 /**
  * A Cumulative Layout Shift (CLS) web vital measurement.
  */
-export const BROWSER_UI_WEBVITAL_CLS_SPAN_OP = 'ui.webvital.cls';
+export const UI_WEBVITAL_CLS = 'ui.webvital.cls';
 
-export const BROWSER_UI_ACTION_SPAN_OP = 'ui.action';
+export const UI_ACTION = 'ui.action';
 
-export const BROWSER_UI_ACTION_CLICK_SPAN_OP = 'ui.action.click';
+export const UI_ACTION_CLICK = 'ui.action.click';
 
-export const BROWSER_UI_REACT_SPAN_OP = 'ui.react';
+export const UI_REACT = 'ui.react';
 
-export const BROWSER_UI_REACT_MOUNT_SPAN_OP = 'ui.react.mount';
+export const UI_REACT_MOUNT = 'ui.react.mount';
 
-export const BROWSER_UI_REACT_RENDER_SPAN_OP = 'ui.react.render';
+export const UI_REACT_RENDER = 'ui.react.render';
 
-export const BROWSER_UI_REACT_UPDATE_SPAN_OP = 'ui.react.update';
+export const UI_REACT_UPDATE = 'ui.react.update';
 
-export const BROWSER_UI_VUE_SPAN_OP = 'ui.vue';
+export const UI_VUE = 'ui.vue';
 
-export const BROWSER_UI_SVELTE_SPAN_OP = 'ui.svelte';
+export const UI_SVELTE = 'ui.svelte';
 
-export const BROWSER_UI_ANGULAR_SPAN_OP = 'ui.angular';
+export const UI_ANGULAR = 'ui.angular';
 
-export const BROWSER_UI_EMBER_SPAN_OP = 'ui.ember';
+export const UI_EMBER = 'ui.ember';
 
-export const BROWSER_UI_LIVEWIRE_SPAN_OP = 'ui.livewire';
+export const UI_LIVEWIRE = 'ui.livewire';
 
 // Path: model/op/database.json
 // Name: database
 
 // Description: Database related spans are expected to follow OpenTelemetry's Database semantic conventions when possible.
 
-export const DATABASE_DB_SPAN_OP = 'db';
+export const DB = 'db';
 
-export const DATABASE_DB_QUERY_SPAN_OP = 'db.query';
+export const DB_QUERY = 'db.query';
 
-export const DATABASE_CACHE_SPAN_OP = 'cache';
+export const CACHE = 'cache';
 
-export const DATABASE_CACHE_GET_SPAN_OP = 'cache.get';
+export const CACHE_GET = 'cache.get';
 
-export const DATABASE_CACHE_PUT_SPAN_OP = 'cache.put';
+export const CACHE_PUT = 'cache.put';
 
-export const DATABASE_CACHE_REMOVE_SPAN_OP = 'cache.remove';
+export const CACHE_REMOVE = 'cache.remove';
 
 // Path: model/op/faas.json
 // Name: faas
 
 // Description: Serverless (FAAS)
 
-export const FAAS_HTTP_SPAN_OP = 'http';
+export const GRPC = 'grpc';
 
-export const FAAS_GRPC_SPAN_OP = 'grpc';
+export const FUNCTION_GCP = 'function.gcp';
 
-export const FAAS_FUNCTION_GCP_SPAN_OP = 'function.gcp';
+export const FUNCTION_AWS = 'function.aws';
 
-export const FAAS_FUNCTION_AWS_SPAN_OP = 'function.aws';
-
-export const FAAS_FUNCTION_AZURE_SPAN_OP = 'function.azure';
+export const FUNCTION_AZURE = 'function.azure';
 
 // Path: model/op/gen_ai.json
 // Name: gen_ai
@@ -255,37 +253,37 @@ export const FAAS_FUNCTION_AZURE_SPAN_OP = 'function.azure';
 /**
  * A chat interaction with a generative AI model
  */
-export const GEN_AI_GEN_AI_CHAT_SPAN_OP = 'gen_ai.chat';
+export const GEN_AI_CHAT = 'gen_ai.chat';
 
 /**
  * Execution of a tool or function by a generative AI model
  */
-export const GEN_AI_GEN_AI_EXECUTE_TOOL_SPAN_OP = 'gen_ai.execute_tool';
+export const GEN_AI_EXECUTE_TOOL = 'gen_ai.execute_tool';
 
 /**
  * Handoff of control between different AI agents or components
  */
-export const GEN_AI_GEN_AI_HANDOFF_SPAN_OP = 'gen_ai.handoff';
+export const GEN_AI_HANDOFF = 'gen_ai.handoff';
 
 /**
  * Invocation of an AI agent to perform a task
  */
-export const GEN_AI_GEN_AI_INVOKE_AGENT_SPAN_OP = 'gen_ai.invoke_agent';
+export const GEN_AI_INVOKE_AGENT = 'gen_ai.invoke_agent';
 
 /**
  * Generation of embeddings by a generative AI model
  */
-export const GEN_AI_GEN_AI_EMBEDDINGS_SPAN_OP = 'gen_ai.embeddings';
+export const GEN_AI_EMBEDDINGS = 'gen_ai.embeddings';
 
 /**
  * Content generation by a generative AI model
  */
-export const GEN_AI_GEN_AI_GENERATE_CONTENT_SPAN_OP = 'gen_ai.generate_content';
+export const GEN_AI_GENERATE_CONTENT = 'gen_ai.generate_content';
 
 /**
  * Reranking of documents or results by a generative AI model
  */
-export const GEN_AI_GEN_AI_RERANK_SPAN_OP = 'gen_ai.rerank';
+export const GEN_AI_RERANK = 'gen_ai.rerank';
 
 // Path: model/op/general.json
 // Name: general
@@ -293,17 +291,17 @@ export const GEN_AI_GEN_AI_RERANK_SPAN_OP = 'gen_ai.rerank';
 /**
  * A general point-in-time span indicating an event
  */
-export const GENERAL_MARK_SPAN_OP = 'mark';
+export const MARK = 'mark';
 
 /**
  * The time it took for a set of instructions to execute
  */
-export const GENERAL_FUNCTION_SPAN_OP = 'function';
+export const FUNCTION = 'function';
 
 /**
  * A user-defined measurement of the duration between two points in time
  */
-export const GENERAL_MEASURE_SPAN_OP = 'measure';
+export const MEASURE = 'measure';
 
 // Path: model/op/messaging.json
 // Name: messaging
@@ -313,87 +311,81 @@ export const GENERAL_MEASURE_SPAN_OP = 'measure';
 /**
  * A general queue operation.
  */
-export const MESSAGING_QUEUE_SPAN_OP = 'queue';
+export const QUEUE = 'queue';
 
 /**
  * Publishing a message to a queue.
  */
-export const MESSAGING_QUEUE_PUBLISH_SPAN_OP = 'queue.publish';
+export const QUEUE_PUBLISH = 'queue.publish';
 
 /**
  * Creating a queue or a message for later publishing.
  */
-export const MESSAGING_QUEUE_CREATE_SPAN_OP = 'queue.create';
+export const QUEUE_CREATE = 'queue.create';
 
 /**
  * Receiving a message from a queue.
  */
-export const MESSAGING_QUEUE_RECEIVE_SPAN_OP = 'queue.receive';
+export const QUEUE_RECEIVE = 'queue.receive';
 
 /**
  * Processing a message from a queue.
  */
-export const MESSAGING_QUEUE_PROCESS_SPAN_OP = 'queue.process';
+export const QUEUE_PROCESS = 'queue.process';
 
 /**
  * Settling a message, e.g. acknowledging or rejecting it.
  */
-export const MESSAGING_QUEUE_SETTLE_SPAN_OP = 'queue.settle';
+export const QUEUE_SETTLE = 'queue.settle';
 
 /**
  * Publishing a message to an arq queue.
  */
-export const MESSAGING_QUEUE_SUBMIT_ARQ_SPAN_OP = 'queue.submit.arq';
+export const QUEUE_SUBMIT_ARQ = 'queue.submit.arq';
 
 /**
  * Processing a message from an arq queue.
  */
-export const MESSAGING_QUEUE_TASK_ARQ_SPAN_OP = 'queue.task.arq';
+export const QUEUE_TASK_ARQ = 'queue.task.arq';
 
 /**
  * Publishing a message to a Celery broker.
  */
-export const MESSAGING_QUEUE_SUBMIT_CELERY_SPAN_OP = 'queue.submit.celery';
+export const QUEUE_SUBMIT_CELERY = 'queue.submit.celery';
 
 /**
  * Processing a message from a Celery queue.
  */
-export const MESSAGING_QUEUE_TASK_CELERY_SPAN_OP = 'queue.task.celery';
+export const QUEUE_TASK_CELERY = 'queue.task.celery';
 
 /**
  * Processing a message from a Dramatiq queue.
  */
-export const MESSAGING_QUEUE_TASK_DRAMATIQ_SPAN_OP = 'queue.task.dramatiq';
+export const QUEUE_TASK_DRAMATIQ = 'queue.task.dramatiq';
 
 /**
  * Publishing a message to a Huey instance.
  */
-export const MESSAGING_QUEUE_SUBMIT_HUEY_SPAN_OP = 'queue.submit.huey';
+export const QUEUE_SUBMIT_HUEY = 'queue.submit.huey';
 
 /**
  * Processing a message from a Huey instance.
  */
-export const MESSAGING_QUEUE_TASK_HUEY_SPAN_OP = 'queue.task.huey';
+export const QUEUE_TASK_HUEY = 'queue.task.huey';
 
 /**
  * Processing a message from an RQ queue.
  */
-export const MESSAGING_QUEUE_TASK_RQ_SPAN_OP = 'queue.task.rq';
+export const QUEUE_TASK_RQ = 'queue.task.rq';
 
 // Path: model/op/mobile.json
 // Name: mobile
 
-export const MOBILE_APP_SPAN_OP = 'app';
+export const APP = 'app';
 
-export const MOBILE_UI_SPAN_OP = 'ui';
+export const FILE = 'file';
 
-export const MOBILE_NAVIGATION_SPAN_OP = 'navigation';
-
-export const MOBILE_FILE_SPAN_OP = 'file';
-
-export const MOBILE_SERIALIZE_SPAN_OP = 'serialize';
-
-export const MOBILE_HTTP_SPAN_OP = 'http';
+export const SERIALIZE = 'serialize';
 
 // Path: model/op/object.json
 // Name: object
@@ -403,47 +395,47 @@ export const MOBILE_HTTP_SPAN_OP = 'http';
 /**
  * Retrieving an object from an object store.
  */
-export const OBJECT_OBJECT_GET_SPAN_OP = 'object.get';
+export const OBJECT_GET = 'object.get';
 
 /**
  * Retrieving the metadata of an object from an object store.
  */
-export const OBJECT_OBJECT_HEAD_SPAN_OP = 'object.head';
+export const OBJECT_HEAD = 'object.head';
 
 /**
  * Storing an object in an object store.
  */
-export const OBJECT_OBJECT_PUT_SPAN_OP = 'object.put';
+export const OBJECT_PUT = 'object.put';
 
 /**
  * Deleting an object from an object store.
  */
-export const OBJECT_OBJECT_DELETE_SPAN_OP = 'object.delete';
+export const OBJECT_DELETE = 'object.delete';
 
 /**
  * Listing objects in an object store.
  */
-export const OBJECT_OBJECT_LIST_SPAN_OP = 'object.list';
+export const OBJECT_LIST = 'object.list';
 
 /**
  * Uploading a single part of a multipart upload to an object store.
  */
-export const OBJECT_OBJECT_UPLOAD_PART_SPAN_OP = 'object.upload_part';
+export const OBJECT_UPLOAD_PART = 'object.upload_part';
 
 /**
  * Aborting a multipart upload to an object store.
  */
-export const OBJECT_OBJECT_MULTIPART_UPLOAD_ABORT_SPAN_OP = 'object.multipart_upload.abort';
+export const OBJECT_MULTIPART_UPLOAD_ABORT = 'object.multipart_upload.abort';
 
 /**
  * Creating a multipart upload to an object store.
  */
-export const OBJECT_OBJECT_MULTIPART_UPLOAD_CREATE_SPAN_OP = 'object.multipart_upload.create';
+export const OBJECT_MULTIPART_UPLOAD_CREATE = 'object.multipart_upload.create';
 
 /**
  * Completing a multipart upload to an object store.
  */
-export const OBJECT_OBJECT_MULTIPART_UPLOAD_COMPLETE_SPAN_OP = 'object.multipart_upload.complete';
+export const OBJECT_MULTIPART_UPLOAD_COMPLETE = 'object.multipart_upload.complete';
 
 // Path: model/op/routing.json
 // Name: routing
@@ -453,7 +445,7 @@ export const OBJECT_OBJECT_MULTIPART_UPLOAD_COMPLETE_SPAN_OP = 'object.multipart
 /**
  * A framework-neutral operation for work performed by an application router.
  */
-export const ROUTING_ROUTER_SPAN_OP = 'router';
+export const ROUTER = 'router';
 
 // Path: model/op/web_server.json
 // Name: web_server
@@ -461,48 +453,38 @@ export const ROUTING_ROUTER_SPAN_OP = 'router';
 /**
  * A general point-in-time span indicating an event
  */
-export const WEB_SERVER_HTTP_SPAN_OP = 'http';
+export const HTTP = 'http';
 
-export const WEB_SERVER_HTTP_CLIENT_SPAN_OP = 'http.client';
+export const HTTP_CLIENT = 'http.client';
 
 /**
  * Consumption of a streaming HTTP client response body
  */
-export const WEB_SERVER_HTTP_CLIENT_STREAM_SPAN_OP = 'http.client.stream';
+export const HTTP_CLIENT_STREAM = 'http.client.stream';
 
-export const WEB_SERVER_HTTP_SERVER_SPAN_OP = 'http.server';
+export const HTTP_SERVER = 'http.server';
 
-export const WEB_SERVER_WEBSOCKET_SPAN_OP = 'websocket';
+export const WEBSOCKET = 'websocket';
 
-export const WEB_SERVER_RPC_SPAN_OP = 'rpc';
+export const RPC = 'rpc';
 
-export const WEB_SERVER_GRPC_SPAN_OP = 'grpc';
+export const GRAPHQL = 'graphql';
 
-export const WEB_SERVER_GRAPHQL_SPAN_OP = 'graphql';
+export const SUBPROCESS = 'subprocess';
 
-export const WEB_SERVER_SUBPROCESS_SPAN_OP = 'subprocess';
-
-export const WEB_SERVER_MIDDLEWARE_SPAN_OP = 'middleware';
+export const MIDDLEWARE = 'middleware';
 
 /**
  * Handling of an incoming request by a web server route handler
  */
-export const WEB_SERVER_HANDLER_SPAN_OP = 'handler';
+export const HANDLER = 'handler';
 
-export const WEB_SERVER_VIEW_SPAN_OP = 'view';
+export const VIEW = 'view';
 
-export const WEB_SERVER_TEMPLATE_SPAN_OP = 'template';
+export const TEMPLATE = 'template';
 
-export const WEB_SERVER_FUNCTION_SPAN_OP = 'function';
+export const FUNCTION_REMIX = 'function.remix';
 
-export const WEB_SERVER_FUNCTION_REMIX_SPAN_OP = 'function.remix';
+export const FUNCTION_NEXTJS = 'function.nextjs';
 
-export const WEB_SERVER_FUNCTION_NEXTJS_SPAN_OP = 'function.nextjs';
-
-export const WEB_SERVER_SERIALIZE_SPAN_OP = 'serialize';
-
-export const WEB_SERVER_CONSOLE_SPAN_OP = 'console';
-
-export const WEB_SERVER_FILE_SPAN_OP = 'file';
-
-export const WEB_SERVER_APP_SPAN_OP = 'app';
+export const CONSOLE = 'console';

--- a/rust/src/op.rs
+++ b/rust/src/op.rs
@@ -4,357 +4,339 @@
 // Name: browser
 
 /// A full page load of a web application.
-pub const BROWSER_PAGELOAD_SPAN_OP: &str = "pageload";
+pub const PAGELOAD: &str = "pageload";
 
 /// Client-side browser history change in a web application.
-pub const BROWSER_NAVIGATION_SPAN_OP: &str = "navigation";
+pub const NAVIGATION: &str = "navigation";
 
 /// A client-side automatic redirect navigation (e.g. from framework router redirects) triggerign a browser history change.
-pub const BROWSER_NAVIGATION_REDIRECT_SPAN_OP: &str = "navigation.redirect";
+pub const NAVIGATION_REDIRECT: &str = "navigation.redirect";
 
 /// Resource as per [Performance Resource Timing](https://w3c.github.io/resource-timing/#sec-performanceresourcetiming). Defaults to resource.other if resource cannot be indentified.
-pub const BROWSER_RESOURCE_SPAN_OP: &str = "resource";
+pub const RESOURCE: &str = "resource";
 
-pub const BROWSER_RESOURCE_SCRIPT_SPAN_OP: &str = "resource.script";
+pub const RESOURCE_SCRIPT: &str = "resource.script";
 
-pub const BROWSER_RESOURCE_LINK_SPAN_OP: &str = "resource.link";
+pub const RESOURCE_LINK: &str = "resource.link";
 
-pub const BROWSER_RESOURCE_IMG_SPAN_OP: &str = "resource.img";
+pub const RESOURCE_IMG: &str = "resource.img";
 
-pub const BROWSER_RESOURCE_CSS_SPAN_OP: &str = "resource.css";
+pub const RESOURCE_CSS: &str = "resource.css";
 
-pub const BROWSER_RESOURCE_AUDIO_SPAN_OP: &str = "resource.audio";
+pub const RESOURCE_AUDIO: &str = "resource.audio";
 
-pub const BROWSER_RESOURCE_VIDEO_SPAN_OP: &str = "resource.video";
+pub const RESOURCE_VIDEO: &str = "resource.video";
 
-pub const BROWSER_RESOURCE_IFRAME_SPAN_OP: &str = "resource.iframe";
+pub const RESOURCE_IFRAME: &str = "resource.iframe";
 
-pub const BROWSER_RESOURCE_OTHER_SPAN_OP: &str = "resource.other";
+pub const RESOURCE_OTHER: &str = "resource.other";
 
 /// Loading of a resource initiated by a worker (e.g. Web Worker or Service Worker).
-pub const BROWSER_RESOURCE_WORKER_SPAN_OP: &str = "resource.worker";
+pub const RESOURCE_WORKER: &str = "resource.worker";
 
 /// Loading of an icon resource.
-pub const BROWSER_RESOURCE_ICON_SPAN_OP: &str = "resource.icon";
+pub const RESOURCE_ICON: &str = "resource.icon";
 
 /// Loading of a resource initiated by a frame.
-pub const BROWSER_RESOURCE_FRAME_SPAN_OP: &str = "resource.frame";
+pub const RESOURCE_FRAME: &str = "resource.frame";
 
 /// Loading of a resource initiated by an `<object>` element.
-pub const BROWSER_RESOURCE_OBJECT_SPAN_OP: &str = "resource.object";
+pub const RESOURCE_OBJECT: &str = "resource.object";
 
 /// A hyperlink auditing ping request.
-pub const BROWSER_RESOURCE_PING_SPAN_OP: &str = "resource.ping";
+pub const RESOURCE_PING: &str = "resource.ping";
 
 /// Loading of a `<track>` element resource (e.g. subtitles or captions).
-pub const BROWSER_RESOURCE_TRACK_SPAN_OP: &str = "resource.track";
+pub const RESOURCE_TRACK: &str = "resource.track";
 
 /// Usage of browser APIs or functionality
-pub const BROWSER_BROWSER_SPAN_OP: &str = "browser";
+pub const BROWSER: &str = "browser";
 
-pub const BROWSER_BROWSER_PAINT_SPAN_OP: &str = "browser.paint";
+pub const BROWSER_PAINT: &str = "browser.paint";
 
 /// The unload event phase of a browser navigation.
-pub const BROWSER_BROWSER_UNLOAD_EVENT_SPAN_OP: &str = "browser.unload_event";
+pub const BROWSER_UNLOAD_EVENT: &str = "browser.unload_event";
 
 /// The redirect phase of a browser navigation.
-pub const BROWSER_BROWSER_REDIRECT_SPAN_OP: &str = "browser.redirect";
+pub const BROWSER_REDIRECT: &str = "browser.redirect";
 
 /// The DOMContentLoaded event phase of a browser navigation.
-pub const BROWSER_BROWSER_DOM_CONTENT_LOADED_EVENT_SPAN_OP: &str = "browser.dom_content_loaded_event";
+pub const BROWSER_DOM_CONTENT_LOADED_EVENT: &str = "browser.dom_content_loaded_event";
 
 /// The load event phase of a browser navigation.
-pub const BROWSER_BROWSER_LOAD_EVENT_SPAN_OP: &str = "browser.load_event";
+pub const BROWSER_LOAD_EVENT: &str = "browser.load_event";
 
 /// The connection phase of a browser navigation.
-pub const BROWSER_BROWSER_CONNECT_SPAN_OP: &str = "browser.connect";
+pub const BROWSER_CONNECT: &str = "browser.connect";
 
 /// The secure connection (TLS/SSL) phase of a browser navigation.
-pub const BROWSER_BROWSER_TLS_SSL_SPAN_OP: &str = "browser.tls_ssl";
+pub const BROWSER_TLS_SSL: &str = "browser.tls_ssl";
 
 /// The cache lookup / fetch start phase of a browser navigation.
-pub const BROWSER_BROWSER_CACHE_SPAN_OP: &str = "browser.cache";
+pub const BROWSER_CACHE: &str = "browser.cache";
 
 /// The DNS domain lookup phase of a browser navigation.
-pub const BROWSER_BROWSER_DNS_SPAN_OP: &str = "browser.dns";
+pub const BROWSER_DNS: &str = "browser.dns";
 
 /// The request phase of a browser navigation.
-pub const BROWSER_BROWSER_REQUEST_SPAN_OP: &str = "browser.request";
+pub const BROWSER_REQUEST: &str = "browser.request";
 
 /// The response phase of a browser navigation.
-pub const BROWSER_BROWSER_RESPONSE_SPAN_OP: &str = "browser.response";
+pub const BROWSER_RESPONSE: &str = "browser.response";
 
 /// Operations related to browser UI
-pub const BROWSER_UI_SPAN_OP: &str = "ui";
+pub const UI: &str = "ui";
 
 /// A task that is taken on the main UI thread. Typically used to indicate to users about things like the [Long Tasks API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming).
-pub const BROWSER_UI_TASK_SPAN_OP: &str = "ui.task";
+pub const UI_TASK: &str = "ui.task";
 
-pub const BROWSER_UI_RENDER_SPAN_OP: &str = "ui.render";
+pub const UI_RENDER: &str = "ui.render";
 
 /// Mounting of a UI component or application (e.g. initial render/bootstrap).
-pub const BROWSER_UI_MOUNT_SPAN_OP: &str = "ui.mount";
+pub const UI_MOUNT: &str = "ui.mount";
 
 /// Updating of an already-mounted UI component.
-pub const BROWSER_UI_UPDATE_SPAN_OP: &str = "ui.update";
+pub const UI_UPDATE: &str = "ui.update";
 
 /// Unmounting/teardown of a UI component.
-pub const BROWSER_UI_UNMOUNT_SPAN_OP: &str = "ui.unmount";
+pub const UI_UNMOUNT: &str = "ui.unmount";
 
 /// A long task on the main UI thread, as reported by the Long Tasks API.
-pub const BROWSER_UI_LONG_TASK_SPAN_OP: &str = "ui.long_task";
+pub const UI_LONG_TASK: &str = "ui.long_task";
 
 /// A long animation frame, as reported by the Long Animation Frames API.
-pub const BROWSER_UI_LONG_ANIMATION_FRAME_SPAN_OP: &str = "ui.long_animation_frame";
+pub const UI_LONG_ANIMATION_FRAME: &str = "ui.long_animation_frame";
 
 /// A click interaction measured via Interaction to Next Paint (INP).
-pub const BROWSER_UI_INTERACTION_CLICK_SPAN_OP: &str = "ui.interaction.click";
+pub const UI_INTERACTION_CLICK: &str = "ui.interaction.click";
 
 /// A hover interaction measured via Interaction to Next Paint (INP).
-pub const BROWSER_UI_INTERACTION_HOVER_SPAN_OP: &str = "ui.interaction.hover";
+pub const UI_INTERACTION_HOVER: &str = "ui.interaction.hover";
 
 /// A drag interaction measured via Interaction to Next Paint (INP).
-pub const BROWSER_UI_INTERACTION_DRAG_SPAN_OP: &str = "ui.interaction.drag";
+pub const UI_INTERACTION_DRAG: &str = "ui.interaction.drag";
 
 /// A key press interaction measured via Interaction to Next Paint (INP).
-pub const BROWSER_UI_INTERACTION_PRESS_SPAN_OP: &str = "ui.interaction.press";
+pub const UI_INTERACTION_PRESS: &str = "ui.interaction.press";
 
 /// A Largest Contentful Paint (LCP) web vital measurement.
-pub const BROWSER_UI_WEBVITAL_LCP_SPAN_OP: &str = "ui.webvital.lcp";
+pub const UI_WEBVITAL_LCP: &str = "ui.webvital.lcp";
 
 /// A Cumulative Layout Shift (CLS) web vital measurement.
-pub const BROWSER_UI_WEBVITAL_CLS_SPAN_OP: &str = "ui.webvital.cls";
+pub const UI_WEBVITAL_CLS: &str = "ui.webvital.cls";
 
-pub const BROWSER_UI_ACTION_SPAN_OP: &str = "ui.action";
+pub const UI_ACTION: &str = "ui.action";
 
-pub const BROWSER_UI_ACTION_CLICK_SPAN_OP: &str = "ui.action.click";
+pub const UI_ACTION_CLICK: &str = "ui.action.click";
 
-pub const BROWSER_UI_REACT_SPAN_OP: &str = "ui.react";
+pub const UI_REACT: &str = "ui.react";
 
-pub const BROWSER_UI_REACT_MOUNT_SPAN_OP: &str = "ui.react.mount";
+pub const UI_REACT_MOUNT: &str = "ui.react.mount";
 
-pub const BROWSER_UI_REACT_RENDER_SPAN_OP: &str = "ui.react.render";
+pub const UI_REACT_RENDER: &str = "ui.react.render";
 
-pub const BROWSER_UI_REACT_UPDATE_SPAN_OP: &str = "ui.react.update";
+pub const UI_REACT_UPDATE: &str = "ui.react.update";
 
-pub const BROWSER_UI_VUE_SPAN_OP: &str = "ui.vue";
+pub const UI_VUE: &str = "ui.vue";
 
-pub const BROWSER_UI_SVELTE_SPAN_OP: &str = "ui.svelte";
+pub const UI_SVELTE: &str = "ui.svelte";
 
-pub const BROWSER_UI_ANGULAR_SPAN_OP: &str = "ui.angular";
+pub const UI_ANGULAR: &str = "ui.angular";
 
-pub const BROWSER_UI_EMBER_SPAN_OP: &str = "ui.ember";
+pub const UI_EMBER: &str = "ui.ember";
 
-pub const BROWSER_UI_LIVEWIRE_SPAN_OP: &str = "ui.livewire";
+pub const UI_LIVEWIRE: &str = "ui.livewire";
 
 // Path: model/op/database.json
 // Name: database
 
 // Description: Database related spans are expected to follow OpenTelemetry's Database semantic conventions when possible.
-pub const DATABASE_DB_SPAN_OP: &str = "db";
+pub const DB: &str = "db";
 
-pub const DATABASE_DB_QUERY_SPAN_OP: &str = "db.query";
+pub const DB_QUERY: &str = "db.query";
 
-pub const DATABASE_CACHE_SPAN_OP: &str = "cache";
+pub const CACHE: &str = "cache";
 
-pub const DATABASE_CACHE_GET_SPAN_OP: &str = "cache.get";
+pub const CACHE_GET: &str = "cache.get";
 
-pub const DATABASE_CACHE_PUT_SPAN_OP: &str = "cache.put";
+pub const CACHE_PUT: &str = "cache.put";
 
-pub const DATABASE_CACHE_REMOVE_SPAN_OP: &str = "cache.remove";
+pub const CACHE_REMOVE: &str = "cache.remove";
 
 // Path: model/op/faas.json
 // Name: faas
 
 // Description: Serverless (FAAS)
-pub const FAAS_HTTP_SPAN_OP: &str = "http";
+pub const GRPC: &str = "grpc";
 
-pub const FAAS_GRPC_SPAN_OP: &str = "grpc";
+pub const FUNCTION_GCP: &str = "function.gcp";
 
-pub const FAAS_FUNCTION_GCP_SPAN_OP: &str = "function.gcp";
+pub const FUNCTION_AWS: &str = "function.aws";
 
-pub const FAAS_FUNCTION_AWS_SPAN_OP: &str = "function.aws";
-
-pub const FAAS_FUNCTION_AZURE_SPAN_OP: &str = "function.azure";
+pub const FUNCTION_AZURE: &str = "function.azure";
 
 // Path: model/op/gen_ai.json
 // Name: gen_ai
 
 // Description: Operations related to Generative AI interactions
 /// A chat interaction with a generative AI model
-pub const GEN_AI_GEN_AI_CHAT_SPAN_OP: &str = "gen_ai.chat";
+pub const GEN_AI_CHAT: &str = "gen_ai.chat";
 
 /// Execution of a tool or function by a generative AI model
-pub const GEN_AI_GEN_AI_EXECUTE_TOOL_SPAN_OP: &str = "gen_ai.execute_tool";
+pub const GEN_AI_EXECUTE_TOOL: &str = "gen_ai.execute_tool";
 
 /// Handoff of control between different AI agents or components
-pub const GEN_AI_GEN_AI_HANDOFF_SPAN_OP: &str = "gen_ai.handoff";
+pub const GEN_AI_HANDOFF: &str = "gen_ai.handoff";
 
 /// Invocation of an AI agent to perform a task
-pub const GEN_AI_GEN_AI_INVOKE_AGENT_SPAN_OP: &str = "gen_ai.invoke_agent";
+pub const GEN_AI_INVOKE_AGENT: &str = "gen_ai.invoke_agent";
 
 /// Generation of embeddings by a generative AI model
-pub const GEN_AI_GEN_AI_EMBEDDINGS_SPAN_OP: &str = "gen_ai.embeddings";
+pub const GEN_AI_EMBEDDINGS: &str = "gen_ai.embeddings";
 
 /// Content generation by a generative AI model
-pub const GEN_AI_GEN_AI_GENERATE_CONTENT_SPAN_OP: &str = "gen_ai.generate_content";
+pub const GEN_AI_GENERATE_CONTENT: &str = "gen_ai.generate_content";
 
 /// Reranking of documents or results by a generative AI model
-pub const GEN_AI_GEN_AI_RERANK_SPAN_OP: &str = "gen_ai.rerank";
+pub const GEN_AI_RERANK: &str = "gen_ai.rerank";
 
 // Path: model/op/general.json
 // Name: general
 
 /// A general point-in-time span indicating an event
-pub const GENERAL_MARK_SPAN_OP: &str = "mark";
+pub const MARK: &str = "mark";
 
 /// The time it took for a set of instructions to execute
-pub const GENERAL_FUNCTION_SPAN_OP: &str = "function";
+pub const FUNCTION: &str = "function";
 
 /// A user-defined measurement of the duration between two points in time
-pub const GENERAL_MEASURE_SPAN_OP: &str = "measure";
+pub const MEASURE: &str = "measure";
 
 // Path: model/op/messaging.json
 // Name: messaging
 
 // Description: Messaging related spans represent operations on topics in streaming data systems and queues, such as producing and consuming messages in Kafka, RabbitMQ.
 /// A general queue operation.
-pub const MESSAGING_QUEUE_SPAN_OP: &str = "queue";
+pub const QUEUE: &str = "queue";
 
 /// Publishing a message to a queue.
-pub const MESSAGING_QUEUE_PUBLISH_SPAN_OP: &str = "queue.publish";
+pub const QUEUE_PUBLISH: &str = "queue.publish";
 
 /// Creating a queue or a message for later publishing.
-pub const MESSAGING_QUEUE_CREATE_SPAN_OP: &str = "queue.create";
+pub const QUEUE_CREATE: &str = "queue.create";
 
 /// Receiving a message from a queue.
-pub const MESSAGING_QUEUE_RECEIVE_SPAN_OP: &str = "queue.receive";
+pub const QUEUE_RECEIVE: &str = "queue.receive";
 
 /// Processing a message from a queue.
-pub const MESSAGING_QUEUE_PROCESS_SPAN_OP: &str = "queue.process";
+pub const QUEUE_PROCESS: &str = "queue.process";
 
 /// Settling a message, e.g. acknowledging or rejecting it.
-pub const MESSAGING_QUEUE_SETTLE_SPAN_OP: &str = "queue.settle";
+pub const QUEUE_SETTLE: &str = "queue.settle";
 
 /// Publishing a message to an arq queue.
-pub const MESSAGING_QUEUE_SUBMIT_ARQ_SPAN_OP: &str = "queue.submit.arq";
+pub const QUEUE_SUBMIT_ARQ: &str = "queue.submit.arq";
 
 /// Processing a message from an arq queue.
-pub const MESSAGING_QUEUE_TASK_ARQ_SPAN_OP: &str = "queue.task.arq";
+pub const QUEUE_TASK_ARQ: &str = "queue.task.arq";
 
 /// Publishing a message to a Celery broker.
-pub const MESSAGING_QUEUE_SUBMIT_CELERY_SPAN_OP: &str = "queue.submit.celery";
+pub const QUEUE_SUBMIT_CELERY: &str = "queue.submit.celery";
 
 /// Processing a message from a Celery queue.
-pub const MESSAGING_QUEUE_TASK_CELERY_SPAN_OP: &str = "queue.task.celery";
+pub const QUEUE_TASK_CELERY: &str = "queue.task.celery";
 
 /// Processing a message from a Dramatiq queue.
-pub const MESSAGING_QUEUE_TASK_DRAMATIQ_SPAN_OP: &str = "queue.task.dramatiq";
+pub const QUEUE_TASK_DRAMATIQ: &str = "queue.task.dramatiq";
 
 /// Publishing a message to a Huey instance.
-pub const MESSAGING_QUEUE_SUBMIT_HUEY_SPAN_OP: &str = "queue.submit.huey";
+pub const QUEUE_SUBMIT_HUEY: &str = "queue.submit.huey";
 
 /// Processing a message from a Huey instance.
-pub const MESSAGING_QUEUE_TASK_HUEY_SPAN_OP: &str = "queue.task.huey";
+pub const QUEUE_TASK_HUEY: &str = "queue.task.huey";
 
 /// Processing a message from an RQ queue.
-pub const MESSAGING_QUEUE_TASK_RQ_SPAN_OP: &str = "queue.task.rq";
+pub const QUEUE_TASK_RQ: &str = "queue.task.rq";
 
 // Path: model/op/mobile.json
 // Name: mobile
 
-pub const MOBILE_APP_SPAN_OP: &str = "app";
+pub const APP: &str = "app";
 
-pub const MOBILE_UI_SPAN_OP: &str = "ui";
+pub const FILE: &str = "file";
 
-pub const MOBILE_NAVIGATION_SPAN_OP: &str = "navigation";
-
-pub const MOBILE_FILE_SPAN_OP: &str = "file";
-
-pub const MOBILE_SERIALIZE_SPAN_OP: &str = "serialize";
-
-pub const MOBILE_HTTP_SPAN_OP: &str = "http";
+pub const SERIALIZE: &str = "serialize";
 
 // Path: model/op/object.json
 // Name: object
 
 // Description: Object storage related spans represent operations on object storage systems such as Cloudflare R2, Amazon S3, and compatible services.
 /// Retrieving an object from an object store.
-pub const OBJECT_OBJECT_GET_SPAN_OP: &str = "object.get";
+pub const OBJECT_GET: &str = "object.get";
 
 /// Retrieving the metadata of an object from an object store.
-pub const OBJECT_OBJECT_HEAD_SPAN_OP: &str = "object.head";
+pub const OBJECT_HEAD: &str = "object.head";
 
 /// Storing an object in an object store.
-pub const OBJECT_OBJECT_PUT_SPAN_OP: &str = "object.put";
+pub const OBJECT_PUT: &str = "object.put";
 
 /// Deleting an object from an object store.
-pub const OBJECT_OBJECT_DELETE_SPAN_OP: &str = "object.delete";
+pub const OBJECT_DELETE: &str = "object.delete";
 
 /// Listing objects in an object store.
-pub const OBJECT_OBJECT_LIST_SPAN_OP: &str = "object.list";
+pub const OBJECT_LIST: &str = "object.list";
 
 /// Uploading a single part of a multipart upload to an object store.
-pub const OBJECT_OBJECT_UPLOAD_PART_SPAN_OP: &str = "object.upload_part";
+pub const OBJECT_UPLOAD_PART: &str = "object.upload_part";
 
 /// Aborting a multipart upload to an object store.
-pub const OBJECT_OBJECT_MULTIPART_UPLOAD_ABORT_SPAN_OP: &str = "object.multipart_upload.abort";
+pub const OBJECT_MULTIPART_UPLOAD_ABORT: &str = "object.multipart_upload.abort";
 
 /// Creating a multipart upload to an object store.
-pub const OBJECT_OBJECT_MULTIPART_UPLOAD_CREATE_SPAN_OP: &str = "object.multipart_upload.create";
+pub const OBJECT_MULTIPART_UPLOAD_CREATE: &str = "object.multipart_upload.create";
 
 /// Completing a multipart upload to an object store.
-pub const OBJECT_OBJECT_MULTIPART_UPLOAD_COMPLETE_SPAN_OP: &str = "object.multipart_upload.complete";
+pub const OBJECT_MULTIPART_UPLOAD_COMPLETE: &str = "object.multipart_upload.complete";
 
 // Path: model/op/routing.json
 // Name: routing
 
 // Description: Routing related spans represent work performed by frontend and backend application routers.
 /// A framework-neutral operation for work performed by an application router.
-pub const ROUTING_ROUTER_SPAN_OP: &str = "router";
+pub const ROUTER: &str = "router";
 
 // Path: model/op/web_server.json
 // Name: web_server
 
 /// A general point-in-time span indicating an event
-pub const WEB_SERVER_HTTP_SPAN_OP: &str = "http";
+pub const HTTP: &str = "http";
 
-pub const WEB_SERVER_HTTP_CLIENT_SPAN_OP: &str = "http.client";
+pub const HTTP_CLIENT: &str = "http.client";
 
 /// Consumption of a streaming HTTP client response body
-pub const WEB_SERVER_HTTP_CLIENT_STREAM_SPAN_OP: &str = "http.client.stream";
+pub const HTTP_CLIENT_STREAM: &str = "http.client.stream";
 
-pub const WEB_SERVER_HTTP_SERVER_SPAN_OP: &str = "http.server";
+pub const HTTP_SERVER: &str = "http.server";
 
-pub const WEB_SERVER_WEBSOCKET_SPAN_OP: &str = "websocket";
+pub const WEBSOCKET: &str = "websocket";
 
-pub const WEB_SERVER_RPC_SPAN_OP: &str = "rpc";
+pub const RPC: &str = "rpc";
 
-pub const WEB_SERVER_GRPC_SPAN_OP: &str = "grpc";
+pub const GRAPHQL: &str = "graphql";
 
-pub const WEB_SERVER_GRAPHQL_SPAN_OP: &str = "graphql";
+pub const SUBPROCESS: &str = "subprocess";
 
-pub const WEB_SERVER_SUBPROCESS_SPAN_OP: &str = "subprocess";
-
-pub const WEB_SERVER_MIDDLEWARE_SPAN_OP: &str = "middleware";
+pub const MIDDLEWARE: &str = "middleware";
 
 /// Handling of an incoming request by a web server route handler
-pub const WEB_SERVER_HANDLER_SPAN_OP: &str = "handler";
+pub const HANDLER: &str = "handler";
 
-pub const WEB_SERVER_VIEW_SPAN_OP: &str = "view";
+pub const VIEW: &str = "view";
 
-pub const WEB_SERVER_TEMPLATE_SPAN_OP: &str = "template";
+pub const TEMPLATE: &str = "template";
 
-pub const WEB_SERVER_FUNCTION_SPAN_OP: &str = "function";
+pub const FUNCTION_REMIX: &str = "function.remix";
 
-pub const WEB_SERVER_FUNCTION_REMIX_SPAN_OP: &str = "function.remix";
+pub const FUNCTION_NEXTJS: &str = "function.nextjs";
 
-pub const WEB_SERVER_FUNCTION_NEXTJS_SPAN_OP: &str = "function.nextjs";
-
-pub const WEB_SERVER_SERIALIZE_SPAN_OP: &str = "serialize";
-
-pub const WEB_SERVER_CONSOLE_SPAN_OP: &str = "console";
-
-pub const WEB_SERVER_FILE_SPAN_OP: &str = "file";
-
-pub const WEB_SERVER_APP_SPAN_OP: &str = "app";
+pub const CONSOLE: &str = "console";

--- a/scripts/generate_op.ts
+++ b/scripts/generate_op.ts
@@ -1,22 +1,79 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+interface OpField {
+  name: string;
+  description?: string;
+}
+
+interface OpCategory {
+  file: string;
+  name: string;
+  description?: string;
+  fields: OpField[];
+}
+
 export async function generateOps() {
   const opDir = path.join(__dirname, '..', 'model', 'op');
 
   const opFiles = await fs.promises.readdir(opDir);
-  writeToJs(opDir, opFiles);
-  writeToRust(opDir, opFiles);
+  const categories = readCategories(opDir, opFiles);
+  const owners = resolveConstantOwners(categories);
+
+  writeToJs(categories, owners);
+  writeToRust(categories, owners);
 }
 
-function writeToRust(opDir: string, opFiles: string[]) {
+function readCategories(opDir: string, opFiles: string[]): OpCategory[] {
+  // Sort for deterministic output: the file order decides both the order of the emitted blocks and,
+  // for ops defined in multiple categories without a description, which category owns the constant.
+  return [...opFiles].sort().map((file) => {
+    const opJson = JSON.parse(fs.readFileSync(path.join(opDir, file), 'utf-8'));
+    return { file, name: opJson.name, description: opJson.description, fields: opJson.fields };
+  });
+}
+
+function constantName(fieldName: string): string {
+  return fieldName.toUpperCase().replaceAll('.', '_');
+}
+
+/**
+ * Constant names don't include the op's category, so the same op defined in multiple categories
+ * (e.g. `http` in `faas`, `mobile` and `web_server`) would yield duplicate constants. Emit each op
+ * exactly once, in the category that documents it, falling back to the first category defining it.
+ *
+ * Returns a map of op name -> file that owns its constant.
+ */
+function resolveConstantOwners(categories: OpCategory[]): Map<string, string> {
+  const owners = new Map<string, { file: string; described: boolean }>();
+
+  for (const category of categories) {
+    for (const field of category.fields) {
+      const owner = owners.get(field.name);
+      if (!owner || (!owner.described && !!field.description)) {
+        owners.set(field.name, { file: category.file, described: !!field.description });
+      }
+    }
+  }
+
+  return new Map([...owners].map(([name, { file }]) => [name, file]));
+}
+
+/** The fields of `category` whose constant is emitted in this category. */
+function ownedFields(category: OpCategory, owners: Map<string, string>): OpField[] {
+  return category.fields.filter((field) => owners.get(field.name) === category.file);
+}
+
+function writeToRust(categories: OpCategory[], owners: Map<string, string>) {
   let opContent = '// This is an auto-generated file. Do not edit!\n\n';
 
-  for (const file of opFiles) {
-    const opPath = path.join(opDir, file);
-    const opJson = JSON.parse(fs.readFileSync(opPath, 'utf-8'));
+  for (const category of categories) {
+    const fields = ownedFields(category, owners);
+    if (fields.length === 0) {
+      continue;
+    }
 
-    const { name, description, fields } = opJson;
+    const { file, name, description } = category;
 
     opContent += `// Path: model/op/${file}\n// Name: ${name}\n\n`;
     if (description) {
@@ -29,9 +86,7 @@ function writeToRust(opDir: string, opFiles: string[]) {
         opContent += field.description.split('\n').join('\n/// ');
         opContent += '\n';
       }
-      opContent += `pub const ${name.toUpperCase().replaceAll('.', '_')}_${field.name
-        .toUpperCase()
-        .replaceAll('.', '_')}_SPAN_OP: &str = "${field.name}";\n\n`;
+      opContent += `pub const ${constantName(field.name)}: &str = "${field.name}";\n\n`;
     }
   }
 
@@ -43,14 +98,16 @@ function writeToRust(opDir: string, opFiles: string[]) {
   fs.writeFileSync(opFilePath, opContent);
 }
 
-function writeToJs(opDir: string, opFiles: string[]) {
+function writeToJs(categories: OpCategory[], owners: Map<string, string>) {
   let opContent = '// This is an auto-generated file. Do not edit!\n';
 
-  for (const file of opFiles) {
-    const opPath = path.join(opDir, file);
-    const opJson = JSON.parse(fs.readFileSync(opPath, 'utf-8'));
+  for (const category of categories) {
+    const fields = ownedFields(category, owners);
+    if (fields.length === 0) {
+      continue;
+    }
 
-    const { name, description, fields } = opJson;
+    const { file, name, description } = category;
 
     opContent += `\n// Path: model/op/${file}\n// Name: ${name}\n`;
     if (description) {
@@ -65,9 +122,7 @@ function writeToJs(opDir: string, opFiles: string[]) {
       } else {
         opContent += '\n';
       }
-      opContent += `export const ${name.toUpperCase().replaceAll('.', '_')}_${field.name
-        .toUpperCase()
-        .replaceAll('.', '_')}_SPAN_OP = '${field.name}';\n`;
+      opContent += `export const ${constantName(field.name)} = '${field.name}';\n`;
     }
   }
 


### PR DESCRIPTION
Span op constants were named `<CATEGORY>_<OP>_SPAN_OP`, where the category only groups the model files and carries no meaning. This cause sub-optimal export names like `GEN_AI_GEN_AI_INVOKE_AGENT_SPAN_OP` or `BROWSER_PAGELOAD_SPAN_OP`. Names are now generated just from the op string: `GEN_AI_INVOKE_AGENT`, `PAGELOAD`. Op values are unchanged, and no model files were harmed during the creation of this PR. This is a breaking change though but I checked and the JS SDK is the only consumer of ops. We're fine with the breakage and can easily handle it.

* Renames apply to the op constants exported from the JS package and the Rust crate.
* Op files are read in sorted order now, so the collision fallback can't differ between Linux and Windows CI.

Fixes getsentry/sentry-conventions#546<br>Refs getsentry/sentry-conventions#546