### PR TITLE
feat(attributes): Add `sentry.event.serialized_meta`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -14088,6 +14088,25 @@ export const SENTRY_EVENT_SERIALIZED_EXTRA = 'sentry.event.serialized_extra';
  */
 export type SENTRY_EVENT_SERIALIZED_EXTRA_TYPE = string;
 
+// Path: model/attributes/sentry/sentry__event__serialized_meta.json
+
+/**
+ * JSON-serialized `_meta` for the `sentry.event.serialized_*` properties from a Sentry event. `sentry.event.serialized_meta`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_EVENT_SERIALIZED_META_TYPE}
+ *
+ * Apply Scrubbing: never
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: internal
+ */
+export const SENTRY_EVENT_SERIALIZED_META = 'sentry.event.serialized_meta';
+
+/**
+ * Type for {@link SENTRY_EVENT_SERIALIZED_META} sentry.event.serialized_meta
+ */
+export type SENTRY_EVENT_SERIALIZED_META_TYPE = string;
+
 // Path: model/attributes/sentry/sentry__exclusive_time.json
 
 /**
@@ -18253,6 +18272,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'sentry.event.serialized_breadcrumbs': 'string',
   'sentry.event.serialized_contexts': 'string',
   'sentry.event.serialized_extra': 'string',
+  'sentry.event.serialized_meta': 'string',
   'sentry.exclusive_time': 'double',
   'sentry.frames.frozen': 'integer',
   'sentry.frames.slow': 'integer',
@@ -19046,6 +19066,7 @@ export type AttributeName =
   | typeof SENTRY_EVENT_SERIALIZED_BREADCRUMBS
   | typeof SENTRY_EVENT_SERIALIZED_CONTEXTS
   | typeof SENTRY_EVENT_SERIALIZED_EXTRA
+  | typeof SENTRY_EVENT_SERIALIZED_META
   | typeof SENTRY_EXCLUSIVE_TIME
   | typeof SENTRY_FRAMES_FROZEN
   | typeof SENTRY_FRAMES_SLOW
@@ -28140,6 +28161,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'internal',
     changelog: [{ version: '0.19.0', prs: [556] }],
   },
+  'sentry.event.serialized_meta': {
+    brief: 'JSON-serialized `_meta` for the `sentry.event.serialized_*` properties from a Sentry event.',
+    type: 'string',
+    applyScrubbing: {
+      key: 'never',
+    },
+    isInOtel: false,
+    visibility: 'internal',
+    changelog: [{ version: 'next' }],
+  },
   'sentry.exclusive_time': {
     brief: 'The exclusive time duration of the span in milliseconds.',
     type: 'double',
@@ -30851,6 +30882,7 @@ export type Attributes = {
   [SENTRY_EVENT_SERIALIZED_BREADCRUMBS]?: SENTRY_EVENT_SERIALIZED_BREADCRUMBS_TYPE;
   [SENTRY_EVENT_SERIALIZED_CONTEXTS]?: SENTRY_EVENT_SERIALIZED_CONTEXTS_TYPE;
   [SENTRY_EVENT_SERIALIZED_EXTRA]?: SENTRY_EVENT_SERIALIZED_EXTRA_TYPE;
+  [SENTRY_EVENT_SERIALIZED_META]?: SENTRY_EVENT_SERIALIZED_META_TYPE;
   [SENTRY_EXCLUSIVE_TIME]?: SENTRY_EXCLUSIVE_TIME_TYPE;
   [SENTRY_FRAMES_FROZEN]?: SENTRY_FRAMES_FROZEN_TYPE;
   [SENTRY_FRAMES_SLOW]?: SENTRY_FRAMES_SLOW_TYPE;

--- a/model/attributes/sentry/sentry__event__serialized_meta.json
+++ b/model/attributes/sentry/sentry__event__serialized_meta.json
@@ -1,0 +1,15 @@
+{
+  "key": "sentry.event.serialized_meta",
+  "brief": "JSON-serialized `_meta` for the `sentry.event.serialized_*` properties from a Sentry event.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "never"
+  },
+  "is_in_otel": false,
+  "visibility": "internal",
+  "changelog": [
+    {
+      "version": "next"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -8236,6 +8236,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Visibility: internal
     """
 
+    # Path: model/attributes/sentry/sentry__event__serialized_meta.json
+    SENTRY_EVENT_SERIALIZED_META: Literal["sentry.event.serialized_meta"] = (
+        "sentry.event.serialized_meta"
+    )
+    """JSON-serialized `_meta` for the `sentry.event.serialized_*` properties from a Sentry event.
+
+    Type: str
+    Apply Scrubbing: never
+    Defined in OTEL: No
+    Visibility: internal
+    """
+
     # Path: model/attributes/sentry/sentry__exclusive_time.json
     SENTRY_EXCLUSIVE_TIME: Literal["sentry.exclusive_time"] = "sentry.exclusive_time"
     """The exclusive time duration of the span in milliseconds.
@@ -19803,6 +19815,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.19.0", prs=[556]),
         ],
     ),
+    "sentry.event.serialized_meta": AttributeMetadata(
+        brief="JSON-serialized `_meta` for the `sentry.event.serialized_*` properties from a Sentry event.",
+        type=AttributeType.STRING,
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.NEVER),
+        is_in_otel=False,
+        visibility=Visibility.INTERNAL,
+        changelog=[
+            ChangelogEntry(version="next"),
+        ],
+    ),
     "sentry.exclusive_time": AttributeMetadata(
         brief="The exclusive time duration of the span in milliseconds.",
         type=AttributeType.DOUBLE,
@@ -22608,6 +22630,7 @@ Attributes = TypedDict(
         "sentry.event.serialized_breadcrumbs": str,
         "sentry.event.serialized_contexts": str,
         "sentry.event.serialized_extra": str,
+        "sentry.event.serialized_meta": str,
         "sentry.exclusive_time": float,
         "sentry.frames.frozen": int,
         "sentry.frames.slow": int,


### PR DESCRIPTION
Add an internal `sentry.event.serialized_meta` attribute for holding Relay's metadata (PII scrubbing, etc) for the contexts, extra, and breadcrumbs in the other `sentry.event.serialized_*` attributes. This is currently used in the span details pane for transaction-event-based transaction/segment spans, and therefore required for backwards compatibility.