### PR TITLE
fix(names): Include tool name in `gen_ai.execute_tool` span names

### DIFF
--- a/model/name/gen_ai.json
+++ b/model/name/gen_ai.json
@@ -22,10 +22,17 @@
       "ops": ["gen_ai", "gen_ai.chat", "gen_ai.execute_tool"],
       "templates": [
         "{{gen_ai.operation.name}} {{gen_ai.request.model}}",
+        "{{gen_ai.operation.name}} {{gen_ai.tool.name}}",
         "{{gen_ai.operation.name}}",
         "Generative AI model operation"
       ],
-      "examples": ["text_completion gpt-4", "embeddings huggingface", "chat claude-opus-4", "chat"]
+      "examples": [
+        "text_completion gpt-4",
+        "embeddings huggingface",
+        "chat claude-opus-4",
+        "execute_tool get_weather",
+        "chat"
+      ]
     }
   ]
 }


### PR DESCRIPTION
`gen_ai.execute_tool` spans carry `gen_ai.tool.name` and no model, so the current templates can only name them `execute_tool`. This PR adds a `{{gen_ai.operation.name}} {{gen_ai.tool.name}}` template, which matches what the JS and Python SDKs named these spans (changing this pending on this PR)

I think, tool names should be low cardinality enough to include in span names but happy to drop if I'm missing something.
