### PR TITLE
feat(attributes):  Name the replacements for the deprecated `http.target`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -10308,7 +10308,7 @@ export type HTTP_STATUS_TEXT_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * @deprecated Use {@link URL_PATH} (url.path) instead - This attribute is being deprecated in favor of url.path and url.query
+ * @deprecated  - This attribute is being deprecated in favor of url.path, url.query and url.fragment. The value holds all three parts at once, so it has no single replacement.
  * @example "/test?foo=bar#buzz"
  */
 export const HTTP_TARGET = 'http.target';
@@ -27366,10 +27366,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: '/test?foo=bar#buzz',
     deprecation: {
-      replacement: 'url.path',
-      reason: 'This attribute is being deprecated in favor of url.path and url.query',
+      reason:
+        'This attribute is being deprecated in favor of url.path, url.query and url.fragment. The value holds all three parts at once, so it has no single replacement.',
     },
-    changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    changelog: [
+      {
+        version: 'next',
+        description: 'Documented url.path, url.query and url.fragment as the replacements for http.target',
+      },
+      { version: '0.1.0', prs: [61] },
+      { version: '0.0.0' },
+    ],
   },
   'http.url': {
     brief: 'The URL of the resource that was fetched.',
@@ -35859,7 +35866,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     deprecationChain: ['http.response.status_text', 'http.status_text'],
   },
   'http.target': {
-    canonicalName: 'url.path',
+    canonicalName: 'http.target',
     type: 'string',
     brief: 'The pathname and query string of the URL.',
     deprecationChain: ['http.target'],

--- a/model/attributes/http/http__target.json
+++ b/model/attributes/http/http__target.json
@@ -9,11 +9,14 @@
   "example": "/test?foo=bar#buzz",
   "deprecation": {
     "_status": null,
-    "replacement": "url.path",
-    "reason": "This attribute is being deprecated in favor of url.path and url.query"
+    "reason": "This attribute is being deprecated in favor of url.path, url.query and url.fragment. The value holds all three parts at once, so it has no single replacement."
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Documented url.path, url.query and url.fragment as the replacements for http.target"
+    },
     {
       "version": "0.1.0",
       "prs": [61]

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -6242,7 +6242,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto
     Defined in OTEL: Yes
     Visibility: public
-    DEPRECATED: Use url.path instead - This attribute is being deprecated in favor of url.path and url.query
+    DEPRECATED: No replacement at this time - This attribute is being deprecated in favor of url.path, url.query and url.fragment. The value holds all three parts at once, so it has no single replacement.
     Example: "/test?foo=bar#buzz"
     """
 
@@ -19267,10 +19267,13 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="/test?foo=bar#buzz",
         deprecation=DeprecationInfo(
-            replacement="url.path",
-            reason="This attribute is being deprecated in favor of url.path and url.query",
+            reason="This attribute is being deprecated in favor of url.path, url.query and url.fragment. The value holds all three parts at once, so it has no single replacement."
         ),
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Documented url.path, url.query and url.fragment as the replacements for http.target",
+            ),
             ChangelogEntry(version="0.1.0", prs=[61]),
             ChangelogEntry(version="0.0.0"),
         ],


### PR DESCRIPTION
`http.target` carried the path, the query string and the fragment in one value, so it cannot be renamed onto a single replacement. v11 of the JavaScript SDK splits it into `url.path`, `url.query` and `url.fragment`.

~Adds the `http_target_to_url_path_and_query` transformation and sets `http.target` to `_status: "transform"`.~

No aliases are added on purpose. An alias group is symmetric, so aliasing `http.target` to both `url.path` and `url.query` would declare those two equivalent to each other. This matches how `gen_ai.request.messages` is modelled.

Replaced by https://github.com/getsentry/sentry-javascript/pull/23575