### PR TITLE
feat(attributes): Add HTTP body size and status text attributes

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8959,6 +8959,9 @@ export type HTTP_CLIENT_IP_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link HTTP_RESPONSE_BODY_DECODED_SIZE} `http.response.body.decoded_size`, {@link HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED} `http.response_content_length_uncompressed`
+ *
+ * @deprecated Use {@link HTTP_RESPONSE_BODY_DECODED_SIZE} (http.response.body.decoded_size) instead
  * @example 456
  */
 export const HTTP_DECODED_RESPONSE_CONTENT_LENGTH = 'http.decoded_response_content_length';
@@ -9103,6 +9106,52 @@ export const HTTP_REQUEST_BODY_DATA = 'http.request.body.data';
  */
 export type HTTP_REQUEST_BODY_DATA_TYPE = string;
 
+// Path: model/attributes/http/http__request__body__decoded_size.json
+
+/**
+ * The decoded body size of the request (in bytes). `http.request.body.decoded_size`
+ *
+ * Attribute Value Type: `number` {@link HTTP_REQUEST_BODY_DECODED_SIZE_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED} `http.request_content_length_uncompressed`
+ *
+ * @example 456
+ */
+export const HTTP_REQUEST_BODY_DECODED_SIZE = 'http.request.body.decoded_size';
+
+/**
+ * Type for {@link HTTP_REQUEST_BODY_DECODED_SIZE} http.request.body.decoded_size
+ */
+export type HTTP_REQUEST_BODY_DECODED_SIZE_TYPE = number;
+
+// Path: model/attributes/http/http__request__body__size.json
+
+/**
+ * The encoded body size of the request (in bytes). `http.request.body.size`
+ *
+ * Attribute Value Type: `number` {@link HTTP_REQUEST_BODY_SIZE_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * Aliases: {@link HTTP_REQUEST_CONTENT_LENGTH} `http.request_content_length`
+ *
+ * @example 123
+ */
+export const HTTP_REQUEST_BODY_SIZE = 'http.request.body.size';
+
+/**
+ * Type for {@link HTTP_REQUEST_BODY_SIZE} http.request.body.size
+ */
+export type HTTP_REQUEST_BODY_SIZE_TYPE = number;
+
 // Path: model/attributes/http/http__request__connection_end.json
 
 /**
@@ -9144,6 +9193,54 @@ export const HTTP_REQUEST_CONNECT_START = 'http.request.connect_start';
  * Type for {@link HTTP_REQUEST_CONNECT_START} http.request.connect_start
  */
 export type HTTP_REQUEST_CONNECT_START_TYPE = number;
+
+// Path: model/attributes/http/http__request_content_length.json
+
+/**
+ * The encoded body size of the request (in bytes). `http.request_content_length`
+ *
+ * Attribute Value Type: `number` {@link HTTP_REQUEST_CONTENT_LENGTH_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * Aliases: {@link HTTP_REQUEST_BODY_SIZE} `http.request.body.size`
+ *
+ * @deprecated Use {@link HTTP_REQUEST_BODY_SIZE} (http.request.body.size) instead
+ * @example 123
+ */
+export const HTTP_REQUEST_CONTENT_LENGTH = 'http.request_content_length';
+
+/**
+ * Type for {@link HTTP_REQUEST_CONTENT_LENGTH} http.request_content_length
+ */
+export type HTTP_REQUEST_CONTENT_LENGTH_TYPE = number;
+
+// Path: model/attributes/http/http__request_content_length_uncompressed.json
+
+/**
+ * The decoded body size of the request (in bytes). `http.request_content_length_uncompressed`
+ *
+ * Attribute Value Type: `number` {@link HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * Aliases: {@link HTTP_REQUEST_BODY_DECODED_SIZE} `http.request.body.decoded_size`
+ *
+ * @deprecated Use {@link HTTP_REQUEST_BODY_DECODED_SIZE} (http.request.body.decoded_size) instead
+ * @example 456
+ */
+export const HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED = 'http.request_content_length_uncompressed';
+
+/**
+ * Type for {@link HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED} http.request_content_length_uncompressed
+ */
+export type HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED_TYPE = number;
 
 // Path: model/attributes/http/http__request__domain_lookup_end.json
 
@@ -9495,6 +9592,29 @@ export const HTTP_REQUEST_WORKER_START = 'http.request.worker_start';
  */
 export type HTTP_REQUEST_WORKER_START_TYPE = number;
 
+// Path: model/attributes/http/http__response__body__decoded_size.json
+
+/**
+ * The decoded body size of the response (in bytes). `http.response.body.decoded_size`
+ *
+ * Attribute Value Type: `number` {@link HTTP_RESPONSE_BODY_DECODED_SIZE_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link HTTP_DECODED_RESPONSE_CONTENT_LENGTH} `http.decoded_response_content_length`, {@link HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED} `http.response_content_length_uncompressed`
+ *
+ * @example 456
+ */
+export const HTTP_RESPONSE_BODY_DECODED_SIZE = 'http.response.body.decoded_size';
+
+/**
+ * Type for {@link HTTP_RESPONSE_BODY_DECODED_SIZE} http.response.body.decoded_size
+ */
+export type HTTP_RESPONSE_BODY_DECODED_SIZE_TYPE = number;
+
 // Path: model/attributes/http/http__response__body__size.json
 
 /**
@@ -9541,6 +9661,30 @@ export const HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length';
  * Type for {@link HTTP_RESPONSE_CONTENT_LENGTH} http.response_content_length
  */
 export type HTTP_RESPONSE_CONTENT_LENGTH_TYPE = number;
+
+// Path: model/attributes/http/http__response_content_length_uncompressed.json
+
+/**
+ * The decoded body size of the response (in bytes). `http.response_content_length_uncompressed`
+ *
+ * Attribute Value Type: `number` {@link HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * Aliases: {@link HTTP_RESPONSE_BODY_DECODED_SIZE} `http.response.body.decoded_size`, {@link HTTP_DECODED_RESPONSE_CONTENT_LENGTH} `http.decoded_response_content_length`
+ *
+ * @deprecated Use {@link HTTP_RESPONSE_BODY_DECODED_SIZE} (http.response.body.decoded_size) instead
+ * @example 456
+ */
+export const HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED = 'http.response_content_length_uncompressed';
+
+/**
+ * Type for {@link HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED} http.response_content_length_uncompressed
+ */
+export type HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED_TYPE = number;
 
 // Path: model/attributes/http/http__response__header__content-length.json
 
