### PR TITLE
feat(attributes): Add legacy Vercel AI span attributes (deprecated)

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -176,7 +176,7 @@ export type AI_FUNCTION_CALL_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link GEN_AI_RESPONSE_ID} `gen_ai.response.id`
+ * Aliases: {@link GEN_AI_RESPONSE_ID} `gen_ai.response.id`, {@link AI_RESPONSE_ID} `ai.response.id`
  *
  * @deprecated Use {@link GEN_AI_RESPONSE_ID} (gen_ai.response.id) instead
  * @example "gen_123abc"
@@ -256,10 +256,10 @@ export const AI_METADATA = 'ai.metadata';
  */
 export type AI_METADATA_TYPE = string;
 
-// Path: model/attributes/ai/ai__model_id.json
+// Path: model/attributes/ai/ai__model__id.json
 
 /**
- * The vendor-specific ID of the model used. `ai.model_id`
+ * The id of the model used by the Vercel AI SDK. `ai.model.id`
  *
  * Attribute Value Type: `string` {@link AI_MODEL_ID_TYPE}
  *
@@ -268,17 +268,41 @@ export type AI_METADATA_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link GEN_AI_REQUEST_MODEL} `gen_ai.request.model`
+ * Aliases: {@link GEN_AI_REQUEST_MODEL} `gen_ai.request.model`, {@link _AI_MODEL_ID} `ai.model_id`
+ *
+ * @deprecated Use {@link GEN_AI_REQUEST_MODEL} (gen_ai.request.model) instead - This attribute is being deprecated in favor of gen_ai.request.model.
+ * @example "gpt-4o"
+ */
+export const AI_MODEL_ID = 'ai.model.id';
+
+/**
+ * Type for {@link AI_MODEL_ID} ai.model.id
+ */
+export type AI_MODEL_ID_TYPE = string;
+
+// Path: model/attributes/ai/ai__model_id.json
+
+/**
+ * The vendor-specific ID of the model used. `ai.model_id`
+ *
+ * Attribute Value Type: `string` {@link _AI_MODEL_ID_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link GEN_AI_REQUEST_MODEL} `gen_ai.request.model`, {@link AI_MODEL_ID} `ai.model.id`
  *
  * @deprecated Use {@link GEN_AI_REQUEST_MODEL} (gen_ai.request.model) instead
  * @example "gpt-4"
  */
-export const AI_MODEL_ID = 'ai.model_id';
+export const _AI_MODEL_ID = 'ai.model_id';
 
 /**
- * Type for {@link AI_MODEL_ID} ai.model_id
+ * Type for {@link _AI_MODEL_ID} ai.model_id
  */
-export type AI_MODEL_ID_TYPE = string;
+export type _AI_MODEL_ID_TYPE = string;
 
 // Path: model/attributes/ai/ai__model__provider.json
 
@@ -376,6 +400,30 @@ export const AI_PRESENCE_PENALTY = 'ai.presence_penalty';
  */
 export type AI_PRESENCE_PENALTY_TYPE = number;
 
+// Path: model/attributes/ai/ai__prompt.json
+
+/**
+ * The prompt passed to the Vercel AI SDK, as a stringified object. `ai.prompt`
+ *
+ * Attribute Value Type: `string` {@link AI_PROMPT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link GEN_AI_INPUT_MESSAGES} `gen_ai.input.messages`, {@link AI_TEXTS} `ai.texts`, {@link AI_PROMPT_MESSAGES} `ai.prompt.messages`, {@link GEN_AI_PROMPT} `gen_ai.prompt`
+ *
+ * @deprecated Use {@link GEN_AI_INPUT_MESSAGES} (gen_ai.input.messages) instead - This attribute is being deprecated in favor of gen_ai.input.messages.
+ * @example "{\"prompt\":\"What is the weather in Paris?\"}"
+ */
+export const AI_PROMPT = 'ai.prompt';
+
+/**
+ * Type for {@link AI_PROMPT} ai.prompt
+ */
+export type AI_PROMPT_TYPE = string;
+
 // Path: model/attributes/ai/ai__prompt__messages.json
 
 /**
@@ -388,7 +436,7 @@ export type AI_PRESENCE_PENALTY_TYPE = number;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link GEN_AI_INPUT_MESSAGES} `gen_ai.input.messages`, {@link AI_TEXTS} `ai.texts`, {@link GEN_AI_PROMPT} `gen_ai.prompt`
+ * Aliases: {@link GEN_AI_INPUT_MESSAGES} `gen_ai.input.messages`, {@link AI_TEXTS} `ai.texts`, {@link GEN_AI_PROMPT} `gen_ai.prompt`, {@link AI_PROMPT} `ai.prompt`
  *
  * @deprecated Use {@link GEN_AI_INPUT_MESSAGES} (gen_ai.input.messages) instead
  * @example "[{\"role\": \"user\", \"message\": \"hello\"}]"
@@ -423,6 +471,28 @@ export const AI_PROMPT_TOKENS_USED = 'ai.prompt_tokens.used';
  * Type for {@link AI_PROMPT_TOKENS_USED} ai.prompt_tokens.used
  */
 export type AI_PROMPT_TOKENS_USED_TYPE = number;
+
+// Path: model/attributes/ai/ai__prompt__tools.json
+
+/**
+ * The tools made available to the model, as an array of stringified tool definitions. `ai.prompt.tools`
+ *
+ * Attribute Value Type: `Array<string>` {@link AI_PROMPT_TOOLS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @deprecated Use {@link GEN_AI_TOOL_DEFINITIONS} (gen_ai.tool.definitions) instead - This attribute is being deprecated in favor of gen_ai.tool.definitions.
+ * @example ["{\"type\":\"function\",\"name\":\"get_weather\"}"]
+ */
+export const AI_PROMPT_TOOLS = 'ai.prompt.tools';
+
+/**
+ * Type for {@link AI_PROMPT_TOOLS} ai.prompt.tools
+ */
+export type AI_PROMPT_TOOLS_TYPE = Array<string>;
 
 // Path: model/attributes/ai/ai__raw_prompting.json
 
@@ -490,6 +560,76 @@ export const AI_RESPONSE_FORMAT = 'ai.response_format';
  */
 export type AI_RESPONSE_FORMAT_TYPE = string;
 
+// Path: model/attributes/ai/ai__response__id.json
+
+/**
+ * The id of the response returned by the model. `ai.response.id`
+ *
+ * Attribute Value Type: `string` {@link AI_RESPONSE_ID_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link GEN_AI_RESPONSE_ID} `gen_ai.response.id`, {@link AI_GENERATION_ID} `ai.generation_id`
+ *
+ * @deprecated Use {@link GEN_AI_RESPONSE_ID} (gen_ai.response.id) instead - This attribute is being deprecated in favor of gen_ai.response.id.
+ * @example "chatcmpl-BuKJgVSKAMTUYbBSjHTMUuNGKzOPY"
+ */
+export const AI_RESPONSE_ID = 'ai.response.id';
+
+/**
+ * Type for {@link AI_RESPONSE_ID} ai.response.id
+ */
+export type AI_RESPONSE_ID_TYPE = string;
+
+// Path: model/attributes/ai/ai__response__model.json
+
+/**
+ * The id of the model that produced the response. `ai.response.model`
+ *
+ * Attribute Value Type: `string` {@link AI_RESPONSE_MODEL_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link GEN_AI_RESPONSE_MODEL} `gen_ai.response.model`
+ *
+ * @deprecated Use {@link GEN_AI_RESPONSE_MODEL} (gen_ai.response.model) instead - This attribute is being deprecated in favor of gen_ai.response.model.
+ * @example "gpt-4o-2024-08-06"
+ */
+export const AI_RESPONSE_MODEL = 'ai.response.model';
+
+/**
+ * Type for {@link AI_RESPONSE_MODEL} ai.response.model
+ */
+export type AI_RESPONSE_MODEL_TYPE = string;
+
+// Path: model/attributes/ai/ai__response__object.json
+
+/**
+ * The type of the object returned by the model. `ai.response.object`
+ *
+ * Attribute Value Type: `string` {@link AI_RESPONSE_OBJECT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @deprecated  - This attribute is deprecated. The Sentry conventions have no replacement for the raw Vercel AI response object type.
+ * @example "chat.completion"
+ */
+export const AI_RESPONSE_OBJECT = 'ai.response.object';
+
+/**
+ * Type for {@link AI_RESPONSE_OBJECT} ai.response.object
+ */
+export type AI_RESPONSE_OBJECT_TYPE = string;
+
 // Path: model/attributes/ai/ai__response__text.json
 
 /**
@@ -514,6 +654,28 @@ export const AI_RESPONSE_TEXT = 'ai.response.text';
  */
 export type AI_RESPONSE_TEXT_TYPE = string;
 
+// Path: model/attributes/ai/ai__response__timestamp.json
+
+/**
+ * The ISO 8601 timestamp at which the response was produced. `ai.response.timestamp`
+ *
+ * Attribute Value Type: `string` {@link AI_RESPONSE_TIMESTAMP_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @deprecated  - This attribute is deprecated. The span start and end timestamps carry the same information.
+ * @example "2026-02-19T15:32:11.000Z"
+ */
+export const AI_RESPONSE_TIMESTAMP = 'ai.response.timestamp';
+
+/**
+ * Type for {@link AI_RESPONSE_TIMESTAMP} ai.response.timestamp
+ */
+export type AI_RESPONSE_TIMESTAMP_TYPE = string;
+
 // Path: model/attributes/ai/ai__response__toolCalls.json
 
 /**
@@ -537,6 +699,28 @@ export const AI_RESPONSE_TOOLCALLS = 'ai.response.toolCalls';
  * Type for {@link AI_RESPONSE_TOOLCALLS} ai.response.toolCalls
  */
 export type AI_RESPONSE_TOOLCALLS_TYPE = string;
+
+// Path: model/attributes/ai/ai__schema.json
+
+/**
+ * The stringified JSON schema the model output must conform to. `ai.schema`
+ *
+ * Attribute Value Type: `string` {@link AI_SCHEMA_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @deprecated  - This attribute is deprecated. The Sentry conventions have no replacement for the requested output schema.
+ * @example "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}"
+ */
+export const AI_SCHEMA = 'ai.schema';
+
+/**
+ * Type for {@link AI_SCHEMA} ai.schema
+ */
+export type AI_SCHEMA_TYPE = string;
 
 // Path: model/attributes/ai/ai__search_queries.json
 
@@ -688,7 +872,7 @@ export type AI_TEMPERATURE_TYPE = number;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link GEN_AI_INPUT_MESSAGES} `gen_ai.input.messages`, {@link AI_PROMPT_MESSAGES} `ai.prompt.messages`, {@link GEN_AI_PROMPT} `gen_ai.prompt`
+ * Aliases: {@link GEN_AI_INPUT_MESSAGES} `gen_ai.input.messages`, {@link AI_PROMPT_MESSAGES} `ai.prompt.messages`, {@link GEN_AI_PROMPT} `gen_ai.prompt`, {@link AI_PROMPT} `ai.prompt`
  *
  * @deprecated Use {@link GEN_AI_INPUT_MESSAGES} (gen_ai.input.messages) instead
  * @example ["Hello, how are you?","What is the capital of France?"]
@@ -876,7 +1060,7 @@ export type AI_TOTAL_COST_TYPE = number;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link GEN_AI_USAGE_TOTAL_TOKENS} `gen_ai.usage.total_tokens`
+ * Aliases: {@link GEN_AI_USAGE_TOTAL_TOKENS} `gen_ai.usage.total_tokens`, {@link AI_USAGE_TOKENS} `ai.usage.tokens`
  *
  * @deprecated Use {@link GEN_AI_USAGE_TOTAL_TOKENS} (gen_ai.usage.total_tokens) instead
  * @example 30
@@ -887,6 +1071,52 @@ export const AI_TOTAL_TOKENS_USED = 'ai.total_tokens.used';
  * Type for {@link AI_TOTAL_TOKENS_USED} ai.total_tokens.used
  */
 export type AI_TOTAL_TOKENS_USED_TYPE = number;
+
+// Path: model/attributes/ai/ai__usage__tokens.json
+
+/**
+ * The total number of tokens used for the request and the response. `ai.usage.tokens`
+ *
+ * Attribute Value Type: `number` {@link AI_USAGE_TOKENS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link GEN_AI_USAGE_TOTAL_TOKENS} `gen_ai.usage.total_tokens`, {@link AI_TOTAL_TOKENS_USED} `ai.total_tokens.used`
+ *
+ * @deprecated Use {@link GEN_AI_USAGE_TOTAL_TOKENS} (gen_ai.usage.total_tokens) instead - This attribute is being deprecated in favor of gen_ai.usage.total_tokens.
+ * @example 150
+ */
+export const AI_USAGE_TOKENS = 'ai.usage.tokens';
+
+/**
+ * Type for {@link AI_USAGE_TOKENS} ai.usage.tokens
+ */
+export type AI_USAGE_TOKENS_TYPE = number;
+
+// Path: model/attributes/ai/ai__values.json
+
+/**
+ * The stringified values produced by a Vercel AI SDK object or array generation. `ai.values`
+ *
+ * Attribute Value Type: `string` {@link AI_VALUES_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @deprecated  - This attribute is deprecated. Use gen_ai.output.messages for model output instead.
+ * @example "[{\"city\":\"Paris\"}]"
+ */
+export const AI_VALUES = 'ai.values';
+
+/**
+ * Type for {@link AI_VALUES} ai.values
+ */
+export type AI_VALUES_TYPE = string;
 
 // Path: model/attributes/ai/ai__warnings.json
 
