### PR TITLE
fix(attributes): Add status `backfill` to deprecated attributes with renamed replacements

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -11858,6 +11858,7 @@ export type NETWORK_CONNECTION_TYPE_TYPE = string;
  * Aliases: {@link NET_HOST_IP} `net.host.ip`, {@link NET_SOCK_HOST_ADDR} `net.sock.host.addr`
  *
  * @example "10.1.2.80"
+ * @example "/var/run/my.sock"
  */
 export const NETWORK_LOCAL_ADDRESS = 'network.local.address';
 
@@ -27469,6 +27470,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: '10.1.2.80',
+    examples: ['10.1.2.80', '/var/run/my.sock'],
     aliases: ['net.host.ip', 'net.sock.host.addr'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -19254,7 +19254,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   address: {
     brief: 'The destination hostname or IP address for a TCP connection.',
     type: 'string',
-    keys: ['server.address', 'address', 'server_name'],
+    keys: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -21184,7 +21184,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'aws.request.url': {
     brief: 'The URL of the AWS API request.',
     type: 'string',
-    keys: ['url.full', 'aws.request.url'],
+    keys: ['url.full', 'aws.request.url', 'http.url', 'url'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -21339,7 +21339,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'browser.name': {
     brief: 'The name of the browser.',
     type: 'string',
-    keys: ['browser.name'],
+    keys: ['browser.name', 'sentry.browser.name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -21430,7 +21430,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'browser.version': {
     brief: 'The version of the browser.',
     type: 'string',
-    keys: ['browser.version'],
+    keys: ['browser.version', 'sentry.browser.version'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -21740,7 +21740,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
     type: 'string',
-    keys: ['client.address'],
+    keys: ['client.address', 'http.client_ip'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -22140,7 +22140,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).',
     type: 'string',
-    keys: ['code.filepath'],
+    keys: ['code.file.path', 'code.filepath'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -22149,6 +22149,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '/app/myapplication/http/handler/server.py',
     deprecation: {
       replacement: 'code.file.path',
+      status: 'backfill',
     },
     aliases: ['code.file.path'],
     changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
@@ -22157,7 +22158,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).',
     type: 'string',
-    keys: ['code.file.path'],
+    keys: ['code.file.path', 'code.filepath'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -22205,7 +22206,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function',
     type: 'integer',
-    keys: ['code.lineno'],
+    keys: ['code.line.number', 'code.lineno'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -22214,6 +22215,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 42,
     deprecation: {
       replacement: 'code.line.number',
+      status: 'backfill',
     },
     aliases: ['code.line.number'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61, 108] }, { version: '0.0.0' }],
@@ -22222,7 +22224,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function',
     type: 'integer',
-    keys: ['code.line.number'],
+    keys: ['code.line.number', 'code.lineno'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -22411,7 +22413,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'db.name': {
     brief: 'The name of the database being accessed.',
     type: 'string',
-    keys: ['db.name'],
+    keys: ['db.namespace', 'db.name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -22420,6 +22422,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'customers',
     deprecation: {
       replacement: 'db.namespace',
+      status: 'backfill',
     },
     aliases: ['db.namespace'],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
@@ -22427,7 +22430,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'db.namespace': {
     brief: 'The name of the database being accessed.',
     type: 'string',
-    keys: ['db.namespace'],
+    keys: ['db.namespace', 'db.name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -25414,7 +25417,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
     type: 'string',
-    keys: ['http.client_ip'],
+    keys: ['client.address', 'http.client_ip'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -25423,6 +25426,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'example.com',
     deprecation: {
       replacement: 'client.address',
+      status: 'backfill',
     },
     aliases: ['client.address'],
     changelog: [{ version: '0.1.0', prs: [61, 106, 127] }, { version: '0.0.0' }],
@@ -25446,7 +25450,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'http.flavor': {
     brief: 'The actual version of the protocol used for network communication.',
     type: 'string',
-    keys: ['http.flavor'],
+    keys: ['network.protocol.version', 'http.flavor', 'net.protocol.version'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -25455,6 +25459,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '1.1',
     deprecation: {
       replacement: 'network.protocol.version',
+      status: 'backfill',
     },
     aliases: ['network.protocol.version', 'net.protocol.version'],
     changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
@@ -25865,7 +25870,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'http.response.status_code': {
     brief: 'The status code of the HTTP response.',
     type: 'integer',
-    keys: ['http.response.status_code', 'http.response_status_code'],
+    keys: ['http.response.status_code', 'http.response_status_code', 'http.status_code'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -25928,7 +25933,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'http.scheme': {
     brief: 'The URI scheme component identifying the used protocol.',
     type: 'string',
-    keys: ['http.scheme'],
+    keys: ['url.scheme', 'http.scheme'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -25937,6 +25942,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'https',
     deprecation: {
       replacement: 'url.scheme',
+      status: 'backfill',
     },
     aliases: ['url.scheme'],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
@@ -25944,7 +25950,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'http.server_name': {
     brief: 'The server domain name',
     type: 'string',
-    keys: ['http.server_name'],
+    keys: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -25953,6 +25959,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'example.com',
     deprecation: {
       replacement: 'server.address',
+      status: 'backfill',
     },
     aliases: ['address', 'server.address', 'net.host.name', 'http.host', 'server_name'],
     changelog: [
@@ -25977,7 +25984,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'http.status_code': {
     brief: 'The status code of the HTTP response.',
     type: 'integer',
-    keys: ['http.status_code'],
+    keys: ['http.response.status_code', 'http.response_status_code', 'http.status_code'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -25986,6 +25993,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 404,
     deprecation: {
       replacement: 'http.response.status_code',
+      status: 'backfill',
     },
     aliases: ['http.response.status_code'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
@@ -26009,7 +26017,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'http.url': {
     brief: 'The URL of the resource that was fetched.',
     type: 'string',
-    keys: ['http.url'],
+    keys: ['url.full', 'aws.request.url', 'http.url', 'url'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -26018,6 +26026,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'https://example.com/test?foo=bar#buzz',
     deprecation: {
       replacement: 'url.full',
+      status: 'backfill',
     },
     aliases: ['url.full', 'url', 'aws.request.url'],
     changelog: [{ version: '0.1.0', prs: [61, 108] }, { version: '0.0.0' }],
@@ -26025,7 +26034,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'http.user_agent': {
     brief: 'Value of the HTTP User-Agent header sent by the client.',
     type: 'string',
-    keys: ['http.user_agent'],
+    keys: ['user_agent.original', 'http.user_agent'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -26035,6 +26044,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1',
     deprecation: {
       replacement: 'user_agent.original',
+      status: 'backfill',
     },
     aliases: ['user_agent.original'],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
@@ -26752,7 +26762,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'mcp.resource.protocol': {
     brief: 'Protocol of the resource URI being accessed, extracted from the URI.',
     type: 'string',
-    keys: ['network.protocol.name', 'mcp.resource.protocol'],
+    keys: ['network.protocol.name', 'mcp.resource.protocol', 'net.protocol.name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -26926,7 +26936,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'mcp.transport': {
     brief: 'Transport method used for MCP communication.',
     type: 'string',
-    keys: ['network.transport', 'mcp.transport'],
+    keys: ['network.transport', 'mcp.transport', 'net.transport'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27452,7 +27462,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'network.local.address': {
     brief: 'Local address of the network connection - IP address or Unix domain socket name.',
     type: 'string',
-    keys: ['network.local.address'],
+    keys: ['network.local.address', 'net.host.ip', 'net.sock.host.addr'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27465,7 +27475,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'network.local.port': {
     brief: 'Local port number of the network connection.',
     type: 'integer',
-    keys: ['network.local.port'],
+    keys: ['network.local.port', 'net.sock.host.port'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27478,7 +27488,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'network.peer.address': {
     brief: 'Peer address of the network connection - IP address or Unix domain socket name.',
     type: 'string',
-    keys: ['network.peer.address'],
+    keys: ['network.peer.address', 'net.peer.ip', 'net.sock.peer.addr'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -27491,7 +27501,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'network.peer.port': {
     brief: 'Peer port number of the network connection.',
     type: 'integer',
-    keys: ['network.peer.port'],
+    keys: ['network.peer.port', 'net.sock.peer.port'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27503,7 +27513,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'network.protocol.name': {
     brief: 'OSI application layer or non-OSI equivalent.',
     type: 'string',
-    keys: ['network.protocol.name', 'mcp.resource.protocol'],
+    keys: ['network.protocol.name', 'mcp.resource.protocol', 'net.protocol.name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27516,7 +27526,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'network.protocol.version': {
     brief: 'The actual version of the protocol used for network communication.',
     type: 'string',
-    keys: ['network.protocol.version'],
+    keys: ['network.protocol.version', 'http.flavor', 'net.protocol.version'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27529,7 +27539,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'network.transport': {
     brief: 'OSI transport layer or inter-process communication method.',
     type: 'string',
-    keys: ['network.transport', 'mcp.transport'],
+    keys: ['network.transport', 'mcp.transport', 'net.transport'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27554,7 +27564,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'net.host.ip': {
     brief: 'Local address of the network connection - IP address or Unix domain socket name.',
     type: 'string',
-    keys: ['net.host.ip'],
+    keys: ['network.local.address', 'net.host.ip', 'net.sock.host.addr'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27563,6 +27573,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '192.168.0.1',
     deprecation: {
       replacement: 'network.local.address',
+      status: 'backfill',
     },
     aliases: ['network.local.address', 'net.sock.host.addr'],
     changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
@@ -27571,7 +27582,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
     type: 'string',
-    keys: ['net.host.name'],
+    keys: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27580,6 +27591,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'example.com',
     deprecation: {
       replacement: 'server.address',
+      status: 'backfill',
     },
     aliases: ['address', 'server.address', 'http.server_name', 'http.host', 'server_name'],
     changelog: [
@@ -27591,7 +27603,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'net.host.port': {
     brief: 'Server port number.',
     type: 'integer',
-    keys: ['net.host.port'],
+    keys: ['server.port', 'net.host.port', 'port'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27600,6 +27612,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 1337,
     deprecation: {
       replacement: 'server.port',
+      status: 'backfill',
     },
     aliases: ['server.port', 'port'],
     changelog: [
@@ -27612,7 +27625,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'net.peer.ip': {
     brief: 'Peer address of the network connection - IP address or Unix domain socket name.',
     type: 'string',
-    keys: ['net.peer.ip'],
+    keys: ['network.peer.address', 'net.peer.ip', 'net.sock.peer.addr'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -27621,6 +27634,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '192.168.0.1',
     deprecation: {
       replacement: 'network.peer.address',
+      status: 'backfill',
     },
     aliases: ['network.peer.address', 'net.sock.peer.addr'],
     changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
@@ -27661,7 +27675,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'net.protocol.name': {
     brief: 'OSI application layer or non-OSI equivalent.',
     type: 'string',
-    keys: ['net.protocol.name'],
+    keys: ['network.protocol.name', 'mcp.resource.protocol', 'net.protocol.name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27670,6 +27684,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'http',
     deprecation: {
       replacement: 'network.protocol.name',
+      status: 'backfill',
     },
     aliases: ['network.protocol.name', 'mcp.resource.protocol'],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
@@ -27677,7 +27692,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'net.protocol.version': {
     brief: 'The actual version of the protocol used for network communication.',
     type: 'string',
-    keys: ['net.protocol.version'],
+    keys: ['network.protocol.version', 'http.flavor', 'net.protocol.version'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27686,6 +27701,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '1.1',
     deprecation: {
       replacement: 'network.protocol.version',
+      status: 'backfill',
     },
     aliases: ['network.protocol.version', 'http.flavor'],
     changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
@@ -27709,7 +27725,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'net.sock.host.addr': {
     brief: 'Local address of the network connection mapping to Unix domain socket name.',
     type: 'string',
-    keys: ['net.sock.host.addr'],
+    keys: ['network.local.address', 'net.host.ip', 'net.sock.host.addr'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27718,6 +27734,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '/var/my.sock',
     deprecation: {
       replacement: 'network.local.address',
+      status: 'backfill',
     },
     aliases: ['network.local.address', 'net.host.ip'],
     changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
@@ -27725,7 +27742,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'net.sock.host.port': {
     brief: 'Local port number of the network connection.',
     type: 'integer',
-    keys: ['net.sock.host.port'],
+    keys: ['network.local.port', 'net.sock.host.port'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27734,6 +27751,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 8080,
     deprecation: {
       replacement: 'network.local.port',
+      status: 'backfill',
     },
     aliases: ['network.local.port'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
@@ -27741,7 +27759,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'net.sock.peer.addr': {
     brief: 'Peer address of the network connection - IP address',
     type: 'string',
-    keys: ['net.sock.peer.addr'],
+    keys: ['network.peer.address', 'net.peer.ip', 'net.sock.peer.addr'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -27750,6 +27768,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '192.168.0.1',
     deprecation: {
       replacement: 'network.peer.address',
+      status: 'backfill',
     },
     aliases: ['network.peer.address', 'net.peer.ip'],
     changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
@@ -27772,7 +27791,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'net.sock.peer.port': {
     brief: 'Peer port number of the network connection.',
     type: 'integer',
-    keys: ['net.sock.peer.port'],
+    keys: ['network.peer.port', 'net.sock.peer.port'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27781,13 +27800,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 8080,
     deprecation: {
       replacement: 'network.peer.port',
+      status: 'backfill',
     },
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
   },
   'net.transport': {
     brief: 'OSI transport layer or inter-process communication method.',
     type: 'string',
-    keys: ['net.transport'],
+    keys: ['network.transport', 'mcp.transport', 'net.transport'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27796,6 +27816,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'tcp',
     deprecation: {
       replacement: 'network.transport',
+      status: 'backfill',
     },
     aliases: ['network.transport', 'mcp.transport'],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
@@ -28055,7 +28076,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   port: {
     brief: 'The destination port for a TCP connection.',
     type: 'integer',
-    keys: ['server.port', 'port'],
+    keys: ['server.port', 'net.host.port', 'port'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -28128,7 +28149,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment. Equivalent to `raw_description` in the Sentry runtime context.',
     type: 'string',
-    keys: ['process.runtime.description'],
+    keys: ['process.runtime.description', 'runtime.raw_description'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -28165,7 +28186,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'process.runtime.name': {
     brief: 'The name of the runtime. Equivalent to `name` in the Sentry runtime context.',
     type: 'string',
-    keys: ['process.runtime.name'],
+    keys: ['process.runtime.name', 'runtime.name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -28179,7 +28200,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'The version of the runtime of this process, as returned by the runtime without modification. Equivalent to `version` in the Sentry runtime context.',
     type: 'string',
-    keys: ['process.runtime.version'],
+    keys: ['process.runtime.version', 'runtime.version'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -28546,7 +28567,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'runtime.name': {
     brief: 'The name of the runtime. For example node, CPython, or rustc.',
     type: 'string',
-    keys: ['runtime.name'],
+    keys: ['process.runtime.name', 'runtime.name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -28556,6 +28577,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'process.runtime.name',
       reason: 'Prefer OTel-aligned process.runtime.name',
+      status: 'backfill',
     },
     aliases: ['process.runtime.name'],
     changelog: [
@@ -28570,7 +28592,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'Unprocessed description string as obtained from the runtime. Used to extract name and version for well-known runtimes.',
     type: 'string',
-    keys: ['runtime.raw_description'],
+    keys: ['process.runtime.description', 'runtime.raw_description'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -28580,6 +28602,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'process.runtime.description',
       reason: 'Prefer OTel-aligned process.runtime.description',
+      status: 'backfill',
     },
     aliases: ['process.runtime.description'],
     changelog: [
@@ -28593,7 +28616,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'runtime.version': {
     brief: 'The version of the runtime.',
     type: 'string',
-    keys: ['runtime.version'],
+    keys: ['process.runtime.version', 'runtime.version'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -28603,6 +28626,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'process.runtime.version',
       reason: 'Prefer OTel-aligned process.runtime.version',
+      status: 'backfill',
     },
     aliases: ['process.runtime.version'],
     changelog: [
@@ -28684,7 +28708,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'sentry.browser.name': {
     brief: 'The name of the browser.',
     type: 'string',
-    keys: ['sentry.browser.name', 'browser.name'],
+    keys: ['browser.name', 'sentry.browser.name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -28693,6 +28717,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'Chrome',
     deprecation: {
       replacement: 'browser.name',
+      status: 'backfill',
     },
     aliases: ['browser.name'],
     changelog: [{ version: '0.1.0', prs: [139] }],
@@ -28703,7 +28728,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'sentry.browser.version': {
     brief: 'The version of the browser.',
     type: 'string',
-    keys: ['sentry.browser.version'],
+    keys: ['browser.version', 'sentry.browser.version'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -28712,6 +28737,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '120.0.6099.130',
     deprecation: {
       replacement: 'browser.version',
+      status: 'backfill',
     },
     aliases: ['browser.version'],
     changelog: [{ version: '0.1.0', prs: [139] }],
@@ -29821,7 +29847,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'sentry.user.email': {
     brief: 'User email address.',
     type: 'string',
-    keys: ['sentry.user.email', 'user.email'],
+    keys: ['user.email', 'sentry.user.email'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -29829,6 +29855,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.email',
+      status: 'backfill',
     },
     aliases: ['user.email'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -29839,7 +29866,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'sentry.user.geo.city': {
     brief: 'Human readable city name.',
     type: 'string',
-    keys: ['sentry.user.geo.city', 'user.geo.city'],
+    keys: ['user.geo.city', 'sentry.user.geo.city'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -29847,6 +29874,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.geo.city',
+      status: 'backfill',
     },
     aliases: ['user.geo.city'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -29857,7 +29885,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'sentry.user.geo.country_code': {
     brief: 'Two-letter country code (ISO 3166-1 alpha-2).',
     type: 'string',
-    keys: ['sentry.user.geo.country_code', 'user.geo.country_code'],
+    keys: ['user.geo.country_code', 'sentry.user.geo.country_code'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -29865,6 +29893,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.geo.country_code',
+      status: 'backfill',
     },
     aliases: ['user.geo.country_code'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -29875,7 +29904,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'sentry.user.geo.region': {
     brief: 'Human readable region name or code.',
     type: 'string',
-    keys: ['sentry.user.geo.region', 'user.geo.region'],
+    keys: ['user.geo.region', 'sentry.user.geo.region'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -29883,6 +29912,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.geo.region',
+      status: 'backfill',
     },
     aliases: ['user.geo.region'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -29893,7 +29923,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'sentry.user.geo.subdivision': {
     brief: 'Human readable subdivision name.',
     type: 'string',
-    keys: ['sentry.user.geo.subdivision', 'user.geo.subdivision'],
+    keys: ['user.geo.subdivision', 'sentry.user.geo.subdivision'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -29901,6 +29931,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.geo.subdivision',
+      status: 'backfill',
     },
     aliases: ['user.geo.subdivision'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -29911,7 +29942,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'sentry.user.id': {
     brief: 'Unique identifier of the user.',
     type: 'string',
-    keys: ['sentry.user.id', 'user.id'],
+    keys: ['user.id', 'sentry.user.id'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -29919,6 +29950,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.id',
+      status: 'backfill',
     },
     aliases: ['user.id'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -29929,7 +29961,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'sentry.user.ip': {
     brief: 'The IP address of the user.',
     type: 'string',
-    keys: ['sentry.user.ip', 'user.ip'],
+    keys: ['user.ip_address', 'sentry.user.ip', 'user.ip'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -29937,6 +29969,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.ip_address',
+      status: 'backfill',
     },
     aliases: ['user.ip_address'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -29947,7 +29980,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'sentry.user.username': {
     brief: 'Short name or login/username of the user.',
     type: 'string',
-    keys: ['sentry.user.username', 'user.username'],
+    keys: ['user.name', 'sentry.user.username', 'user.username'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -29955,6 +29988,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.name',
+      status: 'backfill',
     },
     aliases: ['user.name'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -29966,7 +30000,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
     type: 'string',
-    keys: ['server.address', 'address', 'server_name'],
+    keys: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -29984,7 +30018,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
     type: 'string',
-    keys: ['server.address', 'address', 'server_name'],
+    keys: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -30009,7 +30043,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'server.port': {
     brief: 'Server port number.',
     type: 'integer',
-    keys: ['server.port', 'port'],
+    keys: ['server.port', 'net.host.port', 'port'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -30520,7 +30554,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   url: {
     brief: 'The URL of the resource that was fetched.',
     type: 'string',
-    keys: ['url'],
+    keys: ['url.full', 'aws.request.url', 'http.url', 'url'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -30529,6 +30563,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'https://example.com/test?foo=bar#buzz',
     deprecation: {
       replacement: 'url.full',
+      status: 'backfill',
     },
     aliases: ['url.full', 'http.url', 'aws.request.url'],
     changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
@@ -30562,7 +30597,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'url.full': {
     brief: 'The URL of the resource that was fetched.',
     type: 'string',
-    keys: ['url.full', 'aws.request.url'],
+    keys: ['url.full', 'aws.request.url', 'http.url', 'url'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -30657,7 +30692,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'url.scheme': {
     brief: 'The URI scheme component identifying the used protocol.',
     type: 'string',
-    keys: ['url.scheme'],
+    keys: ['url.scheme', 'http.scheme'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -30695,7 +30730,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'user_agent.original': {
     brief: 'Value of the HTTP User-Agent header sent by the client.',
     type: 'string',
-    keys: ['user_agent.original'],
+    keys: ['user_agent.original', 'http.user_agent'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -30709,7 +30744,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'user.email': {
     brief: 'User email address.',
     type: 'string',
-    keys: ['user.email'],
+    keys: ['user.email', 'sentry.user.email'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -30734,7 +30769,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'user.geo.city': {
     brief: 'Human readable city name.',
     type: 'string',
-    keys: ['user.geo.city'],
+    keys: ['user.geo.city', 'sentry.user.geo.city'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -30747,7 +30782,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'user.geo.country_code': {
     brief: 'Two-letter country code (ISO 3166-1 alpha-2).',
     type: 'string',
-    keys: ['user.geo.country_code'],
+    keys: ['user.geo.country_code', 'sentry.user.geo.country_code'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -30760,7 +30795,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'user.geo.region': {
     brief: 'Human readable region name or code.',
     type: 'string',
-    keys: ['user.geo.region'],
+    keys: ['user.geo.region', 'sentry.user.geo.region'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -30773,7 +30808,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'user.geo.subdivision': {
     brief: 'Human readable subdivision name.',
     type: 'string',
-    keys: ['user.geo.subdivision'],
+    keys: ['user.geo.subdivision', 'sentry.user.geo.subdivision'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -30798,7 +30833,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'user.id': {
     brief: 'Unique identifier of the user.',
     type: 'string',
-    keys: ['user.id'],
+    keys: ['user.id', 'sentry.user.id'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -30811,7 +30846,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'user.ip_address': {
     brief: 'The IP address of the user.',
     type: 'string',
-    keys: ['user.ip_address'],
+    keys: ['user.ip_address', 'sentry.user.ip', 'user.ip'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -30824,7 +30859,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'user.name': {
     brief: 'Short name or login/username of the user.',
     type: 'string',
-    keys: ['user.name'],
+    keys: ['user.name', 'sentry.user.username', 'user.username'],
     applyScrubbing: {
       key: 'auto',
     },

--- a/model/attributes/code/code__filepath.json
+++ b/model/attributes/code/code__filepath.json
@@ -9,7 +9,7 @@
   "example": "/app/myapplication/http/handler/server.py",
   "alias": ["code.file.path"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "code.file.path"
   },
   "visibility": "public",

--- a/model/attributes/code/code__lineno.json
+++ b/model/attributes/code/code__lineno.json
@@ -9,7 +9,7 @@
   "example": 42,
   "alias": ["code.line.number"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "code.line.number"
   },
   "visibility": "public",

--- a/model/attributes/db/db__name.json
+++ b/model/attributes/db/db__name.json
@@ -9,7 +9,7 @@
   "example": "customers",
   "alias": ["db.namespace"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "db.namespace"
   },
   "visibility": "public",

--- a/model/attributes/http/http__client_ip.json
+++ b/model/attributes/http/http__client_ip.json
@@ -9,7 +9,7 @@
   "example": "example.com",
   "alias": ["client.address"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "client.address"
   },
   "visibility": "public",

--- a/model/attributes/http/http__flavor.json
+++ b/model/attributes/http/http__flavor.json
@@ -9,7 +9,7 @@
   "example": "1.1",
   "alias": ["network.protocol.version", "net.protocol.version"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "network.protocol.version"
   },
   "visibility": "public",

--- a/model/attributes/http/http__scheme.json
+++ b/model/attributes/http/http__scheme.json
@@ -9,7 +9,7 @@
   "example": "https",
   "alias": ["url.scheme"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "url.scheme"
   },
   "visibility": "public",

--- a/model/attributes/http/http__server_name.json
+++ b/model/attributes/http/http__server_name.json
@@ -9,7 +9,7 @@
   "example": "example.com",
   "alias": ["address", "server.address", "net.host.name", "http.host", "server_name"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "server.address"
   },
   "visibility": "public",

--- a/model/attributes/http/http__status_code.json
+++ b/model/attributes/http/http__status_code.json
@@ -9,7 +9,7 @@
   "example": 404,
   "alias": ["http.response.status_code"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "http.response.status_code"
   },
   "visibility": "public",

--- a/model/attributes/http/http__url.json
+++ b/model/attributes/http/http__url.json
@@ -9,7 +9,7 @@
   "example": "https://example.com/test?foo=bar#buzz",
   "alias": ["url.full", "url", "aws.request.url"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "url.full"
   },
   "visibility": "public",

--- a/model/attributes/http/http__user_agent.json
+++ b/model/attributes/http/http__user_agent.json
@@ -9,7 +9,7 @@
   "example": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1",
   "alias": ["user_agent.original"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "user_agent.original"
   },
   "visibility": "public",

--- a/model/attributes/net/net__host__ip.json
+++ b/model/attributes/net/net__host__ip.json
@@ -9,7 +9,7 @@
   "example": "192.168.0.1",
   "alias": ["network.local.address", "net.sock.host.addr"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "network.local.address"
   },
   "visibility": "public",

--- a/model/attributes/net/net__host__name.json
+++ b/model/attributes/net/net__host__name.json
@@ -9,7 +9,7 @@
   "example": "example.com",
   "alias": ["address", "server.address", "http.server_name", "http.host", "server_name"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "server.address"
   },
   "visibility": "public",

--- a/model/attributes/net/net__host__port.json
+++ b/model/attributes/net/net__host__port.json
@@ -9,7 +9,7 @@
   "example": 1337,
   "alias": ["server.port", "port"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "server.port"
   },
   "visibility": "public",

--- a/model/attributes/net/net__peer__ip.json
+++ b/model/attributes/net/net__peer__ip.json
@@ -9,7 +9,7 @@
   "example": "192.168.0.1",
   "alias": ["network.peer.address", "net.sock.peer.addr"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "network.peer.address"
   },
   "visibility": "public",

--- a/model/attributes/net/net__protocol__name.json
+++ b/model/attributes/net/net__protocol__name.json
@@ -9,7 +9,7 @@
   "example": "http",
   "alias": ["network.protocol.name", "mcp.resource.protocol"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "network.protocol.name"
   },
   "visibility": "public",

--- a/model/attributes/net/net__protocol__version.json
+++ b/model/attributes/net/net__protocol__version.json
@@ -9,7 +9,7 @@
   "example": "1.1",
   "alias": ["network.protocol.version", "http.flavor"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "network.protocol.version"
   },
   "visibility": "public",

--- a/model/attributes/net/net__sock__host__addr.json
+++ b/model/attributes/net/net__sock__host__addr.json
@@ -9,7 +9,7 @@
   "example": "/var/my.sock",
   "alias": ["network.local.address", "net.host.ip"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "network.local.address"
   },
   "visibility": "public",

--- a/model/attributes/net/net__sock__host__port.json
+++ b/model/attributes/net/net__sock__host__port.json
@@ -9,7 +9,7 @@
   "example": 8080,
   "alias": ["network.local.port"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "network.local.port"
   },
   "visibility": "public",

--- a/model/attributes/net/net__sock__peer__addr.json
+++ b/model/attributes/net/net__sock__peer__addr.json
@@ -9,7 +9,7 @@
   "example": "192.168.0.1",
   "alias": ["network.peer.address", "net.peer.ip"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "network.peer.address"
   },
   "visibility": "public",

--- a/model/attributes/net/net__sock__peer__port.json
+++ b/model/attributes/net/net__sock__peer__port.json
@@ -8,7 +8,7 @@
   "is_in_otel": true,
   "example": 8080,
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "network.peer.port"
   },
   "visibility": "public",

--- a/model/attributes/net/net__transport.json
+++ b/model/attributes/net/net__transport.json
@@ -9,7 +9,7 @@
   "example": "tcp",
   "alias": ["network.transport", "mcp.transport"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "network.transport"
   },
   "visibility": "public",

--- a/model/attributes/network/network__local__address.json
+++ b/model/attributes/network/network__local__address.json
@@ -6,7 +6,7 @@
     "key": "manual"
   },
   "is_in_otel": true,
-  "example": "10.1.2.80",
+  "examples": ["10.1.2.80", "/var/run/my.sock"],
   "alias": ["net.host.ip", "net.sock.host.addr"],
   "visibility": "public",
   "changelog": [

--- a/model/attributes/runtime/runtime__name.json
+++ b/model/attributes/runtime/runtime__name.json
@@ -11,7 +11,7 @@
   "deprecation": {
     "replacement": "process.runtime.name",
     "reason": "Prefer OTel-aligned process.runtime.name",
-    "_status": null
+    "_status": "backfill"
   },
   "alias": ["process.runtime.name"],
   "changelog": [

--- a/model/attributes/runtime/runtime__raw_description.json
+++ b/model/attributes/runtime/runtime__raw_description.json
@@ -11,7 +11,7 @@
   "deprecation": {
     "replacement": "process.runtime.description",
     "reason": "Prefer OTel-aligned process.runtime.description",
-    "_status": null
+    "_status": "backfill"
   },
   "alias": ["process.runtime.description"],
   "changelog": [

--- a/model/attributes/runtime/runtime__version.json
+++ b/model/attributes/runtime/runtime__version.json
@@ -11,7 +11,7 @@
   "deprecation": {
     "replacement": "process.runtime.version",
     "reason": "Prefer OTel-aligned process.runtime.version",
-    "_status": null
+    "_status": "backfill"
   },
   "alias": ["process.runtime.version"],
   "changelog": [

--- a/model/attributes/sentry/sentry__browser__name.json
+++ b/model/attributes/sentry/sentry__browser__name.json
@@ -9,7 +9,7 @@
   "example": "Chrome",
   "alias": ["browser.name"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "browser.name"
   },
   "visibility": "public",

--- a/model/attributes/sentry/sentry__browser__version.json
+++ b/model/attributes/sentry/sentry__browser__version.json
@@ -9,7 +9,7 @@
   "example": "120.0.6099.130",
   "alias": ["browser.version"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "browser.version"
   },
   "visibility": "public",

--- a/model/attributes/sentry/sentry__user__email.json
+++ b/model/attributes/sentry/sentry__user__email.json
@@ -9,7 +9,7 @@
   "alias": ["user.email"],
   "deprecation": {
     "replacement": "user.email",
-    "_status": null
+    "_status": "backfill"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/sentry/sentry__user__geo__city.json
+++ b/model/attributes/sentry/sentry__user__geo__city.json
@@ -9,7 +9,7 @@
   "alias": ["user.geo.city"],
   "deprecation": {
     "replacement": "user.geo.city",
-    "_status": null
+    "_status": "backfill"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/sentry/sentry__user__geo__country_code.json
+++ b/model/attributes/sentry/sentry__user__geo__country_code.json
@@ -9,7 +9,7 @@
   "alias": ["user.geo.country_code"],
   "deprecation": {
     "replacement": "user.geo.country_code",
-    "_status": null
+    "_status": "backfill"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/sentry/sentry__user__geo__region.json
+++ b/model/attributes/sentry/sentry__user__geo__region.json
@@ -9,7 +9,7 @@
   "alias": ["user.geo.region"],
   "deprecation": {
     "replacement": "user.geo.region",
-    "_status": null
+    "_status": "backfill"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/sentry/sentry__user__geo__subdivision.json
+++ b/model/attributes/sentry/sentry__user__geo__subdivision.json
@@ -9,7 +9,7 @@
   "alias": ["user.geo.subdivision"],
   "deprecation": {
     "replacement": "user.geo.subdivision",
-    "_status": null
+    "_status": "backfill"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/sentry/sentry__user__id.json
+++ b/model/attributes/sentry/sentry__user__id.json
@@ -9,7 +9,7 @@
   "alias": ["user.id"],
   "deprecation": {
     "replacement": "user.id",
-    "_status": null
+    "_status": "backfill"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/sentry/sentry__user__ip.json
+++ b/model/attributes/sentry/sentry__user__ip.json
@@ -9,7 +9,7 @@
   "alias": ["user.ip_address"],
   "deprecation": {
     "replacement": "user.ip_address",
-    "_status": null
+    "_status": "backfill"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/sentry/sentry__user__username.json
+++ b/model/attributes/sentry/sentry__user__username.json
@@ -9,7 +9,7 @@
   "alias": ["user.name"],
   "deprecation": {
     "replacement": "user.name",
-    "_status": null
+    "_status": "backfill"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/url.json
+++ b/model/attributes/url.json
@@ -9,7 +9,7 @@
   "example": "https://example.com/test?foo=bar#buzz",
   "alias": ["url.full", "http.url", "aws.request.url"],
   "deprecation": {
-    "_status": null,
+    "_status": "backfill",
     "replacement": "url.full"
   },
   "visibility": "public",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -7260,6 +7260,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Visibility: public
     Aliases: net.host.ip, net.sock.host.addr
     Example: "10.1.2.80"
+    Example: "/var/run/my.sock"
     """
 
     # Path: model/attributes/network/network__local__port.json
@@ -20122,6 +20123,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="10.1.2.80",
+        examples=["10.1.2.80", "/var/run/my.sock"],
         aliases=["net.host.ip", "net.sock.host.addr"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -10185,6 +10185,8 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "server.address",
             "address",
+            "http.server_name",
+            "net.host.name",
             "server_name",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
@@ -12527,6 +12529,8 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "url.full",
             "aws.request.url",
+            "http.url",
+            "url",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=False,
@@ -12755,7 +12759,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "browser.name": AttributeMetadata(
         brief="The name of the browser.",
         type=AttributeType.STRING,
-        keys=("browser.name",),
+        keys=(
+            "browser.name",
+            "sentry.browser.name",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
@@ -12860,7 +12867,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "browser.version": AttributeMetadata(
         brief="The version of the browser.",
         type=AttributeType.STRING,
-        keys=("browser.version",),
+        keys=(
+            "browser.version",
+            "sentry.browser.version",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
@@ -13231,7 +13241,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "client.address": AttributeMetadata(
         brief="Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
         type=AttributeType.STRING,
-        keys=("client.address",),
+        keys=(
+            "client.address",
+            "http.client_ip",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -13704,7 +13717,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "code.file.path": AttributeMetadata(
         brief="The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).",
         type=AttributeType.STRING,
-        keys=("code.file.path",),
+        keys=(
+            "code.file.path",
+            "code.filepath",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -13717,12 +13733,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "code.filepath": AttributeMetadata(
         brief="The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).",
         type=AttributeType.STRING,
-        keys=("code.filepath",),
+        keys=(
+            "code.file.path",
+            "code.filepath",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="/app/myapplication/http/handler/server.py",
-        deprecation=DeprecationInfo(replacement="code.file.path"),
+        deprecation=DeprecationInfo(
+            replacement="code.file.path", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["code.file.path"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61]),
@@ -13778,7 +13799,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "code.line.number": AttributeMetadata(
         brief="The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function",
         type=AttributeType.INTEGER,
-        keys=("code.line.number",),
+        keys=(
+            "code.line.number",
+            "code.lineno",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -13792,12 +13816,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "code.lineno": AttributeMetadata(
         brief="The line number in code.filepath best representing the operation. It SHOULD point within the code unit named in code.function",
         type=AttributeType.INTEGER,
-        keys=("code.lineno",),
+        keys=(
+            "code.line.number",
+            "code.lineno",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example=42,
-        deprecation=DeprecationInfo(replacement="code.line.number"),
+        deprecation=DeprecationInfo(
+            replacement="code.line.number", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["code.line.number"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
@@ -14015,12 +14044,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "db.name": AttributeMetadata(
         brief="The name of the database being accessed.",
         type=AttributeType.STRING,
-        keys=("db.name",),
+        keys=(
+            "db.namespace",
+            "db.name",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="customers",
-        deprecation=DeprecationInfo(replacement="db.namespace"),
+        deprecation=DeprecationInfo(
+            replacement="db.namespace", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["db.namespace"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
@@ -14030,7 +14064,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "db.namespace": AttributeMetadata(
         brief="The name of the database being accessed.",
         type=AttributeType.STRING,
-        keys=("db.namespace",),
+        keys=(
+            "db.namespace",
+            "db.name",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -17490,12 +17527,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "http.client_ip": AttributeMetadata(
         brief="Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
         type=AttributeType.STRING,
-        keys=("http.client_ip",),
+        keys=(
+            "client.address",
+            "http.client_ip",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="example.com",
-        deprecation=DeprecationInfo(replacement="client.address"),
+        deprecation=DeprecationInfo(
+            replacement="client.address", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["client.address"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 106, 127]),
@@ -17521,12 +17563,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "http.flavor": AttributeMetadata(
         brief="The actual version of the protocol used for network communication.",
         type=AttributeType.STRING,
-        keys=("http.flavor",),
+        keys=(
+            "network.protocol.version",
+            "http.flavor",
+            "net.protocol.version",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="1.1",
-        deprecation=DeprecationInfo(replacement="network.protocol.version"),
+        deprecation=DeprecationInfo(
+            replacement="network.protocol.version", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["network.protocol.version", "net.protocol.version"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 108, 127]),
@@ -17970,6 +18018,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "http.response.status_code",
             "http.response_status_code",
+            "http.status_code",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
@@ -18054,12 +18103,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "http.scheme": AttributeMetadata(
         brief="The URI scheme component identifying the used protocol.",
         type=AttributeType.STRING,
-        keys=("http.scheme",),
+        keys=(
+            "url.scheme",
+            "http.scheme",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="https",
-        deprecation=DeprecationInfo(replacement="url.scheme"),
+        deprecation=DeprecationInfo(
+            replacement="url.scheme", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["url.scheme"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
@@ -18081,12 +18135,20 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "http.server_name": AttributeMetadata(
         brief="The server domain name",
         type=AttributeType.STRING,
-        keys=("http.server_name",),
+        keys=(
+            "server.address",
+            "address",
+            "http.server_name",
+            "net.host.name",
+            "server_name",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="example.com",
-        deprecation=DeprecationInfo(replacement="server.address"),
+        deprecation=DeprecationInfo(
+            replacement="server.address", status=DeprecationStatus.BACKFILL
+        ),
         aliases=[
             "address",
             "server.address",
@@ -18105,12 +18167,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "http.status_code": AttributeMetadata(
         brief="The status code of the HTTP response.",
         type=AttributeType.INTEGER,
-        keys=("http.status_code",),
+        keys=(
+            "http.response.status_code",
+            "http.response_status_code",
+            "http.status_code",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example=404,
-        deprecation=DeprecationInfo(replacement="http.response.status_code"),
+        deprecation=DeprecationInfo(
+            replacement="http.response.status_code", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["http.response.status_code"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
@@ -18138,12 +18206,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "http.url": AttributeMetadata(
         brief="The URL of the resource that was fetched.",
         type=AttributeType.STRING,
-        keys=("http.url",),
+        keys=(
+            "url.full",
+            "aws.request.url",
+            "http.url",
+            "url",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="https://example.com/test?foo=bar#buzz",
-        deprecation=DeprecationInfo(replacement="url.full"),
+        deprecation=DeprecationInfo(
+            replacement="url.full", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["url.full", "url", "aws.request.url"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 108]),
@@ -18153,12 +18228,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "http.user_agent": AttributeMetadata(
         brief="Value of the HTTP User-Agent header sent by the client.",
         type=AttributeType.STRING,
-        keys=("http.user_agent",),
+        keys=(
+            "user_agent.original",
+            "http.user_agent",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1",
-        deprecation=DeprecationInfo(replacement="user_agent.original"),
+        deprecation=DeprecationInfo(
+            replacement="user_agent.original", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["user_agent.original"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
@@ -18945,6 +19025,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "network.protocol.name",
             "mcp.resource.protocol",
+            "net.protocol.name",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
@@ -19144,6 +19225,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "network.transport",
             "mcp.transport",
+            "net.transport",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
@@ -19657,12 +19739,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "net.host.ip": AttributeMetadata(
         brief="Local address of the network connection - IP address or Unix domain socket name.",
         type=AttributeType.STRING,
-        keys=("net.host.ip",),
+        keys=(
+            "network.local.address",
+            "net.host.ip",
+            "net.sock.host.addr",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="192.168.0.1",
-        deprecation=DeprecationInfo(replacement="network.local.address"),
+        deprecation=DeprecationInfo(
+            replacement="network.local.address", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["network.local.address", "net.sock.host.addr"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 108, 127]),
@@ -19672,12 +19760,20 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "net.host.name": AttributeMetadata(
         brief="Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
         type=AttributeType.STRING,
-        keys=("net.host.name",),
+        keys=(
+            "server.address",
+            "address",
+            "http.server_name",
+            "net.host.name",
+            "server_name",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="example.com",
-        deprecation=DeprecationInfo(replacement="server.address"),
+        deprecation=DeprecationInfo(
+            replacement="server.address", status=DeprecationStatus.BACKFILL
+        ),
         aliases=[
             "address",
             "server.address",
@@ -19696,12 +19792,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "net.host.port": AttributeMetadata(
         brief="Server port number.",
         type=AttributeType.INTEGER,
-        keys=("net.host.port",),
+        keys=(
+            "server.port",
+            "net.host.port",
+            "port",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example=1337,
-        deprecation=DeprecationInfo(replacement="server.port"),
+        deprecation=DeprecationInfo(
+            replacement="server.port", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["server.port", "port"],
         changelog=[
             ChangelogEntry(
@@ -19715,12 +19817,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "net.peer.ip": AttributeMetadata(
         brief="Peer address of the network connection - IP address or Unix domain socket name.",
         type=AttributeType.STRING,
-        keys=("net.peer.ip",),
+        keys=(
+            "network.peer.address",
+            "net.peer.ip",
+            "net.sock.peer.addr",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="192.168.0.1",
-        deprecation=DeprecationInfo(replacement="network.peer.address"),
+        deprecation=DeprecationInfo(
+            replacement="network.peer.address", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["network.peer.address", "net.sock.peer.addr"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 108, 127]),
@@ -19765,12 +19873,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "net.protocol.name": AttributeMetadata(
         brief="OSI application layer or non-OSI equivalent.",
         type=AttributeType.STRING,
-        keys=("net.protocol.name",),
+        keys=(
+            "network.protocol.name",
+            "mcp.resource.protocol",
+            "net.protocol.name",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="http",
-        deprecation=DeprecationInfo(replacement="network.protocol.name"),
+        deprecation=DeprecationInfo(
+            replacement="network.protocol.name", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["network.protocol.name", "mcp.resource.protocol"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
@@ -19780,12 +19894,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "net.protocol.version": AttributeMetadata(
         brief="The actual version of the protocol used for network communication.",
         type=AttributeType.STRING,
-        keys=("net.protocol.version",),
+        keys=(
+            "network.protocol.version",
+            "http.flavor",
+            "net.protocol.version",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="1.1",
-        deprecation=DeprecationInfo(replacement="network.protocol.version"),
+        deprecation=DeprecationInfo(
+            replacement="network.protocol.version", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["network.protocol.version", "http.flavor"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 108, 127]),
@@ -19812,12 +19932,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "net.sock.host.addr": AttributeMetadata(
         brief="Local address of the network connection mapping to Unix domain socket name.",
         type=AttributeType.STRING,
-        keys=("net.sock.host.addr",),
+        keys=(
+            "network.local.address",
+            "net.host.ip",
+            "net.sock.host.addr",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="/var/my.sock",
-        deprecation=DeprecationInfo(replacement="network.local.address"),
+        deprecation=DeprecationInfo(
+            replacement="network.local.address", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["network.local.address", "net.host.ip"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 108, 127]),
@@ -19827,12 +19953,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "net.sock.host.port": AttributeMetadata(
         brief="Local port number of the network connection.",
         type=AttributeType.INTEGER,
-        keys=("net.sock.host.port",),
+        keys=(
+            "network.local.port",
+            "net.sock.host.port",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example=8080,
-        deprecation=DeprecationInfo(replacement="network.local.port"),
+        deprecation=DeprecationInfo(
+            replacement="network.local.port", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["network.local.port"],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
@@ -19843,12 +19974,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "net.sock.peer.addr": AttributeMetadata(
         brief="Peer address of the network connection - IP address",
         type=AttributeType.STRING,
-        keys=("net.sock.peer.addr",),
+        keys=(
+            "network.peer.address",
+            "net.peer.ip",
+            "net.sock.peer.addr",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="192.168.0.1",
-        deprecation=DeprecationInfo(replacement="network.peer.address"),
+        deprecation=DeprecationInfo(
+            replacement="network.peer.address", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["network.peer.address", "net.peer.ip"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 108, 127]),
@@ -19874,12 +20011,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "net.sock.peer.port": AttributeMetadata(
         brief="Peer port number of the network connection.",
         type=AttributeType.INTEGER,
-        keys=("net.sock.peer.port",),
+        keys=(
+            "network.peer.port",
+            "net.sock.peer.port",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example=8080,
-        deprecation=DeprecationInfo(replacement="network.peer.port"),
+        deprecation=DeprecationInfo(
+            replacement="network.peer.port", status=DeprecationStatus.BACKFILL
+        ),
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[61]),
@@ -19889,12 +20031,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "net.transport": AttributeMetadata(
         brief="OSI transport layer or inter-process communication method.",
         type=AttributeType.STRING,
-        keys=("net.transport",),
+        keys=(
+            "network.transport",
+            "mcp.transport",
+            "net.transport",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="tcp",
-        deprecation=DeprecationInfo(replacement="network.transport"),
+        deprecation=DeprecationInfo(
+            replacement="network.transport", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["network.transport", "mcp.transport"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
@@ -19965,7 +20113,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "network.local.address": AttributeMetadata(
         brief="Local address of the network connection - IP address or Unix domain socket name.",
         type=AttributeType.STRING,
-        keys=("network.local.address",),
+        keys=(
+            "network.local.address",
+            "net.host.ip",
+            "net.sock.host.addr",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -19979,7 +20131,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "network.local.port": AttributeMetadata(
         brief="Local port number of the network connection.",
         type=AttributeType.INTEGER,
-        keys=("network.local.port",),
+        keys=(
+            "network.local.port",
+            "net.sock.host.port",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -19993,7 +20148,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "network.peer.address": AttributeMetadata(
         brief="Peer address of the network connection - IP address or Unix domain socket name.",
         type=AttributeType.STRING,
-        keys=("network.peer.address",),
+        keys=(
+            "network.peer.address",
+            "net.peer.ip",
+            "net.sock.peer.addr",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -20007,7 +20166,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "network.peer.port": AttributeMetadata(
         brief="Peer port number of the network connection.",
         type=AttributeType.INTEGER,
-        keys=("network.peer.port",),
+        keys=(
+            "network.peer.port",
+            "net.sock.peer.port",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -20023,6 +20185,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "network.protocol.name",
             "mcp.resource.protocol",
+            "net.protocol.name",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
@@ -20037,7 +20200,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "network.protocol.version": AttributeMetadata(
         brief="The actual version of the protocol used for network communication.",
         type=AttributeType.STRING,
-        keys=("network.protocol.version",),
+        keys=(
+            "network.protocol.version",
+            "http.flavor",
+            "net.protocol.version",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -20054,6 +20221,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "network.transport",
             "mcp.transport",
+            "net.transport",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
@@ -20381,6 +20549,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         type=AttributeType.INTEGER,
         keys=(
             "server.port",
+            "net.host.port",
             "port",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
@@ -20467,7 +20636,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "process.runtime.description": AttributeMetadata(
         brief="An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment. Equivalent to `raw_description` in the Sentry runtime context.",
         type=AttributeType.STRING,
-        keys=("process.runtime.description",),
+        keys=(
+            "process.runtime.description",
+            "runtime.raw_description",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -20505,7 +20677,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "process.runtime.name": AttributeMetadata(
         brief="The name of the runtime. Equivalent to `name` in the Sentry runtime context.",
         type=AttributeType.STRING,
-        keys=("process.runtime.name",),
+        keys=(
+            "process.runtime.name",
+            "runtime.name",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -20519,7 +20694,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "process.runtime.version": AttributeMetadata(
         brief="The version of the runtime of this process, as returned by the runtime without modification. Equivalent to `version` in the Sentry runtime context.",
         type=AttributeType.STRING,
-        keys=("process.runtime.version",),
+        keys=(
+            "process.runtime.version",
+            "runtime.version",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -20937,7 +21115,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "runtime.name": AttributeMetadata(
         brief="The name of the runtime. For example node, CPython, or rustc.",
         type=AttributeType.STRING,
-        keys=("runtime.name",),
+        keys=(
+            "process.runtime.name",
+            "runtime.name",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
@@ -20945,6 +21126,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="process.runtime.name",
             reason="Prefer OTel-aligned process.runtime.name",
+            status=DeprecationStatus.BACKFILL,
         ),
         aliases=["process.runtime.name"],
         changelog=[
@@ -20958,7 +21140,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "runtime.raw_description": AttributeMetadata(
         brief="Unprocessed description string as obtained from the runtime. Used to extract name and version for well-known runtimes.",
         type=AttributeType.STRING,
-        keys=("runtime.raw_description",),
+        keys=(
+            "process.runtime.description",
+            "runtime.raw_description",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
@@ -20966,6 +21151,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="process.runtime.description",
             reason="Prefer OTel-aligned process.runtime.description",
+            status=DeprecationStatus.BACKFILL,
         ),
         aliases=["process.runtime.description"],
         changelog=[
@@ -20979,7 +21165,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "runtime.version": AttributeMetadata(
         brief="The version of the runtime.",
         type=AttributeType.STRING,
-        keys=("runtime.version",),
+        keys=(
+            "process.runtime.version",
+            "runtime.version",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
@@ -20987,6 +21176,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="process.runtime.version",
             reason="Prefer OTel-aligned process.runtime.version",
+            status=DeprecationStatus.BACKFILL,
         ),
         aliases=["process.runtime.version"],
         changelog=[
@@ -21079,14 +21269,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="The name of the browser.",
         type=AttributeType.STRING,
         keys=(
-            "sentry.browser.name",
             "browser.name",
+            "sentry.browser.name",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="Chrome",
-        deprecation=DeprecationInfo(replacement="browser.name"),
+        deprecation=DeprecationInfo(
+            replacement="browser.name", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["browser.name"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[139]),
@@ -21096,12 +21288,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "sentry.browser.version": AttributeMetadata(
         brief="The version of the browser.",
         type=AttributeType.STRING,
-        keys=("sentry.browser.version",),
+        keys=(
+            "browser.version",
+            "sentry.browser.version",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="120.0.6099.130",
-        deprecation=DeprecationInfo(replacement="browser.version"),
+        deprecation=DeprecationInfo(
+            replacement="browser.version", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["browser.version"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[139]),
@@ -22323,13 +22520,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="User email address.",
         type=AttributeType.STRING,
         keys=(
-            "sentry.user.email",
             "user.email",
+            "sentry.user.email",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
-        deprecation=DeprecationInfo(replacement="user.email"),
+        deprecation=DeprecationInfo(
+            replacement="user.email", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["user.email"],
         changelog=[
             ChangelogEntry(version="0.10.0", prs=[406]),
@@ -22340,13 +22539,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="Human readable city name.",
         type=AttributeType.STRING,
         keys=(
-            "sentry.user.geo.city",
             "user.geo.city",
+            "sentry.user.geo.city",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
-        deprecation=DeprecationInfo(replacement="user.geo.city"),
+        deprecation=DeprecationInfo(
+            replacement="user.geo.city", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["user.geo.city"],
         changelog=[
             ChangelogEntry(version="0.10.0", prs=[406]),
@@ -22357,13 +22558,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="Two-letter country code (ISO 3166-1 alpha-2).",
         type=AttributeType.STRING,
         keys=(
-            "sentry.user.geo.country_code",
             "user.geo.country_code",
+            "sentry.user.geo.country_code",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
-        deprecation=DeprecationInfo(replacement="user.geo.country_code"),
+        deprecation=DeprecationInfo(
+            replacement="user.geo.country_code", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["user.geo.country_code"],
         changelog=[
             ChangelogEntry(version="0.10.0", prs=[406]),
@@ -22374,13 +22577,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="Human readable region name or code.",
         type=AttributeType.STRING,
         keys=(
-            "sentry.user.geo.region",
             "user.geo.region",
+            "sentry.user.geo.region",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
-        deprecation=DeprecationInfo(replacement="user.geo.region"),
+        deprecation=DeprecationInfo(
+            replacement="user.geo.region", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["user.geo.region"],
         changelog=[
             ChangelogEntry(version="0.10.0", prs=[406]),
@@ -22391,13 +22596,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="Human readable subdivision name.",
         type=AttributeType.STRING,
         keys=(
-            "sentry.user.geo.subdivision",
             "user.geo.subdivision",
+            "sentry.user.geo.subdivision",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
-        deprecation=DeprecationInfo(replacement="user.geo.subdivision"),
+        deprecation=DeprecationInfo(
+            replacement="user.geo.subdivision", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["user.geo.subdivision"],
         changelog=[
             ChangelogEntry(version="0.10.0", prs=[406]),
@@ -22408,13 +22615,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="Unique identifier of the user.",
         type=AttributeType.STRING,
         keys=(
-            "sentry.user.id",
             "user.id",
+            "sentry.user.id",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
-        deprecation=DeprecationInfo(replacement="user.id"),
+        deprecation=DeprecationInfo(
+            replacement="user.id", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["user.id"],
         changelog=[
             ChangelogEntry(version="0.10.0", prs=[406]),
@@ -22425,13 +22634,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="The IP address of the user.",
         type=AttributeType.STRING,
         keys=(
+            "user.ip_address",
             "sentry.user.ip",
             "user.ip",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
-        deprecation=DeprecationInfo(replacement="user.ip_address"),
+        deprecation=DeprecationInfo(
+            replacement="user.ip_address", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["user.ip_address"],
         changelog=[
             ChangelogEntry(version="0.10.0", prs=[406]),
@@ -22442,13 +22654,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="Short name or login/username of the user.",
         type=AttributeType.STRING,
         keys=(
+            "user.name",
             "sentry.user.username",
             "user.username",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
-        deprecation=DeprecationInfo(replacement="user.name"),
+        deprecation=DeprecationInfo(
+            replacement="user.name", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["user.name"],
         changelog=[
             ChangelogEntry(version="0.10.0", prs=[406]),
@@ -22461,6 +22676,8 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "server.address",
             "address",
+            "http.server_name",
+            "net.host.name",
             "server_name",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
@@ -22487,6 +22704,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         type=AttributeType.INTEGER,
         keys=(
             "server.port",
+            "net.host.port",
             "port",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
@@ -22508,6 +22726,8 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "server.address",
             "address",
+            "http.server_name",
+            "net.host.name",
             "server_name",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
@@ -23151,6 +23371,8 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "url.full",
             "aws.request.url",
+            "http.url",
+            "url",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=True,
@@ -23252,7 +23474,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "url.scheme": AttributeMetadata(
         brief="The URI scheme component identifying the used protocol.",
         type=AttributeType.STRING,
-        keys=("url.scheme",),
+        keys=(
+            "url.scheme",
+            "http.scheme",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -23289,12 +23514,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "url": AttributeMetadata(
         brief="The URL of the resource that was fetched.",
         type=AttributeType.STRING,
-        keys=("url",),
+        keys=(
+            "url.full",
+            "aws.request.url",
+            "http.url",
+            "url",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="https://example.com/test?foo=bar#buzz",
-        deprecation=DeprecationInfo(replacement="url.full"),
+        deprecation=DeprecationInfo(
+            replacement="url.full", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["url.full", "http.url", "aws.request.url"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61]),
@@ -23304,7 +23536,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "user.email": AttributeMetadata(
         brief="User email address.",
         type=AttributeType.STRING,
-        keys=("user.email",),
+        keys=(
+            "user.email",
+            "sentry.user.email",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -23329,7 +23564,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "user.geo.city": AttributeMetadata(
         brief="Human readable city name.",
         type=AttributeType.STRING,
-        keys=("user.geo.city",),
+        keys=(
+            "user.geo.city",
+            "sentry.user.geo.city",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
@@ -23342,7 +23580,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "user.geo.country_code": AttributeMetadata(
         brief="Two-letter country code (ISO 3166-1 alpha-2).",
         type=AttributeType.STRING,
-        keys=("user.geo.country_code",),
+        keys=(
+            "user.geo.country_code",
+            "sentry.user.geo.country_code",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
@@ -23355,7 +23596,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "user.geo.region": AttributeMetadata(
         brief="Human readable region name or code.",
         type=AttributeType.STRING,
-        keys=("user.geo.region",),
+        keys=(
+            "user.geo.region",
+            "sentry.user.geo.region",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
@@ -23368,7 +23612,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "user.geo.subdivision": AttributeMetadata(
         brief="Human readable subdivision name.",
         type=AttributeType.STRING,
-        keys=("user.geo.subdivision",),
+        keys=(
+            "user.geo.subdivision",
+            "sentry.user.geo.subdivision",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
@@ -23393,7 +23640,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "user.id": AttributeMetadata(
         brief="Unique identifier of the user.",
         type=AttributeType.STRING,
-        keys=("user.id",),
+        keys=(
+            "user.id",
+            "sentry.user.id",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -23406,7 +23656,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "user.ip_address": AttributeMetadata(
         brief="The IP address of the user.",
         type=AttributeType.STRING,
-        keys=("user.ip_address",),
+        keys=(
+            "user.ip_address",
+            "sentry.user.ip",
+            "user.ip",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
@@ -23419,7 +23673,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "user.name": AttributeMetadata(
         brief="Short name or login/username of the user.",
         type=AttributeType.STRING,
-        keys=("user.name",),
+        keys=(
+            "user.name",
+            "sentry.user.username",
+            "user.username",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
@@ -23444,7 +23702,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "user_agent.original": AttributeMetadata(
         brief="Value of the HTTP User-Agent header sent by the client.",
         type=AttributeType.STRING,
-        keys=("user_agent.original",),
+        keys=(
+            "user_agent.original",
+            "http.user_agent",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,

--- a/python/tests/test_attribute_keys.py
+++ b/python/tests/test_attribute_keys.py
@@ -38,12 +38,10 @@ def test_chains_only_contain_keys_holding_the_same_value() -> None:
 
 
 def test_non_rewriting_deprecation_chain_holds_only_its_own_names() -> None:
-    # http.url names url.full as its replacement and also lists it under alias, but its value is
-    # never rewritten there, so the chain stops at itself.
-    assert ATTRIBUTE_METADATA["http.url"].keys == ("http.url",)
-    assert "http.url" not in ATTRIBUTE_METADATA["url.full"].keys
-    # http.host aliases both server.address and client.address; neither is a substitute.
+    # http.host names server.address as its replacement and also lists it under alias (next to
+    # client.address), but its value is never rewritten there, so the chain stops at itself.
     assert ATTRIBUTE_METADATA["http.host"].keys == ("http.host",)
+    assert "http.host" not in ATTRIBUTE_METADATA["server.address"].keys
 
 
 def test_family_members_share_one_key_chain() -> None:
@@ -73,10 +71,13 @@ def test_key_chain_includes_deprecated_search_aliases() -> None:
 
 
 def test_key_chain_omits_deprecated_aliases_outside_the_family() -> None:
-    # address aliases several deprecated attributes replaced by other keys; only its own
-    # replacement and its fellow predecessor belong in the chain.
+    # address aliases five deprecated attributes. Its replacement server.address heads the chain and
+    # the other backfilled ones follow as fellow predecessors, but http.host is left out: its value
+    # is never rewritten onto server.address.
     assert ATTRIBUTE_METADATA["address"].keys == (
         "server.address",
         "address",
+        "http.server_name",
+        "net.host.name",
         "server_name",
     )

--- a/test/generated-attribute-keys.test.ts
+++ b/test/generated-attribute-keys.test.ts
@@ -239,12 +239,10 @@ describe('generated attribute key chains', () => {
   });
 
   it('gives a non-rewriting deprecation a chain of only its own names', () => {
-    // `http.url` names `url.full` as its replacement and also lists it under `alias`, but its value
-    // is never rewritten there, so the chain stops at itself.
-    expect(ATTRIBUTE_METADATA['http.url']?.keys).toEqual(['http.url']);
-    expect(ATTRIBUTE_METADATA['url.full']?.keys).not.toContain('http.url');
-    // `http.host` aliases both `server.address` and `client.address`; neither is a substitute.
+    // `http.host` names `server.address` as its replacement and also lists it under `alias` (next to
+    // `client.address`), but its value is never rewritten there, so the chain stops at itself.
     expect(ATTRIBUTE_METADATA['http.host']?.keys).toEqual(['http.host']);
+    expect(ATTRIBUTE_METADATA['server.address']?.keys).not.toContain('http.host');
   });
 
   it('shares one chain across every member of a family', () => {
@@ -308,8 +306,15 @@ describe('generated attribute key chains', () => {
   });
 
   it('omits deprecated aliases that are not part of the family', () => {
-    // `address` aliases several deprecated attributes that are replaced by other keys; only
-    // `server.address` (its replacement) and `server_name` (a fellow predecessor) belong here.
-    expect(ATTRIBUTE_METADATA['address']?.keys).toEqual(['server.address', 'address', 'server_name']);
+    // `address` aliases five deprecated attributes. Its replacement `server.address` heads the chain
+    // and the other backfilled ones follow as fellow predecessors, but `http.host` is left out: its
+    // value is never rewritten onto `server.address`.
+    expect(ATTRIBUTE_METADATA['address']?.keys).toEqual([
+      'server.address',
+      'address',
+      'http.server_name',
+      'net.host.name',
+      'server_name',
+    ]);
   });
 });


### PR DESCRIPTION
## Description

This PR applies the deprecation status `"backfill"` to a bunch of attributes that were straight renames but for unknown reasons had status `null`. This means, these attributes are now added to the deprecation chains on the `ATTRIBUTE_METADATA` object to allow for deprecation-safe attribute accesses.

closes https://github.com/getsentry/sentry-conventions/issues/570

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
