### PR TITLE
ci: Type-check TypeScript sources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,3 +141,9 @@ This repo uses [oxlint](https://oxc.rs/docs/guide/usage/linter.html) and [oxfmt]
 ```bash
 yarn lint
 ```
+
+This includes TypeScript type checking, which you can also run on its own:
+
+```bash
+yarn lint:types
+```

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,8 @@
     "build": "astro build && yarn postbuild",
     "postbuild": "pagefind --site dist --output-subdir pagefind",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "lint:types": "astro sync && tsc --noEmit"
   },
   "dependencies": {
     "@astrojs/svelte": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,11 @@
     "format": "yarn format:js && yarn format:python",
     "format:js": "oxfmt",
     "format:python": "(cd python && uv run black src/ && uv run isort src/)",
-    "lint": "yarn lint:js && yarn lint:python",
+    "lint": "yarn lint:js && yarn lint:types && yarn lint:python",
     "lint:js": "oxfmt --check && oxlint",
+    "lint:types": "yarn lint:types:js && yarn lint:types:docs",
+    "lint:types:js": "tsc --noEmit",
+    "lint:types:docs": "yarn workspace docs lint:types",
     "lint:python": "(cd python && uv run pyflakes src/ && uv run mypy .)",
     "lint-fix": "oxlint --fix",
     "test": "yarn test:js && yarn test:python",
@@ -43,6 +46,7 @@
     "oxlint": "^1.71.0",
     "tar": "^7.5.19",
     "tsx": "^4.22.4",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   },
   "resolutions": {

--- a/scripts/clear_attribute_changelog.ts
+++ b/scripts/clear_attribute_changelog.ts
@@ -57,8 +57,8 @@ if (args.includes('--all')) {
   });
 } else {
   const keyIndex = args.indexOf('--key');
-  if (keyIndex !== -1 && args[keyIndex + 1]) {
-    const key = args[keyIndex + 1];
+  const key = keyIndex !== -1 ? args[keyIndex + 1] : undefined;
+  if (key) {
     clearByKey(key).catch((err) => {
       console.error(err);
       process.exit(1);

--- a/scripts/generate_attributes.ts
+++ b/scripts/generate_attributes.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { getAttributeExamples } from './attribute_examples';
-import type { AttributeJson } from './types';
+import type { AttributeJson, AttributeValue } from './types';
 
 interface GenerateAttributesOptions {
   attributesDir: string;
@@ -122,7 +122,7 @@ function writeToJs(attributesDir: string, attributeFiles: string[], outputFilePa
   let individualConstants = '';
 
   // Generate individual attribute constants with documentation AND build the explicit type map
-  for (const { file, key, constantName, attributeJson, _isDeprecated } of allAttributes) {
+  for (const { file, key, constantName, attributeJson } of allAttributes) {
     const { brief, type, apply_scrubbing, is_in_otel, has_dynamic_suffix, deprecation, alias } = attributeJson;
     const examples = getAttributeExamples(attributeJson);
     const visibility = getVisibility(attributeJson);
@@ -717,7 +717,9 @@ function getAttributeTypeEnum(type: AttributeJson['type']): string {
   }
 }
 
-function convertToPythonLiteral(value: AttributeJson['example']): string {
+// Accepts a nested array as well, so that an attribute's full `examples` list can be
+// converted into a single Python list literal via the recursive `Array.isArray` branch.
+function convertToPythonLiteral(value: AttributeValue | AttributeValue[] | undefined): string {
   if (value === null) return 'None';
   if (typeof value === 'boolean') return value ? 'True' : 'False';
   if (typeof value === 'string') return JSON.stringify(value);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
-  "exclude": ["node_modules"],
+  // `docs` is an Astro project and is type-checked separately via `yarn lint:types:docs`,
+  // because it needs Astro's generated types (`astro sync`) to resolve `astro:*` modules.
+  "exclude": ["node_modules", "docs", "**/dist", ".claude"],
   "compilerOptions": {
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
The root `tsconfig.json` was never actually run, so type errors in `scripts/` could land unnoticed. This adds a `lint:types` script wired into `yarn lint` (which CI already runs) and fixes the errors it surfaced.

- Promotes `typescript` to a root devDependency instead of relying on it being hoisted out of the `javascript/sentry-conventions` workspace.
- Scopes the root project away from `docs` — it's an Astro project needing `astro sync` to resolve its `astro:*` virtual modules, so it gets its own type-check. Also excludes `**/dist` and `.claude` so local builds and nested worktrees stay out.
- Fixes three pre-existing errors in `scripts/`: a destructured property that never existed and a too-narrow `convertToPythonLiteral` signature in `generate_attributes.ts`, plus a truthiness check that didn't narrow a separate index access in `clear_attribute_changelog.ts`.
- `yarn generate` output is byte-identical, so the codegen fixes change no behavior. No `docs/` source needed changing — it's already clean once synced.

Fixes GH-548
Refs CON-102
