### PR TITLE
feat(attributes): Add graphql.processing.type

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8595,6 +8595,30 @@ export const GRAPHQL_OPERATION_TYPE = 'graphql.operation.type';
  */
 export type GRAPHQL_OPERATION_TYPE_TYPE = string;
 
+// Path: model/attributes/graphql/graphql__processing__type.json
+
+/**
+ * The type of processing represented by this span. `graphql.processing.type`
+ *
+ * Attribute Value Type: `string` {@link GRAPHQL_PROCESSING_TYPE_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "parse"
+ * @example "validate"
+ * @example "execute"
+ * @example "resolve"
+ */
+export const GRAPHQL_PROCESSING_TYPE = 'graphql.processing.type';
+
+/**
+ * Type for {@link GRAPHQL_PROCESSING_TYPE} graphql.processing.type
+ */
+export type GRAPHQL_PROCESSING_TYPE_TYPE = string;
+
 // Path: model/attributes/grpc/grpc__error__bad_request__field_violations.json
 
 /**
@@ -18064,6 +18088,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'graphql.document': 'string',
   'graphql.operation.name': 'string',
   'graphql.operation.type': 'string',
+  'graphql.processing.type': 'string',
   'grpc.error.bad_request.field_violations': 'string[]',
   'grpc.error.debug_info.detail': 'string',
   'grpc.error.debug_info.stack_entries': 'string[]',
@@ -18858,6 +18883,7 @@ export type AttributeName =
   | typeof GRAPHQL_DOCUMENT
   | typeof GRAPHQL_OPERATION_NAME
   | typeof GRAPHQL_OPERATION_TYPE
+  | typeof GRAPHQL_PROCESSING_TYPE
   | typeof GRPC_ERROR_BAD_REQUEST_FIELD_VIOLATIONS
   | typeof GRPC_ERROR_DEBUG_INFO_DETAIL
   | typeof GRPC_ERROR_DEBUG_INFO_STACK_ENTRIES
@@ -25222,6 +25248,23 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'query',
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+  },
+  'graphql.processing.type': {
+    brief: 'The type of processing represented by this span.',
+    type: 'string',
+    keys: ['graphql.processing.type'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'parse',
+    examples: ['parse', 'validate', 'execute', 'resolve'],
+    changelog: [{ version: 'next', prs: [572], description: 'Added graphql.processing.type attribute' }],
+    additionalContext: [
+      'Well-known values are request, parse, validate, variable_coercion, plan, execute, subscription_event, step_execute, resolve, dataloader_dispatch, dataloader_batch and _OTHER. Use one of these if it applies, otherwise a custom value.',
+      'Not to be confused with graphql.operation.type, which holds the GraphQL operation type (query, mutation, subscription) and only applies to spans that run an operation.',
+    ],
   },
   'grpc.error.bad_request.field_violations': {
     brief:
@@ -33769,6 +33812,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     brief: 'The type of the operation being executed.',
     deprecationChain: ['graphql.operation.type'],
   },
+  'graphql.processing.type': {
+    canonicalName: 'graphql.processing.type',
+    type: 'string',
+    brief: 'The type of processing represented by this span.',
+    deprecationChain: ['graphql.processing.type'],
+  },
   'grpc.error.bad_request.field_violations': {
     canonicalName: 'grpc.error.bad_request.field_violations',
     type: 'string[]',
@@ -36684,6 +36733,7 @@ export type Attributes = {
   [GRAPHQL_DOCUMENT]?: GRAPHQL_DOCUMENT_TYPE;
   [GRAPHQL_OPERATION_NAME]?: GRAPHQL_OPERATION_NAME_TYPE;
   [GRAPHQL_OPERATION_TYPE]?: GRAPHQL_OPERATION_TYPE_TYPE;
+  [GRAPHQL_PROCESSING_TYPE]?: GRAPHQL_PROCESSING_TYPE_TYPE;
   [GRPC_ERROR_BAD_REQUEST_FIELD_VIOLATIONS]?: GRPC_ERROR_BAD_REQUEST_FIELD_VIOLATIONS_TYPE;
   [GRPC_ERROR_DEBUG_INFO_DETAIL]?: GRPC_ERROR_DEBUG_INFO_DETAIL_TYPE;
   [GRPC_ERROR_DEBUG_INFO_STACK_ENTRIES]?: GRPC_ERROR_DEBUG_INFO_STACK_ENTRIES_TYPE;

--- a/model/attributes/graphql/graphql__processing__type.json
+++ b/model/attributes/graphql/graphql__processing__type.json
@@ -1,0 +1,22 @@
+{
+  "key": "graphql.processing.type",
+  "brief": "The type of processing represented by this span.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["parse", "validate", "execute", "resolve"],
+  "additional_context": [
+    "Well-known values are request, parse, validate, variable_coercion, plan, execute, subscription_event, step_execute, resolve, dataloader_dispatch, dataloader_batch and _OTHER. Use one of these if it applies, otherwise a custom value.",
+    "Not to be confused with graphql.operation.type, which holds the GraphQL operation type (query, mutation, subscription) and only applies to spans that run an operation."
+  ],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [572],
+      "description": "Added graphql.processing.type attribute"
+    }
+  ]
+}

--- a/model/name/graphql.json
+++ b/model/name/graphql.json
@@ -20,8 +20,15 @@
         "graphql.subscription",
         "graphql.validate"
       ],
-      "templates": ["GraphQL {{graphql.operation.type}}", "GraphQL Operation"],
-      "examples": ["GraphQL query", "GraphQL mutation", "GraphQL subscription", "GraphQL Operation"]
+      "templates": ["GraphQL {{graphql.operation.type}}", "GraphQL {{graphql.processing.type}}", "GraphQL Operation"],
+      "examples": [
+        "GraphQL query",
+        "GraphQL mutation",
+        "GraphQL subscription",
+        "GraphQL parse",
+        "GraphQL resolve",
+        "GraphQL Operation"
+      ]
     }
   ]
 }

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5221,6 +5221,22 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "query"
     """
 
+    # Path: model/attributes/graphql/graphql__processing__type.json
+    GRAPHQL_PROCESSING_TYPE: Literal["graphql.processing.type"] = (
+        "graphql.processing.type"
+    )
+    """The type of processing represented by this span.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "parse"
+    Example: "validate"
+    Example: "execute"
+    Example: "resolve"
+    """
+
     # Path: model/attributes/grpc/grpc__error__bad_request__field_violations.json
     GRPC_ERROR_BAD_REQUEST_FIELD_VIOLATIONS: Literal[
         "grpc.error.bad_request.field_violations"
@@ -17282,6 +17298,27 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "graphql.processing.type": AttributeMetadata(
+        brief="The type of processing represented by this span.",
+        type=AttributeType.STRING,
+        keys=("graphql.processing.type",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="parse",
+        examples=["parse", "validate", "execute", "resolve"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[572],
+                description="Added graphql.processing.type attribute",
+            ),
+        ],
+        additional_context=[
+            "Well-known values are request, parse, validate, variable_coercion, plan, execute, subscription_event, step_execute, resolve, dataloader_dispatch, dataloader_batch and _OTHER. Use one of these if it applies, otherwise a custom value.",
+            "Not to be confused with graphql.operation.type, which holds the GraphQL operation type (query, mutation, subscription) and only applies to spans that run an operation.",
+        ],
+    ),
     "grpc.error.bad_request.field_violations": AttributeMetadata(
         brief="The individual field violations from a google.rpc.BadRequest error detail. Each entry is a JSON-encoded object with field, description, reason, and (optional) localized_message keys, mirroring google.rpc.BadRequest.FieldViolation.",
         type=AttributeType.STRING_ARRAY,
@@ -24552,6 +24589,7 @@ Attributes = TypedDict(
         "graphql.document": str,
         "graphql.operation.name": str,
         "graphql.operation.type": str,
+        "graphql.processing.type": str,
         "grpc.error.bad_request.field_violations": List[str],
         "grpc.error.debug_info.detail": str,
         "grpc.error.debug_info.stack_entries": List[str],


### PR DESCRIPTION
## Description

Adds `graphql.processing.type`, which says which part of GraphQL request processing a span represents: `parse`, `validate`, `execute`, `resolve` and so on. Adds it to the `graphql` span name templates as well, so the phases get a name of their own:

```
GraphQL {{graphql.operation.type}}
GraphQL {{graphql.processing.type}}
GraphQL Operation
```

GraphQL span names are low cardinality and carry the operation type at most, so a parse span and a validate span are otherwise indistinguishable. A parse span carries no GraphQL attribute at all today.

Both attributes are set on an operation span, and only `graphql.processing.type` on the phases, so the template order keeps `GraphQL query` for operations and gives `GraphQL parse` / `GraphQL validate` / `GraphQL resolve` to the rest.

Also replaces the `mutation` and `query` examples, which no template can produce since Sentry prefixes GraphQL span names with `GraphQL `, as the `otel_notes` on the same entry says. They predate that prefix.

The attribute name and its value list follow the GraphQL OpenTelemetry Working Group proposal in https://github.com/open-telemetry/semantic-conventions/pull/3515. That PR is still a working draft, so `is_in_otel` is `false` for now and should be flipped once it lands upstream. Note that the working group deliberately did not widen `graphql.operation.type` for this, since that attribute holds the GraphQL operation type (`query`, `mutation`, `subscription`) and applies only to spans that run an operation.

`@sentry/javascript` wants this for https://github.com/getsentry/sentry-javascript/pull/23542, where streamed GraphQL spans lose the operation name and the resolver field path from their names.

## PR Checklist

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)
