### PR TITLE
feat(attributes): Add legacy AMQP and Redis span attributes (deprecated)

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4663,7 +4663,7 @@ export type DB_COLLECTION_NAME_TYPE = string;
  *
  * Apply Scrubbing: auto
  *
- * Attribute defined in OTEL: No
+ * Attribute defined in OTEL: Yes
  * Visibility: public
  *
  * @deprecated  - This attribute is deprecated. The connection is described by server.address and server.port instead, so the value cannot be copied to a single replacement attribute.
@@ -22844,7 +22844,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     applyScrubbing: {
       key: 'auto',
     },
-    isInOtel: false,
+    isInOtel: true,
     visibility: 'public',
     example: 'redis://localhost:6379',
     examples: ['redis://localhost:6379'],

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -2760,7 +2760,7 @@ export type _AWS_REQUEST_ID_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link URL_FULL} `url.full`, {@link HTTP_URL} `http.url`, {@link URL} `url`
+ * Aliases: {@link URL_FULL} `url.full`, {@link HTTP_URL} `http.url`, {@link URL} `url`, {@link MESSAGING_URL} `messaging.url`
  *
  * @deprecated Use {@link URL_FULL} (url.full) instead - This attribute is being deprecated in favor of url.full, which is the OTel-aligned replacement.
  * @example "https://sqs.us-east-1.amazonaws.com/123456789/my-queue"
@@ -4653,6 +4653,28 @@ export const DB_COLLECTION_NAME = 'db.collection.name';
  * Type for {@link DB_COLLECTION_NAME} db.collection.name
  */
 export type DB_COLLECTION_NAME_TYPE = string;
+
+// Path: model/attributes/db/db__connection_string.json
+
+/**
+ * The connection string used to connect to the database. `db.connection_string`
+ *
+ * Attribute Value Type: `string` {@link DB_CONNECTION_STRING_TYPE}
+ *
+ * Apply Scrubbing: auto
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @deprecated  - This attribute is deprecated. The connection is described by server.address and server.port instead, so the value cannot be copied to a single replacement attribute.
+ * @example "redis://localhost:6379"
+ */
+export const DB_CONNECTION_STRING = 'db.connection_string';
+
+/**
+ * Type for {@link DB_CONNECTION_STRING} db.connection_string
+ */
+export type DB_CONNECTION_STRING_TYPE = string;
 
 // Path: model/attributes/db/db__driver__name.json
 
@@ -8983,7 +9005,7 @@ export type HTTP_DECODED_RESPONSE_CONTENT_LENGTH_TYPE = number;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link NETWORK_PROTOCOL_VERSION} `network.protocol.version`, {@link NET_PROTOCOL_VERSION} `net.protocol.version`
+ * Aliases: {@link NETWORK_PROTOCOL_VERSION} `network.protocol.version`, {@link NET_PROTOCOL_VERSION} `net.protocol.version`, {@link MESSAGING_PROTOCOL_VERSION} `messaging.protocol_version`
  *
  * @deprecated Use {@link NETWORK_PROTOCOL_VERSION} (network.protocol.version) instead
  * @example "1.1"
@@ -10006,7 +10028,7 @@ export type HTTP_TARGET_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link URL_FULL} `url.full`, {@link URL} `url`, {@link AWS_REQUEST_URL} `aws.request.url`
+ * Aliases: {@link URL_FULL} `url.full`, {@link URL} `url`, {@link AWS_REQUEST_URL} `aws.request.url`, {@link MESSAGING_URL} `messaging.url`
  *
  * @deprecated Use {@link URL_FULL} (url.full) instead
  * @example "https://example.com/test?foo=bar#buzz"
@@ -11105,7 +11127,7 @@ export type MCP_REQUEST_ID_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link NETWORK_PROTOCOL_NAME} `network.protocol.name`, {@link NET_PROTOCOL_NAME} `net.protocol.name`
+ * Aliases: {@link NETWORK_PROTOCOL_NAME} `network.protocol.name`, {@link NET_PROTOCOL_NAME} `net.protocol.name`, {@link MESSAGING_PROTOCOL} `messaging.protocol`
  *
  * @deprecated Use {@link NETWORK_PROTOCOL_NAME} (network.protocol.name) instead - OTel uses the generic network.protocol.name attribute
  * @example "file"
@@ -11386,6 +11408,30 @@ export const MESSAGING_BATCH_MESSAGE_COUNT = 'messaging.batch.message_count';
  */
 export type MESSAGING_BATCH_MESSAGE_COUNT_TYPE = number;
 
+// Path: model/attributes/messaging/messaging__conversation_id.json
+
+/**
+ * The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". `messaging.conversation_id`
+ *
+ * Attribute Value Type: `string` {@link MESSAGING_CONVERSATION_ID_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link MESSAGING_MESSAGE_CONVERSATION_ID} `messaging.message.conversation_id`
+ *
+ * @deprecated Use {@link MESSAGING_MESSAGE_CONVERSATION_ID} (messaging.message.conversation_id) instead - This attribute is being deprecated in favor of messaging.message.conversation_id.
+ * @example "MyConversationId"
+ */
+export const MESSAGING_CONVERSATION_ID = 'messaging.conversation_id';
+
+/**
+ * Type for {@link MESSAGING_CONVERSATION_ID} messaging.conversation_id
+ */
+export type MESSAGING_CONVERSATION_ID_TYPE = string;
+
 // Path: model/attributes/messaging/messaging__destination.json
 
 /**
@@ -11593,6 +11639,8 @@ export type MESSAGING_MESSAGE_BODY_SIZE_TYPE = number;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
+ * Aliases: {@link MESSAGING_CONVERSATION_ID} `messaging.conversation_id`
+ *
  * @example "MyConversationId"
  */
 export const MESSAGING_MESSAGE_CONVERSATION_ID = 'messaging.message.conversation_id';
@@ -11635,6 +11683,8 @@ export type MESSAGING_MESSAGE_ENVELOPE_SIZE_TYPE = number;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
+ * Aliases: {@link _MESSAGING_MESSAGE_ID} `messaging.message_id`
+ *
  * @example "f47ac10b58cc4372a5670e02b2c3d479"
  */
 export const MESSAGING_MESSAGE_ID = 'messaging.message.id';
@@ -11643,6 +11693,30 @@ export const MESSAGING_MESSAGE_ID = 'messaging.message.id';
  * Type for {@link MESSAGING_MESSAGE_ID} messaging.message.id
  */
 export type MESSAGING_MESSAGE_ID_TYPE = string;
+
+// Path: model/attributes/messaging/messaging__message_id.json
+
+/**
+ * A value used by the messaging system as an identifier for the message, represented as a string. `messaging.message_id`
+ *
+ * Attribute Value Type: `string` {@link _MESSAGING_MESSAGE_ID_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link MESSAGING_MESSAGE_ID} `messaging.message.id`
+ *
+ * @deprecated Use {@link MESSAGING_MESSAGE_ID} (messaging.message.id) instead - This attribute is being deprecated in favor of messaging.message.id.
+ * @example "452a7c7c7c7048c2f887f0e7"
+ */
+export const _MESSAGING_MESSAGE_ID = 'messaging.message_id';
+
+/**
+ * Type for {@link _MESSAGING_MESSAGE_ID} messaging.message_id
+ */
+export type _MESSAGING_MESSAGE_ID_TYPE = string;
 
 // Path: model/attributes/messaging/messaging__message__receive__latency.json
 
@@ -11686,6 +11760,30 @@ export const MESSAGING_MESSAGE_RETRY_COUNT = 'messaging.message.retry.count';
  */
 export type MESSAGING_MESSAGE_RETRY_COUNT_TYPE = number;
 
+// Path: model/attributes/messaging/messaging__operation.json
+
+/**
+ * The name of the messaging operation being performed. `messaging.operation`
+ *
+ * Attribute Value Type: `string` {@link MESSAGING_OPERATION_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link MESSAGING_OPERATION_NAME} `messaging.operation.name`
+ *
+ * @deprecated Use {@link MESSAGING_OPERATION_NAME} (messaging.operation.name) instead - This attribute is being deprecated in favor of messaging.operation.name.
+ * @example "publish"
+ */
+export const MESSAGING_OPERATION = 'messaging.operation';
+
+/**
+ * Type for {@link MESSAGING_OPERATION} messaging.operation
+ */
+export type MESSAGING_OPERATION_TYPE = string;
+
 // Path: model/attributes/messaging/messaging__operation__name.json
 
 /**
@@ -11697,6 +11795,8 @@ export type MESSAGING_MESSAGE_RETRY_COUNT_TYPE = number;
  *
  * Attribute defined in OTEL: Yes
  * Visibility: public
+ *
+ * Aliases: {@link MESSAGING_OPERATION} `messaging.operation`
  *
  * @example "send"
  */
@@ -11728,6 +11828,54 @@ export const MESSAGING_OPERATION_TYPE = 'messaging.operation.type';
  */
 export type MESSAGING_OPERATION_TYPE_TYPE = string;
 
+// Path: model/attributes/messaging/messaging__protocol.json
+
+/**
+ * OSI application layer or non-OSI equivalent. `messaging.protocol`
+ *
+ * Attribute Value Type: `string` {@link MESSAGING_PROTOCOL_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link NETWORK_PROTOCOL_NAME} `network.protocol.name`, {@link NET_PROTOCOL_NAME} `net.protocol.name`, {@link MCP_RESOURCE_PROTOCOL} `mcp.resource.protocol`
+ *
+ * @deprecated Use {@link NETWORK_PROTOCOL_NAME} (network.protocol.name) instead - This attribute is being deprecated in favor of network.protocol.name.
+ * @example "AMQP"
+ */
+export const MESSAGING_PROTOCOL = 'messaging.protocol';
+
+/**
+ * Type for {@link MESSAGING_PROTOCOL} messaging.protocol
+ */
+export type MESSAGING_PROTOCOL_TYPE = string;
+
+// Path: model/attributes/messaging/messaging__protocol_version.json
+
+/**
+ * The actual version of the protocol used for network communication. `messaging.protocol_version`
+ *
+ * Attribute Value Type: `string` {@link MESSAGING_PROTOCOL_VERSION_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link NETWORK_PROTOCOL_VERSION} `network.protocol.version`, {@link HTTP_FLAVOR} `http.flavor`, {@link NET_PROTOCOL_VERSION} `net.protocol.version`
+ *
+ * @deprecated Use {@link NETWORK_PROTOCOL_VERSION} (network.protocol.version) instead - This attribute is being deprecated in favor of network.protocol.version.
+ * @example "0.9.1"
+ */
+export const MESSAGING_PROTOCOL_VERSION = 'messaging.protocol_version';
+
+/**
+ * Type for {@link MESSAGING_PROTOCOL_VERSION} messaging.protocol_version
+ */
+export type MESSAGING_PROTOCOL_VERSION_TYPE = string;
+
 // Path: model/attributes/messaging/messaging__rabbitmq__destination__routing_key.json
 
 /**
@@ -11740,6 +11888,8 @@ export type MESSAGING_OPERATION_TYPE_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
+ * Aliases: {@link MESSAGING_RABBITMQ_ROUTING_KEY} `messaging.rabbitmq.routing_key`
+ *
  * @example "myKey"
  */
 export const MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY = 'messaging.rabbitmq.destination.routing_key';
