### PR TITLE
fix(docs): Add missing file and test docs building in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,3 +87,24 @@ jobs:
             python/**/*.whl
             model/**/*.tgz
           if-no-files-found: error
+
+  build-docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: 'package.json'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build Astro site
+        working-directory: docs
+        run: yarn build
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/docs/src/components/InfoTooltip.astro
+++ b/docs/src/components/InfoTooltip.astro
@@ -1,0 +1,22 @@
+---
+interface Props {
+  /** The explanatory text shown on hover/focus. */
+  text: string;
+  /** Render the bubble below the icon instead of above. */
+  below?: boolean;
+}
+
+const { text, below = false } = Astro.props;
+---
+
+<span class="info-tooltip" tabindex="0" role="note" aria-label={text}>
+  {/*
+    One filled path with fill-rule="evenodd": the dot and stem are knocked out of a
+    solid disc. Filled shapes stay crisp at 16px where hairline strokes smear — the
+    stem is a full 2px wide at this size instead of a sub-pixel line.
+  */}
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" aria-hidden="true">
+    <path d="M12 1.5a10.5 10.5 0 100 21 10.5 10.5 0 000-21ZM12 5.4a1.6 1.6 0 110 3.2 1.6 1.6 0 010-3.2ZM10.5 11.9a1.5 1.5 0 013 0v5.2a1.5 1.5 0 01-3 0Z"/>
+  </svg>
+  <span class:list={['info-tooltip-content', { 'info-tooltip-below': below }]}>{text}</span>
+</span>


### PR DESCRIPTION
#492 made docs changes but I forgot to add a new Astro component. CI doesn't build docs on PRs, which should have caught this. Therefore, this PR:

- adds the missing component file
- adds a "Build Docs" job to CI to catch build failures right away