### PR TITLE
feat(attributes): Add `service.namespace`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -16182,6 +16182,27 @@ export const SERVICE_NAME = 'service.name';
  */
 export type SERVICE_NAME_TYPE = string;
 
+// Path: model/attributes/service/service__namespace.json
+
+/**
+ * A namespace for service.name. Distinguishes a group of services, for example the cluster or team name. `service.namespace`
+ *
+ * Attribute Value Type: `string` {@link SERVICE_NAMESPACE_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: Yes
+ * Visibility: public
+ *
+ * @example "Shop"
+ */
+export const SERVICE_NAMESPACE = 'service.namespace';
+
+/**
+ * Type for {@link SERVICE_NAMESPACE} service.namespace
+ */
+export type SERVICE_NAMESPACE_TYPE = string;
+
 // Path: model/attributes/service/service__version.json
 
 /**
@@ -18975,6 +18996,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   server_name: 'string',
   'server.port': 'integer',
   'service.name': 'string',
+  'service.namespace': 'string',
   'service.version': 'string',
   'session.id': 'string',
   stall_percentage: 'double',
@@ -19793,6 +19815,7 @@ export type AttributeName =
   | typeof SERVER_NAME
   | typeof SERVER_PORT
   | typeof SERVICE_NAME
+  | typeof SERVICE_NAMESPACE
   | typeof SERVICE_VERSION
   | typeof SESSION_ID
   | typeof STALL_PERCENTAGE
@@ -31293,6 +31316,19 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'omegastar',
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
+  'service.namespace': {
+    brief: 'A namespace for service.name. Distinguishes a group of services, for example the cluster or team name.',
+    type: 'string',
+    keys: ['service.namespace'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: true,
+    visibility: 'public',
+    example: 'Shop',
+    examples: ['Shop'],
+    changelog: [{ version: 'next', prs: [585], description: 'Added service.namespace attribute' }],
+  },
   'service.version': {
     brief: 'The version string of the service API or implementation. The format is not defined by these conventions.',
     type: 'string',
@@ -37068,6 +37104,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     brief: 'Logical name of the service.',
     deprecationChain: ['service.name'],
   },
+  'service.namespace': {
+    canonicalName: 'service.namespace',
+    type: 'string',
+    brief: 'A namespace for service.name. Distinguishes a group of services, for example the cluster or team name.',
+    deprecationChain: ['service.namespace'],
+  },
   'service.version': {
     canonicalName: 'service.version',
     type: 'string',
@@ -38448,6 +38490,7 @@ export type Attributes = {
   [SERVER_NAME]?: SERVER_NAME_TYPE;
   [SERVER_PORT]?: SERVER_PORT_TYPE;
   [SERVICE_NAME]?: SERVICE_NAME_TYPE;
+  [SERVICE_NAMESPACE]?: SERVICE_NAMESPACE_TYPE;
   [SERVICE_VERSION]?: SERVICE_VERSION_TYPE;
   [SESSION_ID]?: SESSION_ID_TYPE;
   [STALL_PERCENTAGE]?: STALL_PERCENTAGE_TYPE;

--- a/model/attributes/service/service__namespace.json
+++ b/model/attributes/service/service__namespace.json
@@ -1,0 +1,18 @@
+{
+  "key": "service.namespace",
+  "brief": "A namespace for service.name. Distinguishes a group of services, for example the cluster or team name.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": true,
+  "visibility": "public",
+  "examples": ["Shop"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [585],
+      "description": "Added service.namespace attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -9470,6 +9470,17 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "omegastar"
     """
 
+    # Path: model/attributes/service/service__namespace.json
+    SERVICE_NAMESPACE: Literal["service.namespace"] = "service.namespace"
+    """A namespace for service.name. Distinguishes a group of services, for example the cluster or team name.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: Yes
+    Visibility: public
+    Example: "Shop"
+    """
+
     # Path: model/attributes/service/service__version.json
     SERVICE_VERSION: Literal["service.version"] = "service.version"
     """The version string of the service API or implementation. The format is not defined by these conventions.
@@ -23870,6 +23881,23 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "service.namespace": AttributeMetadata(
+        brief="A namespace for service.name. Distinguishes a group of services, for example the cluster or team name.",
+        type=AttributeType.STRING,
+        keys=("service.namespace",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=True,
+        visibility=Visibility.PUBLIC,
+        example="Shop",
+        examples=["Shop"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[585],
+                description="Added service.namespace attribute",
+            ),
+        ],
+    ),
     "service.version": AttributeMetadata(
         brief="The version string of the service API or implementation. The format is not defined by these conventions.",
         type=AttributeType.STRING,
@@ -25997,6 +26025,7 @@ Attributes = TypedDict(
         "server.port": int,
         "server_name": str,
         "service.name": str,
+        "service.namespace": str,
         "service.version": str,
         "session.id": str,
         "stall_percentage": float,


### PR DESCRIPTION
`service.namespace` is an OpenTelemetry resource attribute that SDKs emit alongside the already documented `service.name` and `service.version`, but it was never defined here.

It is added as a live attribute, not as a deprecated one. The JavaScript SDK stopped collecting OpenTelemetry resources in v11 and so no longer emits any `service.*` attribute, but that is a JavaScript-only change and other SDKs still send them. Deprecating the `service.*` family repo-wide would therefore be wrong.

Prompted by https://github.com/getsentry/sentry-javascript/pull/23013