@@ -7357,7 +7587,7 @@ export type GEN_AI_FUNCTION_ID_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link AI_TEXTS} `ai.texts`, {@link AI_PROMPT_MESSAGES} `ai.prompt.messages`, {@link GEN_AI_PROMPT} `gen_ai.prompt`
+ * Aliases: {@link AI_TEXTS} `ai.texts`, {@link AI_PROMPT_MESSAGES} `ai.prompt.messages`, {@link GEN_AI_PROMPT} `gen_ai.prompt`, {@link AI_PROMPT} `ai.prompt`
  *
  * @example "[{\"role\": \"user\", \"parts\": [{\"type\": \"text\", \"content\": \"Weather in Paris?\"}]}, {\"role\": \"assistant\", \"parts\": [{\"type\": \"tool_call\", \"id\": \"call_VSPygqKTWdrhaFErNvMV18Yl\", \"name\": \"get_weather\", \"arguments\": {\"location\": \"Paris\"}}]}, {\"role\": \"tool\", \"parts\": [{\"type\": \"tool_call_response\", \"id\": \"call_VSPygqKTWdrhaFErNvMV18Yl\", \"result\": \"rainy, 57°F\"}]}]"
  */
@@ -7468,7 +7698,7 @@ export type GEN_AI_PIPELINE_NAME_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link GEN_AI_INPUT_MESSAGES} `gen_ai.input.messages`, {@link AI_TEXTS} `ai.texts`, {@link AI_PROMPT_MESSAGES} `ai.prompt.messages`
+ * Aliases: {@link GEN_AI_INPUT_MESSAGES} `gen_ai.input.messages`, {@link AI_TEXTS} `ai.texts`, {@link AI_PROMPT_MESSAGES} `ai.prompt.messages`, {@link AI_PROMPT} `ai.prompt`
  *
  * @deprecated Use {@link GEN_AI_INPUT_MESSAGES} (gen_ai.input.messages) instead - Deprecated from OTEL, use gen_ai.input.messages with the new format instead.
  * @example "[{\"role\": \"user\", \"message\": \"hello\"}]"
@@ -7628,7 +7858,7 @@ export type GEN_AI_REQUEST_MESSAGES_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link AI_MODEL_ID} `ai.model_id`
+ * Aliases: {@link _AI_MODEL_ID} `ai.model_id`, {@link AI_MODEL_ID} `ai.model.id`
  *
  * @example "gpt-4-turbo-preview"
  */
@@ -7682,6 +7912,28 @@ export const GEN_AI_REQUEST_REASONING_LEVEL = 'gen_ai.request.reasoning.level';
  * Type for {@link GEN_AI_REQUEST_REASONING_LEVEL} gen_ai.request.reasoning.level
  */
 export type GEN_AI_REQUEST_REASONING_LEVEL_TYPE = string;
+
+// Path: model/attributes/gen_ai/gen_ai__request__schema.json
+
+/**
+ * The stringified JSON schema the model output must conform to. `gen_ai.request.schema`
+ *
+ * Attribute Value Type: `string` {@link GEN_AI_REQUEST_SCHEMA_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @deprecated  - This attribute is deprecated. The Sentry conventions have no replacement for the requested output schema.
+ * @example "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}"
+ */
+export const GEN_AI_REQUEST_SCHEMA = 'gen_ai.request.schema';
+
+/**
+ * Type for {@link GEN_AI_REQUEST_SCHEMA} gen_ai.request.schema
+ */
+export type GEN_AI_REQUEST_SCHEMA_TYPE = string;
 
 // Path: model/attributes/gen_ai/gen_ai__request__seed.json
 
@@ -7855,7 +8107,7 @@ export type GEN_AI_RESPONSE_FINISH_REASONS_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link AI_GENERATION_ID} `ai.generation_id`
+ * Aliases: {@link AI_GENERATION_ID} `ai.generation_id`, {@link AI_RESPONSE_ID} `ai.response.id`
  *
  * @example "gen_123abc"
  */
@@ -7878,6 +8130,8 @@ export type GEN_AI_RESPONSE_ID_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
+ * Aliases: {@link AI_RESPONSE_MODEL} `ai.response.model`
+ *
  * @example "gpt-4"
  */
 export const GEN_AI_RESPONSE_MODEL = 'gen_ai.response.model';
@@ -7886,6 +8140,28 @@ export const GEN_AI_RESPONSE_MODEL = 'gen_ai.response.model';
  * Type for {@link GEN_AI_RESPONSE_MODEL} gen_ai.response.model
  */
 export type GEN_AI_RESPONSE_MODEL_TYPE = string;
+
+// Path: model/attributes/gen_ai/gen_ai__response__object.json
+
+/**
+ * The type of the object returned by the model. `gen_ai.response.object`
+ *
+ * Attribute Value Type: `string` {@link GEN_AI_RESPONSE_OBJECT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @deprecated  - This attribute is deprecated. The Sentry conventions have no replacement for the raw response object type.
+ * @example "chat.completion"
+ */
+export const GEN_AI_RESPONSE_OBJECT = 'gen_ai.response.object';
+
+/**
+ * Type for {@link GEN_AI_RESPONSE_OBJECT} gen_ai.response.object
+ */
+export type GEN_AI_RESPONSE_OBJECT_TYPE = string;
 
 // Path: model/attributes/gen_ai/gen_ai__response__streaming.json
 
@@ -8543,7 +8819,7 @@ export type GEN_AI_USAGE_REASONING_OUTPUT_TOKENS_TYPE = number;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link AI_TOTAL_TOKENS_USED} `ai.total_tokens.used`
+ * Aliases: {@link AI_TOTAL_TOKENS_USED} `ai.total_tokens.used`, {@link AI_USAGE_TOKENS} `ai.usage.tokens`
  *
  * @example 20
  */
@@ -18104,18 +18380,26 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'ai.input_messages': 'string',
   'ai.is_search_required': 'boolean',
   'ai.metadata': 'string',
+  'ai.model.id': 'string',
   'ai.model_id': 'string',
   'ai.model.provider': 'string',
   'ai.pipeline.name': 'string',
   'ai.preamble': 'string',
   'ai.presence_penalty': 'double',
+  'ai.prompt': 'string',
   'ai.prompt.messages': 'string',
   'ai.prompt_tokens.used': 'integer',
+  'ai.prompt.tools': 'string[]',
   'ai.raw_prompting': 'boolean',
   'ai.responses': 'string[]',
   'ai.response_format': 'string',
+  'ai.response.id': 'string',
+  'ai.response.model': 'string',
+  'ai.response.object': 'string',
   'ai.response.text': 'string',
+  'ai.response.timestamp': 'string',
   'ai.response.toolCalls': 'string',
+  'ai.schema': 'string',
   'ai.search_queries': 'string[]',
   'ai.search_results': 'string[]',
   'ai.seed': 'string',
@@ -18131,6 +18415,8 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'ai.top_p': 'double',
   'ai.total_cost': 'double',
   'ai.total_tokens.used': 'integer',
+  'ai.usage.tokens': 'integer',
+  'ai.values': 'string',
   'ai.warnings': 'string[]',
   'angular.version': 'string',
   'app.app_build': 'string',
@@ -18439,6 +18725,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'gen_ai.request.model': 'string',
   'gen_ai.request.presence_penalty': 'double',
   'gen_ai.request.reasoning.level': 'string',
+  'gen_ai.request.schema': 'string',
   'gen_ai.request.seed': 'string',
   'gen_ai.request.stop_sequences': 'string[]',
   'gen_ai.request.temperature': 'double',
@@ -18448,6 +18735,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'gen_ai.response.finish_reasons': 'string',
   'gen_ai.response.id': 'string',
   'gen_ai.response.model': 'string',
+  'gen_ai.response.object': 'string',
   'gen_ai.response.streaming': 'boolean',
   'gen_ai.response.text': 'string',
   'gen_ai.response.time_to_first_chunk': 'double',
@@ -18916,17 +19204,25 @@ export type AttributeName =
   | typeof AI_IS_SEARCH_REQUIRED
   | typeof AI_METADATA
   | typeof AI_MODEL_ID
+  | typeof _AI_MODEL_ID
   | typeof AI_MODEL_PROVIDER
   | typeof AI_PIPELINE_NAME
   | typeof AI_PREAMBLE
   | typeof AI_PRESENCE_PENALTY
+  | typeof AI_PROMPT
   | typeof AI_PROMPT_MESSAGES
   | typeof AI_PROMPT_TOKENS_USED
+  | typeof AI_PROMPT_TOOLS
   | typeof AI_RAW_PROMPTING
   | typeof AI_RESPONSES
   | typeof AI_RESPONSE_FORMAT
+  | typeof AI_RESPONSE_ID
+  | typeof AI_RESPONSE_MODEL
+  | typeof AI_RESPONSE_OBJECT
   | typeof AI_RESPONSE_TEXT
+  | typeof AI_RESPONSE_TIMESTAMP
   | typeof AI_RESPONSE_TOOLCALLS
+  | typeof AI_SCHEMA
   | typeof AI_SEARCH_QUERIES
   | typeof AI_SEARCH_RESULTS
   | typeof AI_SEED
@@ -18942,6 +19238,8 @@ export type AttributeName =
   | typeof AI_TOP_P
   | typeof AI_TOTAL_COST
   | typeof AI_TOTAL_TOKENS_USED
+  | typeof AI_USAGE_TOKENS
+  | typeof AI_VALUES
   | typeof AI_WARNINGS
   | typeof ANGULAR_VERSION
   | typeof APP_APP_BUILD
@@ -19250,6 +19548,7 @@ export type AttributeName =
   | typeof GEN_AI_REQUEST_MODEL
   | typeof GEN_AI_REQUEST_PRESENCE_PENALTY
   | typeof GEN_AI_REQUEST_REASONING_LEVEL
+  | typeof GEN_AI_REQUEST_SCHEMA
   | typeof GEN_AI_REQUEST_SEED
   | typeof GEN_AI_REQUEST_STOP_SEQUENCES
   | typeof GEN_AI_REQUEST_TEMPERATURE
@@ -19259,6 +19558,7 @@ export type AttributeName =
   | typeof GEN_AI_RESPONSE_FINISH_REASONS
   | typeof GEN_AI_RESPONSE_ID
   | typeof GEN_AI_RESPONSE_MODEL
+  | typeof GEN_AI_RESPONSE_OBJECT
   | typeof GEN_AI_RESPONSE_STREAMING
   | typeof GEN_AI_RESPONSE_TEXT
   | typeof GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK
@@ -19841,7 +20141,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'ai.generation_id': {
     brief: 'Unique identifier for the completion.',
     type: 'string',
-    keys: ['gen_ai.response.id', 'ai.generation_id'],
+    keys: ['gen_ai.response.id', 'ai.generation_id', 'ai.response.id'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -19852,13 +20152,23 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.response.id',
       status: 'backfill',
     },
-    aliases: ['gen_ai.response.id'],
-    changelog: [{ version: '0.1.0', prs: [55, 57, 61, 108, 127] }],
+    aliases: ['gen_ai.response.id', 'ai.response.id'],
+    changelog: [
+      { version: 'next', description: 'Added ai.response.id as an alias' },
+      { version: '0.1.0', prs: [55, 57, 61, 108, 127] },
+    ],
   },
   'ai.input_messages': {
     brief: 'The input messages sent to the model',
     type: 'string',
-    keys: ['gen_ai.input.messages', 'ai.input_messages', 'ai.prompt.messages', 'ai.texts', 'gen_ai.prompt'],
+    keys: [
+      'gen_ai.input.messages',
+      'ai.input_messages',
+      'ai.prompt',
+      'ai.prompt.messages',
+      'ai.texts',
+      'gen_ai.prompt',
+    ],
     applyScrubbing: {
       key: 'manual',
     },
@@ -19904,10 +20214,29 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: '0.1.0', prs: [55, 127] },
     ],
   },
+  'ai.model.id': {
+    brief: 'The id of the model used by the Vercel AI SDK.',
+    type: 'string',
+    keys: ['gen_ai.request.model', 'ai.model.id', 'ai.model_id'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'gpt-4o',
+    examples: ['gpt-4o'],
+    deprecation: {
+      replacement: 'gen_ai.request.model',
+      reason: 'This attribute is being deprecated in favor of gen_ai.request.model.',
+      status: 'backfill',
+    },
+    aliases: ['gen_ai.request.model', 'ai.model_id'],
+    changelog: [{ version: 'next', prs: [583], description: 'Added ai.model.id attribute' }],
+  },
   'ai.model_id': {
     brief: 'The vendor-specific ID of the model used.',
     type: 'string',
-    keys: ['gen_ai.request.model', 'ai.model_id'],
+    keys: ['gen_ai.request.model', 'ai.model.id', 'ai.model_id'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -19918,8 +20247,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.request.model',
       status: 'backfill',
     },
-    aliases: ['gen_ai.request.model'],
-    changelog: [{ version: '0.1.0', prs: [57, 61, 127] }, { version: '0.0.0' }],
+    aliases: ['gen_ai.request.model', 'ai.model.id'],
+    changelog: [
+      { version: 'next', description: 'Added ai.model.id as an alias' },
+      { version: '0.1.0', prs: [57, 61, 127] },
+      { version: '0.0.0' },
+    ],
   },
   'ai.model.provider': {
     brief: 'The provider of the model.',
@@ -20000,10 +20333,43 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: '0.1.0', prs: [55, 57, 61, 108] },
     ],
   },