@@ -9638,6 +9782,29 @@ export const HTTP_RESPONSE_STATUS_CODE = 'http.response.status_code';
  * Type for {@link HTTP_RESPONSE_STATUS_CODE} http.response.status_code
  */
 export type HTTP_RESPONSE_STATUS_CODE_TYPE = number;
+
+// Path: model/attributes/http/http__response__status_text.json
+
+/**
+ * The reason phrase of the HTTP response. `http.response.status_text`
+ *
+ * Attribute Value Type: `string` {@link HTTP_RESPONSE_STATUS_TEXT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link HTTP_STATUS_TEXT} `http.status_text`
+ *
+ * @example "NOT FOUND"
+ */
+export const HTTP_RESPONSE_STATUS_TEXT = 'http.response.status_text';
+
+/**
+ * Type for {@link HTTP_RESPONSE_STATUS_TEXT} http.response.status_text
+ */
+export type HTTP_RESPONSE_STATUS_TEXT_TYPE = string;
 
 // Path: model/attributes/http/http__response_transfer_size.json
 
@@ -9780,6 +9947,29 @@ export const HTTP_STATUS_CODE = 'http.status_code';
  * Type for {@link HTTP_STATUS_CODE} http.status_code
  */
 export type HTTP_STATUS_CODE_TYPE = number;
+
+// Path: model/attributes/http/http__status_text.json
+
+/**
+ * The reason phrase of the HTTP response `http.status_text`
+ *
+ * Attribute Value Type: `string` {@link HTTP_STATUS_TEXT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link HTTP_RESPONSE_STATUS_TEXT} `http.response.status_text`
+ *
+ * @example "NOT FOUND"
+ */
+export const HTTP_STATUS_TEXT = 'http.status_text';
+
+/**
+ * Type for {@link HTTP_STATUS_TEXT} http.status_text
+ */
+export type HTTP_STATUS_TEXT_TYPE = string;
 
 // Path: model/attributes/http/http__target.json
 
@@ -18111,8 +18301,12 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'http.method': 'string',
   'http.query': 'string',
   'http.request.body.data': 'string',
+  'http.request.body.decoded_size': 'integer',
+  'http.request.body.size': 'integer',
   'http.request.connection_end': 'double',
   'http.request.connect_start': 'double',
+  'http.request_content_length': 'integer',
+  'http.request_content_length_uncompressed': 'integer',
   'http.request.domain_lookup_end': 'double',
   'http.request.domain_lookup_start': 'double',
   'http.request.fetch_start': 'double',
@@ -18129,18 +18323,22 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'http.request.secure_connection_start': 'double',
   'http.request.time_to_first_byte': 'double',
   'http.request.worker_start': 'double',
+  'http.response.body.decoded_size': 'integer',
   'http.response.body.size': 'integer',
   'http.response_content_length': 'integer',
+  'http.response_content_length_uncompressed': 'integer',
   'http.response.header.content-length': 'string',
   'http.response.header.<key>': 'string[]',
   'http.response.size': 'integer',
   'http.response.status_code': 'integer',
+  'http.response.status_text': 'string',
   'http.response_transfer_size': 'integer',
   'http.route': 'string',
   'http.scheme': 'string',
   'http.server_name': 'string',
   'http.server.request.time_in_queue': 'double',
   'http.status_code': 'integer',
+  'http.status_text': 'string',
   'http.target': 'string',
   'http.url': 'string',
   'http.user_agent': 'string',
@@ -18906,8 +19104,12 @@ export type AttributeName =
   | typeof HTTP_METHOD
   | typeof HTTP_QUERY
   | typeof HTTP_REQUEST_BODY_DATA
+  | typeof HTTP_REQUEST_BODY_DECODED_SIZE
+  | typeof HTTP_REQUEST_BODY_SIZE
   | typeof HTTP_REQUEST_CONNECTION_END
   | typeof HTTP_REQUEST_CONNECT_START
+  | typeof HTTP_REQUEST_CONTENT_LENGTH
+  | typeof HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED
   | typeof HTTP_REQUEST_DOMAIN_LOOKUP_END
   | typeof HTTP_REQUEST_DOMAIN_LOOKUP_START
   | typeof HTTP_REQUEST_FETCH_START
@@ -18924,18 +19126,22 @@ export type AttributeName =
   | typeof HTTP_REQUEST_SECURE_CONNECTION_START
   | typeof HTTP_REQUEST_TIME_TO_FIRST_BYTE
   | typeof HTTP_REQUEST_WORKER_START
+  | typeof HTTP_RESPONSE_BODY_DECODED_SIZE
   | typeof HTTP_RESPONSE_BODY_SIZE
   | typeof HTTP_RESPONSE_CONTENT_LENGTH
+  | typeof HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED
   | typeof HTTP_RESPONSE_HEADER_CONTENT_LENGTH
   | typeof HTTP_RESPONSE_HEADER_KEY
   | typeof HTTP_RESPONSE_SIZE
   | typeof HTTP_RESPONSE_STATUS_CODE
+  | typeof HTTP_RESPONSE_STATUS_TEXT
   | typeof HTTP_RESPONSE_TRANSFER_SIZE
   | typeof HTTP_ROUTE
   | typeof HTTP_SCHEME
   | typeof HTTP_SERVER_NAME
   | typeof HTTP_SERVER_REQUEST_TIME_IN_QUEUE
   | typeof HTTP_STATUS_CODE
+  | typeof HTTP_STATUS_TEXT
   | typeof HTTP_TARGET
   | typeof HTTP_URL
   | typeof HTTP_USER_AGENT
