### PR TITLE
feat(attributes): Add `graphql.source` (deprecated) in favor of `graphql.document`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -8842,6 +8842,8 @@ export type GEN_AI_USAGE_TOTAL_TOKENS_TYPE = number;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
+ * Aliases: {@link GRAPHQL_SOURCE} `graphql.source`
+ *
  * @example "query findBookById { bookById(id: ?) { name } }"
  */
 export const GRAPHQL_DOCUMENT = 'graphql.document';
@@ -8916,6 +8918,30 @@ export const GRAPHQL_PROCESSING_TYPE = 'graphql.processing.type';
  * Type for {@link GRAPHQL_PROCESSING_TYPE} graphql.processing.type
  */
 export type GRAPHQL_PROCESSING_TYPE_TYPE = string;
+
+// Path: model/attributes/graphql/graphql__source.json
+
+/**
+ * The GraphQL document being executed. `graphql.source`
+ *
+ * Attribute Value Type: `string` {@link GRAPHQL_SOURCE_TYPE}
+ *
+ * Apply Scrubbing: auto
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link GRAPHQL_DOCUMENT} `graphql.document`
+ *
+ * @deprecated Use {@link GRAPHQL_DOCUMENT} (graphql.document) instead - This attribute is being deprecated in favor of graphql.document, which is the OpenTelemetry name for the same value.
+ * @example "query findBookById { bookById(id: ?) { name } }"
+ */
+export const GRAPHQL_SOURCE = 'graphql.source';
+
+/**
+ * Type for {@link GRAPHQL_SOURCE} graphql.source
+ */
+export type GRAPHQL_SOURCE_TYPE = string;
 
 // Path: model/attributes/grpc/grpc__error__bad_request__field_violations.json
 
@@ -18769,6 +18795,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'graphql.operation.name': 'string',
   'graphql.operation.type': 'string',
   'graphql.processing.type': 'string',
+  'graphql.source': 'string',
   'grpc.error.bad_request.field_violations': 'string[]',
   'grpc.error.debug_info.detail': 'string',
   'grpc.error.debug_info.stack_entries': 'string[]',
@@ -19592,6 +19619,7 @@ export type AttributeName =
   | typeof GRAPHQL_OPERATION_NAME
   | typeof GRAPHQL_OPERATION_TYPE
   | typeof GRAPHQL_PROCESSING_TYPE
+  | typeof GRAPHQL_SOURCE
   | typeof GRPC_ERROR_BAD_REQUEST_FIELD_VIOLATIONS
   | typeof GRPC_ERROR_DEBUG_INFO_DETAIL
   | typeof GRPC_ERROR_DEBUG_INFO_STACK_ENTRIES