+  'ai.prompt': {
+    brief: 'The prompt passed to the Vercel AI SDK, as a stringified object.',
+    type: 'string',
+    keys: [
+      'gen_ai.input.messages',
+      'ai.input_messages',
+      'ai.prompt',
+      'ai.prompt.messages',
+      'ai.texts',
+      'gen_ai.prompt',
+    ],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '{"prompt":"What is the weather in Paris?"}',
+    examples: ['{"prompt":"What is the weather in Paris?"}'],
+    deprecation: {
+      replacement: 'gen_ai.input.messages',
+      reason: 'This attribute is being deprecated in favor of gen_ai.input.messages.',
+      status: 'backfill',
+    },
+    aliases: ['gen_ai.input.messages', 'ai.texts', 'ai.prompt.messages', 'gen_ai.prompt'],
+    changelog: [{ version: 'next', prs: [583], description: 'Added ai.prompt attribute' }],
+  },
   'ai.prompt.messages': {
     brief: 'The input messages sent to the AI model.',
     type: 'string',
-    keys: ['gen_ai.input.messages', 'ai.input_messages', 'ai.prompt.messages', 'ai.texts', 'gen_ai.prompt'],
+    keys: [
+      'gen_ai.input.messages',
+      'ai.input_messages',
+      'ai.prompt',
+      'ai.prompt.messages',
+      'ai.texts',
+      'gen_ai.prompt',
+    ],
     applyScrubbing: {
       key: 'manual',
     },
@@ -20014,8 +20380,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.input.messages',
       status: 'backfill',
     },
-    aliases: ['gen_ai.input.messages', 'ai.texts', 'gen_ai.prompt'],
-    changelog: [{ version: '0.19.0', prs: [498], description: 'Added ai.prompt.messages attribute' }],
+    aliases: ['gen_ai.input.messages', 'ai.texts', 'gen_ai.prompt', 'ai.prompt'],
+    changelog: [
+      { version: 'next', description: 'Added ai.prompt as an alias' },
+      { version: '0.19.0', prs: [498], description: 'Added ai.prompt.messages attribute' },
+    ],
   },
   'ai.prompt_tokens.used': {
     brief: 'The number of tokens used to process just the prompt.',
@@ -20033,6 +20402,24 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     aliases: ['gen_ai.usage.prompt_tokens', 'gen_ai.usage.input_tokens'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [57, 61] }, { version: '0.0.0' }],
+  },
+  'ai.prompt.tools': {
+    brief: 'The tools made available to the model, as an array of stringified tool definitions.',
+    type: 'string[]',
+    keys: ['gen_ai.tool.definitions', 'ai.prompt.tools', 'ai.tools', 'gen_ai.request.available_tools'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: ['{"type":"function","name":"get_weather"}'],
+    examples: [['{"type":"function","name":"get_weather"}']],
+    deprecation: {
+      replacement: 'gen_ai.tool.definitions',
+      reason: 'This attribute is being deprecated in favor of gen_ai.tool.definitions.',
+      status: 'backfill',
+    },
+    changelog: [{ version: 'next', prs: [583], description: 'Added ai.prompt.tools attribute' }],
   },
   'ai.raw_prompting': {
     brief: 'When enabled, the user’s prompt will be sent to the model without any pre-processing.',
@@ -20082,6 +20469,61 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: '0.1.0', prs: [55, 127] },
     ],
   },