@@ -25491,14 +25697,27 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'http.decoded_response_content_length': {
     brief: 'The decoded body size of the response (in bytes).',
     type: 'integer',
-    keys: ['http.decoded_response_content_length'],
+    keys: [
+      'http.response.body.decoded_size',
+      'http.decoded_response_content_length',
+      'http.response_content_length_uncompressed',
+    ],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: false,
     visibility: 'public',
     example: 456,
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    deprecation: {
+      replacement: 'http.response.body.decoded_size',
+      status: 'backfill',
+    },
+    aliases: ['http.response.body.decoded_size', 'http.response_content_length_uncompressed'],
+    changelog: [
+      { version: 'next', prs: [574], description: 'Deprecated in favor of http.response.body.decoded_size' },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.0.0' },
+    ],
     searchAlias: {
       name: 'http.decoded_response_content_length',
       type: 'byte',
@@ -25599,6 +25818,39 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '[{"role": "user", "message": "hello"}]',
     changelog: [{ version: '0.6.0', prs: [336], description: 'Added http.request.body.data attribute' }],
   },
+  'http.request.body.decoded_size': {
+    brief: 'The decoded body size of the request (in bytes).',
+    type: 'integer',
+    keys: ['http.request.body.decoded_size', 'http.request_content_length_uncompressed'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 456,
+    aliases: ['http.request_content_length_uncompressed'],
+    changelog: [{ version: 'next', prs: [574], description: 'Added http.request.body.decoded_size attribute' }],
+    additionalContext: [
+      'This is the size after content decoding. Set it only when the decoded size is actually known, for example by measuring a decompressed request stream.',
+      'Do not derive this from the `content-length` header, which always carries the encoded size. Use `http.request.body.size` for that.',
+    ],
+  },
+  'http.request.body.size': {
+    brief: 'The encoded body size of the request (in bytes).',
+    type: 'integer',
+    keys: ['http.request.body.size', 'http.request_content_length'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 123,
+    aliases: ['http.request_content_length'],
+    changelog: [{ version: 'next', prs: [574], description: 'Added http.request.body.size attribute' }],
+    additionalContext: [
+      'This is the on-the-wire (encoded) size. The `content-length` header always carries the encoded size, so set this attribute whenever `content-length` is known, regardless of whether `content-encoding` is present.',
+    ],
+  },
   'http.request.connection_end': {
     brief:
       'The UNIX timestamp representing the time immediately after the browser finishes establishing the connection to the server to retrieve the resource. The timestamp value includes the time interval to establish the transport connection, as well as other time intervals such as TLS handshake and SOCKS authentication.',
@@ -25624,6 +25876,53 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 1732829555.111,
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [134] }, { version: '0.0.0' }],
+  },
+  'http.request_content_length': {
+    brief: 'The encoded body size of the request (in bytes).',
+    type: 'integer',
+    keys: ['http.request.body.size', 'http.request_content_length'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 123,
+    deprecation: {
+      replacement: 'http.request.body.size',
+      status: 'backfill',
+    },
+    aliases: ['http.request.body.size'],
+    changelog: [
+      {
+        version: 'next',
+        prs: [574],
+        description: 'Added http.request_content_length attribute, deprecated in favor of http.request.body.size',
+      },
+    ],
+  },
+  'http.request_content_length_uncompressed': {
+    brief: 'The decoded body size of the request (in bytes).',
+    type: 'integer',
+    keys: ['http.request.body.decoded_size', 'http.request_content_length_uncompressed'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 456,
+    deprecation: {
+      replacement: 'http.request.body.decoded_size',
+      status: 'backfill',
+    },
+    aliases: ['http.request.body.decoded_size'],
+    changelog: [
+      {
+        version: 'next',
+        prs: [574],
+        description:
+          'Added http.request_content_length_uncompressed attribute, deprecated in favor of http.request.body.decoded_size',
+      },
+    ],
   },
   'http.request.domain_lookup_end': {
     brief:
@@ -25847,6 +26146,27 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: '0.1.0', prs: [130, 134] },
     ],
   },
+  'http.response.body.decoded_size': {
+    brief: 'The decoded body size of the response (in bytes).',
+    type: 'integer',
+    keys: [
+      'http.response.body.decoded_size',
+      'http.decoded_response_content_length',
+      'http.response_content_length_uncompressed',
+    ],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 456,
+    aliases: ['http.decoded_response_content_length', 'http.response_content_length_uncompressed'],
+    changelog: [{ version: 'next', prs: [574], description: 'Added http.response.body.decoded_size attribute' }],
+    additionalContext: [
+      'This is the size after content decoding. Set it only when the decoded size is actually known, for example from the browser Resource Timing `decodedBodySize` or by measuring a decompressed response stream.',
+      'Do not derive this from the `content-length` header, which always carries the encoded size. Use `http.response.body.size` for that.',
+    ],
+  },
   'http.response.body.size': {
     brief: 'The encoded body size of the response (in bytes).',
     type: 'integer',
@@ -25880,6 +26200,34 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       name: 'http.response_content_length',
       type: 'byte',
     },
+  },
+  'http.response_content_length_uncompressed': {
+    brief: 'The decoded body size of the response (in bytes).',
+    type: 'integer',
+    keys: [
+      'http.response.body.decoded_size',
+      'http.decoded_response_content_length',
+      'http.response_content_length_uncompressed',
+    ],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 456,
+    deprecation: {
+      replacement: 'http.response.body.decoded_size',
+      status: 'backfill',
+    },
+    aliases: ['http.response.body.decoded_size', 'http.decoded_response_content_length'],
+    changelog: [
+      {
+        version: 'next',
+        prs: [574],
+        description:
+          'Added http.response_content_length_uncompressed attribute, deprecated in favor of http.response.body.decoded_size',
+      },
+    ],
   },
   'http.response.header.content-length': {
     brief: 'The size of the message body sent to the recipient (in bytes)',
@@ -25939,6 +26287,22 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     searchAlias: {
       name: 'http.response_status_code',
     },
+  },
+  'http.response.status_text': {
+    brief: 'The reason phrase of the HTTP response.',
+    type: 'string',
+    keys: ['http.response.status_text', 'http.status_text'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'NOT FOUND',
+    aliases: ['http.status_text'],
+    changelog: [{ version: 'next', prs: [574], description: 'Added http.response.status_text attribute' }],
+    additionalContext: [
+      'HTTP/2 and HTTP/3 do not carry a reason phrase. Do not set this attribute when the protocol provides none; use `http.response.status_code` instead.',
+    ],
   },
   'http.response_transfer_size': {
     brief: 'The transfer size of the response (in bytes).',
@@ -26054,6 +26418,20 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     aliases: ['http.response.status_code'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+  },
+  'http.status_text': {
+    brief: 'The reason phrase of the HTTP response',
+    type: 'string',
+    keys: ['http.status_text', 'http.response.status_text'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'NOT FOUND',
+    examples: ['NOT FOUND'],
+    aliases: ['http.response.status_text'],
+    changelog: [{ version: 'next', prs: [574], description: 'Added http.status_text attribute' }],
   },
   'http.target': {
     brief: 'The pathname and query string of the URL.',
@@ -36756,8 +37134,12 @@ export type Attributes = {
   [HTTP_METHOD]?: HTTP_METHOD_TYPE;
   [HTTP_QUERY]?: HTTP_QUERY_TYPE;
   [HTTP_REQUEST_BODY_DATA]?: HTTP_REQUEST_BODY_DATA_TYPE;
+  [HTTP_REQUEST_BODY_DECODED_SIZE]?: HTTP_REQUEST_BODY_DECODED_SIZE_TYPE;
+  [HTTP_REQUEST_BODY_SIZE]?: HTTP_REQUEST_BODY_SIZE_TYPE;
   [HTTP_REQUEST_CONNECTION_END]?: HTTP_REQUEST_CONNECTION_END_TYPE;
   [HTTP_REQUEST_CONNECT_START]?: HTTP_REQUEST_CONNECT_START_TYPE;
+  [HTTP_REQUEST_CONTENT_LENGTH]?: HTTP_REQUEST_CONTENT_LENGTH_TYPE;
+  [HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED]?: HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED_TYPE;
   [HTTP_REQUEST_DOMAIN_LOOKUP_END]?: HTTP_REQUEST_DOMAIN_LOOKUP_END_TYPE;
   [HTTP_REQUEST_DOMAIN_LOOKUP_START]?: HTTP_REQUEST_DOMAIN_LOOKUP_START_TYPE;
   [HTTP_REQUEST_FETCH_START]?: HTTP_REQUEST_FETCH_START_TYPE;
@@ -36774,18 +37156,22 @@ export type Attributes = {
   [HTTP_REQUEST_SECURE_CONNECTION_START]?: HTTP_REQUEST_SECURE_CONNECTION_START_TYPE;
   [HTTP_REQUEST_TIME_TO_FIRST_BYTE]?: HTTP_REQUEST_TIME_TO_FIRST_BYTE_TYPE;
   [HTTP_REQUEST_WORKER_START]?: HTTP_REQUEST_WORKER_START_TYPE;
+  [HTTP_RESPONSE_BODY_DECODED_SIZE]?: HTTP_RESPONSE_BODY_DECODED_SIZE_TYPE;
   [HTTP_RESPONSE_BODY_SIZE]?: HTTP_RESPONSE_BODY_SIZE_TYPE;
   [HTTP_RESPONSE_CONTENT_LENGTH]?: HTTP_RESPONSE_CONTENT_LENGTH_TYPE;
+  [HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED]?: HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED_TYPE;
   [HTTP_RESPONSE_HEADER_CONTENT_LENGTH]?: HTTP_RESPONSE_HEADER_CONTENT_LENGTH_TYPE;
   [HTTP_RESPONSE_HEADER_KEY]?: HTTP_RESPONSE_HEADER_KEY_TYPE;
   [HTTP_RESPONSE_SIZE]?: HTTP_RESPONSE_SIZE_TYPE;
   [HTTP_RESPONSE_STATUS_CODE]?: HTTP_RESPONSE_STATUS_CODE_TYPE;
+  [HTTP_RESPONSE_STATUS_TEXT]?: HTTP_RESPONSE_STATUS_TEXT_TYPE;
   [HTTP_RESPONSE_TRANSFER_SIZE]?: HTTP_RESPONSE_TRANSFER_SIZE_TYPE;
   [HTTP_ROUTE]?: HTTP_ROUTE_TYPE;
   [HTTP_SCHEME]?: HTTP_SCHEME_TYPE;
   [HTTP_SERVER_NAME]?: HTTP_SERVER_NAME_TYPE;
   [HTTP_SERVER_REQUEST_TIME_IN_QUEUE]?: HTTP_SERVER_REQUEST_TIME_IN_QUEUE_TYPE;
   [HTTP_STATUS_CODE]?: HTTP_STATUS_CODE_TYPE;
+  [HTTP_STATUS_TEXT]?: HTTP_STATUS_TEXT_TYPE;
   [HTTP_TARGET]?: HTTP_TARGET_TYPE;
   [HTTP_URL]?: HTTP_URL_TYPE;
   [HTTP_USER_AGENT]?: HTTP_USER_AGENT_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -9962,6 +9962,7 @@ export type HTTP_STATUS_CODE_TYPE = number;
  *
  * Aliases: {@link HTTP_RESPONSE_STATUS_TEXT} `http.response.status_text`
  *
+ * @deprecated Use {@link HTTP_RESPONSE_STATUS_TEXT} (http.response.status_text) instead
  * @example "NOT FOUND"
  */
 export const HTTP_STATUS_TEXT = 'http.status_text';
@@ -26422,7 +26423,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'http.status_text': {
     brief: 'The reason phrase of the HTTP response',
     type: 'string',
-    keys: ['http.status_text', 'http.response.status_text'],
+    keys: ['http.response.status_text', 'http.status_text'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -26430,8 +26431,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'NOT FOUND',
     examples: ['NOT FOUND'],
+    deprecation: {
+      replacement: 'http.response.status_text',
+      status: 'backfill',
+    },
     aliases: ['http.response.status_text'],
-    changelog: [{ version: 'next', prs: [574], description: 'Added http.status_text attribute' }],
+    changelog: [
+      {
+        version: 'next',
+        prs: [574],
+        description: 'Added http.status_text attribute, deprecated in favor of http.response.status_text',
+      },
+    ],
   },
   'http.target': {
     brief: 'The pathname and query string of the URL.',
@@ -34299,10 +34310,14 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     deprecationChain: ['client.address', 'http.client_ip'],
   },
   'http.decoded_response_content_length': {
-    canonicalName: 'http.decoded_response_content_length',
+    canonicalName: 'http.response.body.decoded_size',
     type: 'byte',
     brief: 'The decoded body size of the response (in bytes).',
-    deprecationChain: ['http.decoded_response_content_length'],
+    deprecationChain: [
+      'http.response.body.decoded_size',
+      'http.decoded_response_content_length',
+      'http.response_content_length_uncompressed',
+    ],
   },
   'http.flavor': {
     canonicalName: 'network.protocol.version',
@@ -34341,6 +34356,18 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief: 'HTTP request body data. Can be given as string or structural data of any format.',
     deprecationChain: ['http.request.body.data'],
+  },
+  'http.request.body.decoded_size': {
+    canonicalName: 'http.request.body.decoded_size',
+    type: 'integer',
+    brief: 'The decoded body size of the request (in bytes).',
+    deprecationChain: ['http.request.body.decoded_size', 'http.request_content_length_uncompressed'],
+  },
+  'http.request.body.size': {
+    canonicalName: 'http.request.body.size',
+    type: 'integer',
+    brief: 'The encoded body size of the request (in bytes).',
+    deprecationChain: ['http.request.body.size', 'http.request_content_length'],
   },
   'http.request.connect_start': {
     canonicalName: 'http.request.connect_start',
@@ -34456,11 +34483,33 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
       'The UNIX timestamp representing the timestamp immediately before dispatching the FetchEvent if a Service Worker thread is already running, or immediately before starting the Service Worker thread if it is not already running.',
     deprecationChain: ['http.request.worker_start'],
   },
+  'http.request_content_length': {
+    canonicalName: 'http.request.body.size',
+    type: 'integer',
+    brief: 'The encoded body size of the request (in bytes).',
+    deprecationChain: ['http.request.body.size', 'http.request_content_length'],
+  },
+  'http.request_content_length_uncompressed': {
+    canonicalName: 'http.request.body.decoded_size',
+    type: 'integer',
+    brief: 'The decoded body size of the request (in bytes).',
+    deprecationChain: ['http.request.body.decoded_size', 'http.request_content_length_uncompressed'],
+  },
   'http.request_method': {
     canonicalName: 'http.request.method',
     type: 'string',
     brief: 'The HTTP method used.',
     deprecationChain: ['http.request.method', 'http.method', 'http.request_method', 'method'],
+  },
+  'http.response.body.decoded_size': {
+    canonicalName: 'http.response.body.decoded_size',
+    type: 'integer',
+    brief: 'The decoded body size of the response (in bytes).',
+    deprecationChain: [
+      'http.response.body.decoded_size',
+      'http.decoded_response_content_length',
+      'http.response_content_length_uncompressed',
+    ],
   },
   'http.response.body.size': {
     canonicalName: 'http.response.body.size',
@@ -34495,6 +34544,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     brief: 'The transfer size of the response (in bytes).',
     deprecationChain: ['http.response.size', 'http.response_transfer_size'],
   },
+  'http.response.status_text': {
+    canonicalName: 'http.response.status_text',
+    type: 'string',
+    brief: 'The reason phrase of the HTTP response.',
+    deprecationChain: ['http.response.status_text', 'http.status_text'],
+  },
   'http.response_content_length': {
     canonicalName: 'http.response.body.size',
     type: 'byte',
@@ -34503,6 +34558,16 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
       'http.response.body.size',
       'http.response.header.content-length',
       'http.response_content_length',
+    ],
+  },
+  'http.response_content_length_uncompressed': {
+    canonicalName: 'http.response.body.decoded_size',
+    type: 'integer',
+    brief: 'The decoded body size of the response (in bytes).',
+    deprecationChain: [
+      'http.response.body.decoded_size',
+      'http.decoded_response_content_length',
+      'http.response_content_length_uncompressed',
     ],
   },
   'http.response_status_code': {
@@ -34547,6 +34612,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'integer',
     brief: 'The status code of the HTTP response.',
     deprecationChain: ['http.response.status_code', 'http.response_status_code', 'http.status_code'],
+  },
+  'http.status_text': {
+    canonicalName: 'http.response.status_text',
+    type: 'string',
+    brief: 'The reason phrase of the HTTP response',
+    deprecationChain: ['http.response.status_text', 'http.status_text'],
   },
   'http.target': {
     canonicalName: 'url.path',

--- a/model/attributes/http/http__decoded_response_content_length.json
+++ b/model/attributes/http/http__decoded_response_content_length.json
@@ -7,12 +7,22 @@
   },
   "is_in_otel": false,
   "example": 456,
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "http.response.body.decoded_size"
+  },
+  "alias": ["http.response.body.decoded_size", "http.response_content_length_uncompressed"],
   "visibility": "public",
   "search_alias": {
     "name": "http.decoded_response_content_length",
     "type": "byte"
   },
   "changelog": [
+    {
+      "version": "next",
+      "prs": [574],
+      "description": "Deprecated in favor of http.response.body.decoded_size"
+    },
     {
       "version": "0.4.0",
       "prs": [228]

--- a/model/attributes/http/http__request__body__decoded_size.json
+++ b/model/attributes/http/http__request__body__decoded_size.json
@@ -1,0 +1,23 @@
+{
+  "key": "http.request.body.decoded_size",
+  "brief": "The decoded body size of the request (in bytes).",
+  "additional_context": [
+    "This is the size after content decoding. Set it only when the decoded size is actually known, for example by measuring a decompressed request stream.",
+    "Do not derive this from the `content-length` header, which always carries the encoded size. Use `http.request.body.size` for that."
+  ],
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 456,
+  "alias": ["http.request_content_length_uncompressed"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [574],
+      "description": "Added http.request.body.decoded_size attribute"
+    }
+  ]
+}

--- a/model/attributes/http/http__request__body__size.json
+++ b/model/attributes/http/http__request__body__size.json
@@ -1,0 +1,22 @@
+{
+  "key": "http.request.body.size",
+  "brief": "The encoded body size of the request (in bytes).",
+  "additional_context": [
+    "This is the on-the-wire (encoded) size. The `content-length` header always carries the encoded size, so set this attribute whenever `content-length` is known, regardless of whether `content-encoding` is present."
+  ],
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 123,
+  "alias": ["http.request_content_length"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [574],
+      "description": "Added http.request.body.size attribute"
+    }
+  ]
+}

--- a/model/attributes/http/http__request_content_length.json
+++ b/model/attributes/http/http__request_content_length.json
@@ -1,0 +1,23 @@
+{
+  "key": "http.request_content_length",
+  "brief": "The encoded body size of the request (in bytes).",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 123,
+  "alias": ["http.request.body.size"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "http.request.body.size"
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [574],
+      "description": "Added http.request_content_length attribute, deprecated in favor of http.request.body.size"
+    }
+  ]
+}

--- a/model/attributes/http/http__request_content_length_uncompressed.json
+++ b/model/attributes/http/http__request_content_length_uncompressed.json
@@ -1,0 +1,23 @@
+{
+  "key": "http.request_content_length_uncompressed",
+  "brief": "The decoded body size of the request (in bytes).",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 456,
+  "alias": ["http.request.body.decoded_size"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "http.request.body.decoded_size"
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [574],
+      "description": "Added http.request_content_length_uncompressed attribute, deprecated in favor of http.request.body.decoded_size"
+    }
+  ]
+}

--- a/model/attributes/http/http__response__body__decoded_size.json
+++ b/model/attributes/http/http__response__body__decoded_size.json
@@ -1,0 +1,23 @@
+{
+  "key": "http.response.body.decoded_size",
+  "brief": "The decoded body size of the response (in bytes).",
+  "additional_context": [
+    "This is the size after content decoding. Set it only when the decoded size is actually known, for example from the browser Resource Timing `decodedBodySize` or by measuring a decompressed response stream.",
+    "Do not derive this from the `content-length` header, which always carries the encoded size. Use `http.response.body.size` for that."
+  ],
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": 456,
+  "alias": ["http.decoded_response_content_length", "http.response_content_length_uncompressed"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [574],
+      "description": "Added http.response.body.decoded_size attribute"
+    }
+  ]
+}

--- a/model/attributes/http/http__response__status_text.json
+++ b/model/attributes/http/http__response__status_text.json
@@ -1,0 +1,22 @@
+{
+  "key": "http.response.status_text",
+  "brief": "The reason phrase of the HTTP response.",
+  "additional_context": [
+    "HTTP/2 and HTTP/3 do not carry a reason phrase. Do not set this attribute when the protocol provides none; use `http.response.status_code` instead."
+  ],
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": "NOT FOUND",
+  "alias": ["http.status_text"],
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [574],
+      "description": "Added http.response.status_text attribute"
+    }
+  ]
+}

