### PR TITLE
fix(names): Add missing `gen_ai` ops to span name rules

### DIFF
--- a/model/name/gen_ai.json
+++ b/model/name/gen_ai.json
@@ -6,7 +6,7 @@
       "brief": "Generative AI agent operations (e.g., spawning a new agent, an agent performing an action on behalf of a user, and agent handing off work to another agent).",
       "is_in_otel": true,
       "otel_notes": "The \"gen_ai.handoff\" operation is not present in OpenTelemetry.",
-      "ops": ["gen_ai.handoff", "gen_ai.invoke_agent"],
+      "ops": ["gen_ai.create_agent", "gen_ai.handoff", "gen_ai.invoke_agent"],
       "templates": [
         "{{gen_ai.operation.name}} {{gen_ai.agent.name}}",
         "{{gen_ai.operation.name}}",
@@ -19,7 +19,16 @@
       "brief": "Generative AI inference operations. Requests to a generative AI model to perform some unit of work (e.g., autocomplete, translation, chat completion, response to a query).",
       "is_in_otel": true,
       "otel_notes": "",
-      "ops": ["gen_ai", "gen_ai.chat", "gen_ai.execute_tool"],
+      "ops": [
+        "gen_ai",
+        "gen_ai.chat",
+        "gen_ai.embeddings",
+        "gen_ai.execute_tool",
+        "gen_ai.generate_content",
+        "gen_ai.rerank",
+        "gen_ai.responses",
+        "gen_ai.text_completion"
+      ],
       "templates": [
         "{{gen_ai.operation.name}} {{gen_ai.request.model}}",
         "{{gen_ai.operation.name}}",


### PR DESCRIPTION
The `gen_ai` span name rules only listed `chat`, `execute_tool`, `handoff` and `invoke_agent`. Add the remaining ops emitted by the JS and Python SDKs, all of which fit the existing templates:

- `gen_ai.create_agent`
- `gen_ai.embeddings`
- `gen_ai.generate_content`
- `gen_ai.rerank`
- `gen_ai.responses`
- `gen_ai.text_completion`