+  'ai.response.id': {
+    brief: 'The id of the response returned by the model.',
+    type: 'string',
+    keys: ['gen_ai.response.id', 'ai.generation_id', 'ai.response.id'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'chatcmpl-BuKJgVSKAMTUYbBSjHTMUuNGKzOPY',
+    examples: ['chatcmpl-BuKJgVSKAMTUYbBSjHTMUuNGKzOPY'],
+    deprecation: {
+      replacement: 'gen_ai.response.id',
+      reason: 'This attribute is being deprecated in favor of gen_ai.response.id.',
+      status: 'backfill',
+    },
+    aliases: ['gen_ai.response.id', 'ai.generation_id'],
+    changelog: [{ version: 'next', prs: [583], description: 'Added ai.response.id attribute' }],
+  },
+  'ai.response.model': {
+    brief: 'The id of the model that produced the response.',
+    type: 'string',
+    keys: ['gen_ai.response.model', 'ai.response.model'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'gpt-4o-2024-08-06',
+    examples: ['gpt-4o-2024-08-06'],
+    deprecation: {
+      replacement: 'gen_ai.response.model',
+      reason: 'This attribute is being deprecated in favor of gen_ai.response.model.',
+      status: 'backfill',
+    },
+    aliases: ['gen_ai.response.model'],
+    changelog: [{ version: 'next', prs: [583], description: 'Added ai.response.model attribute' }],
+  },
+  'ai.response.object': {
+    brief: 'The type of the object returned by the model.',
+    type: 'string',
+    keys: ['ai.response.object'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'chat.completion',
+    examples: ['chat.completion'],
+    deprecation: {
+      reason:
+        'This attribute is deprecated. The Sentry conventions have no replacement for the raw Vercel AI response object type.',
+    },
+    changelog: [{ version: 'next', prs: [583], description: 'Added ai.response.object attribute' }],
+  },
   'ai.response.text': {
     brief: 'The text response from the AI model.',
     type: 'string',
@@ -20099,6 +20541,22 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     aliases: ['gen_ai.output.messages', 'ai.response.toolCalls'],
     changelog: [{ version: '0.19.0', prs: [498], description: 'Added ai.response.text attribute' }],
   },
+  'ai.response.timestamp': {
+    brief: 'The ISO 8601 timestamp at which the response was produced.',
+    type: 'string',
+    keys: ['ai.response.timestamp'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '2026-02-19T15:32:11.000Z',
+    examples: ['2026-02-19T15:32:11.000Z'],
+    deprecation: {
+      reason: 'This attribute is deprecated. The span start and end timestamps carry the same information.',
+    },
+    changelog: [{ version: 'next', prs: [583], description: 'Added ai.response.timestamp attribute' }],
+  },
   'ai.response.toolCalls': {
     brief: 'The tool calls in the AI model response.',
     type: 'string',
@@ -20115,6 +20573,23 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     aliases: ['gen_ai.output.messages', 'ai.response.text'],
     changelog: [{ version: '0.19.0', prs: [498], description: 'Added ai.response.toolCalls attribute' }],
+  },
+  'ai.schema': {
+    brief: 'The stringified JSON schema the model output must conform to.',
+    type: 'string',
+    keys: ['ai.schema'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '{"type":"object","properties":{"city":{"type":"string"}}}',
+    examples: ['{"type":"object","properties":{"city":{"type":"string"}}}'],
+    deprecation: {
+      reason:
+        'This attribute is deprecated. The Sentry conventions have no replacement for the requested output schema.',
+    },
+    changelog: [{ version: 'next', prs: [583], description: 'Added ai.schema attribute' }],
   },
   'ai.search_queries': {
     brief: 'Queries used to search for relevant context or documents.',
@@ -20222,7 +20697,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'ai.texts': {
     brief: 'Raw text inputs provided to the model.',
     type: 'string[]',
-    keys: ['gen_ai.input.messages', 'ai.input_messages', 'ai.prompt.messages', 'ai.texts', 'gen_ai.prompt'],
+    keys: [
+      'gen_ai.input.messages',
+      'ai.input_messages',
+      'ai.prompt',
+      'ai.prompt.messages',
+      'ai.texts',
+      'gen_ai.prompt',
+    ],
     applyScrubbing: {
       key: 'auto',
     },
@@ -20233,8 +20715,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.input.messages',
       status: 'backfill',
     },
-    aliases: ['gen_ai.input.messages', 'ai.prompt.messages', 'gen_ai.prompt'],
+    aliases: ['gen_ai.input.messages', 'ai.prompt.messages', 'gen_ai.prompt', 'ai.prompt'],
     changelog: [
+      { version: 'next', description: 'Added ai.prompt as an alias' },
       { version: '0.5.0', prs: [264] },
       { version: '0.1.0', prs: [55] },
     ],
@@ -20282,7 +20765,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'ai.tools': {
     brief: 'For an AI model call, the functions that are available',
     type: 'string[]',
-    keys: ['gen_ai.tool.definitions', 'ai.tools', 'gen_ai.request.available_tools'],
+    keys: ['gen_ai.tool.definitions', 'ai.prompt.tools', 'ai.tools', 'gen_ai.request.available_tools'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -20381,7 +20864,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'ai.total_tokens.used': {
     brief: 'The total number of tokens used to process the prompt.',
     type: 'integer',
-    keys: ['gen_ai.usage.total_tokens', 'ai.total_tokens.used'],
+    keys: ['gen_ai.usage.total_tokens', 'ai.total_tokens.used', 'ai.usage.tokens'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -20392,8 +20875,48 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'gen_ai.usage.total_tokens',
       status: 'backfill',
     },
-    aliases: ['gen_ai.usage.total_tokens'],
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [57, 61, 108] }, { version: '0.0.0' }],
+    aliases: ['gen_ai.usage.total_tokens', 'ai.usage.tokens'],
+    changelog: [
+      { version: 'next', description: 'Added ai.usage.tokens as an alias' },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [57, 61, 108] },
+      { version: '0.0.0' },
+    ],
+  },
+  'ai.usage.tokens': {
+    brief: 'The total number of tokens used for the request and the response.',
+    type: 'integer',
+    keys: ['gen_ai.usage.total_tokens', 'ai.total_tokens.used', 'ai.usage.tokens'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 150,
+    examples: [150],
+    deprecation: {
+      replacement: 'gen_ai.usage.total_tokens',
+      reason: 'This attribute is being deprecated in favor of gen_ai.usage.total_tokens.',
+      status: 'backfill',
+    },
+    aliases: ['gen_ai.usage.total_tokens', 'ai.total_tokens.used'],
+    changelog: [{ version: 'next', prs: [583], description: 'Added ai.usage.tokens attribute' }],
+  },
+  'ai.values': {
+    brief: 'The stringified values produced by a Vercel AI SDK object or array generation.',
+    type: 'string',
+    keys: ['ai.values'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '[{"city":"Paris"}]',
+    examples: ['[{"city":"Paris"}]'],
+    deprecation: {
+      reason: 'This attribute is deprecated. Use gen_ai.output.messages for model output instead.',
+    },
+    changelog: [{ version: 'next', prs: [583], description: 'Added ai.values attribute' }],
   },
   'ai.warnings': {
     brief: 'Warning messages generated during model execution.',
@@ -24704,7 +25227,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'The messages passed to the model. It has to be a stringified version of an array of objects. The `role` attribute of each object must be `"user"`, `"assistant"`, `"tool"`, or `"system"`. For messages of the role `"tool"`, the `content` can be a string or an arbitrary object with information about the tool call. For other messages the `content` can be either a string or a list of objects in the format `{type: "text", text:"..."}`.',
     type: 'string',
-    keys: ['gen_ai.input.messages', 'ai.input_messages', 'ai.prompt.messages', 'ai.texts', 'gen_ai.prompt'],
+    keys: [
+      'gen_ai.input.messages',
+      'ai.input_messages',
+      'ai.prompt',
+      'ai.prompt.messages',
+      'ai.texts',
+      'gen_ai.prompt',
+    ],
     applyScrubbing: {
       key: 'manual',
     },
@@ -24712,8 +25242,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example:
       '[{"role": "user", "parts": [{"type": "text", "content": "Weather in Paris?"}]}, {"role": "assistant", "parts": [{"type": "tool_call", "id": "call_VSPygqKTWdrhaFErNvMV18Yl", "name": "get_weather", "arguments": {"location": "Paris"}}]}, {"role": "tool", "parts": [{"type": "tool_call_response", "id": "call_VSPygqKTWdrhaFErNvMV18Yl", "result": "rainy, 57°F"}]}]',
-    aliases: ['ai.texts', 'ai.prompt.messages', 'gen_ai.prompt'],
+    aliases: ['ai.texts', 'ai.prompt.messages', 'gen_ai.prompt', 'ai.prompt'],
     changelog: [
+      { version: 'next', description: 'Added ai.prompt as an alias' },
       { version: '0.5.0', prs: [264] },
       { version: '0.4.0', prs: [221] },
     ],
@@ -24781,7 +25312,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'gen_ai.prompt': {
     brief: 'The input messages sent to the model',
     type: 'string',
-    keys: ['gen_ai.input.messages', 'ai.input_messages', 'ai.prompt.messages', 'ai.texts', 'gen_ai.prompt'],
+    keys: [
+      'gen_ai.input.messages',
+      'ai.input_messages',
+      'ai.prompt',
+      'ai.prompt.messages',
+      'ai.texts',
+      'gen_ai.prompt',
+    ],
     applyScrubbing: {
       key: 'manual',
     },
@@ -24793,8 +25331,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'Deprecated from OTEL, use gen_ai.input.messages with the new format instead.',
       status: 'backfill',
     },
-    aliases: ['gen_ai.input.messages', 'ai.texts', 'ai.prompt.messages'],
-    changelog: [{ version: '0.1.0', prs: [74, 108, 119] }, { version: '0.0.0' }],
+    aliases: ['gen_ai.input.messages', 'ai.texts', 'ai.prompt.messages', 'ai.prompt'],
+    changelog: [
+      { version: 'next', description: 'Added ai.prompt as an alias' },
+      { version: '0.1.0', prs: [74, 108, 119] },
+      { version: '0.0.0' },
+    ],
   },
   'gen_ai.prompt.name': {
     brief: 'The name of the prompt that uniquely identifies it.',
@@ -24826,7 +25368,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'gen_ai.request.available_tools': {
     brief: 'The available tools for the model. It has to be a stringified version of an array of objects.',
     type: 'string',
-    keys: ['gen_ai.tool.definitions', 'ai.tools', 'gen_ai.request.available_tools'],
+    keys: ['gen_ai.tool.definitions', 'ai.prompt.tools', 'ai.tools', 'gen_ai.request.available_tools'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -24901,15 +25443,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'gen_ai.request.model': {
     brief: 'The model identifier being used for the request.',
     type: 'string',
-    keys: ['gen_ai.request.model', 'ai.model_id'],
+    keys: ['gen_ai.request.model', 'ai.model.id', 'ai.model_id'],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: true,
     visibility: 'public',
     example: 'gpt-4-turbo-preview',
-    aliases: ['ai.model_id'],
-    changelog: [{ version: '0.1.0', prs: [62, 127] }],
+    aliases: ['ai.model_id', 'ai.model.id'],
+    changelog: [
+      { version: 'next', description: 'Added ai.model.id as an alias' },
+      { version: '0.1.0', prs: [62, 127] },
+    ],
   },
   'gen_ai.request.presence_penalty': {
     brief:
@@ -24939,6 +25484,23 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'high',
     changelog: [{ version: '0.17.0', prs: [502], description: 'Added gen_ai.request.reasoning.level attribute' }],
+  },
+  'gen_ai.request.schema': {
+    brief: 'The stringified JSON schema the model output must conform to.',
+    type: 'string',
+    keys: ['gen_ai.request.schema'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '{"type":"object","properties":{"city":{"type":"string"}}}',
+    examples: ['{"type":"object","properties":{"city":{"type":"string"}}}'],
+    deprecation: {
+      reason:
+        'This attribute is deprecated. The Sentry conventions have no replacement for the requested output schema.',
+    },
+    changelog: [{ version: 'next', prs: [583], description: 'Added gen_ai.request.schema attribute' }],
   },
   'gen_ai.request.seed': {
     brief: 'The seed, ideally models given the same seed and same other parameters will produce the exact same output.',
@@ -25049,27 +25611,52 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'gen_ai.response.id': {
     brief: 'Unique identifier for the completion.',
     type: 'string',
-    keys: ['gen_ai.response.id', 'ai.generation_id'],
+    keys: ['gen_ai.response.id', 'ai.generation_id', 'ai.response.id'],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: true,
     visibility: 'public',
     example: 'gen_123abc',
-    aliases: ['ai.generation_id'],
-    changelog: [{ version: '0.1.0', prs: [57, 127] }],
+    aliases: ['ai.generation_id', 'ai.response.id'],
+    changelog: [
+      { version: 'next', description: 'Added ai.response.id as an alias' },
+      { version: '0.1.0', prs: [57, 127] },
+    ],
   },
   'gen_ai.response.model': {
     brief: 'The vendor-specific ID of the model used.',
     type: 'string',
-    keys: ['gen_ai.response.model'],
+    keys: ['gen_ai.response.model', 'ai.response.model'],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: true,
     visibility: 'public',
     example: 'gpt-4',
-    changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+    aliases: ['ai.response.model'],
+    changelog: [
+      { version: 'next', description: 'Added ai.response.model as an alias' },
+      { version: '0.1.0', prs: [127] },
+      { version: '0.0.0' },
+    ],
+  },
+  'gen_ai.response.object': {
+    brief: 'The type of the object returned by the model.',
+    type: 'string',
+    keys: ['gen_ai.response.object'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'chat.completion',
+    examples: ['chat.completion'],
+    deprecation: {
+      reason:
+        'This attribute is deprecated. The Sentry conventions have no replacement for the raw response object type.',
+    },
+    changelog: [{ version: 'next', prs: [583], description: 'Added gen_ai.response.object attribute' }],
   },
   'gen_ai.response.streaming': {
     brief: "Whether or not the AI model call's response was streamed back asynchronously",
@@ -25270,7 +25857,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'gen_ai.tool.definitions': {
     brief: 'The list of source system tool definitions available to the GenAI agent or model.',
     type: 'string',
-    keys: ['gen_ai.tool.definitions', 'ai.tools', 'gen_ai.request.available_tools'],
+    keys: ['gen_ai.tool.definitions', 'ai.prompt.tools', 'ai.tools', 'gen_ai.request.available_tools'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -25629,15 +26216,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'gen_ai.usage.total_tokens': {
     brief: 'The total number of tokens used to process the prompt. (input tokens plus output todkens)',
     type: 'integer',
-    keys: ['gen_ai.usage.total_tokens', 'ai.total_tokens.used'],
+    keys: ['gen_ai.usage.total_tokens', 'ai.total_tokens.used', 'ai.usage.tokens'],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: false,
     visibility: 'public',
     example: 20,
-    aliases: ['ai.total_tokens.used'],
+    aliases: ['ai.total_tokens.used', 'ai.usage.tokens'],
     changelog: [
+      { version: 'next', description: 'Added ai.usage.tokens as an alias' },
       { version: '0.9.0', prs: [397], description: 'Add additional_context' },
       { version: '0.4.0', prs: [228] },
       { version: '0.1.0', prs: [57] },
@@ -32236,13 +32824,20 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'gen_ai.response.id',
     type: 'string',
     brief: 'Unique identifier for the completion.',
-    deprecationChain: ['gen_ai.response.id', 'ai.generation_id'],
+    deprecationChain: ['gen_ai.response.id', 'ai.generation_id', 'ai.response.id'],
   },
   'ai.input_messages': {
     canonicalName: 'gen_ai.input.messages',
     type: 'string',
     brief: 'The input messages sent to the model',
-    deprecationChain: ['gen_ai.input.messages', 'ai.input_messages', 'ai.prompt.messages', 'ai.texts', 'gen_ai.prompt'],
+    deprecationChain: [
+      'gen_ai.input.messages',
+      'ai.input_messages',
+      'ai.prompt',
+      'ai.prompt.messages',
+      'ai.texts',
+      'gen_ai.prompt',
+    ],
   },
   'ai.is_search_required': {
     canonicalName: 'ai.is_search_required',
@@ -32256,6 +32851,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     brief: 'Extra metadata passed to an AI pipeline step.',
     deprecationChain: ['ai.metadata'],
   },
+  'ai.model.id': {
+    canonicalName: 'gen_ai.request.model',
+    type: 'string',
+    brief: 'The id of the model used by the Vercel AI SDK.',
+    deprecationChain: ['gen_ai.request.model', 'ai.model.id', 'ai.model_id'],
+  },
   'ai.model.provider': {
     canonicalName: 'gen_ai.provider.name',
     type: 'string',
@@ -32266,7 +32867,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'gen_ai.request.model',
     type: 'string',
     brief: 'The vendor-specific ID of the model used.',
-    deprecationChain: ['gen_ai.request.model', 'ai.model_id'],
+    deprecationChain: ['gen_ai.request.model', 'ai.model.id', 'ai.model_id'],
   },
   'ai.pipeline.name': {
     canonicalName: 'gen_ai.pipeline.name',
@@ -32288,11 +32889,37 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
       'Used to reduce repetitiveness of generated tokens. Similar to frequency_penalty, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies.',
     deprecationChain: ['gen_ai.request.presence_penalty', 'ai.presence_penalty'],
   },
+  'ai.prompt': {
+    canonicalName: 'gen_ai.input.messages',
+    type: 'string',
+    brief: 'The prompt passed to the Vercel AI SDK, as a stringified object.',
+    deprecationChain: [
+      'gen_ai.input.messages',
+      'ai.input_messages',
+      'ai.prompt',
+      'ai.prompt.messages',
+      'ai.texts',
+      'gen_ai.prompt',
+    ],
+  },
   'ai.prompt.messages': {
     canonicalName: 'gen_ai.input.messages',
     type: 'string',
     brief: 'The input messages sent to the AI model.',
-    deprecationChain: ['gen_ai.input.messages', 'ai.input_messages', 'ai.prompt.messages', 'ai.texts', 'gen_ai.prompt'],
+    deprecationChain: [
+      'gen_ai.input.messages',
+      'ai.input_messages',
+      'ai.prompt',
+      'ai.prompt.messages',
+      'ai.texts',
+      'gen_ai.prompt',
+    ],
+  },
+  'ai.prompt.tools': {
+    canonicalName: 'gen_ai.tool.definitions',
+    type: 'string[]',
+    brief: 'The tools made available to the model, as an array of stringified tool definitions.',
+    deprecationChain: ['gen_ai.tool.definitions', 'ai.prompt.tools', 'ai.tools', 'gen_ai.request.available_tools'],
   },
   'ai.prompt_tokens.used': {
     canonicalName: 'gen_ai.usage.input_tokens',
@@ -32306,6 +32933,24 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     brief: 'When enabled, the user’s prompt will be sent to the model without any pre-processing.',
     deprecationChain: ['ai.raw_prompting'],
   },
+  'ai.response.id': {
+    canonicalName: 'gen_ai.response.id',
+    type: 'string',
+    brief: 'The id of the response returned by the model.',
+    deprecationChain: ['gen_ai.response.id', 'ai.generation_id', 'ai.response.id'],
+  },
+  'ai.response.model': {
+    canonicalName: 'gen_ai.response.model',
+    type: 'string',
+    brief: 'The id of the model that produced the response.',
+    deprecationChain: ['gen_ai.response.model', 'ai.response.model'],
+  },
+  'ai.response.object': {
+    canonicalName: 'ai.response.object',
+    type: 'string',
+    brief: 'The type of the object returned by the model.',
+    deprecationChain: ['ai.response.object'],
+  },
   'ai.response.text': {
     canonicalName: 'gen_ai.output.messages',
     type: 'string',
@@ -32317,6 +32962,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
       'ai.responses',
       'ai.tool_calls',
     ],
+  },
+  'ai.response.timestamp': {
+    canonicalName: 'ai.response.timestamp',
+    type: 'string',
+    brief: 'The ISO 8601 timestamp at which the response was produced.',
+    deprecationChain: ['ai.response.timestamp'],
   },
   'ai.response.toolCalls': {
     canonicalName: 'gen_ai.output.messages',
@@ -32347,6 +32998,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
       'ai.responses',
       'ai.tool_calls',
     ],
+  },
+  'ai.schema': {
+    canonicalName: 'ai.schema',
+    type: 'string',
+    brief: 'The stringified JSON schema the model output must conform to.',
+    deprecationChain: ['ai.schema'],
   },
   'ai.search_queries': {
     canonicalName: 'ai.search_queries',
@@ -32389,7 +33046,14 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'gen_ai.input.messages',
     type: 'string[]',
     brief: 'Raw text inputs provided to the model.',
-    deprecationChain: ['gen_ai.input.messages', 'ai.input_messages', 'ai.prompt.messages', 'ai.texts', 'gen_ai.prompt'],
+    deprecationChain: [
+      'gen_ai.input.messages',
+      'ai.input_messages',
+      'ai.prompt',
+      'ai.prompt.messages',
+      'ai.texts',
+      'gen_ai.prompt',
+    ],
   },
   'ai.toolCall.args': {
     canonicalName: 'gen_ai.tool.call.arguments',
@@ -32425,7 +33089,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'gen_ai.tool.definitions',
     type: 'string[]',
     brief: 'For an AI model call, the functions that are available',
-    deprecationChain: ['gen_ai.tool.definitions', 'ai.tools', 'gen_ai.request.available_tools'],
+    deprecationChain: ['gen_ai.tool.definitions', 'ai.prompt.tools', 'ai.tools', 'gen_ai.request.available_tools'],
   },
   'ai.top_k': {
     canonicalName: 'gen_ai.request.top_k',
@@ -32451,7 +33115,19 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'gen_ai.usage.total_tokens',
     type: 'integer',
     brief: 'The total number of tokens used to process the prompt.',
-    deprecationChain: ['gen_ai.usage.total_tokens', 'ai.total_tokens.used'],
+    deprecationChain: ['gen_ai.usage.total_tokens', 'ai.total_tokens.used', 'ai.usage.tokens'],
+  },
+  'ai.usage.tokens': {
+    canonicalName: 'gen_ai.usage.total_tokens',
+    type: 'integer',
+    brief: 'The total number of tokens used for the request and the response.',
+    deprecationChain: ['gen_ai.usage.total_tokens', 'ai.total_tokens.used', 'ai.usage.tokens'],
+  },
+  'ai.values': {
+    canonicalName: 'ai.values',
+    type: 'string',
+    brief: 'The stringified values produced by a Vercel AI SDK object or array generation.',
+    deprecationChain: ['ai.values'],
   },
   'ai.warnings': {
     canonicalName: 'ai.warnings',
@@ -34254,7 +34930,14 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief:
       'The messages passed to the model. It has to be a stringified version of an array of objects. The `role` attribute of each object must be `"user"`, `"assistant"`, `"tool"`, or `"system"`. For messages of the role `"tool"`, the `content` can be a string or an arbitrary object with information about the tool call. For other messages the `content` can be either a string or a list of objects in the format `{type: "text", text:"..."}`.',
-    deprecationChain: ['gen_ai.input.messages', 'ai.input_messages', 'ai.prompt.messages', 'ai.texts', 'gen_ai.prompt'],
+    deprecationChain: [
+      'gen_ai.input.messages',
+      'ai.input_messages',
+      'ai.prompt',
+      'ai.prompt.messages',
+      'ai.texts',
+      'gen_ai.prompt',
+    ],
   },
   'gen_ai.operation.name': {
     canonicalName: 'gen_ai.operation.name',
@@ -34293,7 +34976,14 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'gen_ai.input.messages',
     type: 'string',
     brief: 'The input messages sent to the model',
-    deprecationChain: ['gen_ai.input.messages', 'ai.input_messages', 'ai.prompt.messages', 'ai.texts', 'gen_ai.prompt'],
+    deprecationChain: [
+      'gen_ai.input.messages',
+      'ai.input_messages',
+      'ai.prompt',
+      'ai.prompt.messages',
+      'ai.texts',
+      'gen_ai.prompt',
+    ],
   },
   'gen_ai.prompt.name': {
     canonicalName: 'gen_ai.prompt.name',
@@ -34311,7 +35001,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'gen_ai.tool.definitions',
     type: 'string',
     brief: 'The available tools for the model. It has to be a stringified version of an array of objects.',
-    deprecationChain: ['gen_ai.tool.definitions', 'ai.tools', 'gen_ai.request.available_tools'],
+    deprecationChain: ['gen_ai.tool.definitions', 'ai.prompt.tools', 'ai.tools', 'gen_ai.request.available_tools'],
   },
   'gen_ai.request.frequency_penalty': {
     canonicalName: 'gen_ai.request.frequency_penalty',
@@ -34337,7 +35027,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'gen_ai.request.model',
     type: 'string',
     brief: 'The model identifier being used for the request.',
-    deprecationChain: ['gen_ai.request.model', 'ai.model_id'],
+    deprecationChain: ['gen_ai.request.model', 'ai.model.id', 'ai.model_id'],
   },
   'gen_ai.request.presence_penalty': {
     canonicalName: 'gen_ai.request.presence_penalty',
@@ -34351,6 +35041,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief: 'The reasoning or thinking effort level requested for a GenAI model.',
     deprecationChain: ['gen_ai.request.reasoning.level'],
+  },
+  'gen_ai.request.schema': {
+    canonicalName: 'gen_ai.request.schema',
+    type: 'string',
+    brief: 'The stringified JSON schema the model output must conform to.',
+    deprecationChain: ['gen_ai.request.schema'],
   },
   'gen_ai.request.seed': {
     canonicalName: 'gen_ai.request.seed',
@@ -34401,13 +35097,19 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'gen_ai.response.id',
     type: 'string',
     brief: 'Unique identifier for the completion.',
-    deprecationChain: ['gen_ai.response.id', 'ai.generation_id'],
+    deprecationChain: ['gen_ai.response.id', 'ai.generation_id', 'ai.response.id'],
   },
   'gen_ai.response.model': {
     canonicalName: 'gen_ai.response.model',
     type: 'string',
     brief: 'The vendor-specific ID of the model used.',
-    deprecationChain: ['gen_ai.response.model'],
+    deprecationChain: ['gen_ai.response.model', 'ai.response.model'],
+  },
+  'gen_ai.response.object': {
+    canonicalName: 'gen_ai.response.object',
+    type: 'string',
+    brief: 'The type of the object returned by the model.',
+    deprecationChain: ['gen_ai.response.object'],
   },
   'gen_ai.response.streaming': {
     canonicalName: 'gen_ai.response.streaming',
@@ -34486,7 +35188,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'gen_ai.tool.definitions',
     type: 'string',
     brief: 'The list of source system tool definitions available to the GenAI agent or model.',
-    deprecationChain: ['gen_ai.tool.definitions', 'ai.tools', 'gen_ai.request.available_tools'],
+    deprecationChain: ['gen_ai.tool.definitions', 'ai.prompt.tools', 'ai.tools', 'gen_ai.request.available_tools'],
   },
   'gen_ai.tool.description': {
     canonicalName: 'gen_ai.tool.description',
@@ -34600,7 +35302,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'gen_ai.usage.total_tokens',
     type: 'integer',
     brief: 'The total number of tokens used to process the prompt. (input tokens plus output todkens)',
-    deprecationChain: ['gen_ai.usage.total_tokens', 'ai.total_tokens.used'],
+    deprecationChain: ['gen_ai.usage.total_tokens', 'ai.total_tokens.used', 'ai.usage.tokens'],
   },
   'graphql.document': {
     canonicalName: 'graphql.document',
@@ -37285,17 +37987,25 @@ export type Attributes = {
   [AI_IS_SEARCH_REQUIRED]?: AI_IS_SEARCH_REQUIRED_TYPE;
   [AI_METADATA]?: AI_METADATA_TYPE;
   [AI_MODEL_ID]?: AI_MODEL_ID_TYPE;
+  [_AI_MODEL_ID]?: _AI_MODEL_ID_TYPE;
   [AI_MODEL_PROVIDER]?: AI_MODEL_PROVIDER_TYPE;
   [AI_PIPELINE_NAME]?: AI_PIPELINE_NAME_TYPE;
   [AI_PREAMBLE]?: AI_PREAMBLE_TYPE;
   [AI_PRESENCE_PENALTY]?: AI_PRESENCE_PENALTY_TYPE;
+  [AI_PROMPT]?: AI_PROMPT_TYPE;
   [AI_PROMPT_MESSAGES]?: AI_PROMPT_MESSAGES_TYPE;
   [AI_PROMPT_TOKENS_USED]?: AI_PROMPT_TOKENS_USED_TYPE;
+  [AI_PROMPT_TOOLS]?: AI_PROMPT_TOOLS_TYPE;
   [AI_RAW_PROMPTING]?: AI_RAW_PROMPTING_TYPE;
   [AI_RESPONSES]?: AI_RESPONSES_TYPE;
   [AI_RESPONSE_FORMAT]?: AI_RESPONSE_FORMAT_TYPE;
+  [AI_RESPONSE_ID]?: AI_RESPONSE_ID_TYPE;
+  [AI_RESPONSE_MODEL]?: AI_RESPONSE_MODEL_TYPE;
+  [AI_RESPONSE_OBJECT]?: AI_RESPONSE_OBJECT_TYPE;
   [AI_RESPONSE_TEXT]?: AI_RESPONSE_TEXT_TYPE;
+  [AI_RESPONSE_TIMESTAMP]?: AI_RESPONSE_TIMESTAMP_TYPE;
   [AI_RESPONSE_TOOLCALLS]?: AI_RESPONSE_TOOLCALLS_TYPE;
+  [AI_SCHEMA]?: AI_SCHEMA_TYPE;
   [AI_SEARCH_QUERIES]?: AI_SEARCH_QUERIES_TYPE;
   [AI_SEARCH_RESULTS]?: AI_SEARCH_RESULTS_TYPE;
   [AI_SEED]?: AI_SEED_TYPE;
@@ -37311,6 +38021,8 @@ export type Attributes = {
   [AI_TOP_P]?: AI_TOP_P_TYPE;
   [AI_TOTAL_COST]?: AI_TOTAL_COST_TYPE;
   [AI_TOTAL_TOKENS_USED]?: AI_TOTAL_TOKENS_USED_TYPE;
+  [AI_USAGE_TOKENS]?: AI_USAGE_TOKENS_TYPE;
+  [AI_VALUES]?: AI_VALUES_TYPE;
   [AI_WARNINGS]?: AI_WARNINGS_TYPE;
   [ANGULAR_VERSION]?: ANGULAR_VERSION_TYPE;
   [APP_APP_BUILD]?: APP_APP_BUILD_TYPE;
@@ -37619,6 +38331,7 @@ export type Attributes = {
   [GEN_AI_REQUEST_MODEL]?: GEN_AI_REQUEST_MODEL_TYPE;
   [GEN_AI_REQUEST_PRESENCE_PENALTY]?: GEN_AI_REQUEST_PRESENCE_PENALTY_TYPE;
   [GEN_AI_REQUEST_REASONING_LEVEL]?: GEN_AI_REQUEST_REASONING_LEVEL_TYPE;
+  [GEN_AI_REQUEST_SCHEMA]?: GEN_AI_REQUEST_SCHEMA_TYPE;
   [GEN_AI_REQUEST_SEED]?: GEN_AI_REQUEST_SEED_TYPE;
   [GEN_AI_REQUEST_STOP_SEQUENCES]?: GEN_AI_REQUEST_STOP_SEQUENCES_TYPE;
   [GEN_AI_REQUEST_TEMPERATURE]?: GEN_AI_REQUEST_TEMPERATURE_TYPE;
@@ -37628,6 +38341,7 @@ export type Attributes = {
   [GEN_AI_RESPONSE_FINISH_REASONS]?: GEN_AI_RESPONSE_FINISH_REASONS_TYPE;
   [GEN_AI_RESPONSE_ID]?: GEN_AI_RESPONSE_ID_TYPE;
   [GEN_AI_RESPONSE_MODEL]?: GEN_AI_RESPONSE_MODEL_TYPE;
+  [GEN_AI_RESPONSE_OBJECT]?: GEN_AI_RESPONSE_OBJECT_TYPE;
   [GEN_AI_RESPONSE_STREAMING]?: GEN_AI_RESPONSE_STREAMING_TYPE;
   [GEN_AI_RESPONSE_TEXT]?: GEN_AI_RESPONSE_TEXT_TYPE;
   [GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK]?: GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK_TYPE;

--- a/model/attributes/ai/ai__generation_id.json
+++ b/model/attributes/ai/ai__generation_id.json
@@ -7,13 +7,17 @@
   },
   "is_in_otel": false,
   "example": "gen_123abc",
-  "alias": ["gen_ai.response.id"],
+  "alias": ["gen_ai.response.id", "ai.response.id"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.response.id"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added ai.response.id as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [55, 57, 61, 108, 127]

--- a/model/attributes/ai/ai__model__id.json
+++ b/model/attributes/ai/ai__model__id.json
@@ -1,0 +1,24 @@
+{
+  "key": "ai.model.id",
+  "brief": "The id of the model used by the Vercel AI SDK.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["gpt-4o"],
+  "alias": ["gen_ai.request.model", "ai.model_id"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "gen_ai.request.model",
+    "reason": "This attribute is being deprecated in favor of gen_ai.request.model."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [583],
+      "description": "Added ai.model.id attribute"
+    }
+  ]
+}

--- a/model/attributes/ai/ai__model_id.json
+++ b/model/attributes/ai/ai__model_id.json
@@ -7,13 +7,17 @@
   },
   "is_in_otel": false,
   "example": "gpt-4",
-  "alias": ["gen_ai.request.model"],
+  "alias": ["gen_ai.request.model", "ai.model.id"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.request.model"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added ai.model.id as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [57, 61, 127]

--- a/model/attributes/ai/ai__prompt.json
+++ b/model/attributes/ai/ai__prompt.json
@@ -1,0 +1,24 @@
+{
+  "key": "ai.prompt",
+  "brief": "The prompt passed to the Vercel AI SDK, as a stringified object.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["{\"prompt\":\"What is the weather in Paris?\"}"],
+  "alias": ["gen_ai.input.messages", "ai.texts", "ai.prompt.messages", "gen_ai.prompt"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "gen_ai.input.messages",
+    "reason": "This attribute is being deprecated in favor of gen_ai.input.messages."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [583],
+      "description": "Added ai.prompt attribute"
+    }
+  ]
+}

--- a/model/attributes/ai/ai__prompt__messages.json
+++ b/model/attributes/ai/ai__prompt__messages.json
@@ -6,14 +6,18 @@
     "key": "manual"
   },
   "is_in_otel": false,
-  "visibility": "public",
   "example": "[{\"role\": \"user\", \"message\": \"hello\"}]",
-  "alias": ["gen_ai.input.messages", "ai.texts", "gen_ai.prompt"],
+  "alias": ["gen_ai.input.messages", "ai.texts", "gen_ai.prompt", "ai.prompt"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.input.messages"
   },
+  "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added ai.prompt as an alias"
+    },
     {
       "version": "0.19.0",
       "prs": [498],

--- a/model/attributes/ai/ai__prompt__tools.json
+++ b/model/attributes/ai/ai__prompt__tools.json
@@ -1,0 +1,23 @@
+{
+  "key": "ai.prompt.tools",
+  "brief": "The tools made available to the model, as an array of stringified tool definitions.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": [["{\"type\":\"function\",\"name\":\"get_weather\"}"]],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "gen_ai.tool.definitions",
+    "reason": "This attribute is being deprecated in favor of gen_ai.tool.definitions."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [583],
+      "description": "Added ai.prompt.tools attribute"
+    }
+  ]
+}

--- a/model/attributes/ai/ai__response__id.json
+++ b/model/attributes/ai/ai__response__id.json
@@ -1,0 +1,24 @@
+{
+  "key": "ai.response.id",
+  "brief": "The id of the response returned by the model.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["chatcmpl-BuKJgVSKAMTUYbBSjHTMUuNGKzOPY"],
+  "alias": ["gen_ai.response.id", "ai.generation_id"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "gen_ai.response.id",
+    "reason": "This attribute is being deprecated in favor of gen_ai.response.id."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [583],
+      "description": "Added ai.response.id attribute"
+    }
+  ]
+}

--- a/model/attributes/ai/ai__response__model.json
+++ b/model/attributes/ai/ai__response__model.json
@@ -1,0 +1,24 @@
+{
+  "key": "ai.response.model",
+  "brief": "The id of the model that produced the response.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["gpt-4o-2024-08-06"],
+  "alias": ["gen_ai.response.model"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "gen_ai.response.model",
+    "reason": "This attribute is being deprecated in favor of gen_ai.response.model."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [583],
+      "description": "Added ai.response.model attribute"
+    }
+  ]
+}

--- a/model/attributes/ai/ai__response__object.json
+++ b/model/attributes/ai/ai__response__object.json
@@ -1,0 +1,22 @@
+{
+  "key": "ai.response.object",
+  "brief": "The type of the object returned by the model.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["chat.completion"],
+  "deprecation": {
+    "_status": null,
+    "reason": "This attribute is deprecated. The Sentry conventions have no replacement for the raw Vercel AI response object type."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [583],
+      "description": "Added ai.response.object attribute"
+    }
+  ]
+}

--- a/model/attributes/ai/ai__response__timestamp.json
+++ b/model/attributes/ai/ai__response__timestamp.json
@@ -1,0 +1,22 @@
+{
+  "key": "ai.response.timestamp",
+  "brief": "The ISO 8601 timestamp at which the response was produced.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["2026-02-19T15:32:11.000Z"],
+  "deprecation": {
+    "_status": null,
+    "reason": "This attribute is deprecated. The span start and end timestamps carry the same information."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [583],
+      "description": "Added ai.response.timestamp attribute"
+    }
+  ]
+}

--- a/model/attributes/ai/ai__schema.json
+++ b/model/attributes/ai/ai__schema.json
@@ -1,0 +1,22 @@
+{
+  "key": "ai.schema",
+  "brief": "The stringified JSON schema the model output must conform to.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}"],
+  "deprecation": {
+    "_status": null,
+    "reason": "This attribute is deprecated. The Sentry conventions have no replacement for the requested output schema."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [583],
+      "description": "Added ai.schema attribute"
+    }
+  ]
+}

--- a/model/attributes/ai/ai__texts.json
+++ b/model/attributes/ai/ai__texts.json
@@ -7,13 +7,17 @@
   },
   "is_in_otel": false,
   "example": ["Hello, how are you?", "What is the capital of France?"],
-  "alias": ["gen_ai.input.messages", "ai.prompt.messages", "gen_ai.prompt"],
+  "alias": ["gen_ai.input.messages", "ai.prompt.messages", "gen_ai.prompt", "ai.prompt"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.input.messages"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added ai.prompt as an alias"
+    },
     {
       "version": "0.5.0",
       "prs": [264]

--- a/model/attributes/ai/ai__total_tokens__used.json
+++ b/model/attributes/ai/ai__total_tokens__used.json
@@ -7,13 +7,17 @@
   },
   "is_in_otel": false,
   "example": 30,
-  "alias": ["gen_ai.usage.total_tokens"],
+  "alias": ["gen_ai.usage.total_tokens", "ai.usage.tokens"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.usage.total_tokens"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added ai.usage.tokens as an alias"
+    },
     {
       "version": "0.4.0",
       "prs": [228]

--- a/model/attributes/ai/ai__usage__tokens.json
+++ b/model/attributes/ai/ai__usage__tokens.json
@@ -1,0 +1,24 @@
+{
+  "key": "ai.usage.tokens",
+  "brief": "The total number of tokens used for the request and the response.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": [150],
+  "alias": ["gen_ai.usage.total_tokens", "ai.total_tokens.used"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "gen_ai.usage.total_tokens",
+    "reason": "This attribute is being deprecated in favor of gen_ai.usage.total_tokens."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [583],
+      "description": "Added ai.usage.tokens attribute"
+    }
+  ]
+}

--- a/model/attributes/ai/ai__values.json
+++ b/model/attributes/ai/ai__values.json
@@ -1,0 +1,22 @@
+{
+  "key": "ai.values",
+  "brief": "The stringified values produced by a Vercel AI SDK object or array generation.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["[{\"city\":\"Paris\"}]"],
+  "deprecation": {
+    "_status": null,
+    "reason": "This attribute is deprecated. Use gen_ai.output.messages for model output instead."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [583],
+      "description": "Added ai.values attribute"
+    }
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__input__messages.json
+++ b/model/attributes/gen_ai/gen_ai__input__messages.json
@@ -7,9 +7,13 @@
   },
   "is_in_otel": true,
   "example": "[{\"role\": \"user\", \"parts\": [{\"type\": \"text\", \"content\": \"Weather in Paris?\"}]}, {\"role\": \"assistant\", \"parts\": [{\"type\": \"tool_call\", \"id\": \"call_VSPygqKTWdrhaFErNvMV18Yl\", \"name\": \"get_weather\", \"arguments\": {\"location\": \"Paris\"}}]}, {\"role\": \"tool\", \"parts\": [{\"type\": \"tool_call_response\", \"id\": \"call_VSPygqKTWdrhaFErNvMV18Yl\", \"result\": \"rainy, 57°F\"}]}]",
-  "alias": ["ai.texts", "ai.prompt.messages", "gen_ai.prompt"],
+  "alias": ["ai.texts", "ai.prompt.messages", "gen_ai.prompt", "ai.prompt"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added ai.prompt as an alias"
+    },
     {
       "version": "0.5.0",
       "prs": [264]

--- a/model/attributes/gen_ai/gen_ai__prompt.json
+++ b/model/attributes/gen_ai/gen_ai__prompt.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "[{\"role\": \"user\", \"message\": \"hello\"}]",
-  "alias": ["gen_ai.input.messages", "ai.texts", "ai.prompt.messages"],
+  "alias": ["gen_ai.input.messages", "ai.texts", "ai.prompt.messages", "ai.prompt"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "gen_ai.input.messages",
@@ -15,6 +15,10 @@
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added ai.prompt as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [74, 108, 119]

--- a/model/attributes/gen_ai/gen_ai__request__model.json
+++ b/model/attributes/gen_ai/gen_ai__request__model.json
@@ -7,9 +7,13 @@
   },
   "is_in_otel": true,
   "example": "gpt-4-turbo-preview",
-  "alias": ["ai.model_id"],
+  "alias": ["ai.model_id", "ai.model.id"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added ai.model.id as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [62, 127]

--- a/model/attributes/gen_ai/gen_ai__request__schema.json
+++ b/model/attributes/gen_ai/gen_ai__request__schema.json
@@ -1,0 +1,22 @@
+{
+  "key": "gen_ai.request.schema",
+  "brief": "The stringified JSON schema the model output must conform to.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}"],
+  "deprecation": {
+    "_status": null,
+    "reason": "This attribute is deprecated. The Sentry conventions have no replacement for the requested output schema."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [583],
+      "description": "Added gen_ai.request.schema attribute"
+    }
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__response__id.json
+++ b/model/attributes/gen_ai/gen_ai__response__id.json
@@ -7,9 +7,13 @@
   },
   "is_in_otel": true,
   "example": "gen_123abc",
-  "alias": ["ai.generation_id"],
+  "alias": ["ai.generation_id", "ai.response.id"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added ai.response.id as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [57, 127]

--- a/model/attributes/gen_ai/gen_ai__response__model.json
+++ b/model/attributes/gen_ai/gen_ai__response__model.json
@@ -7,8 +7,13 @@
   },
   "is_in_otel": true,
   "example": "gpt-4",
+  "alias": ["ai.response.model"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added ai.response.model as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [127]

--- a/model/attributes/gen_ai/gen_ai__response__object.json
+++ b/model/attributes/gen_ai/gen_ai__response__object.json
@@ -1,0 +1,22 @@
+{
+  "key": "gen_ai.response.object",
+  "brief": "The type of the object returned by the model.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "examples": ["chat.completion"],
+  "deprecation": {
+    "_status": null,
+    "reason": "This attribute is deprecated. The Sentry conventions have no replacement for the raw response object type."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [583],
+      "description": "Added gen_ai.response.object attribute"
+    }
+  ]
+}

--- a/model/attributes/gen_ai/gen_ai__usage__total_tokens.json
+++ b/model/attributes/gen_ai/gen_ai__usage__total_tokens.json
@@ -1,19 +1,23 @@
 {
   "key": "gen_ai.usage.total_tokens",
   "brief": "The total number of tokens used to process the prompt. (input tokens plus output todkens)",
+  "additional_context": [
+    "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
+    "This is the sum of gen_ai.usage.input_tokens and gen_ai.usage.output_tokens. Do not sum this with either of them — they are already included."
+  ],
   "type": "integer",
   "apply_scrubbing": {
     "key": "manual"
   },
   "is_in_otel": false,
   "example": 20,
-  "additional_context": [
-    "This attribute appears on both agent parent spans (aggregated totals) and LLM child spans (per-call values). When using sum() to count tokens, filter to gen_ai.operation.type:ai_client to avoid double-counting hierarchical spans.",
-    "This is the sum of gen_ai.usage.input_tokens and gen_ai.usage.output_tokens. Do not sum this with either of them — they are already included."
-  ],
-  "alias": ["ai.total_tokens.used"],
+  "alias": ["ai.total_tokens.used", "ai.usage.tokens"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added ai.usage.tokens as an alias"
+    },
     {
       "version": "0.9.0",
       "prs": [397],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -164,18 +164,26 @@ class _AttributeNamesMeta(type):
         "AI_INPUT_MESSAGES",
         "AI_IS_SEARCH_REQUIRED",
         "AI_METADATA",
-        "AI_MODEL_PROVIDER",
         "AI_MODEL_ID",
+        "AI_MODEL_PROVIDER",
+        "_AI_MODEL_ID",
         "AI_PIPELINE_NAME",
         "AI_PREAMBLE",
         "AI_PRESENCE_PENALTY",
+        "AI_PROMPT",
         "AI_PROMPT_MESSAGES",
+        "AI_PROMPT_TOOLS",
         "AI_PROMPT_TOKENS_USED",
         "AI_RAW_PROMPTING",
+        "AI_RESPONSE_ID",
+        "AI_RESPONSE_MODEL",
+        "AI_RESPONSE_OBJECT",
         "AI_RESPONSE_TEXT",
+        "AI_RESPONSE_TIMESTAMP",
         "AI_RESPONSE_TOOLCALLS",
         "AI_RESPONSE_FORMAT",
         "AI_RESPONSES",
+        "AI_SCHEMA",
         "AI_SEARCH_QUERIES",
         "AI_SEARCH_RESULTS",
         "AI_SEED",
@@ -191,6 +199,8 @@ class _AttributeNamesMeta(type):
         "AI_TOP_P",
         "AI_TOTAL_COST",
         "AI_TOTAL_TOKENS_USED",
+        "AI_USAGE_TOKENS",
+        "AI_VALUES",
         "AI_WARNINGS",
         "APP_APP_BUILD",
         "APP_APP_IDENTIFIER",
@@ -248,7 +258,9 @@ class _AttributeNamesMeta(type):
         "GEN_AI_PROMPT",
         "GEN_AI_REQUEST_AVAILABLE_TOOLS",
         "GEN_AI_REQUEST_MESSAGES",
+        "GEN_AI_REQUEST_SCHEMA",
         "GEN_AI_RESPONSE_FINISH_REASON",
+        "GEN_AI_RESPONSE_OBJECT",
         "GEN_AI_RESPONSE_TEXT",
         "GEN_AI_RESPONSE_TIME_TO_FIRST_TOKEN",
         "GEN_AI_RESPONSE_TOOL_CALLS",
@@ -497,7 +509,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: gen_ai.response.id
+    Aliases: gen_ai.response.id, ai.response.id
     DEPRECATED: Use gen_ai.response.id instead
     Example: "gen_123abc"
     """
@@ -539,6 +551,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "{\"user_id\": 123, \"session_id\": \"abc123\"}"
     """
 
+    # Path: model/attributes/ai/ai__model__id.json
+    AI_MODEL_ID: Literal["ai.model.id"] = "ai.model.id"
+    """The id of the model used by the Vercel AI SDK.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: gen_ai.request.model, ai.model_id
+    DEPRECATED: Use gen_ai.request.model instead - This attribute is being deprecated in favor of gen_ai.request.model.
+    Example: "gpt-4o"
+    """
+
     # Path: model/attributes/ai/ai__model__provider.json
     AI_MODEL_PROVIDER: Literal["ai.model.provider"] = "ai.model.provider"
     """The provider of the model.
@@ -553,14 +578,14 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """
 
     # Path: model/attributes/ai/ai__model_id.json
-    AI_MODEL_ID: Literal["ai.model_id"] = "ai.model_id"
+    _AI_MODEL_ID: Literal["ai.model_id"] = "ai.model_id"
     """The vendor-specific ID of the model used.
 
     Type: str
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: gen_ai.request.model
+    Aliases: gen_ai.request.model, ai.model.id
     DEPRECATED: Use gen_ai.request.model instead
     Example: "gpt-4"
     """
@@ -604,6 +629,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 0.5
     """
 
+    # Path: model/attributes/ai/ai__prompt.json
+    AI_PROMPT: Literal["ai.prompt"] = "ai.prompt"
+    """The prompt passed to the Vercel AI SDK, as a stringified object.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: gen_ai.input.messages, ai.texts, ai.prompt.messages, gen_ai.prompt
+    DEPRECATED: Use gen_ai.input.messages instead - This attribute is being deprecated in favor of gen_ai.input.messages.
+    Example: "{\"prompt\":\"What is the weather in Paris?\"}"
+    """
+
     # Path: model/attributes/ai/ai__prompt__messages.json
     AI_PROMPT_MESSAGES: Literal["ai.prompt.messages"] = "ai.prompt.messages"
     """The input messages sent to the AI model.
@@ -612,9 +650,21 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: gen_ai.input.messages, ai.texts, gen_ai.prompt
+    Aliases: gen_ai.input.messages, ai.texts, gen_ai.prompt, ai.prompt
     DEPRECATED: Use gen_ai.input.messages instead
     Example: "[{\"role\": \"user\", \"message\": \"hello\"}]"
+    """
+
+    # Path: model/attributes/ai/ai__prompt__tools.json
+    AI_PROMPT_TOOLS: Literal["ai.prompt.tools"] = "ai.prompt.tools"
+    """The tools made available to the model, as an array of stringified tool definitions.
+
+    Type: List[str]
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    DEPRECATED: Use gen_ai.tool.definitions instead - This attribute is being deprecated in favor of gen_ai.tool.definitions.
+    Example: ["{\"type\":\"function\",\"name\":\"get_weather\"}"]
     """
 
     # Path: model/attributes/ai/ai__prompt_tokens__used.json
@@ -642,6 +692,44 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: true
     """
 
+    # Path: model/attributes/ai/ai__response__id.json
+    AI_RESPONSE_ID: Literal["ai.response.id"] = "ai.response.id"
+    """The id of the response returned by the model.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: gen_ai.response.id, ai.generation_id
+    DEPRECATED: Use gen_ai.response.id instead - This attribute is being deprecated in favor of gen_ai.response.id.
+    Example: "chatcmpl-BuKJgVSKAMTUYbBSjHTMUuNGKzOPY"
+    """
+
+    # Path: model/attributes/ai/ai__response__model.json
+    AI_RESPONSE_MODEL: Literal["ai.response.model"] = "ai.response.model"
+    """The id of the model that produced the response.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: gen_ai.response.model
+    DEPRECATED: Use gen_ai.response.model instead - This attribute is being deprecated in favor of gen_ai.response.model.
+    Example: "gpt-4o-2024-08-06"
+    """
+
+    # Path: model/attributes/ai/ai__response__object.json
+    AI_RESPONSE_OBJECT: Literal["ai.response.object"] = "ai.response.object"
+    """The type of the object returned by the model.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    DEPRECATED: No replacement at this time - This attribute is deprecated. The Sentry conventions have no replacement for the raw Vercel AI response object type.
+    Example: "chat.completion"
+    """
+
     # Path: model/attributes/ai/ai__response__text.json
     AI_RESPONSE_TEXT: Literal["ai.response.text"] = "ai.response.text"
     """The text response from the AI model.
@@ -653,6 +741,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Aliases: gen_ai.output.messages, ai.response.toolCalls
     DEPRECATED: Use gen_ai.output.messages instead
     Example: "The weather in Paris is currently rainy."
+    """
+
+    # Path: model/attributes/ai/ai__response__timestamp.json
+    AI_RESPONSE_TIMESTAMP: Literal["ai.response.timestamp"] = "ai.response.timestamp"
+    """The ISO 8601 timestamp at which the response was produced.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    DEPRECATED: No replacement at this time - This attribute is deprecated. The span start and end timestamps carry the same information.
+    Example: "2026-02-19T15:32:11.000Z"
     """
 
     # Path: model/attributes/ai/ai__response__toolCalls.json
@@ -690,6 +790,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Visibility: public
     DEPRECATED: Use gen_ai.output.messages instead
     Example: ["hello","world"]
+    """
+
+    # Path: model/attributes/ai/ai__schema.json
+    AI_SCHEMA: Literal["ai.schema"] = "ai.schema"
+    """The stringified JSON schema the model output must conform to.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    DEPRECATED: No replacement at this time - This attribute is deprecated. The Sentry conventions have no replacement for the requested output schema.
+    Example: "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}"
     """
 
     # Path: model/attributes/ai/ai__search_queries.json
@@ -775,7 +887,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto
     Defined in OTEL: No
     Visibility: public
-    Aliases: gen_ai.input.messages, ai.prompt.messages, gen_ai.prompt
+    Aliases: gen_ai.input.messages, ai.prompt.messages, gen_ai.prompt, ai.prompt
     DEPRECATED: Use gen_ai.input.messages instead
     Example: ["Hello, how are you?","What is the capital of France?"]
     """
@@ -877,9 +989,34 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: gen_ai.usage.total_tokens
+    Aliases: gen_ai.usage.total_tokens, ai.usage.tokens
     DEPRECATED: Use gen_ai.usage.total_tokens instead
     Example: 30
+    """
+
+    # Path: model/attributes/ai/ai__usage__tokens.json
+    AI_USAGE_TOKENS: Literal["ai.usage.tokens"] = "ai.usage.tokens"
+    """The total number of tokens used for the request and the response.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: gen_ai.usage.total_tokens, ai.total_tokens.used
+    DEPRECATED: Use gen_ai.usage.total_tokens instead - This attribute is being deprecated in favor of gen_ai.usage.total_tokens.
+    Example: 150
+    """
+
+    # Path: model/attributes/ai/ai__values.json
+    AI_VALUES: Literal["ai.values"] = "ai.values"
+    """The stringified values produced by a Vercel AI SDK object or array generation.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    DEPRECATED: No replacement at this time - This attribute is deprecated. Use gen_ai.output.messages for model output instead.
+    Example: "[{\"city\":\"Paris\"}]"
     """
 
     # Path: model/attributes/ai/ai__warnings.json
@@ -4519,7 +4656,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: ai.texts, ai.prompt.messages, gen_ai.prompt
+    Aliases: ai.texts, ai.prompt.messages, gen_ai.prompt, ai.prompt
     Example: "[{\"role\": \"user\", \"parts\": [{\"type\": \"text\", \"content\": \"Weather in Paris?\"}]}, {\"role\": \"assistant\", \"parts\": [{\"type\": \"tool_call\", \"id\": \"call_VSPygqKTWdrhaFErNvMV18Yl\", \"name\": \"get_weather\", \"arguments\": {\"location\": \"Paris\"}}]}, {\"role\": \"tool\", \"parts\": [{\"type\": \"tool_call_response\", \"id\": \"call_VSPygqKTWdrhaFErNvMV18Yl\", \"result\": \"rainy, 57°F\"}]}]"
     """
 
@@ -4577,7 +4714,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: gen_ai.input.messages, ai.texts, ai.prompt.messages
+    Aliases: gen_ai.input.messages, ai.texts, ai.prompt.messages, ai.prompt
     DEPRECATED: Use gen_ai.input.messages instead - Deprecated from OTEL, use gen_ai.input.messages with the new format instead.
     Example: "[{\"role\": \"user\", \"message\": \"hello\"}]"
     """
@@ -4670,7 +4807,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: ai.model_id
+    Aliases: ai.model_id, ai.model.id
     Example: "gpt-4-turbo-preview"
     """
 
@@ -4699,6 +4836,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Example: "high"
+    """
+
+    # Path: model/attributes/gen_ai/gen_ai__request__schema.json
+    GEN_AI_REQUEST_SCHEMA: Literal["gen_ai.request.schema"] = "gen_ai.request.schema"
+    """The stringified JSON schema the model output must conform to.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    DEPRECATED: No replacement at this time - This attribute is deprecated. The Sentry conventions have no replacement for the requested output schema.
+    Example: "{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}}}"
     """
 
     # Path: model/attributes/gen_ai/gen_ai__request__seed.json
@@ -4801,7 +4950,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: ai.generation_id
+    Aliases: ai.generation_id, ai.response.id
     Example: "gen_123abc"
     """
 
@@ -4813,7 +4962,20 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: ai.response.model
     Example: "gpt-4"
+    """
+
+    # Path: model/attributes/gen_ai/gen_ai__response__object.json
+    GEN_AI_RESPONSE_OBJECT: Literal["gen_ai.response.object"] = "gen_ai.response.object"
+    """The type of the object returned by the model.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    DEPRECATED: No replacement at this time - This attribute is deprecated. The Sentry conventions have no replacement for the raw response object type.
+    Example: "chat.completion"
     """
 
     # Path: model/attributes/gen_ai/gen_ai__response__streaming.json
@@ -5209,7 +5371,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: ai.total_tokens.used
+    Aliases: ai.total_tokens.used, ai.usage.tokens
     Example: 20
     """
 
@@ -10587,6 +10749,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "gen_ai.response.id",
             "ai.generation_id",
+            "ai.response.id",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
@@ -10595,8 +10758,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="gen_ai.response.id", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["gen_ai.response.id"],
+        aliases=["gen_ai.response.id", "ai.response.id"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added ai.response.id as an alias"
+            ),
             ChangelogEntry(version="0.1.0", prs=[55, 57, 61, 108, 127]),
         ],
     ),
@@ -10606,6 +10772,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "gen_ai.input.messages",
             "ai.input_messages",
+            "ai.prompt",
             "ai.prompt.messages",
             "ai.texts",
             "gen_ai.prompt",
@@ -10651,6 +10818,31 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[55, 127]),
         ],
     ),
+    "ai.model.id": AttributeMetadata(
+        brief="The id of the model used by the Vercel AI SDK.",
+        type=AttributeType.STRING,
+        keys=(
+            "gen_ai.request.model",
+            "ai.model.id",
+            "ai.model_id",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="gpt-4o",
+        examples=["gpt-4o"],
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.request.model",
+            reason="This attribute is being deprecated in favor of gen_ai.request.model.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["gen_ai.request.model", "ai.model_id"],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[583], description="Added ai.model.id attribute"
+            ),
+        ],
+    ),
     "ai.model.provider": AttributeMetadata(
         brief="The provider of the model.",
         type=AttributeType.STRING,
@@ -10677,6 +10869,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         type=AttributeType.STRING,
         keys=(
             "gen_ai.request.model",
+            "ai.model.id",
             "ai.model_id",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
@@ -10686,8 +10879,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="gen_ai.request.model", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["gen_ai.request.model"],
+        aliases=["gen_ai.request.model", "ai.model.id"],
         changelog=[
+            ChangelogEntry(version="next", description="Added ai.model.id as an alias"),
             ChangelogEntry(version="0.1.0", prs=[57, 61, 127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -10753,12 +10947,46 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[55, 57, 61, 108]),
         ],
     ),
+    "ai.prompt": AttributeMetadata(
+        brief="The prompt passed to the Vercel AI SDK, as a stringified object.",
+        type=AttributeType.STRING,
+        keys=(
+            "gen_ai.input.messages",
+            "ai.input_messages",
+            "ai.prompt",
+            "ai.prompt.messages",
+            "ai.texts",
+            "gen_ai.prompt",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example='{"prompt":"What is the weather in Paris?"}',
+        examples=['{"prompt":"What is the weather in Paris?"}'],
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.input.messages",
+            reason="This attribute is being deprecated in favor of gen_ai.input.messages.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=[
+            "gen_ai.input.messages",
+            "ai.texts",
+            "ai.prompt.messages",
+            "gen_ai.prompt",
+        ],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[583], description="Added ai.prompt attribute"
+            ),
+        ],
+    ),
     "ai.prompt.messages": AttributeMetadata(
         brief="The input messages sent to the AI model.",
         type=AttributeType.STRING,
         keys=(
             "gen_ai.input.messages",
             "ai.input_messages",
+            "ai.prompt",
             "ai.prompt.messages",
             "ai.texts",
             "gen_ai.prompt",
@@ -10770,12 +10998,38 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="gen_ai.input.messages", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["gen_ai.input.messages", "ai.texts", "gen_ai.prompt"],
+        aliases=["gen_ai.input.messages", "ai.texts", "gen_ai.prompt", "ai.prompt"],
         changelog=[
+            ChangelogEntry(version="next", description="Added ai.prompt as an alias"),
             ChangelogEntry(
                 version="0.19.0",
                 prs=[498],
                 description="Added ai.prompt.messages attribute",
+            ),
+        ],
+    ),
+    "ai.prompt.tools": AttributeMetadata(
+        brief="The tools made available to the model, as an array of stringified tool definitions.",
+        type=AttributeType.STRING_ARRAY,
+        keys=(
+            "gen_ai.tool.definitions",
+            "ai.prompt.tools",
+            "ai.tools",
+            "gen_ai.request.available_tools",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=['{"type":"function","name":"get_weather"}'],
+        examples=[['{"type":"function","name":"get_weather"}']],
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.tool.definitions",
+            reason="This attribute is being deprecated in favor of gen_ai.tool.definitions.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[583], description="Added ai.prompt.tools attribute"
             ),
         ],
     ),
@@ -10815,6 +11069,77 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[55]),
         ],
     ),
+    "ai.response.id": AttributeMetadata(
+        brief="The id of the response returned by the model.",
+        type=AttributeType.STRING,
+        keys=(
+            "gen_ai.response.id",
+            "ai.generation_id",
+            "ai.response.id",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="chatcmpl-BuKJgVSKAMTUYbBSjHTMUuNGKzOPY",
+        examples=["chatcmpl-BuKJgVSKAMTUYbBSjHTMUuNGKzOPY"],
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.response.id",
+            reason="This attribute is being deprecated in favor of gen_ai.response.id.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["gen_ai.response.id", "ai.generation_id"],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[583], description="Added ai.response.id attribute"
+            ),
+        ],
+    ),
+    "ai.response.model": AttributeMetadata(
+        brief="The id of the model that produced the response.",
+        type=AttributeType.STRING,
+        keys=(
+            "gen_ai.response.model",
+            "ai.response.model",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="gpt-4o-2024-08-06",
+        examples=["gpt-4o-2024-08-06"],
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.response.model",
+            reason="This attribute is being deprecated in favor of gen_ai.response.model.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["gen_ai.response.model"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[583],
+                description="Added ai.response.model attribute",
+            ),
+        ],
+    ),
+    "ai.response.object": AttributeMetadata(
+        brief="The type of the object returned by the model.",
+        type=AttributeType.STRING,
+        keys=("ai.response.object",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="chat.completion",
+        examples=["chat.completion"],
+        deprecation=DeprecationInfo(
+            reason="This attribute is deprecated. The Sentry conventions have no replacement for the raw Vercel AI response object type."
+        ),
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[583],
+                description="Added ai.response.object attribute",
+            ),
+        ],
+    ),
     "ai.response.text": AttributeMetadata(
         brief="The text response from the AI model.",
         type=AttributeType.STRING,
@@ -10838,6 +11163,26 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
                 version="0.19.0",
                 prs=[498],
                 description="Added ai.response.text attribute",
+            ),
+        ],
+    ),
+    "ai.response.timestamp": AttributeMetadata(
+        brief="The ISO 8601 timestamp at which the response was produced.",
+        type=AttributeType.STRING,
+        keys=("ai.response.timestamp",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="2026-02-19T15:32:11.000Z",
+        examples=["2026-02-19T15:32:11.000Z"],
+        deprecation=DeprecationInfo(
+            reason="This attribute is deprecated. The span start and end timestamps carry the same information."
+        ),
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[583],
+                description="Added ai.response.timestamp attribute",
             ),
         ],
     ),