@@ -11748,6 +11898,30 @@ export const MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY = 'messaging.rabbitmq.de
  * Type for {@link MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY} messaging.rabbitmq.destination.routing_key
  */
 export type MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY_TYPE = string;
+
+// Path: model/attributes/messaging/messaging__rabbitmq__routing_key.json
+
+/**
+ * RabbitMQ message routing key. `messaging.rabbitmq.routing_key`
+ *
+ * Attribute Value Type: `string` {@link MESSAGING_RABBITMQ_ROUTING_KEY_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY} `messaging.rabbitmq.destination.routing_key`
+ *
+ * @deprecated Use {@link MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY} (messaging.rabbitmq.destination.routing_key) instead - This attribute is being deprecated in favor of messaging.rabbitmq.destination.routing_key.
+ * @example "myKey"
+ */
+export const MESSAGING_RABBITMQ_ROUTING_KEY = 'messaging.rabbitmq.routing_key';
+
+/**
+ * Type for {@link MESSAGING_RABBITMQ_ROUTING_KEY} messaging.rabbitmq.routing_key
+ */
+export type MESSAGING_RABBITMQ_ROUTING_KEY_TYPE = string;
 
 // Path: model/attributes/messaging/messaging__system.json
 
@@ -11769,6 +11943,30 @@ export const MESSAGING_SYSTEM = 'messaging.system';
  * Type for {@link MESSAGING_SYSTEM} messaging.system
  */
 export type MESSAGING_SYSTEM_TYPE = string;
+
+// Path: model/attributes/messaging/messaging__url.json
+
+/**
+ * The connection string of the messaging broker. `messaging.url`
+ *
+ * Attribute Value Type: `string` {@link MESSAGING_URL_TYPE}
+ *
+ * Apply Scrubbing: auto
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link URL_FULL} `url.full`, {@link HTTP_URL} `http.url`, {@link URL} `url`, {@link AWS_REQUEST_URL} `aws.request.url`
+ *
+ * @deprecated Use {@link URL_FULL} (url.full) instead - This attribute is being deprecated in favor of url.full.
+ * @example "amqp://guest:guest@localhost:5672"
+ */
+export const MESSAGING_URL = 'messaging.url';
+
+/**
+ * Type for {@link MESSAGING_URL} messaging.url
+ */
+export type MESSAGING_URL_TYPE = string;
 
 // Path: model/attributes/method.json
 
@@ -12161,7 +12359,7 @@ export type NETWORK_PEER_PORT_TYPE = number;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link NET_PROTOCOL_NAME} `net.protocol.name`, {@link MCP_RESOURCE_PROTOCOL} `mcp.resource.protocol`
+ * Aliases: {@link NET_PROTOCOL_NAME} `net.protocol.name`, {@link MCP_RESOURCE_PROTOCOL} `mcp.resource.protocol`, {@link MESSAGING_PROTOCOL} `messaging.protocol`
  *
  * @example "http"
  */
@@ -12184,7 +12382,7 @@ export type NETWORK_PROTOCOL_NAME_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link HTTP_FLAVOR} `http.flavor`, {@link NET_PROTOCOL_VERSION} `net.protocol.version`
+ * Aliases: {@link HTTP_FLAVOR} `http.flavor`, {@link NET_PROTOCOL_VERSION} `net.protocol.version`, {@link MESSAGING_PROTOCOL_VERSION} `messaging.protocol_version`
  *
  * @example "1.1"
  */
@@ -12391,7 +12589,7 @@ export type NET_PEER_PORT_TYPE = number;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link NETWORK_PROTOCOL_NAME} `network.protocol.name`, {@link MCP_RESOURCE_PROTOCOL} `mcp.resource.protocol`
+ * Aliases: {@link NETWORK_PROTOCOL_NAME} `network.protocol.name`, {@link MCP_RESOURCE_PROTOCOL} `mcp.resource.protocol`, {@link MESSAGING_PROTOCOL} `messaging.protocol`
  *
  * @deprecated Use {@link NETWORK_PROTOCOL_NAME} (network.protocol.name) instead
  * @example "http"
@@ -12415,7 +12613,7 @@ export type NET_PROTOCOL_NAME_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link NETWORK_PROTOCOL_VERSION} `network.protocol.version`, {@link HTTP_FLAVOR} `http.flavor`
+ * Aliases: {@link NETWORK_PROTOCOL_VERSION} `network.protocol.version`, {@link HTTP_FLAVOR} `http.flavor`, {@link MESSAGING_PROTOCOL_VERSION} `messaging.protocol_version`
  *
  * @deprecated Use {@link NETWORK_PROTOCOL_VERSION} (network.protocol.version) instead
  * @example "1.1"
@@ -16518,7 +16716,7 @@ export type UI_ELEMENT_WIDTH_TYPE = number;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link URL_FULL} `url.full`, {@link HTTP_URL} `http.url`, {@link AWS_REQUEST_URL} `aws.request.url`
+ * Aliases: {@link URL_FULL} `url.full`, {@link HTTP_URL} `http.url`, {@link AWS_REQUEST_URL} `aws.request.url`, {@link MESSAGING_URL} `messaging.url`
  *
  * @deprecated Use {@link URL_FULL} (url.full) instead
  * @example "https://example.com/test?foo=bar#buzz"
@@ -16584,7 +16782,7 @@ export type URL_FRAGMENT_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link HTTP_URL} `http.url`, {@link URL} `url`, {@link AWS_REQUEST_URL} `aws.request.url`
+ * Aliases: {@link HTTP_URL} `http.url`, {@link URL} `url`, {@link AWS_REQUEST_URL} `aws.request.url`, {@link MESSAGING_URL} `messaging.url`
  *
  * @example "https://example.com/test?foo=bar#buzz"
  */
@@ -18103,6 +18301,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'culture.locale': 'string',
   'culture.timezone': 'string',
   'db.collection.name': 'string',
+  'db.connection_string': 'string',
   'db.driver.name': 'string',
   'db.mongodb.collection': 'string',
   'db.name': 'string',
@@ -18406,6 +18605,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'mcp.transport': 'string',
   'mdc.<key>': 'string',
   'messaging.batch.message_count': 'integer',
+  'messaging.conversation_id': 'string',
   'messaging.destination': 'string',
   'messaging.destination.connection': 'string',
   'messaging.destination_kind': 'string',
@@ -18418,12 +18618,18 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'messaging.message.conversation_id': 'string',
   'messaging.message.envelope.size': 'integer',
   'messaging.message.id': 'string',
+  'messaging.message_id': 'string',
   'messaging.message.receive.latency': 'integer',
   'messaging.message.retry.count': 'integer',
+  'messaging.operation': 'string',
   'messaging.operation.name': 'string',
   'messaging.operation.type': 'string',
+  'messaging.protocol': 'string',
+  'messaging.protocol_version': 'string',
   'messaging.rabbitmq.destination.routing_key': 'string',
+  'messaging.rabbitmq.routing_key': 'string',
   'messaging.system': 'string',
+  'messaging.url': 'string',
   method: 'string',
   'middleware.name': 'string',
   'navigation.origin': 'string',
@@ -18906,6 +19112,7 @@ export type AttributeName =
   | typeof CULTURE_LOCALE
   | typeof CULTURE_TIMEZONE
   | typeof DB_COLLECTION_NAME
+  | typeof DB_CONNECTION_STRING
   | typeof DB_DRIVER_NAME
   | typeof DB_MONGODB_COLLECTION
   | typeof DB_NAME
@@ -19209,6 +19416,7 @@ export type AttributeName =
   | typeof MCP_TRANSPORT
   | typeof MDC_KEY
   | typeof MESSAGING_BATCH_MESSAGE_COUNT
+  | typeof MESSAGING_CONVERSATION_ID
   | typeof MESSAGING_DESTINATION
   | typeof MESSAGING_DESTINATION_CONNECTION
   | typeof MESSAGING_DESTINATION_KIND
@@ -19221,12 +19429,18 @@ export type AttributeName =
   | typeof MESSAGING_MESSAGE_CONVERSATION_ID
   | typeof MESSAGING_MESSAGE_ENVELOPE_SIZE
   | typeof MESSAGING_MESSAGE_ID
+  | typeof _MESSAGING_MESSAGE_ID
   | typeof MESSAGING_MESSAGE_RECEIVE_LATENCY
   | typeof MESSAGING_MESSAGE_RETRY_COUNT
+  | typeof MESSAGING_OPERATION
   | typeof MESSAGING_OPERATION_NAME
   | typeof MESSAGING_OPERATION_TYPE
+  | typeof MESSAGING_PROTOCOL
+  | typeof MESSAGING_PROTOCOL_VERSION
   | typeof MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY
+  | typeof MESSAGING_RABBITMQ_ROUTING_KEY
   | typeof MESSAGING_SYSTEM
+  | typeof MESSAGING_URL
   | typeof METHOD
   | typeof MIDDLEWARE_NAME
   | typeof NAVIGATION_ORIGIN