--- a/model/attributes/http/http__response_content_length_uncompressed.json
+++ b/model/attributes/http/http__response_content_length_uncompressed.json
@@ -1,0 +1,23 @@
+{
+  "key": "http.response_content_length_uncompressed",
+  "brief": "The decoded body size of the response (in bytes).",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "example": 456,
+  "alias": ["http.response.body.decoded_size", "http.decoded_response_content_length"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "http.response.body.decoded_size"
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [574],
+      "description": "Added http.response_content_length_uncompressed attribute, deprecated in favor of http.response.body.decoded_size"
+    }
+  ]
+}

--- a/model/attributes/http/http__status_text.json
+++ b/model/attributes/http/http__status_text.json
@@ -9,11 +9,15 @@
   "visibility": "public",
   "examples": ["NOT FOUND"],
   "alias": ["http.response.status_text"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "http.response.status_text"
+  },
   "changelog": [
     {
       "version": "next",
       "prs": [574],
-      "description": "Added http.status_text attribute"
+      "description": "Added http.status_text attribute, deprecated in favor of http.response.status_text"
     }
   ]
 }

--- a/model/attributes/http/http__status_text.json
+++ b/model/attributes/http/http__status_text.json
@@ -1,0 +1,19 @@
+{
+  "key": "http.status_text",
+  "brief": "The reason phrase of the HTTP response",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["NOT FOUND"],
+  "alias": ["http.response.status_text"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [574],
+      "description": "Added http.status_text attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -277,6 +277,7 @@ class _AttributeNamesMeta(type):
         "HTTP_SCHEME",
         "HTTP_SERVER_NAME",
         "HTTP_STATUS_CODE",
+        "HTTP_STATUS_TEXT",
         "HTTP_TARGET",
         "HTTP_URL",
         "HTTP_USER_AGENT",
@@ -6031,6 +6032,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Visibility: public
     Aliases: http.response.status_text
+    DEPRECATED: Use http.response.status_text instead
     Example: "NOT FOUND"
     """
 
@@ -18535,20 +18537,23 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="The reason phrase of the HTTP response",
         type=AttributeType.STRING,
         keys=(
-            "http.status_text",
             "http.response.status_text",
+            "http.status_text",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="NOT FOUND",
         examples=["NOT FOUND"],
+        deprecation=DeprecationInfo(
+            replacement="http.response.status_text", status=DeprecationStatus.BACKFILL
+        ),
         aliases=["http.response.status_text"],
         changelog=[
             ChangelogEntry(
                 version="next",
                 prs=[574],
-                description="Added http.status_text attribute",
+                description="Added http.status_text attribute, deprecated in favor of http.response.status_text",
             ),
         ],
     ),

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -264,11 +264,15 @@ class _AttributeNamesMeta(type):
         "GEN_AI_USAGE_PROMPT_TOKENS",
         "HARDWARECONCURRENCY",
         "HTTP_CLIENT_IP",
+        "HTTP_DECODED_RESPONSE_CONTENT_LENGTH",
         "HTTP_FLAVOR",
         "HTTP_HOST",
         "HTTP_METHOD",
+        "HTTP_REQUEST_CONTENT_LENGTH",
+        "HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED",
         "_HTTP_REQUEST_METHOD",
         "HTTP_RESPONSE_CONTENT_LENGTH",
+        "HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED",
         "HTTP_RESPONSE_TRANSFER_SIZE",
         "HTTP_SCHEME",
         "HTTP_SERVER_NAME",
@@ -5443,6 +5447,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
+    Aliases: http.response.body.decoded_size, http.response_content_length_uncompressed
+    DEPRECATED: Use http.response.body.decoded_size instead
     Example: 456
     """
 
@@ -5516,6 +5522,32 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Visibility: public
     Example: "[{\"role\": \"user\", \"message\": \"hello\"}]"
+    """
+
+    # Path: model/attributes/http/http__request__body__decoded_size.json
+    HTTP_REQUEST_BODY_DECODED_SIZE: Literal["http.request.body.decoded_size"] = (
+        "http.request.body.decoded_size"
+    )
+    """The decoded body size of the request (in bytes).
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: http.request_content_length_uncompressed
+    Example: 456
+    """
+
+    # Path: model/attributes/http/http__request__body__size.json
+    HTTP_REQUEST_BODY_SIZE: Literal["http.request.body.size"] = "http.request.body.size"
+    """The encoded body size of the request (in bytes).
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Aliases: http.request_content_length
+    Example: 123
     """
 
     # Path: model/attributes/http/http__request__connect_start.json
@@ -5740,6 +5772,36 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 1732829553.68
     """
 
+    # Path: model/attributes/http/http__request_content_length.json
+    HTTP_REQUEST_CONTENT_LENGTH: Literal["http.request_content_length"] = (
+        "http.request_content_length"
+    )
+    """The encoded body size of the request (in bytes).
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Aliases: http.request.body.size
+    DEPRECATED: Use http.request.body.size instead
+    Example: 123
+    """
+
+    # Path: model/attributes/http/http__request_content_length_uncompressed.json
+    HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED: Literal[
+        "http.request_content_length_uncompressed"
+    ] = "http.request_content_length_uncompressed"
+    """The decoded body size of the request (in bytes).
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Aliases: http.request.body.decoded_size
+    DEPRECATED: Use http.request.body.decoded_size instead
+    Example: 456
+    """
+
     # Path: model/attributes/http/http__request_method.json
     _HTTP_REQUEST_METHOD: Literal["http.request_method"] = "http.request_method"
     """The HTTP method used.
@@ -5751,6 +5813,20 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Aliases: method, http.method, http.request.method
     DEPRECATED: Use http.request.method instead
     Example: "GET"
+    """
+
+    # Path: model/attributes/http/http__response__body__decoded_size.json
+    HTTP_RESPONSE_BODY_DECODED_SIZE: Literal["http.response.body.decoded_size"] = (
+        "http.response.body.decoded_size"
+    )
+    """The decoded body size of the response (in bytes).
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: http.decoded_response_content_length, http.response_content_length_uncompressed
+    Example: 456
     """
 
     # Path: model/attributes/http/http__response__body__size.json
@@ -5821,6 +5897,20 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 404
     """
 
+    # Path: model/attributes/http/http__response__status_text.json
+    HTTP_RESPONSE_STATUS_TEXT: Literal["http.response.status_text"] = (
+        "http.response.status_text"
+    )
+    """The reason phrase of the HTTP response.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: http.status_text
+    Example: "NOT FOUND"
+    """
+
     # Path: model/attributes/http/http__response_content_length.json
     HTTP_RESPONSE_CONTENT_LENGTH: Literal["http.response_content_length"] = (
         "http.response_content_length"
@@ -5834,6 +5924,21 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Aliases: http.response.body.size, http.response.header.content-length
     DEPRECATED: Use http.response.body.size instead
     Example: 123
+    """
+
+    # Path: model/attributes/http/http__response_content_length_uncompressed.json
+    HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED: Literal[
+        "http.response_content_length_uncompressed"
+    ] = "http.response_content_length_uncompressed"
+    """The decoded body size of the response (in bytes).
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Aliases: http.response.body.decoded_size, http.decoded_response_content_length
+    DEPRECATED: Use http.response.body.decoded_size instead
+    Example: 456
     """
 
     # Path: model/attributes/http/http__response_transfer_size.json
@@ -5915,6 +6020,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Aliases: http.response.status_code
     DEPRECATED: Use http.response.status_code instead
     Example: 404
+    """
+
+    # Path: model/attributes/http/http__status_text.json
+    HTTP_STATUS_TEXT: Literal["http.status_text"] = "http.status_text"
+    """The reason phrase of the HTTP response
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: http.response.status_text
+    Example: "NOT FOUND"
     """
 
     # Path: model/attributes/http/http__target.json
@@ -17585,12 +17702,29 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "http.decoded_response_content_length": AttributeMetadata(
         brief="The decoded body size of the response (in bytes).",
         type=AttributeType.INTEGER,
-        keys=("http.decoded_response_content_length",),
+        keys=(
+            "http.response.body.decoded_size",
+            "http.decoded_response_content_length",
+            "http.response_content_length_uncompressed",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=456,
+        deprecation=DeprecationInfo(
+            replacement="http.response.body.decoded_size",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=[
+            "http.response.body.decoded_size",
+            "http.response_content_length_uncompressed",
+        ],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[574],
+                description="Deprecated in favor of http.response.body.decoded_size",
+            ),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -17710,6 +17844,53 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
                 prs=[336],
                 description="Added http.request.body.data attribute",
             ),
+        ],
+    ),
+    "http.request.body.decoded_size": AttributeMetadata(
+        brief="The decoded body size of the request (in bytes).",
+        type=AttributeType.INTEGER,
+        keys=(
+            "http.request.body.decoded_size",
+            "http.request_content_length_uncompressed",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=456,
+        aliases=["http.request_content_length_uncompressed"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[574],
+                description="Added http.request.body.decoded_size attribute",
+            ),
+        ],
+        additional_context=[
+            "This is the size after content decoding. Set it only when the decoded size is actually known, for example by measuring a decompressed request stream.",
+            "Do not derive this from the `content-length` header, which always carries the encoded size. Use `http.request.body.size` for that.",
+        ],
+    ),
+    "http.request.body.size": AttributeMetadata(
+        brief="The encoded body size of the request (in bytes).",
+        type=AttributeType.INTEGER,
+        keys=(
+            "http.request.body.size",
+            "http.request_content_length",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=123,
+        aliases=["http.request_content_length"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[574],
+                description="Added http.request.body.size attribute",
+            ),
+        ],
+        additional_context=[
+            "This is the on-the-wire (encoded) size. The `content-length` header always carries the encoded size, so set this attribute whenever `content-length` is known, regardless of whether `content-encoding` is present."
         ],
     ),
     "http.request.connect_start": AttributeMetadata(
@@ -17957,6 +18138,53 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[130, 134]),
         ],
     ),
+    "http.request_content_length": AttributeMetadata(
+        brief="The encoded body size of the request (in bytes).",
+        type=AttributeType.INTEGER,
+        keys=(
+            "http.request.body.size",
+            "http.request_content_length",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=123,
+        deprecation=DeprecationInfo(
+            replacement="http.request.body.size", status=DeprecationStatus.BACKFILL
+        ),
+        aliases=["http.request.body.size"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[574],
+                description="Added http.request_content_length attribute, deprecated in favor of http.request.body.size",
+            ),
+        ],
+    ),
+    "http.request_content_length_uncompressed": AttributeMetadata(
+        brief="The decoded body size of the request (in bytes).",
+        type=AttributeType.INTEGER,
+        keys=(
+            "http.request.body.decoded_size",
+            "http.request_content_length_uncompressed",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=456,
+        deprecation=DeprecationInfo(
+            replacement="http.request.body.decoded_size",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["http.request.body.decoded_size"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[574],
+                description="Added http.request_content_length_uncompressed attribute, deprecated in favor of http.request.body.decoded_size",
+            ),
+        ],
+    ),
     "http.request_method": AttributeMetadata(
         brief="The HTTP method used.",
         type=AttributeType.STRING,
@@ -17980,6 +18208,34 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
                 prs=[343],
                 description="Added http.request_method attribute",
             ),
+        ],
+    ),
+    "http.response.body.decoded_size": AttributeMetadata(
+        brief="The decoded body size of the response (in bytes).",
+        type=AttributeType.INTEGER,
+        keys=(
+            "http.response.body.decoded_size",
+            "http.decoded_response_content_length",
+            "http.response_content_length_uncompressed",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=456,
+        aliases=[
+            "http.decoded_response_content_length",
+            "http.response_content_length_uncompressed",
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[574],
+                description="Added http.response.body.decoded_size attribute",
+            ),
+        ],
+        additional_context=[
+            "This is the size after content decoding. Set it only when the decoded size is actually known, for example from the browser Resource Timing `decodedBodySize` or by measuring a decompressed response stream.",
+            "Do not derive this from the `content-length` header, which always carries the encoded size. Use `http.response.body.size` for that.",
         ],
     ),
     "http.response.body.size": AttributeMetadata(
@@ -18069,6 +18325,29 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
         search_alias=SearchAlias(name="http.response_status_code"),
     ),
+    "http.response.status_text": AttributeMetadata(
+        brief="The reason phrase of the HTTP response.",
+        type=AttributeType.STRING,
+        keys=(
+            "http.response.status_text",
+            "http.status_text",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="NOT FOUND",
+        aliases=["http.status_text"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[574],
+                description="Added http.response.status_text attribute",
+            ),
+        ],
+        additional_context=[
+            "HTTP/2 and HTTP/3 do not carry a reason phrase. Do not set this attribute when the protocol provides none; use `http.response.status_code` instead."
+        ],
+    ),
     "http.response_content_length": AttributeMetadata(
         brief="The encoded body size of the response (in bytes).",
         type=AttributeType.INTEGER,
@@ -18091,6 +18370,34 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
         search_alias=SearchAlias(name="http.response_content_length", type="byte"),
+    ),
+    "http.response_content_length_uncompressed": AttributeMetadata(
+        brief="The decoded body size of the response (in bytes).",
+        type=AttributeType.INTEGER,
+        keys=(
+            "http.response.body.decoded_size",
+            "http.decoded_response_content_length",
+            "http.response_content_length_uncompressed",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example=456,
+        deprecation=DeprecationInfo(
+            replacement="http.response.body.decoded_size",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=[
+            "http.response.body.decoded_size",
+            "http.decoded_response_content_length",
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[574],
+                description="Added http.response_content_length_uncompressed attribute, deprecated in favor of http.response.body.decoded_size",
+            ),
+        ],
     ),
     "http.response_transfer_size": AttributeMetadata(
         brief="The transfer size of the response (in bytes).",
@@ -18222,6 +18529,27 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[61]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "http.status_text": AttributeMetadata(
+        brief="The reason phrase of the HTTP response",
+        type=AttributeType.STRING,
+        keys=(
+            "http.status_text",
+            "http.response.status_text",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="NOT FOUND",
+        examples=["NOT FOUND"],
+        aliases=["http.response.status_text"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[574],
+                description="Added http.status_text attribute",
+            ),
         ],
     ),
     "http.target": AttributeMetadata(
@@ -24612,6 +24940,8 @@ Attributes = TypedDict(
         "http.method": str,
         "http.query": str,
         "http.request.body.data": str,
+        "http.request.body.decoded_size": int,
+        "http.request.body.size": int,
         "http.request.connect_start": float,
         "http.request.connection_end": float,
         "http.request.domain_lookup_end": float,
@@ -24629,19 +24959,25 @@ Attributes = TypedDict(
         "http.request.secure_connection_start": float,
         "http.request.time_to_first_byte": float,
         "http.request.worker_start": float,
+        "http.request_content_length": int,
+        "http.request_content_length_uncompressed": int,
         "http.request_method": str,
+        "http.response.body.decoded_size": int,
         "http.response.body.size": int,
         "http.response.header.<key>": List[str],
         "http.response.header.content-length": str,
         "http.response.size": int,
         "http.response.status_code": int,
+        "http.response.status_text": str,
         "http.response_content_length": int,
+        "http.response_content_length_uncompressed": int,
         "http.response_transfer_size": int,
         "http.route": str,
         "http.scheme": str,
         "http.server.request.time_in_queue": float,
         "http.server_name": str,
         "http.status_code": int,
+        "http.status_text": str,
         "http.target": str,
         "http.url": str,
         "http.user_agent": str,


### PR DESCRIPTION
## Description

- Registers 4 deprecated HTTP attributes the JS SDK currently emits:
  - `http.request_content_length`
  - `http.request_content_length_uncompressed`
  - `http.response_content_length_uncompressed`
  - `http.status_text`,

- deprecates the existing `http.decoded_response_content_length`

- and registers the following replacements:
  - `http.request.body.size`
  - `http.request.body.decoded_size`
  - `http.response.body.decoded_size`
  - `http.response.status_text`

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