@@ -10901,6 +11246,24 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[65, 127]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "ai.schema": AttributeMetadata(
+        brief="The stringified JSON schema the model output must conform to.",
+        type=AttributeType.STRING,
+        keys=("ai.schema",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example='{"type":"object","properties":{"city":{"type":"string"}}}',
+        examples=['{"type":"object","properties":{"city":{"type":"string"}}}'],
+        deprecation=DeprecationInfo(
+            reason="This attribute is deprecated. The Sentry conventions have no replacement for the requested output schema."
+        ),
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[583], description="Added ai.schema attribute"
+            ),
         ],
     ),
     "ai.search_queries": AttributeMetadata(
@@ -11010,6 +11373,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "gen_ai.input.messages",
             "ai.input_messages",
+            "ai.prompt",
             "ai.prompt.messages",
             "ai.texts",
             "gen_ai.prompt",
@@ -11021,8 +11385,14 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="gen_ai.input.messages", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["gen_ai.input.messages", "ai.prompt.messages", "gen_ai.prompt"],
+        aliases=[
+            "gen_ai.input.messages",
+            "ai.prompt.messages",
+            "gen_ai.prompt",
+            "ai.prompt",
+        ],
         changelog=[
+            ChangelogEntry(version="next", description="Added ai.prompt as an alias"),
             ChangelogEntry(version="0.5.0", prs=[264]),
             ChangelogEntry(version="0.1.0", prs=[55]),
         ],
@@ -11108,6 +11478,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         type=AttributeType.STRING_ARRAY,
         keys=(
             "gen_ai.tool.definitions",
+            "ai.prompt.tools",
             "ai.tools",
             "gen_ai.request.available_tools",
         ),
@@ -11190,6 +11561,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "gen_ai.usage.total_tokens",
             "ai.total_tokens.used",
+            "ai.usage.tokens",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
@@ -11198,11 +11570,57 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="gen_ai.usage.total_tokens", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["gen_ai.usage.total_tokens"],
+        aliases=["gen_ai.usage.total_tokens", "ai.usage.tokens"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added ai.usage.tokens as an alias"
+            ),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[57, 61, 108]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "ai.usage.tokens": AttributeMetadata(
+        brief="The total number of tokens used for the request and the response.",
+        type=AttributeType.INTEGER,
+        keys=(
+            "gen_ai.usage.total_tokens",
+            "ai.total_tokens.used",
+            "ai.usage.tokens",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=150,
+        examples=[150],
+        deprecation=DeprecationInfo(
+            replacement="gen_ai.usage.total_tokens",
+            reason="This attribute is being deprecated in favor of gen_ai.usage.total_tokens.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["gen_ai.usage.total_tokens", "ai.total_tokens.used"],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[583], description="Added ai.usage.tokens attribute"
+            ),
+        ],
+    ),
+    "ai.values": AttributeMetadata(
+        brief="The stringified values produced by a Vercel AI SDK object or array generation.",
+        type=AttributeType.STRING,
+        keys=("ai.values",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example='[{"city":"Paris"}]',
+        examples=['[{"city":"Paris"}]'],
+        deprecation=DeprecationInfo(
+            reason="This attribute is deprecated. Use gen_ai.output.messages for model output instead."
+        ),
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[583], description="Added ai.values attribute"
+            ),
         ],
     ),
     "ai.warnings": AttributeMetadata(
@@ -16445,6 +16863,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "gen_ai.input.messages",
             "ai.input_messages",
+            "ai.prompt",
             "ai.prompt.messages",
             "ai.texts",
             "gen_ai.prompt",
@@ -16453,8 +16872,9 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example='[{"role": "user", "parts": [{"type": "text", "content": "Weather in Paris?"}]}, {"role": "assistant", "parts": [{"type": "tool_call", "id": "call_VSPygqKTWdrhaFErNvMV18Yl", "name": "get_weather", "arguments": {"location": "Paris"}}]}, {"role": "tool", "parts": [{"type": "tool_call_response", "id": "call_VSPygqKTWdrhaFErNvMV18Yl", "result": "rainy, 57°F"}]}]',
-        aliases=["ai.texts", "ai.prompt.messages", "gen_ai.prompt"],
+        aliases=["ai.texts", "ai.prompt.messages", "gen_ai.prompt", "ai.prompt"],
         changelog=[
+            ChangelogEntry(version="next", description="Added ai.prompt as an alias"),
             ChangelogEntry(version="0.5.0", prs=[264]),
             ChangelogEntry(version="0.4.0", prs=[221]),
         ],
@@ -16526,6 +16946,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "gen_ai.input.messages",
             "ai.input_messages",
+            "ai.prompt",
             "ai.prompt.messages",
             "ai.texts",
             "gen_ai.prompt",
@@ -16539,8 +16960,14 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             reason="Deprecated from OTEL, use gen_ai.input.messages with the new format instead.",
             status=DeprecationStatus.BACKFILL,
         ),