@@ -21433,7 +21647,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'aws.request.url': {
     brief: 'The URL of the AWS API request.',
     type: 'string',
-    keys: ['url.full', 'aws.request.url', 'http.url', 'url'],
+    keys: ['url.full', 'aws.request.url', 'http.url', 'messaging.url', 'url'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -21445,8 +21659,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'This attribute is being deprecated in favor of url.full, which is the OTel-aligned replacement.',
       status: 'backfill',
     },
-    aliases: ['url.full', 'http.url', 'url'],
+    aliases: ['url.full', 'http.url', 'url', 'messaging.url'],
     changelog: [
+      { version: 'next', description: 'Added messaging.url as an alias' },
       {
         version: '0.19.0',
         prs: [488],
@@ -22621,6 +22836,23 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: '0.1.0', prs: [106, 127] },
       { version: '0.0.0' },
     ],
+  },
+  'db.connection_string': {
+    brief: 'The connection string used to connect to the database.',
+    type: 'string',
+    keys: ['db.connection_string'],
+    applyScrubbing: {
+      key: 'auto',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'redis://localhost:6379',
+    examples: ['redis://localhost:6379'],
+    deprecation: {
+      reason:
+        'This attribute is deprecated. The connection is described by server.address and server.port instead, so the value cannot be copied to a single replacement attribute.',
+    },
+    changelog: [{ version: 'next', prs: [581], description: 'Added db.connection_string attribute' }],
   },
   'db.driver.name': {
     brief: 'The name of the driver used for the database connection.',
@@ -25729,7 +25961,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'http.flavor': {
     brief: 'The actual version of the protocol used for network communication.',
     type: 'string',
-    keys: ['network.protocol.version', 'http.flavor', 'net.protocol.version'],
+    keys: ['network.protocol.version', 'http.flavor', 'messaging.protocol_version', 'net.protocol.version'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -25740,8 +25972,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'network.protocol.version',
       status: 'backfill',
     },
-    aliases: ['network.protocol.version', 'net.protocol.version'],
-    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+    aliases: ['network.protocol.version', 'net.protocol.version', 'messaging.protocol_version'],
+    changelog: [
+      { version: 'next', description: 'Added messaging.protocol_version as an alias' },
+      { version: '0.1.0', prs: [61, 108, 127] },
+      { version: '0.0.0' },
+    ],
   },
   'http.fragment': {
     brief:
@@ -26465,7 +26701,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'http.url': {
     brief: 'The URL of the resource that was fetched.',
     type: 'string',
-    keys: ['url.full', 'aws.request.url', 'http.url', 'url'],
+    keys: ['url.full', 'aws.request.url', 'http.url', 'messaging.url', 'url'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -26476,8 +26712,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'url.full',
       status: 'backfill',
     },
-    aliases: ['url.full', 'url', 'aws.request.url'],
-    changelog: [{ version: '0.1.0', prs: [61, 108] }, { version: '0.0.0' }],
+    aliases: ['url.full', 'url', 'aws.request.url', 'messaging.url'],
+    changelog: [
+      { version: 'next', description: 'Added messaging.url as an alias' },
+      { version: '0.1.0', prs: [61, 108] },
+      { version: '0.0.0' },
+    ],
   },
   'http.user_agent': {
     brief: 'Value of the HTTP User-Agent header sent by the client.',
@@ -27210,7 +27450,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'mcp.resource.protocol': {
     brief: 'Protocol of the resource URI being accessed, extracted from the URI.',
     type: 'string',
-    keys: ['network.protocol.name', 'mcp.resource.protocol', 'net.protocol.name'],
+    keys: ['network.protocol.name', 'mcp.resource.protocol', 'messaging.protocol', 'net.protocol.name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27222,8 +27462,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'OTel uses the generic network.protocol.name attribute',
       status: 'backfill',
     },
-    aliases: ['network.protocol.name', 'net.protocol.name'],
+    aliases: ['network.protocol.name', 'net.protocol.name', 'messaging.protocol'],
     changelog: [
+      { version: 'next', description: 'Added messaging.protocol as an alias' },
       { version: '0.12.0', prs: [420], description: 'Deprecated in favor of network.protocol.name' },
       { version: '0.3.0', prs: [171] },
     ],
@@ -27428,6 +27669,26 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 10,
     changelog: [{ version: '0.6.0', prs: [341], description: 'Added messaging.batch.message_count attribute' }],
   },
+  'messaging.conversation_id': {
+    brief:
+      'The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID".',
+    type: 'string',
+    keys: ['messaging.message.conversation_id', 'messaging.conversation_id'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'MyConversationId',
+    examples: ['MyConversationId'],
+    deprecation: {
+      replacement: 'messaging.message.conversation_id',
+      reason: 'This attribute is being deprecated in favor of messaging.message.conversation_id.',
+      status: 'backfill',
+    },
+    aliases: ['messaging.message.conversation_id'],
+    changelog: [{ version: 'next', prs: [581], description: 'Added messaging.conversation_id attribute' }],
+  },
   'messaging.destination': {
     brief: 'The message destination name.',
     type: 'string',
@@ -27575,14 +27836,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID".',
     type: 'string',
-    keys: ['messaging.message.conversation_id'],
+    keys: ['messaging.message.conversation_id', 'messaging.conversation_id'],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: true,
     visibility: 'public',
     example: 'MyConversationId',
-    changelog: [{ version: '0.16.0', prs: [468], description: 'Added messaging.message.conversation_id attribute' }],
+    aliases: ['messaging.conversation_id'],
+    changelog: [
+      { version: 'next', description: 'Added messaging.conversation_id as an alias' },
+      { version: '0.16.0', prs: [468], description: 'Added messaging.message.conversation_id attribute' },
+    ],
   },
   'messaging.message.envelope.size': {
     brief: 'The size of the message body and metadata in bytes.',
@@ -27599,14 +27864,38 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'messaging.message.id': {
     brief: 'A value used by the messaging system as an identifier for the message, represented as a string.',
     type: 'string',
-    keys: ['messaging.message.id'],
+    keys: ['messaging.message.id', 'messaging.message_id'],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: true,
     visibility: 'public',
     example: 'f47ac10b58cc4372a5670e02b2c3d479',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    aliases: ['messaging.message_id'],
+    changelog: [
+      { version: 'next', description: 'Added messaging.message_id as an alias' },
+      { version: '0.1.0', prs: [127] },
+      { version: '0.0.0' },
+    ],
+  },
+  'messaging.message_id': {
+    brief: 'A value used by the messaging system as an identifier for the message, represented as a string.',
+    type: 'string',
+    keys: ['messaging.message.id', 'messaging.message_id'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '452a7c7c7c7048c2f887f0e7',
+    examples: ['452a7c7c7c7048c2f887f0e7'],
+    deprecation: {
+      replacement: 'messaging.message.id',
+      reason: 'This attribute is being deprecated in favor of messaging.message.id.',
+      status: 'backfill',
+    },
+    aliases: ['messaging.message.id'],
+    changelog: [{ version: 'next', prs: [581], description: 'Added messaging.message_id attribute' }],
   },
   'messaging.message.receive.latency': {
     brief: 'The latency between when the message was published and received.',
@@ -27636,17 +27925,40 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 2,
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
   },
+  'messaging.operation': {
+    brief: 'The name of the messaging operation being performed.',
+    type: 'string',
+    keys: ['messaging.operation.name', 'messaging.operation'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'publish',
+    examples: ['publish'],
+    deprecation: {
+      replacement: 'messaging.operation.name',
+      reason: 'This attribute is being deprecated in favor of messaging.operation.name.',
+      status: 'backfill',
+    },
+    aliases: ['messaging.operation.name'],
+    changelog: [{ version: 'next', prs: [581], description: 'Added messaging.operation attribute' }],
+  },
   'messaging.operation.name': {
     brief: 'The name of the messaging operation being performed',
     type: 'string',
-    keys: ['messaging.operation.name'],
+    keys: ['messaging.operation.name', 'messaging.operation'],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: true,
     visibility: 'public',
     example: 'send',
-    changelog: [{ version: '0.11.0', prs: [392], description: 'Added messaging.operation.name attribute' }],
+    aliases: ['messaging.operation'],
+    changelog: [
+      { version: 'next', description: 'Added messaging.operation as an alias' },
+      { version: '0.11.0', prs: [392], description: 'Added messaging.operation.name attribute' },
+    ],
   },
   'messaging.operation.type': {
     brief: 'A string identifying the type of the messaging operation',
@@ -27660,19 +27972,78 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'create',
     changelog: [{ version: '0.1.0', prs: [51, 127] }],
   },
+  'messaging.protocol': {
+    brief: 'OSI application layer or non-OSI equivalent.',
+    type: 'string',
+    keys: ['network.protocol.name', 'mcp.resource.protocol', 'messaging.protocol', 'net.protocol.name'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'AMQP',
+    examples: ['AMQP'],
+    deprecation: {
+      replacement: 'network.protocol.name',
+      reason: 'This attribute is being deprecated in favor of network.protocol.name.',
+      status: 'backfill',
+    },
+    aliases: ['network.protocol.name', 'net.protocol.name', 'mcp.resource.protocol'],
+    changelog: [{ version: 'next', prs: [581], description: 'Added messaging.protocol attribute' }],
+  },
+  'messaging.protocol_version': {
+    brief: 'The actual version of the protocol used for network communication.',
+    type: 'string',
+    keys: ['network.protocol.version', 'http.flavor', 'messaging.protocol_version', 'net.protocol.version'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '0.9.1',
+    examples: ['0.9.1'],
+    deprecation: {
+      replacement: 'network.protocol.version',
+      reason: 'This attribute is being deprecated in favor of network.protocol.version.',
+      status: 'backfill',
+    },
+    aliases: ['network.protocol.version', 'http.flavor', 'net.protocol.version'],
+    changelog: [{ version: 'next', prs: [581], description: 'Added messaging.protocol_version attribute' }],
+  },
   'messaging.rabbitmq.destination.routing_key': {
     brief: 'RabbitMQ message routing key.',
     type: 'string',
-    keys: ['messaging.rabbitmq.destination.routing_key'],
+    keys: ['messaging.rabbitmq.destination.routing_key', 'messaging.rabbitmq.routing_key'],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: true,
     visibility: 'public',
     example: 'myKey',
+    aliases: ['messaging.rabbitmq.routing_key'],
     changelog: [
+      { version: 'next', description: 'Added messaging.rabbitmq.routing_key as an alias' },
       { version: '0.16.0', prs: [468], description: 'Added messaging.rabbitmq.destination.routing_key attribute' },
     ],
+  },
+  'messaging.rabbitmq.routing_key': {
+    brief: 'RabbitMQ message routing key.',
+    type: 'string',
+    keys: ['messaging.rabbitmq.destination.routing_key', 'messaging.rabbitmq.routing_key'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'myKey',
+    examples: ['myKey'],
+    deprecation: {
+      replacement: 'messaging.rabbitmq.destination.routing_key',
+      reason: 'This attribute is being deprecated in favor of messaging.rabbitmq.destination.routing_key.',
+      status: 'backfill',
+    },
+    aliases: ['messaging.rabbitmq.destination.routing_key'],
+    changelog: [{ version: 'next', prs: [581], description: 'Added messaging.rabbitmq.routing_key attribute' }],
   },
   'messaging.system': {
     brief: 'The messaging system as identified by the client instrumentation.',
@@ -27685,6 +28056,25 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'activemq',
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+  },
+  'messaging.url': {
+    brief: 'The connection string of the messaging broker.',
+    type: 'string',
+    keys: ['url.full', 'aws.request.url', 'http.url', 'messaging.url', 'url'],
+    applyScrubbing: {
+      key: 'auto',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'amqp://guest:guest@localhost:5672',
+    examples: ['amqp://guest:guest@localhost:5672'],
+    deprecation: {
+      replacement: 'url.full',
+      reason: 'This attribute is being deprecated in favor of url.full.',
+      status: 'backfill',
+    },
+    aliases: ['url.full', 'http.url', 'url', 'aws.request.url'],
+    changelog: [{ version: 'next', prs: [581], description: 'Added messaging.url attribute' }],
   },
   method: {
     brief: 'The HTTP method used.',
@@ -27962,28 +28352,36 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'network.protocol.name': {
     brief: 'OSI application layer or non-OSI equivalent.',
     type: 'string',
-    keys: ['network.protocol.name', 'mcp.resource.protocol', 'net.protocol.name'],
+    keys: ['network.protocol.name', 'mcp.resource.protocol', 'messaging.protocol', 'net.protocol.name'],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: true,
     visibility: 'public',
     example: 'http',
-    aliases: ['net.protocol.name', 'mcp.resource.protocol'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    aliases: ['net.protocol.name', 'mcp.resource.protocol', 'messaging.protocol'],
+    changelog: [
+      { version: 'next', description: 'Added messaging.protocol as an alias' },
+      { version: '0.1.0', prs: [127] },
+      { version: '0.0.0' },
+    ],
   },
   'network.protocol.version': {
     brief: 'The actual version of the protocol used for network communication.',
     type: 'string',
-    keys: ['network.protocol.version', 'http.flavor', 'net.protocol.version'],
+    keys: ['network.protocol.version', 'http.flavor', 'messaging.protocol_version', 'net.protocol.version'],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: true,
     visibility: 'public',
     example: '1.1',
-    aliases: ['http.flavor', 'net.protocol.version'],
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    aliases: ['http.flavor', 'net.protocol.version', 'messaging.protocol_version'],
+    changelog: [
+      { version: 'next', description: 'Added messaging.protocol_version as an alias' },
+      { version: '0.1.0', prs: [127] },
+      { version: '0.0.0' },
+    ],
   },
   'network.transport': {
     brief: 'OSI transport layer or inter-process communication method.',
@@ -28124,7 +28522,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'net.protocol.name': {
     brief: 'OSI application layer or non-OSI equivalent.',
     type: 'string',
-    keys: ['network.protocol.name', 'mcp.resource.protocol', 'net.protocol.name'],
+    keys: ['network.protocol.name', 'mcp.resource.protocol', 'messaging.protocol', 'net.protocol.name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -28135,13 +28533,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'network.protocol.name',
       status: 'backfill',
     },
-    aliases: ['network.protocol.name', 'mcp.resource.protocol'],
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    aliases: ['network.protocol.name', 'mcp.resource.protocol', 'messaging.protocol'],
+    changelog: [
+      { version: 'next', description: 'Added messaging.protocol as an alias' },
+      { version: '0.1.0', prs: [61, 127] },
+      { version: '0.0.0' },
+    ],
   },
   'net.protocol.version': {
     brief: 'The actual version of the protocol used for network communication.',
     type: 'string',
-    keys: ['network.protocol.version', 'http.flavor', 'net.protocol.version'],
+    keys: ['network.protocol.version', 'http.flavor', 'messaging.protocol_version', 'net.protocol.version'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -28152,8 +28554,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'network.protocol.version',
       status: 'backfill',
     },
-    aliases: ['network.protocol.version', 'http.flavor'],
-    changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
+    aliases: ['network.protocol.version', 'http.flavor', 'messaging.protocol_version'],
+    changelog: [
+      { version: 'next', description: 'Added messaging.protocol_version as an alias' },
+      { version: '0.1.0', prs: [61, 108, 127] },
+      { version: '0.0.0' },
+    ],
   },
   'net.sock.family': {
     brief: 'OSI transport and network layer',
@@ -31003,7 +31409,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   url: {
     brief: 'The URL of the resource that was fetched.',
     type: 'string',
-    keys: ['url.full', 'aws.request.url', 'http.url', 'url'],
+    keys: ['url.full', 'aws.request.url', 'http.url', 'messaging.url', 'url'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -31014,8 +31420,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'url.full',
       status: 'backfill',
     },
-    aliases: ['url.full', 'http.url', 'aws.request.url'],
-    changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    aliases: ['url.full', 'http.url', 'aws.request.url', 'messaging.url'],
+    changelog: [
+      { version: 'next', description: 'Added messaging.url as an alias' },
+      { version: '0.1.0', prs: [61] },
+      { version: '0.0.0' },
+    ],
   },
   'url.domain': {
     brief:
@@ -31046,15 +31456,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'url.full': {
     brief: 'The URL of the resource that was fetched.',
     type: 'string',
-    keys: ['url.full', 'aws.request.url', 'http.url', 'url'],
+    keys: ['url.full', 'aws.request.url', 'http.url', 'messaging.url', 'url'],
     applyScrubbing: {
       key: 'auto',
     },
     isInOtel: true,
     visibility: 'public',
     example: 'https://example.com/test?foo=bar#buzz',
-    aliases: ['http.url', 'url', 'aws.request.url'],
+    aliases: ['http.url', 'url', 'aws.request.url', 'messaging.url'],
     changelog: [
+      { version: 'next', description: 'Added messaging.url as an alias' },
       { version: '0.19.0', prs: [488], description: 'Added aws.request.url as an alias' },
       { version: '0.1.0', prs: [108] },
       { version: '0.0.0' },
@@ -32551,7 +32962,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'url.full',
     type: 'string',
     brief: 'The URL of the AWS API request.',
-    deprecationChain: ['url.full', 'aws.request.url', 'http.url', 'url'],
+    deprecationChain: ['url.full', 'aws.request.url', 'http.url', 'messaging.url', 'url'],
   },
   'aws.request_id': {
     canonicalName: 'aws.request_id',
@@ -33092,6 +33503,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief: 'The name of a collection (table, container) within the database.',
     deprecationChain: ['db.collection.name', 'db.mongodb.collection'],
+  },
+  'db.connection_string': {
+    canonicalName: 'db.connection_string',
+    type: 'string',
+    brief: 'The connection string used to connect to the database.',
+    deprecationChain: ['db.connection_string'],
   },
   'db.driver.name': {
     canonicalName: 'db.driver.name',
@@ -34325,7 +34742,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'network.protocol.version',
     type: 'string',
     brief: 'The actual version of the protocol used for network communication.',
-    deprecationChain: ['network.protocol.version', 'http.flavor', 'net.protocol.version'],
+    deprecationChain: ['network.protocol.version', 'http.flavor', 'messaging.protocol_version', 'net.protocol.version'],
   },
   'http.fragment': {
     canonicalName: 'http.fragment',
@@ -34631,7 +35048,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'url.full',
     type: 'string',
     brief: 'The URL of the resource that was fetched.',
-    deprecationChain: ['url.full', 'aws.request.url', 'http.url', 'url'],
+    deprecationChain: ['url.full', 'aws.request.url', 'http.url', 'messaging.url', 'url'],
   },
   'http.user_agent': {
     canonicalName: 'user_agent.original',
@@ -34938,7 +35355,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'network.protocol.name',
     type: 'string',
     brief: 'Protocol of the resource URI being accessed, extracted from the URI.',
-    deprecationChain: ['network.protocol.name', 'mcp.resource.protocol', 'net.protocol.name'],
+    deprecationChain: ['network.protocol.name', 'mcp.resource.protocol', 'messaging.protocol', 'net.protocol.name'],
   },
   'mcp.resource.uri': {
     canonicalName: 'mcp.resource.uri',
@@ -35019,6 +35436,13 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     brief: 'The number of messages sent, received, or processed in the scope of the batching operation.',
     deprecationChain: ['messaging.batch.message_count'],
   },
+  'messaging.conversation_id': {
+    canonicalName: 'messaging.message.conversation_id',
+    type: 'string',
+    brief:
+      'The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID".',
+    deprecationChain: ['messaging.message.conversation_id', 'messaging.conversation_id'],
+  },
   'messaging.destination': {
     canonicalName: 'messaging.destination.name',
     type: 'string',
@@ -35080,7 +35504,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief:
       'The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID".',
-    deprecationChain: ['messaging.message.conversation_id'],
+    deprecationChain: ['messaging.message.conversation_id', 'messaging.conversation_id'],
   },
   'messaging.message.envelope.size': {
     canonicalName: 'messaging.message.envelope.size',
@@ -35092,7 +35516,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'messaging.message.id',
     type: 'string',
     brief: 'A value used by the messaging system as an identifier for the message, represented as a string.',
-    deprecationChain: ['messaging.message.id'],
+    deprecationChain: ['messaging.message.id', 'messaging.message_id'],
   },
   'messaging.message.receive.latency': {
     canonicalName: 'messaging.message.receive.latency',
@@ -35106,11 +35530,23 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     brief: 'The amount of attempts to send the message.',
     deprecationChain: ['messaging.message.retry.count'],
   },
+  'messaging.message_id': {
+    canonicalName: 'messaging.message.id',
+    type: 'string',
+    brief: 'A value used by the messaging system as an identifier for the message, represented as a string.',
+    deprecationChain: ['messaging.message.id', 'messaging.message_id'],
+  },
+  'messaging.operation': {
+    canonicalName: 'messaging.operation.name',
+    type: 'string',
+    brief: 'The name of the messaging operation being performed.',
+    deprecationChain: ['messaging.operation.name', 'messaging.operation'],
+  },
   'messaging.operation.name': {
     canonicalName: 'messaging.operation.name',
     type: 'string',
     brief: 'The name of the messaging operation being performed',
-    deprecationChain: ['messaging.operation.name'],
+    deprecationChain: ['messaging.operation.name', 'messaging.operation'],
   },
   'messaging.operation.type': {
     canonicalName: 'messaging.operation.type',
@@ -35118,17 +35554,41 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     brief: 'A string identifying the type of the messaging operation',
     deprecationChain: ['messaging.operation.type'],
   },
+  'messaging.protocol': {
+    canonicalName: 'network.protocol.name',
+    type: 'string',
+    brief: 'OSI application layer or non-OSI equivalent.',
+    deprecationChain: ['network.protocol.name', 'mcp.resource.protocol', 'messaging.protocol', 'net.protocol.name'],
+  },
+  'messaging.protocol_version': {
+    canonicalName: 'network.protocol.version',
+    type: 'string',
+    brief: 'The actual version of the protocol used for network communication.',
+    deprecationChain: ['network.protocol.version', 'http.flavor', 'messaging.protocol_version', 'net.protocol.version'],
+  },
   'messaging.rabbitmq.destination.routing_key': {
     canonicalName: 'messaging.rabbitmq.destination.routing_key',
     type: 'string',
     brief: 'RabbitMQ message routing key.',
-    deprecationChain: ['messaging.rabbitmq.destination.routing_key'],
+    deprecationChain: ['messaging.rabbitmq.destination.routing_key', 'messaging.rabbitmq.routing_key'],
+  },
+  'messaging.rabbitmq.routing_key': {
+    canonicalName: 'messaging.rabbitmq.destination.routing_key',
+    type: 'string',
+    brief: 'RabbitMQ message routing key.',
+    deprecationChain: ['messaging.rabbitmq.destination.routing_key', 'messaging.rabbitmq.routing_key'],
   },
   'messaging.system': {
     canonicalName: 'messaging.system',
     type: 'string',
     brief: 'The messaging system as identified by the client instrumentation.',
     deprecationChain: ['messaging.system'],
+  },
+  'messaging.url': {
+    canonicalName: 'url.full',
+    type: 'string',
+    brief: 'The connection string of the messaging broker.',
+    deprecationChain: ['url.full', 'aws.request.url', 'http.url', 'messaging.url', 'url'],
   },
   method: {
     canonicalName: 'http.request.method',
@@ -35271,13 +35731,13 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'network.protocol.name',
     type: 'string',
     brief: 'OSI application layer or non-OSI equivalent.',
-    deprecationChain: ['network.protocol.name', 'mcp.resource.protocol', 'net.protocol.name'],
+    deprecationChain: ['network.protocol.name', 'mcp.resource.protocol', 'messaging.protocol', 'net.protocol.name'],
   },
   'net.protocol.version': {
     canonicalName: 'network.protocol.version',
     type: 'string',
     brief: 'The actual version of the protocol used for network communication.',
-    deprecationChain: ['network.protocol.version', 'http.flavor', 'net.protocol.version'],
+    deprecationChain: ['network.protocol.version', 'http.flavor', 'messaging.protocol_version', 'net.protocol.version'],
   },
   'net.sock.family': {
     canonicalName: 'network.transport',
@@ -35367,13 +35827,13 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'network.protocol.name',
     type: 'string',
     brief: 'OSI application layer or non-OSI equivalent.',
-    deprecationChain: ['network.protocol.name', 'mcp.resource.protocol', 'net.protocol.name'],
+    deprecationChain: ['network.protocol.name', 'mcp.resource.protocol', 'messaging.protocol', 'net.protocol.name'],
   },
   'network.protocol.version': {
     canonicalName: 'network.protocol.version',
     type: 'string',
     brief: 'The actual version of the protocol used for network communication.',
-    deprecationChain: ['network.protocol.version', 'http.flavor', 'net.protocol.version'],
+    deprecationChain: ['network.protocol.version', 'http.flavor', 'messaging.protocol_version', 'net.protocol.version'],
   },
   'network.transport': {
     canonicalName: 'network.transport',
@@ -36442,7 +36902,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'url.full',
     type: 'string',
     brief: 'The URL of the resource that was fetched.',
-    deprecationChain: ['url.full', 'aws.request.url', 'http.url', 'url'],
+    deprecationChain: ['url.full', 'aws.request.url', 'http.url', 'messaging.url', 'url'],
   },
   'url.domain': {
     canonicalName: 'url.domain',
@@ -36462,7 +36922,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'url.full',
     type: 'string',
     brief: 'The URL of the resource that was fetched.',
-    deprecationChain: ['url.full', 'aws.request.url', 'http.url', 'url'],
+    deprecationChain: ['url.full', 'aws.request.url', 'http.url', 'messaging.url', 'url'],
   },
   'url.path': {
     canonicalName: 'url.path',
@@ -37021,6 +37481,7 @@ export type Attributes = {
   [CULTURE_LOCALE]?: CULTURE_LOCALE_TYPE;
   [CULTURE_TIMEZONE]?: CULTURE_TIMEZONE_TYPE;
   [DB_COLLECTION_NAME]?: DB_COLLECTION_NAME_TYPE;
+  [DB_CONNECTION_STRING]?: DB_CONNECTION_STRING_TYPE;
   [DB_DRIVER_NAME]?: DB_DRIVER_NAME_TYPE;
   [DB_MONGODB_COLLECTION]?: DB_MONGODB_COLLECTION_TYPE;
   [DB_NAME]?: DB_NAME_TYPE;
@@ -37324,6 +37785,7 @@ export type Attributes = {
   [MCP_TRANSPORT]?: MCP_TRANSPORT_TYPE;
   [MDC_KEY]?: MDC_KEY_TYPE;
   [MESSAGING_BATCH_MESSAGE_COUNT]?: MESSAGING_BATCH_MESSAGE_COUNT_TYPE;
+  [MESSAGING_CONVERSATION_ID]?: MESSAGING_CONVERSATION_ID_TYPE;
   [MESSAGING_DESTINATION]?: MESSAGING_DESTINATION_TYPE;
   [MESSAGING_DESTINATION_CONNECTION]?: MESSAGING_DESTINATION_CONNECTION_TYPE;
   [MESSAGING_DESTINATION_KIND]?: MESSAGING_DESTINATION_KIND_TYPE;
@@ -37336,12 +37798,18 @@ export type Attributes = {
   [MESSAGING_MESSAGE_CONVERSATION_ID]?: MESSAGING_MESSAGE_CONVERSATION_ID_TYPE;
   [MESSAGING_MESSAGE_ENVELOPE_SIZE]?: MESSAGING_MESSAGE_ENVELOPE_SIZE_TYPE;
   [MESSAGING_MESSAGE_ID]?: MESSAGING_MESSAGE_ID_TYPE;
+  [_MESSAGING_MESSAGE_ID]?: _MESSAGING_MESSAGE_ID_TYPE;
   [MESSAGING_MESSAGE_RECEIVE_LATENCY]?: MESSAGING_MESSAGE_RECEIVE_LATENCY_TYPE;
   [MESSAGING_MESSAGE_RETRY_COUNT]?: MESSAGING_MESSAGE_RETRY_COUNT_TYPE;
+  [MESSAGING_OPERATION]?: MESSAGING_OPERATION_TYPE;
   [MESSAGING_OPERATION_NAME]?: MESSAGING_OPERATION_NAME_TYPE;
   [MESSAGING_OPERATION_TYPE]?: MESSAGING_OPERATION_TYPE_TYPE;
+  [MESSAGING_PROTOCOL]?: MESSAGING_PROTOCOL_TYPE;
+  [MESSAGING_PROTOCOL_VERSION]?: MESSAGING_PROTOCOL_VERSION_TYPE;
   [MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]?: MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY_TYPE;
+  [MESSAGING_RABBITMQ_ROUTING_KEY]?: MESSAGING_RABBITMQ_ROUTING_KEY_TYPE;
   [MESSAGING_SYSTEM]?: MESSAGING_SYSTEM_TYPE;
+  [MESSAGING_URL]?: MESSAGING_URL_TYPE;
   [METHOD]?: METHOD_TYPE;
   [MIDDLEWARE_NAME]?: MIDDLEWARE_NAME_TYPE;
   [NAVIGATION_ORIGIN]?: NAVIGATION_ORIGIN_TYPE;

--- a/model/attributes/aws/aws__request__url.json
+++ b/model/attributes/aws/aws__request__url.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": false,
   "example": "https://sqs.us-east-1.amazonaws.com/123456789/my-queue",
-  "alias": ["url.full", "http.url", "url"],
+  "alias": ["url.full", "http.url", "url", "messaging.url"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "url.full",
@@ -15,6 +15,10 @@
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.url as an alias"
+    },
     {
       "version": "0.19.0",
       "prs": [488],

--- a/model/attributes/db/db__connection_string.json
+++ b/model/attributes/db/db__connection_string.json
@@ -1,0 +1,22 @@
+{
+  "key": "db.connection_string",
+  "brief": "The connection string used to connect to the database.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "auto"
+  },
+  "is_in_otel": false,
+  "examples": ["redis://localhost:6379"],
+  "deprecation": {
+    "_status": null,
+    "reason": "This attribute is deprecated. The connection is described by server.address and server.port instead, so the value cannot be copied to a single replacement attribute."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [581],
+      "description": "Added db.connection_string attribute"
+    }
+  ]
+}

--- a/model/attributes/db/db__connection_string.json
+++ b/model/attributes/db/db__connection_string.json
@@ -5,7 +5,7 @@
   "apply_scrubbing": {
     "key": "auto"
   },
-  "is_in_otel": false,
+  "is_in_otel": true,
   "examples": ["redis://localhost:6379"],
   "deprecation": {
     "_status": null,

--- a/model/attributes/http/http__flavor.json
+++ b/model/attributes/http/http__flavor.json
@@ -7,13 +7,17 @@
   },
   "is_in_otel": true,
   "example": "1.1",
-  "alias": ["network.protocol.version", "net.protocol.version"],
+  "alias": ["network.protocol.version", "net.protocol.version", "messaging.protocol_version"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "network.protocol.version"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.protocol_version as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [61, 108, 127]

--- a/model/attributes/http/http__url.json
+++ b/model/attributes/http/http__url.json
@@ -7,13 +7,17 @@
   },
   "is_in_otel": true,
   "example": "https://example.com/test?foo=bar#buzz",
-  "alias": ["url.full", "url", "aws.request.url"],
+  "alias": ["url.full", "url", "aws.request.url", "messaging.url"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "url.full"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.url as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [61, 108]

--- a/model/attributes/mcp/mcp__resource__protocol.json
+++ b/model/attributes/mcp/mcp__resource__protocol.json
@@ -7,8 +7,18 @@
   },
   "is_in_otel": false,
   "example": "file",
+  "alias": ["network.protocol.name", "net.protocol.name", "messaging.protocol"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "network.protocol.name",
+    "reason": "OTel uses the generic network.protocol.name attribute"
+  },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.protocol as an alias"
+    },
     {
       "version": "0.12.0",
       "prs": [420],
@@ -18,11 +28,5 @@
       "version": "0.3.0",
       "prs": [171]
     }
-  ],
-  "deprecation": {
-    "_status": "backfill",
-    "replacement": "network.protocol.name",
-    "reason": "OTel uses the generic network.protocol.name attribute"
-  },
-  "alias": ["network.protocol.name", "net.protocol.name"]
+  ]
 }

--- a/model/attributes/messaging/messaging__conversation_id.json
+++ b/model/attributes/messaging/messaging__conversation_id.json
@@ -1,0 +1,24 @@
+{
+  "key": "messaging.conversation_id",
+  "brief": "The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called \"Correlation ID\".",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["MyConversationId"],
+  "alias": ["messaging.message.conversation_id"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "messaging.message.conversation_id",
+    "reason": "This attribute is being deprecated in favor of messaging.message.conversation_id."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [581],
+      "description": "Added messaging.conversation_id attribute"
+    }
+  ]
+}

--- a/model/attributes/messaging/messaging__message__conversation_id.json
+++ b/model/attributes/messaging/messaging__message__conversation_id.json
@@ -6,9 +6,14 @@
     "key": "manual"
   },
   "is_in_otel": true,
-  "visibility": "public",
   "example": "MyConversationId",
+  "alias": ["messaging.conversation_id"],
+  "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.conversation_id as an alias"
+    },
     {
       "version": "0.16.0",
       "prs": [468],

--- a/model/attributes/messaging/messaging__message__id.json
+++ b/model/attributes/messaging/messaging__message__id.json
@@ -7,8 +7,13 @@
   },
   "is_in_otel": true,
   "example": "f47ac10b58cc4372a5670e02b2c3d479",
+  "alias": ["messaging.message_id"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.message_id as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [127]

--- a/model/attributes/messaging/messaging__message_id.json
+++ b/model/attributes/messaging/messaging__message_id.json
@@ -1,0 +1,24 @@
+{
+  "key": "messaging.message_id",
+  "brief": "A value used by the messaging system as an identifier for the message, represented as a string.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["452a7c7c7c7048c2f887f0e7"],
+  "alias": ["messaging.message.id"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "messaging.message.id",
+    "reason": "This attribute is being deprecated in favor of messaging.message.id."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [581],
+      "description": "Added messaging.message_id attribute"
+    }
+  ]
+}

--- a/model/attributes/messaging/messaging__operation.json
+++ b/model/attributes/messaging/messaging__operation.json
@@ -1,0 +1,24 @@
+{
+  "key": "messaging.operation",
+  "brief": "The name of the messaging operation being performed.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["publish"],
+  "alias": ["messaging.operation.name"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "messaging.operation.name",
+    "reason": "This attribute is being deprecated in favor of messaging.operation.name."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [581],
+      "description": "Added messaging.operation attribute"
+    }
+  ]
+}

--- a/model/attributes/messaging/messaging__operation__name.json
+++ b/model/attributes/messaging/messaging__operation__name.json
@@ -7,8 +7,13 @@
   },
   "is_in_otel": true,
   "example": "send",
+  "alias": ["messaging.operation"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.operation as an alias"
+    },
     {
       "version": "0.11.0",
       "prs": [392],

--- a/model/attributes/messaging/messaging__protocol.json
+++ b/model/attributes/messaging/messaging__protocol.json
@@ -1,0 +1,24 @@
+{
+  "key": "messaging.protocol",
+  "brief": "OSI application layer or non-OSI equivalent.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["AMQP"],
+  "alias": ["network.protocol.name", "net.protocol.name", "mcp.resource.protocol"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "network.protocol.name",
+    "reason": "This attribute is being deprecated in favor of network.protocol.name."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [581],
+      "description": "Added messaging.protocol attribute"
+    }
+  ]
+}

--- a/model/attributes/messaging/messaging__protocol_version.json
+++ b/model/attributes/messaging/messaging__protocol_version.json
@@ -1,0 +1,24 @@
+{
+  "key": "messaging.protocol_version",
+  "brief": "The actual version of the protocol used for network communication.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["0.9.1"],
+  "alias": ["network.protocol.version", "http.flavor", "net.protocol.version"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "network.protocol.version",
+    "reason": "This attribute is being deprecated in favor of network.protocol.version."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [581],
+      "description": "Added messaging.protocol_version attribute"
+    }
+  ]
+}

--- a/model/attributes/messaging/messaging__rabbitmq__destination__routing_key.json
+++ b/model/attributes/messaging/messaging__rabbitmq__destination__routing_key.json
@@ -6,9 +6,14 @@
     "key": "manual"
   },
   "is_in_otel": true,
-  "visibility": "public",
   "example": "myKey",
+  "alias": ["messaging.rabbitmq.routing_key"],
+  "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.rabbitmq.routing_key as an alias"
+    },
     {
       "version": "0.16.0",
       "prs": [468],

--- a/model/attributes/messaging/messaging__rabbitmq__routing_key.json
+++ b/model/attributes/messaging/messaging__rabbitmq__routing_key.json
@@ -1,0 +1,24 @@
+{
+  "key": "messaging.rabbitmq.routing_key",
+  "brief": "RabbitMQ message routing key.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["myKey"],
+  "alias": ["messaging.rabbitmq.destination.routing_key"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "messaging.rabbitmq.destination.routing_key",
+    "reason": "This attribute is being deprecated in favor of messaging.rabbitmq.destination.routing_key."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [581],
+      "description": "Added messaging.rabbitmq.routing_key attribute"
+    }
+  ]
+}

--- a/model/attributes/messaging/messaging__url.json
+++ b/model/attributes/messaging/messaging__url.json
@@ -1,0 +1,24 @@
+{
+  "key": "messaging.url",
+  "brief": "The connection string of the messaging broker.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "auto"
+  },
+  "is_in_otel": false,
+  "examples": ["amqp://guest:guest@localhost:5672"],
+  "alias": ["url.full", "http.url", "url", "aws.request.url"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "url.full",
+    "reason": "This attribute is being deprecated in favor of url.full."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [581],
+      "description": "Added messaging.url attribute"
+    }
+  ]
+}

--- a/model/attributes/net/net__protocol__name.json
+++ b/model/attributes/net/net__protocol__name.json
@@ -7,13 +7,17 @@
   },
   "is_in_otel": true,
   "example": "http",
-  "alias": ["network.protocol.name", "mcp.resource.protocol"],
+  "alias": ["network.protocol.name", "mcp.resource.protocol", "messaging.protocol"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "network.protocol.name"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.protocol as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [61, 127]

--- a/model/attributes/net/net__protocol__version.json
+++ b/model/attributes/net/net__protocol__version.json
@@ -7,13 +7,17 @@
   },
   "is_in_otel": true,
   "example": "1.1",
-  "alias": ["network.protocol.version", "http.flavor"],
+  "alias": ["network.protocol.version", "http.flavor", "messaging.protocol_version"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "network.protocol.version"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.protocol_version as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [61, 108, 127]

--- a/model/attributes/network/network__protocol__name.json
+++ b/model/attributes/network/network__protocol__name.json
@@ -7,9 +7,13 @@
   },
   "is_in_otel": true,
   "example": "http",
-  "alias": ["net.protocol.name", "mcp.resource.protocol"],
+  "alias": ["net.protocol.name", "mcp.resource.protocol", "messaging.protocol"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.protocol as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [127]

--- a/model/attributes/network/network__protocol__version.json
+++ b/model/attributes/network/network__protocol__version.json
@@ -7,9 +7,13 @@
   },
   "is_in_otel": true,
   "example": "1.1",
-  "alias": ["http.flavor", "net.protocol.version"],
+  "alias": ["http.flavor", "net.protocol.version", "messaging.protocol_version"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.protocol_version as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [127]

--- a/model/attributes/url.json
+++ b/model/attributes/url.json
@@ -7,13 +7,17 @@
   },
   "is_in_otel": false,
   "example": "https://example.com/test?foo=bar#buzz",
-  "alias": ["url.full", "http.url", "aws.request.url"],
+  "alias": ["url.full", "http.url", "aws.request.url", "messaging.url"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "url.full"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.url as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [61]

--- a/model/attributes/url/url__full.json
+++ b/model/attributes/url/url__full.json
@@ -7,9 +7,13 @@
   },
   "is_in_otel": true,
   "example": "https://example.com/test?foo=bar#buzz",
-  "alias": ["http.url", "url", "aws.request.url"],
+  "alias": ["http.url", "url", "aws.request.url", "messaging.url"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added messaging.url as an alias"
+    },
     {
       "version": "0.19.0",
       "prs": [488],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -218,6 +218,7 @@ class _AttributeNamesMeta(type):
         "CODE",
         "CONNECTION_RTT",
         "CONNECTIONTYPE",
+        "DB_CONNECTION_STRING",
         "DB_MONGODB_COLLECTION",
         "DB_NAME",
         "DB_OPERATION",
@@ -298,8 +299,15 @@ class _AttributeNamesMeta(type):
         "MCP_TOOL_RESULT_CONTENT",
         "MCP_TOOL_RESULT_IS_ERROR",
         "MCP_TRANSPORT",
+        "MESSAGING_CONVERSATION_ID",
         "MESSAGING_DESTINATION",
         "MESSAGING_DESTINATION_KIND",
+        "_MESSAGING_MESSAGE_ID",
+        "MESSAGING_OPERATION",
+        "MESSAGING_PROTOCOL",
+        "MESSAGING_PROTOCOL_VERSION",
+        "MESSAGING_RABBITMQ_ROUTING_KEY",
+        "MESSAGING_URL",
         "METHOD",
         "NET_HOST_IP",
         "NET_HOST_NAME",
@@ -1928,7 +1936,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto
     Defined in OTEL: No
     Visibility: public
-    Aliases: url.full, http.url, url
+    Aliases: url.full, http.url, url, messaging.url
     DEPRECATED: Use url.full instead - This attribute is being deprecated in favor of url.full, which is the OTel-aligned replacement.
     Example: "https://sqs.us-east-1.amazonaws.com/123456789/my-queue"
     """
@@ -3026,6 +3034,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Visibility: public
     Aliases: db.mongodb.collection
     Example: "users"
+    """
+
+    # Path: model/attributes/db/db__connection_string.json
+    DB_CONNECTION_STRING: Literal["db.connection_string"] = "db.connection_string"
+    """The connection string used to connect to the database.
+
+    Type: str
+    Apply Scrubbing: auto
+    Defined in OTEL: No
+    Visibility: public
+    DEPRECATED: No replacement at this time - This attribute is deprecated. The connection is described by server.address and server.port instead, so the value cannot be copied to a single replacement attribute.
+    Example: "redis://localhost:6379"
     """
 
     # Path: model/attributes/db/db__driver__name.json
@@ -5461,7 +5481,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: network.protocol.version, net.protocol.version
+    Aliases: network.protocol.version, net.protocol.version, messaging.protocol_version
     DEPRECATED: Use network.protocol.version instead
     Example: "1.1"
     """
@@ -6056,7 +6076,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: url.full, url, aws.request.url
+    Aliases: url.full, url, aws.request.url, messaging.url
     DEPRECATED: Use url.full instead
     Example: "https://example.com/test?foo=bar#buzz"
     """
@@ -6657,7 +6677,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: network.protocol.name, net.protocol.name
+    Aliases: network.protocol.name, net.protocol.name, messaging.protocol
     DEPRECATED: Use network.protocol.name instead - OTel uses the generic network.protocol.name attribute
     Example: "file"
     """
@@ -6810,6 +6830,21 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 10
     """
 
+    # Path: model/attributes/messaging/messaging__conversation_id.json
+    MESSAGING_CONVERSATION_ID: Literal["messaging.conversation_id"] = (
+        "messaging.conversation_id"
+    )
+    """The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID".
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: messaging.message.conversation_id
+    DEPRECATED: Use messaging.message.conversation_id instead - This attribute is being deprecated in favor of messaging.message.conversation_id.
+    Example: "MyConversationId"
+    """
+
     # Path: model/attributes/messaging/messaging__destination.json
     MESSAGING_DESTINATION: Literal["messaging.destination"] = "messaging.destination"
     """The message destination name.
@@ -6937,6 +6972,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: messaging.conversation_id
     Example: "MyConversationId"
     """
 
@@ -6961,6 +6997,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: messaging.message_id
     Example: "f47ac10b58cc4372a5670e02b2c3d479"
     """
 
@@ -6990,6 +7027,32 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 2
     """
 
+    # Path: model/attributes/messaging/messaging__message_id.json
+    _MESSAGING_MESSAGE_ID: Literal["messaging.message_id"] = "messaging.message_id"
+    """A value used by the messaging system as an identifier for the message, represented as a string.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: messaging.message.id
+    DEPRECATED: Use messaging.message.id instead - This attribute is being deprecated in favor of messaging.message.id.
+    Example: "452a7c7c7c7048c2f887f0e7"
+    """
+
+    # Path: model/attributes/messaging/messaging__operation.json
+    MESSAGING_OPERATION: Literal["messaging.operation"] = "messaging.operation"
+    """The name of the messaging operation being performed.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: messaging.operation.name
+    DEPRECATED: Use messaging.operation.name instead - This attribute is being deprecated in favor of messaging.operation.name.
+    Example: "publish"
+    """
+
     # Path: model/attributes/messaging/messaging__operation__name.json
     MESSAGING_OPERATION_NAME: Literal["messaging.operation.name"] = (
         "messaging.operation.name"
@@ -7000,6 +7063,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: messaging.operation
     Example: "send"
     """
 
@@ -7016,6 +7080,34 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "create"
     """
 
+    # Path: model/attributes/messaging/messaging__protocol.json
+    MESSAGING_PROTOCOL: Literal["messaging.protocol"] = "messaging.protocol"
+    """OSI application layer or non-OSI equivalent.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: network.protocol.name, net.protocol.name, mcp.resource.protocol
+    DEPRECATED: Use network.protocol.name instead - This attribute is being deprecated in favor of network.protocol.name.
+    Example: "AMQP"
+    """
+
+    # Path: model/attributes/messaging/messaging__protocol_version.json
+    MESSAGING_PROTOCOL_VERSION: Literal["messaging.protocol_version"] = (
+        "messaging.protocol_version"
+    )
+    """The actual version of the protocol used for network communication.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: network.protocol.version, http.flavor, net.protocol.version
+    DEPRECATED: Use network.protocol.version instead - This attribute is being deprecated in favor of network.protocol.version.
+    Example: "0.9.1"
+    """
+
     # Path: model/attributes/messaging/messaging__rabbitmq__destination__routing_key.json
     MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY: Literal[
         "messaging.rabbitmq.destination.routing_key"
@@ -7026,6 +7118,22 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: messaging.rabbitmq.routing_key
+    Example: "myKey"
+    """
+
+    # Path: model/attributes/messaging/messaging__rabbitmq__routing_key.json
+    MESSAGING_RABBITMQ_ROUTING_KEY: Literal["messaging.rabbitmq.routing_key"] = (
+        "messaging.rabbitmq.routing_key"
+    )
+    """RabbitMQ message routing key.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: messaging.rabbitmq.destination.routing_key
+    DEPRECATED: Use messaging.rabbitmq.destination.routing_key instead - This attribute is being deprecated in favor of messaging.rabbitmq.destination.routing_key.
     Example: "myKey"
     """
 
@@ -7038,6 +7146,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Example: "activemq"
+    """
+
+    # Path: model/attributes/messaging/messaging__url.json
+    MESSAGING_URL: Literal["messaging.url"] = "messaging.url"
+    """The connection string of the messaging broker.
+
+    Type: str
+    Apply Scrubbing: auto
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: url.full, http.url, url, aws.request.url
+    DEPRECATED: Use url.full instead - This attribute is being deprecated in favor of url.full.
+    Example: "amqp://guest:guest@localhost:5672"
     """
 
     # Path: model/attributes/method.json
@@ -7239,7 +7360,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: network.protocol.name, mcp.resource.protocol
+    Aliases: network.protocol.name, mcp.resource.protocol, messaging.protocol
     DEPRECATED: Use network.protocol.name instead
     Example: "http"
     """
@@ -7252,7 +7373,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: network.protocol.version, http.flavor
+    Aliases: network.protocol.version, http.flavor, messaging.protocol_version
     DEPRECATED: Use network.protocol.version instead
     Example: "1.1"
     """
@@ -7441,7 +7562,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: net.protocol.name, mcp.resource.protocol
+    Aliases: net.protocol.name, mcp.resource.protocol, messaging.protocol
     Example: "http"
     """
 
@@ -7455,7 +7576,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: http.flavor, net.protocol.version
+    Aliases: http.flavor, net.protocol.version, messaging.protocol_version
     Example: "1.1"
     """
 
@@ -9655,7 +9776,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: http.url, url, aws.request.url
+    Aliases: http.url, url, aws.request.url, messaging.url
     Example: "https://example.com/test?foo=bar#buzz"
     """
 
@@ -9753,7 +9874,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto
     Defined in OTEL: No
     Visibility: public
-    Aliases: url.full, http.url, aws.request.url
+    Aliases: url.full, http.url, aws.request.url, messaging.url
     DEPRECATED: Use url.full instead
     Example: "https://example.com/test?foo=bar#buzz"
     """
@@ -12666,6 +12787,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "url.full",
             "aws.request.url",
             "http.url",
+            "messaging.url",
             "url",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
@@ -12677,8 +12799,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             reason="This attribute is being deprecated in favor of url.full, which is the OTel-aligned replacement.",
             status=DeprecationStatus.BACKFILL,
         ),
-        aliases=["url.full", "http.url", "url"],
+        aliases=["url.full", "http.url", "url", "messaging.url"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added messaging.url as an alias"
+            ),
             ChangelogEntry(
                 version="0.19.0",
                 prs=[488],
@@ -14136,6 +14261,26 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
             ChangelogEntry(version="0.1.0", prs=[106, 127]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "db.connection_string": AttributeMetadata(
+        brief="The connection string used to connect to the database.",
+        type=AttributeType.STRING,
+        keys=("db.connection_string",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="redis://localhost:6379",
+        examples=["redis://localhost:6379"],
+        deprecation=DeprecationInfo(
+            reason="This attribute is deprecated. The connection is described by server.address and server.port instead, so the value cannot be copied to a single replacement attribute."
+        ),
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[581],
+                description="Added db.connection_string attribute",
+            ),
         ],
     ),
     "db.driver.name": AttributeMetadata(
@@ -17740,6 +17885,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "network.protocol.version",
             "http.flavor",
+            "messaging.protocol_version",
             "net.protocol.version",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
@@ -17749,8 +17895,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="network.protocol.version", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["network.protocol.version", "net.protocol.version"],
+        aliases=[
+            "network.protocol.version",
+            "net.protocol.version",
+            "messaging.protocol_version",
+        ],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added messaging.protocol_version as an alias",
+            ),
             ChangelogEntry(version="0.1.0", prs=[61, 108, 127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -18581,6 +18735,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "url.full",
             "aws.request.url",
             "http.url",
+            "messaging.url",
             "url",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
@@ -18590,8 +18745,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="url.full", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["url.full", "url", "aws.request.url"],
+        aliases=["url.full", "url", "aws.request.url", "messaging.url"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added messaging.url as an alias"
+            ),
             ChangelogEntry(version="0.1.0", prs=[61, 108]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -19396,6 +19554,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "network.protocol.name",
             "mcp.resource.protocol",
+            "messaging.protocol",
             "net.protocol.name",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
@@ -19407,8 +19566,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             reason="OTel uses the generic network.protocol.name attribute",
             status=DeprecationStatus.BACKFILL,
         ),
-        aliases=["network.protocol.name", "net.protocol.name"],
+        aliases=["network.protocol.name", "net.protocol.name", "messaging.protocol"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added messaging.protocol as an alias"
+            ),
             ChangelogEntry(
                 version="0.12.0",
                 prs=[420],
@@ -19646,6 +19808,32 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "messaging.conversation_id": AttributeMetadata(
+        brief='The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID".',
+        type=AttributeType.STRING,
+        keys=(
+            "messaging.message.conversation_id",
+            "messaging.conversation_id",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="MyConversationId",
+        examples=["MyConversationId"],
+        deprecation=DeprecationInfo(
+            replacement="messaging.message.conversation_id",
+            reason="This attribute is being deprecated in favor of messaging.message.conversation_id.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["messaging.message.conversation_id"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[581],
+                description="Added messaging.conversation_id attribute",
+            ),
+        ],
+    ),
     "messaging.destination": AttributeMetadata(
         brief="The message destination name.",
         type=AttributeType.STRING,
@@ -19806,12 +19994,20 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "messaging.message.conversation_id": AttributeMetadata(
         brief='The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID".',
         type=AttributeType.STRING,
-        keys=("messaging.message.conversation_id",),
+        keys=(
+            "messaging.message.conversation_id",
+            "messaging.conversation_id",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="MyConversationId",
+        aliases=["messaging.conversation_id"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added messaging.conversation_id as an alias",
+            ),
             ChangelogEntry(
                 version="0.16.0",
                 prs=[468],
@@ -19835,12 +20031,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "messaging.message.id": AttributeMetadata(
         brief="A value used by the messaging system as an identifier for the message, represented as a string.",
         type=AttributeType.STRING,
-        keys=("messaging.message.id",),
+        keys=(
+            "messaging.message.id",
+            "messaging.message_id",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="f47ac10b58cc4372a5670e02b2c3d479",
+        aliases=["messaging.message_id"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added messaging.message_id as an alias"
+            ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -19874,15 +20077,74 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "messaging.message_id": AttributeMetadata(
+        brief="A value used by the messaging system as an identifier for the message, represented as a string.",
+        type=AttributeType.STRING,
+        keys=(
+            "messaging.message.id",
+            "messaging.message_id",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="452a7c7c7c7048c2f887f0e7",
+        examples=["452a7c7c7c7048c2f887f0e7"],
+        deprecation=DeprecationInfo(
+            replacement="messaging.message.id",
+            reason="This attribute is being deprecated in favor of messaging.message.id.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["messaging.message.id"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[581],
+                description="Added messaging.message_id attribute",
+            ),
+        ],
+    ),
+    "messaging.operation": AttributeMetadata(
+        brief="The name of the messaging operation being performed.",
+        type=AttributeType.STRING,
+        keys=(
+            "messaging.operation.name",
+            "messaging.operation",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="publish",
+        examples=["publish"],
+        deprecation=DeprecationInfo(
+            replacement="messaging.operation.name",
+            reason="This attribute is being deprecated in favor of messaging.operation.name.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["messaging.operation.name"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[581],
+                description="Added messaging.operation attribute",
+            ),
+        ],
+    ),
     "messaging.operation.name": AttributeMetadata(
         brief="The name of the messaging operation being performed",
         type=AttributeType.STRING,
-        keys=("messaging.operation.name",),
+        keys=(
+            "messaging.operation.name",
+            "messaging.operation",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="send",
+        aliases=["messaging.operation"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added messaging.operation as an alias"
+            ),
             ChangelogEntry(
                 version="0.11.0",
                 prs=[392],
@@ -19902,19 +20164,109 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[51, 127]),
         ],
     ),
+    "messaging.protocol": AttributeMetadata(
+        brief="OSI application layer or non-OSI equivalent.",
+        type=AttributeType.STRING,
+        keys=(
+            "network.protocol.name",
+            "mcp.resource.protocol",
+            "messaging.protocol",
+            "net.protocol.name",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="AMQP",
+        examples=["AMQP"],
+        deprecation=DeprecationInfo(
+            replacement="network.protocol.name",
+            reason="This attribute is being deprecated in favor of network.protocol.name.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["network.protocol.name", "net.protocol.name", "mcp.resource.protocol"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[581],
+                description="Added messaging.protocol attribute",
+            ),
+        ],
+    ),
+    "messaging.protocol_version": AttributeMetadata(
+        brief="The actual version of the protocol used for network communication.",
+        type=AttributeType.STRING,
+        keys=(
+            "network.protocol.version",
+            "http.flavor",
+            "messaging.protocol_version",
+            "net.protocol.version",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="0.9.1",
+        examples=["0.9.1"],
+        deprecation=DeprecationInfo(
+            replacement="network.protocol.version",
+            reason="This attribute is being deprecated in favor of network.protocol.version.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["network.protocol.version", "http.flavor", "net.protocol.version"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[581],
+                description="Added messaging.protocol_version attribute",
+            ),
+        ],
+    ),
     "messaging.rabbitmq.destination.routing_key": AttributeMetadata(
         brief="RabbitMQ message routing key.",
         type=AttributeType.STRING,
-        keys=("messaging.rabbitmq.destination.routing_key",),
+        keys=(
+            "messaging.rabbitmq.destination.routing_key",
+            "messaging.rabbitmq.routing_key",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="myKey",
+        aliases=["messaging.rabbitmq.routing_key"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added messaging.rabbitmq.routing_key as an alias",
+            ),
             ChangelogEntry(
                 version="0.16.0",
                 prs=[468],
                 description="Added messaging.rabbitmq.destination.routing_key attribute",
+            ),
+        ],
+    ),
+    "messaging.rabbitmq.routing_key": AttributeMetadata(
+        brief="RabbitMQ message routing key.",
+        type=AttributeType.STRING,
+        keys=(
+            "messaging.rabbitmq.destination.routing_key",
+            "messaging.rabbitmq.routing_key",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="myKey",
+        examples=["myKey"],
+        deprecation=DeprecationInfo(
+            replacement="messaging.rabbitmq.destination.routing_key",
+            reason="This attribute is being deprecated in favor of messaging.rabbitmq.destination.routing_key.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["messaging.rabbitmq.destination.routing_key"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[581],
+                description="Added messaging.rabbitmq.routing_key attribute",
             ),
         ],
     ),
@@ -19929,6 +20281,33 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "messaging.url": AttributeMetadata(
+        brief="The connection string of the messaging broker.",
+        type=AttributeType.STRING,
+        keys=(
+            "url.full",
+            "aws.request.url",
+            "http.url",
+            "messaging.url",
+            "url",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="amqp://guest:guest@localhost:5672",
+        examples=["amqp://guest:guest@localhost:5672"],
+        deprecation=DeprecationInfo(
+            replacement="url.full",
+            reason="This attribute is being deprecated in favor of url.full.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["url.full", "http.url", "url", "aws.request.url"],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[581], description="Added messaging.url attribute"
+            ),
         ],
     ),
     "method": AttributeMetadata(
@@ -20247,6 +20626,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "network.protocol.name",
             "mcp.resource.protocol",
+            "messaging.protocol",
             "net.protocol.name",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
@@ -20256,8 +20636,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="network.protocol.name", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["network.protocol.name", "mcp.resource.protocol"],
+        aliases=[
+            "network.protocol.name",
+            "mcp.resource.protocol",
+            "messaging.protocol",
+        ],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added messaging.protocol as an alias"
+            ),
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -20268,6 +20655,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "network.protocol.version",
             "http.flavor",
+            "messaging.protocol_version",
             "net.protocol.version",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
@@ -20277,8 +20665,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="network.protocol.version", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["network.protocol.version", "http.flavor"],
+        aliases=[
+            "network.protocol.version",
+            "http.flavor",
+            "messaging.protocol_version",
+        ],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added messaging.protocol_version as an alias",
+            ),
             ChangelogEntry(version="0.1.0", prs=[61, 108, 127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -20557,14 +20953,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "network.protocol.name",
             "mcp.resource.protocol",
+            "messaging.protocol",
             "net.protocol.name",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="http",
-        aliases=["net.protocol.name", "mcp.resource.protocol"],
+        aliases=["net.protocol.name", "mcp.resource.protocol", "messaging.protocol"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added messaging.protocol as an alias"
+            ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -20575,14 +20975,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "network.protocol.version",
             "http.flavor",
+            "messaging.protocol_version",
             "net.protocol.version",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="1.1",
-        aliases=["http.flavor", "net.protocol.version"],
+        aliases=["http.flavor", "net.protocol.version", "messaging.protocol_version"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added messaging.protocol_version as an alias",
+            ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -23744,14 +24149,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "url.full",
             "aws.request.url",
             "http.url",
+            "messaging.url",
             "url",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="https://example.com/test?foo=bar#buzz",
-        aliases=["http.url", "url", "aws.request.url"],
+        aliases=["http.url", "url", "aws.request.url", "messaging.url"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added messaging.url as an alias"
+            ),
             ChangelogEntry(
                 version="0.19.0",
                 prs=[488],
@@ -23890,6 +24299,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "url.full",
             "aws.request.url",
             "http.url",
+            "messaging.url",
             "url",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
@@ -23899,8 +24309,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="url.full", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["url.full", "http.url", "aws.request.url"],
+        aliases=["url.full", "http.url", "aws.request.url", "messaging.url"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added messaging.url as an alias"
+            ),
             ChangelogEntry(version="0.1.0", prs=[61]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -24744,6 +25157,7 @@ Attributes = TypedDict(
         "culture.locale": str,
         "culture.timezone": str,
         "db.collection.name": str,
+        "db.connection_string": str,
         "db.driver.name": str,
         "db.mongodb.collection": str,
         "db.name": str,
@@ -25047,6 +25461,7 @@ Attributes = TypedDict(
         "mcp.transport": str,
         "mdc.<key>": str,
         "messaging.batch.message_count": int,
+        "messaging.conversation_id": str,
         "messaging.destination": str,
         "messaging.destination.connection": str,
         "messaging.destination.name": str,
@@ -25061,10 +25476,16 @@ Attributes = TypedDict(
         "messaging.message.id": str,
         "messaging.message.receive.latency": int,
         "messaging.message.retry.count": int,
+        "messaging.message_id": str,
+        "messaging.operation": str,
         "messaging.operation.name": str,
         "messaging.operation.type": str,
+        "messaging.protocol": str,
+        "messaging.protocol_version": str,
         "messaging.rabbitmq.destination.routing_key": str,
+        "messaging.rabbitmq.routing_key": str,
         "messaging.system": str,
+        "messaging.url": str,
         "method": str,
         "middleware.name": str,
         "navigation.origin": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3042,7 +3042,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     Type: str
     Apply Scrubbing: auto
-    Defined in OTEL: No
+    Defined in OTEL: Yes
     Visibility: public
     DEPRECATED: No replacement at this time - This attribute is deprecated. The connection is described by server.address and server.port instead, so the value cannot be copied to a single replacement attribute.
     Example: "redis://localhost:6379"
@@ -14268,7 +14268,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         type=AttributeType.STRING,
         keys=("db.connection_string",),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
-        is_in_otel=False,
+        is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="redis://localhost:6379",
         examples=["redis://localhost:6379"],


### PR DESCRIPTION
Adds the seven legacy AMQP `messaging.*` attributes and `db.connection_string`, which the JavaScript SDK stopped emitting in v11. Without a definition here, nothing tells a user what replaced them.

`db.connection_string` has no single replacement: the connection is now described by `server.address` and `server.port`. It therefore carries a reason instead of a `replacement`, and gets no alias, so that no two-target alias group is created. (is there any protocol on how to treat these?)

`messaging.protocol`, `messaging.protocol_version` and `messaging.url` join existing alias groups, so the other members of those groups gain the new key as well.

Deprecated by https://github.com/getsentry/sentry-javascript/pull/23324