@@ -26238,7 +26266,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'graphql.document': {
     brief: 'The GraphQL document being executed.',
     type: 'string',
-    keys: ['graphql.document'],
+    keys: ['graphql.document', 'graphql.source'],
     applyScrubbing: {
       key: 'auto',
       reason:
@@ -26247,7 +26275,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'query findBookById { bookById(id: ?) { name } }',
+    aliases: ['graphql.source'],
     changelog: [
+      { version: 'next', description: 'Added graphql.source as an alias' },
       {
         version: '0.7.0',
         description: 'Adds the `graphql.document` attribute to track the GraphQL document being executed.',
@@ -26294,6 +26324,26 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       'Well-known values are request, parse, validate, variable_coercion, plan, execute, subscription_event, step_execute, resolve, dataloader_dispatch, dataloader_batch and _OTHER. Use one of these if it applies, otherwise a custom value.',
       'Not to be confused with graphql.operation.type, which holds the GraphQL operation type (query, mutation, subscription) and only applies to spans that run an operation.',
     ],
+  },
+  'graphql.source': {
+    brief: 'The GraphQL document being executed.',
+    type: 'string',
+    keys: ['graphql.document', 'graphql.source'],
+    applyScrubbing: {
+      key: 'auto',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'query findBookById { bookById(id: ?) { name } }',
+    examples: ['query findBookById { bookById(id: ?) { name } }'],
+    deprecation: {
+      replacement: 'graphql.document',
+      reason:
+        'This attribute is being deprecated in favor of graphql.document, which is the OpenTelemetry name for the same value.',
+      status: 'backfill',
+    },
+    aliases: ['graphql.document'],
+    changelog: [{ version: 'next', prs: [584], description: 'Added graphql.source attribute' }],
   },
   'grpc.error.bad_request.field_violations': {
     brief:
@@ -35308,7 +35358,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'graphql.document',
     type: 'string',
     brief: 'The GraphQL document being executed.',
-    deprecationChain: ['graphql.document'],
+    deprecationChain: ['graphql.document', 'graphql.source'],
   },
   'graphql.operation.name': {
     canonicalName: 'graphql.operation.name',
@@ -35327,6 +35377,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief: 'The type of processing represented by this span.',
     deprecationChain: ['graphql.processing.type'],
+  },
+  'graphql.source': {
+    canonicalName: 'graphql.document',
+    type: 'string',
+    brief: 'The GraphQL document being executed.',
+    deprecationChain: ['graphql.document', 'graphql.source'],
   },
   'grpc.error.bad_request.field_violations': {
     canonicalName: 'grpc.error.bad_request.field_violations',
@@ -38375,6 +38431,7 @@ export type Attributes = {
   [GRAPHQL_OPERATION_NAME]?: GRAPHQL_OPERATION_NAME_TYPE;
   [GRAPHQL_OPERATION_TYPE]?: GRAPHQL_OPERATION_TYPE_TYPE;
   [GRAPHQL_PROCESSING_TYPE]?: GRAPHQL_PROCESSING_TYPE_TYPE;
+  [GRAPHQL_SOURCE]?: GRAPHQL_SOURCE_TYPE;
   [GRPC_ERROR_BAD_REQUEST_FIELD_VIOLATIONS]?: GRPC_ERROR_BAD_REQUEST_FIELD_VIOLATIONS_TYPE;
   [GRPC_ERROR_DEBUG_INFO_DETAIL]?: GRPC_ERROR_DEBUG_INFO_DETAIL_TYPE;
   [GRPC_ERROR_DEBUG_INFO_STACK_ENTRIES]?: GRPC_ERROR_DEBUG_INFO_STACK_ENTRIES_TYPE;

--- a/model/attributes/graphql/graphql__document.json
+++ b/model/attributes/graphql/graphql__document.json
@@ -7,9 +7,14 @@
     "reason": "The document may contain sensitive information in arguments or variables. Instrumentation should redact sensitive information when possible."
   },
   "is_in_otel": true,
-  "visibility": "public",
   "example": "query findBookById { bookById(id: ?) { name } }",
+  "alias": ["graphql.source"],
+  "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added graphql.source as an alias"
+    },
     {
       "version": "0.7.0",
       "description": "Adds the `graphql.document` attribute to track the GraphQL document being executed."

--- a/model/attributes/graphql/graphql__source.json
+++ b/model/attributes/graphql/graphql__source.json
@@ -1,0 +1,24 @@
+{
+  "key": "graphql.source",
+  "brief": "The GraphQL document being executed.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "auto"
+  },
+  "is_in_otel": false,
+  "examples": ["query findBookById { bookById(id: ?) { name } }"],
+  "alias": ["graphql.document"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "graphql.document",
+    "reason": "This attribute is being deprecated in favor of graphql.document, which is the OpenTelemetry name for the same value."
+  },
+  "visibility": "public",
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [584],
+      "description": "Added graphql.source attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -275,6 +275,7 @@ class _AttributeNamesMeta(type):
         "GEN_AI_USAGE_INPUT_TOKENS_CACHED",
         "GEN_AI_USAGE_OUTPUT_TOKENS_REASONING",
         "GEN_AI_USAGE_PROMPT_TOKENS",
+        "GRAPHQL_SOURCE",
         "HARDWARECONCURRENCY",
         "HTTP_CLIENT_IP",
         "HTTP_DECODED_RESPONSE_CONTENT_LENGTH",
@@ -5383,6 +5384,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto - The document may contain sensitive information in arguments or variables. Instrumentation should redact sensitive information when possible.
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: graphql.source
     Example: "query findBookById { bookById(id: ?) { name } }"
     """
 
@@ -5422,6 +5424,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "validate"
     Example: "execute"
     Example: "resolve"
+    """
+
+    # Path: model/attributes/graphql/graphql__source.json
+    GRAPHQL_SOURCE: Literal["graphql.source"] = "graphql.source"
+    """The GraphQL document being executed.
+
+    Type: str
+    Apply Scrubbing: auto
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: graphql.document
+    DEPRECATED: Use graphql.document instead - This attribute is being deprecated in favor of graphql.document, which is the OpenTelemetry name for the same value.
+    Example: "query findBookById { bookById(id: ?) { name } }"
     """
 
     # Path: model/attributes/grpc/grpc__error__bad_request__field_violations.json
@@ -18007,7 +18022,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "graphql.document": AttributeMetadata(
         brief="The GraphQL document being executed.",
         type=AttributeType.STRING,
-        keys=("graphql.document",),
+        keys=(
+            "graphql.document",
+            "graphql.source",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(
             key=ApplyScrubbing.AUTO,
             reason="The document may contain sensitive information in arguments or variables. Instrumentation should redact sensitive information when possible.",
@@ -18015,7 +18033,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="query findBookById { bookById(id: ?) { name } }",
+        aliases=["graphql.source"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added graphql.source as an alias"
+            ),
             ChangelogEntry(
                 version="0.7.0",
                 description="Adds the `graphql.document` attribute to track the GraphQL document being executed.",
@@ -18067,6 +18089,30 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         additional_context=[
             "Well-known values are request, parse, validate, variable_coercion, plan, execute, subscription_event, step_execute, resolve, dataloader_dispatch, dataloader_batch and _OTHER. Use one of these if it applies, otherwise a custom value.",
             "Not to be confused with graphql.operation.type, which holds the GraphQL operation type (query, mutation, subscription) and only applies to spans that run an operation.",
+        ],
+    ),
+    "graphql.source": AttributeMetadata(
+        brief="The GraphQL document being executed.",
+        type=AttributeType.STRING,
+        keys=(
+            "graphql.document",
+            "graphql.source",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="query findBookById { bookById(id: ?) { name } }",
+        examples=["query findBookById { bookById(id: ?) { name } }"],
+        deprecation=DeprecationInfo(
+            replacement="graphql.document",
+            reason="This attribute is being deprecated in favor of graphql.document, which is the OpenTelemetry name for the same value.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["graphql.document"],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[584], description="Added graphql.source attribute"
+            ),
         ],
     ),
     "grpc.error.bad_request.field_violations": AttributeMetadata(
@@ -25835,6 +25881,7 @@ Attributes = TypedDict(
         "graphql.operation.name": str,
         "graphql.operation.type": str,
         "graphql.processing.type": str,
+        "graphql.source": str,
         "grpc.error.bad_request.field_violations": List[str],
         "grpc.error.debug_info.detail": str,
         "grpc.error.debug_info.stack_entries": List[str],


### PR DESCRIPTION
The JavaScript SDK emitted `graphql.source` from its vendored GraphQL instrumentation and dropped it in v11. It held the GraphQL document text, which is what `graphql.document` already describes, so this is a plain rename onto the OpenTelemetry name.

Deprecated by https://github.com/getsentry/sentry-javascript/pull/22735