-        aliases=["gen_ai.input.messages", "ai.texts", "ai.prompt.messages"],
+        aliases=[
+            "gen_ai.input.messages",
+            "ai.texts",
+            "ai.prompt.messages",
+            "ai.prompt",
+        ],
         changelog=[
+            ChangelogEntry(version="next", description="Added ai.prompt as an alias"),
             ChangelogEntry(version="0.1.0", prs=[74, 108, 119]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -16590,6 +17017,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         type=AttributeType.STRING,
         keys=(
             "gen_ai.tool.definitions",
+            "ai.prompt.tools",
             "ai.tools",
             "gen_ai.request.available_tools",
         ),
@@ -16659,14 +17087,16 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         type=AttributeType.STRING,
         keys=(
             "gen_ai.request.model",
+            "ai.model.id",
             "ai.model_id",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="gpt-4-turbo-preview",
-        aliases=["ai.model_id"],
+        aliases=["ai.model_id", "ai.model.id"],
         changelog=[
+            ChangelogEntry(version="next", description="Added ai.model.id as an alias"),
             ChangelogEntry(version="0.1.0", prs=[62, 127]),
         ],
     ),
@@ -16700,6 +17130,26 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
                 version="0.17.0",
                 prs=[502],
                 description="Added gen_ai.request.reasoning.level attribute",
+            ),
+        ],
+    ),
+    "gen_ai.request.schema": AttributeMetadata(
+        brief="The stringified JSON schema the model output must conform to.",
+        type=AttributeType.STRING,
+        keys=("gen_ai.request.schema",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example='{"type":"object","properties":{"city":{"type":"string"}}}',
+        examples=['{"type":"object","properties":{"city":{"type":"string"}}}'],
+        deprecation=DeprecationInfo(
+            reason="This attribute is deprecated. The Sentry conventions have no replacement for the requested output schema."
+        ),
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[583],
+                description="Added gen_ai.request.schema attribute",
             ),
         ],
     ),
