### PR TITLE
fix(names): Correct graphql span name examples

### DIFF
--- a/model/name/graphql.json
+++ b/model/name/graphql.json
@@ -21,7 +21,7 @@
         "graphql.validate"
       ],
       "templates": ["GraphQL {{graphql.operation.type}}", "GraphQL Operation"],
-      "examples": ["mutation", "query"]
+      "examples": ["GraphQL query", "GraphQL mutation", "GraphQL subscription", "GraphQL Operation"]
     }
   ]
 }


### PR DESCRIPTION
## Description

The `graphql` span name examples are `mutation` and `query`, which neither template can produce: Sentry prefixes GraphQL span names with `GraphQL `, as the `otel_notes` on the same entry says. They predate that prefix.

Replaces them with names the templates actually produce, and includes the static fallback, matching how sibling name conventions list their examples (`browser.json` lists `Pageload`, `db.json` lists `Database operation`).

No template or behavior change.

## PR Checklist

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

https://claude.ai/code/session_013bjBXkGkJo8eL8hkz48byi