@@ -16834,27 +17284,58 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "gen_ai.response.id",
             "ai.generation_id",
+            "ai.response.id",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="gen_123abc",
-        aliases=["ai.generation_id"],
+        aliases=["ai.generation_id", "ai.response.id"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added ai.response.id as an alias"
+            ),
             ChangelogEntry(version="0.1.0", prs=[57, 127]),
         ],
     ),
     "gen_ai.response.model": AttributeMetadata(
         brief="The vendor-specific ID of the model used.",
         type=AttributeType.STRING,
-        keys=("gen_ai.response.model",),
+        keys=(
+            "gen_ai.response.model",
+            "ai.response.model",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="gpt-4",
+        aliases=["ai.response.model"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added ai.response.model as an alias"
+            ),
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "gen_ai.response.object": AttributeMetadata(
+        brief="The type of the object returned by the model.",
+        type=AttributeType.STRING,
+        keys=("gen_ai.response.object",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="chat.completion",
+        examples=["chat.completion"],
+        deprecation=DeprecationInfo(
+            reason="This attribute is deprecated. The Sentry conventions have no replacement for the raw response object type."
+        ),
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[583],
+                description="Added gen_ai.response.object attribute",
+            ),
         ],
     ),
     "gen_ai.response.streaming": AttributeMetadata(
@@ -17074,6 +17555,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         type=AttributeType.STRING,
         keys=(
             "gen_ai.tool.definitions",
+            "ai.prompt.tools",
             "ai.tools",
             "gen_ai.request.available_tools",
         ),
@@ -17500,13 +17982,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "gen_ai.usage.total_tokens",
             "ai.total_tokens.used",
+            "ai.usage.tokens",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example=20,
-        aliases=["ai.total_tokens.used"],
+        aliases=["ai.total_tokens.used", "ai.usage.tokens"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added ai.usage.tokens as an alias"
+            ),
             ChangelogEntry(
                 version="0.9.0", prs=[397], description="Add additional_context"
             ),
@@ -24960,18 +25446,26 @@ Attributes = TypedDict(
         "ai.input_messages": str,
         "ai.is_search_required": bool,
         "ai.metadata": str,
+        "ai.model.id": str,
         "ai.model.provider": str,
         "ai.model_id": str,
         "ai.pipeline.name": str,
         "ai.preamble": str,
         "ai.presence_penalty": float,
+        "ai.prompt": str,
         "ai.prompt.messages": str,
+        "ai.prompt.tools": List[str],
         "ai.prompt_tokens.used": int,
         "ai.raw_prompting": bool,
+        "ai.response.id": str,
+        "ai.response.model": str,
+        "ai.response.object": str,
         "ai.response.text": str,
+        "ai.response.timestamp": str,
         "ai.response.toolCalls": str,
         "ai.response_format": str,
         "ai.responses": List[str],
+        "ai.schema": str,
         "ai.search_queries": List[str],
         "ai.search_results": List[str],
         "ai.seed": str,
@@ -24987,6 +25481,8 @@ Attributes = TypedDict(
         "ai.top_p": float,
         "ai.total_cost": float,
         "ai.total_tokens.used": int,
+        "ai.usage.tokens": int,
+        "ai.values": str,
         "ai.warnings": List[str],
         "angular.version": str,
         "app.app_build": str,
@@ -25295,6 +25791,7 @@ Attributes = TypedDict(
         "gen_ai.request.model": str,
         "gen_ai.request.presence_penalty": float,
         "gen_ai.request.reasoning.level": str,
+        "gen_ai.request.schema": str,
         "gen_ai.request.seed": str,
         "gen_ai.request.stop_sequences": List[str],
         "gen_ai.request.temperature": float,
@@ -25304,6 +25801,7 @@ Attributes = TypedDict(
         "gen_ai.response.finish_reasons": str,
         "gen_ai.response.id": str,
         "gen_ai.response.model": str,
+        "gen_ai.response.object": str,
         "gen_ai.response.streaming": bool,
         "gen_ai.response.text": str,
         "gen_ai.response.time_to_first_chunk": float,


### PR DESCRIPTION
Adds the twelve `ai.*` and `gen_ai.*` attributes that the JavaScript SDK stopped emitting in v11, when the Vercel AI OpenTelemetry span processor was removed.

Six map onto a `gen_ai.*` replacement and join its alias group: `ai.model.id`, `ai.prompt`, `ai.response.id`, `ai.response.model`, `ai.usage.tokens` and `ai.prompt.tools`. The remaining six have no equivalent in the conventions and carry a reason only.

`ai.prompt.tools` gets a replacement but no alias here, so that the whole `gen_ai.tool.definitions` alias group can be completed in one place, in the last PR of this stack.

Deprecated by https://github.com/getsentry/sentry-javascript/pull/23384