### PR TITLE
feat(attributes): Complete `net.*` aliases and transform `net.transport`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -12,7 +12,7 @@
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`
+ * Aliases: {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`, {@link NET_PEER_NAME} `net.peer.name`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead - Old namespace-less attribute, to be replaced with server.address for span-first future
  * @example "example.com"
@@ -9352,7 +9352,7 @@ export type HTTP_FRAGMENT_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link CLIENT_ADDRESS} `client.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link SERVER_NAME} `server_name`
+ * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link CLIENT_ADDRESS} `client.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link SERVER_NAME} `server_name`, {@link NET_PEER_NAME} `net.peer.name`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead - Deprecated, use one of `server.address` or `client.address`, depending on the usage
  * @example "example.com"
@@ -10215,7 +10215,7 @@ export type HTTP_SCHEME_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`
+ * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`, {@link NET_PEER_NAME} `net.peer.name`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead
  * @example "example.com"
@@ -12640,6 +12640,8 @@ export type NETWORK_PEER_ADDRESS_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
+ * Aliases: {@link NET_SOCK_PEER_PORT} `net.sock.peer.port`
+ *
  * @example 65400
  */
 export const NETWORK_PEER_PORT = 'network.peer.port';
@@ -12775,7 +12777,7 @@ export type NET_HOST_IP_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`
+ * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`, {@link NET_PEER_NAME} `net.peer.name`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead
  * @example "example.com"
@@ -12846,6 +12848,8 @@ export type NET_PEER_IP_TYPE = string;
  *
  * Attribute defined in OTEL: Yes
  * Visibility: public
+ *
+ * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead - Deprecated, use server.address on client spans and client.address on server spans.
  * @example "example.com"
@@ -13055,6 +13059,8 @@ export type NET_SOCK_PEER_NAME_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
+ * Aliases: {@link NETWORK_PEER_PORT} `network.peer.port`
+ *
  * @deprecated Use {@link NETWORK_PEER_PORT} (network.peer.port) instead
  * @example 8080
  */
@@ -13079,7 +13085,7 @@ export type NET_SOCK_PEER_PORT_TYPE = number;
  *
  * Aliases: {@link NETWORK_TRANSPORT} `network.transport`, {@link MCP_TRANSPORT} `mcp.transport`
  *
- * @deprecated Use {@link NETWORK_TRANSPORT} (network.transport) instead
+ * @deprecated Use {@link NETWORK_TRANSPORT} (network.transport) instead - This attribute is being deprecated in favor of network.transport. The values change from ip_tcp and ip_udp to tcp and udp, so the old value cannot be copied over.
  * @example "tcp"
  */
 export const NET_TRANSPORT = 'net.transport';
@@ -16246,7 +16252,7 @@ export type SENTRY_USER_USERNAME_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link ADDRESS} `address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`
+ * Aliases: {@link ADDRESS} `address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`, {@link NET_PEER_NAME} `net.peer.name`
  *
  * @example "example.com"
  */
@@ -16269,7 +16275,7 @@ export type SERVER_ADDRESS_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`
+ * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link NET_PEER_NAME} `net.peer.name`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead - This attribute is being deprecated in favor of server.address, which is the OTel-aligned replacement.
  * @example "example.com"
@@ -20093,8 +20099,11 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'Old namespace-less attribute, to be replaced with server.address for span-first future',
       status: 'backfill',
     },
-    aliases: ['server.address', 'http.server_name', 'net.host.name', 'http.host', 'server_name'],
-    changelog: [{ version: '0.19.0', prs: [534], description: 'Added address attribute' }],
+    aliases: ['server.address', 'http.server_name', 'net.host.name', 'http.host', 'server_name', 'net.peer.name'],
+    changelog: [
+      { version: 'next', description: 'Added net.peer.name as an alias' },
+      { version: '0.19.0', prs: [534], description: 'Added address attribute' },
+    ],
   },
   'ai.citations': {
     brief: 'References or sources cited by the AI model in its response.',
@@ -26679,8 +26688,17 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'server.address',
       reason: 'Deprecated, use one of `server.address` or `client.address`, depending on the usage',
     },
-    aliases: ['address', 'server.address', 'client.address', 'http.server_name', 'net.host.name', 'server_name'],
+    aliases: [
+      'address',
+      'server.address',
+      'client.address',
+      'http.server_name',
+      'net.host.name',
+      'server_name',
+      'net.peer.name',
+    ],
     changelog: [
+      { version: 'next', description: 'Added net.peer.name as an alias' },
       { version: '0.19.0', prs: [534], description: 'Added address as an alias' },
       { version: '0.1.0', prs: [61, 108, 127] },
       { version: '0.0.0' },
@@ -27294,8 +27312,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'server.address',
       status: 'backfill',
     },
-    aliases: ['address', 'server.address', 'net.host.name', 'http.host', 'server_name'],
+    aliases: ['address', 'server.address', 'net.host.name', 'http.host', 'server_name', 'net.peer.name'],
     changelog: [
+      { version: 'next', description: 'Added net.peer.name as an alias' },
       { version: '0.19.0', prs: [534], description: 'Added address as an alias' },
       { version: '0.1.0', prs: [61, 108, 127] },
       { version: '0.0.0' },
@@ -28305,7 +28324,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'mcp.transport': {
     brief: 'Transport method used for MCP communication.',
     type: 'string',
-    keys: ['network.transport', 'mcp.transport', 'net.transport'],
+    keys: ['network.transport', 'mcp.transport'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -29027,7 +29046,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 65400,
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.0.0' }],
+    aliases: ['net.sock.peer.port'],
+    changelog: [
+      { version: 'next', description: 'Added net.sock.peer.port as an alias' },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.0.0' },
+    ],
   },
   'network.protocol.name': {
     brief: 'OSI application layer or non-OSI equivalent.',
@@ -29066,7 +29090,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'network.transport': {
     brief: 'OSI transport layer or inter-process communication method.',
     type: 'string',
-    keys: ['network.transport', 'mcp.transport', 'net.transport'],
+    keys: ['network.transport', 'mcp.transport'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -29120,8 +29144,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'server.address',
       status: 'backfill',
     },
-    aliases: ['address', 'server.address', 'http.server_name', 'http.host', 'server_name'],
+    aliases: ['address', 'server.address', 'http.server_name', 'http.host', 'server_name', 'net.peer.name'],
     changelog: [
+      { version: 'next', description: 'Added net.peer.name as an alias' },
       { version: '0.19.0', prs: [534], description: 'Added address as an alias' },
       { version: '0.1.0', prs: [61, 108, 127] },
       { version: '0.0.0' },
@@ -29181,7 +29206,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'server.address',
       reason: 'Deprecated, use server.address on client spans and client.address on server spans.',
     },
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    aliases: ['address', 'server.address', 'http.server_name', 'net.host.name', 'http.host', 'server_name'],
+    changelog: [
+      { version: 'next', description: 'Added the server.address alias group to net.peer.name' },
+      { version: '0.1.0', prs: [61, 127] },
+      { version: '0.0.0' },
+    ],
   },
   'net.peer.port': {
     brief: 'Peer port number.',
@@ -29337,12 +29367,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'network.peer.port',
       status: 'backfill',
     },
-    changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    aliases: ['network.peer.port'],
+    changelog: [
+      { version: 'next', description: 'Added network.peer.port as an alias' },
+      { version: '0.4.0', prs: [228] },
+      { version: '0.1.0', prs: [61] },
+      { version: '0.0.0' },
+    ],
   },
   'net.transport': {
     brief: 'OSI transport layer or inter-process communication method.',
     type: 'string',
-    keys: ['network.transport', 'mcp.transport', 'net.transport'],
+    keys: ['net.transport'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -29351,10 +29387,18 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'tcp',
     deprecation: {
       replacement: 'network.transport',
-      status: 'backfill',
+      reason:
+        'This attribute is being deprecated in favor of network.transport. The values change from ip_tcp and ip_udp to tcp and udp, so the old value cannot be copied over.',
     },
     aliases: ['network.transport', 'mcp.transport'],
-    changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
+    changelog: [
+      {
+        version: 'next',
+        description: 'Set net.transport to _status null, because its values change on the replacement',
+      },
+      { version: '0.1.0', prs: [61, 127] },
+      { version: '0.0.0' },
+    ],
   },
   'os.build': {
     brief: 'The build ID of the operating system.',
@@ -31545,8 +31589,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: true,
     visibility: 'public',
     example: 'example.com',
-    aliases: ['address', 'http.server_name', 'net.host.name', 'http.host', 'server_name'],
+    aliases: ['address', 'http.server_name', 'net.host.name', 'http.host', 'server_name', 'net.peer.name'],
     changelog: [
+      { version: 'next', description: 'Added net.peer.name as an alias' },
       { version: '0.19.0', prs: [534], description: 'Added address as an alias' },
       { version: '0.1.0', prs: [108, 127] },
       { version: '0.0.0' },
@@ -31568,8 +31613,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'This attribute is being deprecated in favor of server.address, which is the OTel-aligned replacement.',
       status: 'backfill',
     },
-    aliases: ['address', 'server.address', 'http.server_name', 'net.host.name', 'http.host'],
+    aliases: ['address', 'server.address', 'http.server_name', 'net.host.name', 'http.host', 'net.peer.name'],
     changelog: [
+      { version: 'next', description: 'Added net.peer.name as an alias' },
       { version: '0.19.0', prs: [534], description: 'Added address as an alias' },
       {
         version: '0.16.0',
@@ -36248,7 +36294,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'network.transport',
     type: 'string',
     brief: 'Transport method used for MCP communication.',
-    deprecationChain: ['network.transport', 'mcp.transport', 'net.transport'],
+    deprecationChain: ['network.transport', 'mcp.transport'],
   },
   'mdc.<key>': {
     canonicalName: 'mdc.<key>',
@@ -36606,7 +36652,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'network.transport',
     type: 'string',
     brief: 'OSI transport layer or inter-process communication method.',
-    deprecationChain: ['network.transport', 'mcp.transport', 'net.transport'],
+    deprecationChain: ['net.transport'],
   },
   'network.connection.effective_type': {
     canonicalName: 'network.connection.effective_type',
@@ -36666,7 +36712,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'network.transport',
     type: 'string',
     brief: 'OSI transport layer or inter-process communication method.',
-    deprecationChain: ['network.transport', 'mcp.transport', 'net.transport'],
+    deprecationChain: ['network.transport', 'mcp.transport'],
   },
   'network.type': {
     canonicalName: 'network.type',

--- a/model/attributes/address.json
+++ b/model/attributes/address.json
@@ -6,15 +6,19 @@
     "key": "manual"
   },
   "is_in_otel": false,
-  "visibility": "public",
   "examples": ["example.com"],
-  "alias": ["server.address", "http.server_name", "net.host.name", "http.host", "server_name"],
+  "alias": ["server.address", "http.server_name", "net.host.name", "http.host", "server_name", "net.peer.name"],
   "deprecation": {
     "replacement": "server.address",
     "reason": "Old namespace-less attribute, to be replaced with server.address for span-first future",
     "_status": "backfill"
   },
+  "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added net.peer.name as an alias"
+    },
     {
       "version": "0.19.0",
       "prs": [534],

--- a/model/attributes/http/http__host.json
+++ b/model/attributes/http/http__host.json
@@ -7,7 +7,15 @@
   },
   "is_in_otel": true,
   "example": "example.com",
-  "alias": ["address", "server.address", "client.address", "http.server_name", "net.host.name", "server_name"],
+  "alias": [
+    "address",
+    "server.address",
+    "client.address",
+    "http.server_name",
+    "net.host.name",
+    "server_name",
+    "net.peer.name"
+  ],
   "deprecation": {
     "_status": null,
     "replacement": "server.address",
@@ -15,6 +23,10 @@
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added net.peer.name as an alias"
+    },
     {
       "version": "0.19.0",
       "prs": [534],

--- a/model/attributes/http/http__server_name.json
+++ b/model/attributes/http/http__server_name.json
@@ -7,13 +7,17 @@
   },
   "is_in_otel": true,
   "example": "example.com",
-  "alias": ["address", "server.address", "net.host.name", "http.host", "server_name"],
+  "alias": ["address", "server.address", "net.host.name", "http.host", "server_name", "net.peer.name"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "server.address"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added net.peer.name as an alias"
+    },
     {
       "version": "0.19.0",
       "prs": [534],

--- a/model/attributes/net/net__host__name.json
+++ b/model/attributes/net/net__host__name.json
@@ -7,13 +7,17 @@
   },
   "is_in_otel": true,
   "example": "example.com",
-  "alias": ["address", "server.address", "http.server_name", "http.host", "server_name"],
+  "alias": ["address", "server.address", "http.server_name", "http.host", "server_name", "net.peer.name"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "server.address"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added net.peer.name as an alias"
+    },
     {
       "version": "0.19.0",
       "prs": [534],

--- a/model/attributes/net/net__peer__name.json
+++ b/model/attributes/net/net__peer__name.json
@@ -7,6 +7,7 @@
   },
   "is_in_otel": true,
   "example": "example.com",
+  "alias": ["address", "server.address", "http.server_name", "net.host.name", "http.host", "server_name"],
   "deprecation": {
     "_status": null,
     "replacement": "server.address",
@@ -14,6 +15,10 @@
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added the server.address alias group to net.peer.name"
+    },
     {
       "version": "0.1.0",
       "prs": [61, 127]

--- a/model/attributes/net/net__sock__peer__port.json
+++ b/model/attributes/net/net__sock__peer__port.json
@@ -7,12 +7,17 @@
   },
   "is_in_otel": true,
   "example": 8080,
+  "alias": ["network.peer.port"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "network.peer.port"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added network.peer.port as an alias"
+    },
     {
       "version": "0.4.0",
       "prs": [228]

--- a/model/attributes/net/net__transport.json
+++ b/model/attributes/net/net__transport.json
@@ -9,11 +9,16 @@
   "example": "tcp",
   "alias": ["network.transport", "mcp.transport"],
   "deprecation": {
-    "_status": "backfill",
-    "replacement": "network.transport"
+    "_status": null,
+    "replacement": "network.transport",
+    "reason": "This attribute is being deprecated in favor of network.transport. The values change from ip_tcp and ip_udp to tcp and udp, so the old value cannot be copied over."
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Set net.transport to _status null, because its values change on the replacement"
+    },
     {
       "version": "0.1.0",
       "prs": [61, 127]

--- a/model/attributes/network/network__peer__port.json
+++ b/model/attributes/network/network__peer__port.json
@@ -7,8 +7,13 @@
   },
   "is_in_otel": true,
   "example": 65400,
+  "alias": ["net.sock.peer.port"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added net.sock.peer.port as an alias"
+    },
     {
       "version": "0.4.0",
       "prs": [228]

--- a/model/attributes/server/server__address.json
+++ b/model/attributes/server/server__address.json
@@ -7,9 +7,13 @@
   },
   "is_in_otel": true,
   "example": "example.com",
-  "alias": ["address", "http.server_name", "net.host.name", "http.host", "server_name"],
+  "alias": ["address", "http.server_name", "net.host.name", "http.host", "server_name", "net.peer.name"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added net.peer.name as an alias"
+    },
     {
       "version": "0.19.0",
       "prs": [534],

--- a/model/attributes/server_name.json
+++ b/model/attributes/server_name.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": false,
   "example": "example.com",
-  "alias": ["address", "server.address", "http.server_name", "net.host.name", "http.host"],
+  "alias": ["address", "server.address", "http.server_name", "net.host.name", "http.host", "net.peer.name"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "server.address",
@@ -15,6 +15,10 @@
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "description": "Added net.peer.name as an alias"
+    },
     {
       "version": "0.19.0",
       "prs": [534],

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -420,7 +420,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: server.address, http.server_name, net.host.name, http.host, server_name
+    Aliases: server.address, http.server_name, net.host.name, http.host, server_name, net.peer.name
     DEPRECATED: Use server.address instead - Old namespace-less attribute, to be replaced with server.address for span-first future
     Example: "example.com"
     """
@@ -5683,7 +5683,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: address, server.address, client.address, http.server_name, net.host.name, server_name
+    Aliases: address, server.address, client.address, http.server_name, net.host.name, server_name, net.peer.name
     DEPRECATED: Use server.address instead - Deprecated, use one of `server.address` or `client.address`, depending on the usage
     Example: "example.com"
     """
@@ -6203,7 +6203,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: address, server.address, net.host.name, http.host, server_name
+    Aliases: address, server.address, net.host.name, http.host, server_name, net.peer.name
     DEPRECATED: Use server.address instead
     Example: "example.com"
     """
@@ -7475,7 +7475,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: address, server.address, http.server_name, http.host, server_name
+    Aliases: address, server.address, http.server_name, http.host, server_name, net.peer.name
     DEPRECATED: Use server.address instead
     Example: "example.com"
     """
@@ -7514,6 +7514,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: address, server.address, http.server_name, net.host.name, http.host, server_name
     DEPRECATED: Use server.address instead - Deprecated, use server.address on client spans and client.address on server spans.
     Example: "example.com"
     """
@@ -7627,6 +7628,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: network.peer.port
     DEPRECATED: Use network.peer.port instead
     Example: 8080
     """
@@ -7640,7 +7642,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: Yes
     Visibility: public
     Aliases: network.transport, mcp.transport
-    DEPRECATED: Use network.transport instead
+    DEPRECATED: Use network.transport instead - This attribute is being deprecated in favor of network.transport. The values change from ip_tcp and ip_udp to tcp and udp, so the old value cannot be copied over.
     Example: "tcp"
     """
 
@@ -7729,6 +7731,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
+    Aliases: net.sock.peer.port
     Example: 65400
     """
 
@@ -9518,7 +9521,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: address, http.server_name, net.host.name, http.host, server_name
+    Aliases: address, http.server_name, net.host.name, http.host, server_name, net.peer.name
     Example: "example.com"
     """
 
@@ -9542,7 +9545,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: address, server.address, http.server_name, net.host.name, http.host
+    Aliases: address, server.address, http.server_name, net.host.name, http.host, net.peer.name
     DEPRECATED: Use server.address instead - This attribute is being deprecated in favor of server.address, which is the OTel-aligned replacement.
     Example: "example.com"
     """
@@ -10654,8 +10657,12 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "net.host.name",
             "http.host",
             "server_name",
+            "net.peer.name",
         ],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added net.peer.name as an alias"
+            ),
             ChangelogEntry(
                 version="0.19.0", prs=[534], description="Added address attribute"
             ),
@@ -18487,8 +18494,12 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "http.server_name",
             "net.host.name",
             "server_name",
+            "net.peer.name",
         ],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added net.peer.name as an alias"
+            ),
             ChangelogEntry(
                 version="0.19.0", prs=[534], description="Added address as an alias"
             ),
@@ -19203,8 +19214,12 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "net.host.name",
             "http.host",
             "server_name",
+            "net.peer.name",
         ],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added net.peer.name as an alias"
+            ),
             ChangelogEntry(
                 version="0.19.0", prs=[534], description="Added address as an alias"
             ),
@@ -20308,7 +20323,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "network.transport",
             "mcp.transport",
-            "net.transport",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
@@ -21080,8 +21094,12 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "http.server_name",
             "http.host",
             "server_name",
+            "net.peer.name",
         ],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added net.peer.name as an alias"
+            ),
             ChangelogEntry(
                 version="0.19.0", prs=[534], description="Added address as an alias"
             ),
@@ -21147,7 +21165,19 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             replacement="server.address",
             reason="Deprecated, use server.address on client spans and client.address on server spans.",
         ),
+        aliases=[
+            "address",
+            "server.address",
+            "http.server_name",
+            "net.host.name",
+            "http.host",
+            "server_name",
+        ],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Added the server.address alias group to net.peer.name",
+            ),
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -21339,7 +21369,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="network.peer.port", status=DeprecationStatus.BACKFILL
         ),
+        aliases=["network.peer.port"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added network.peer.port as an alias"
+            ),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.1.0", prs=[61]),
             ChangelogEntry(version="0.0.0"),
@@ -21348,20 +21382,21 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "net.transport": AttributeMetadata(
         brief="OSI transport layer or inter-process communication method.",
         type=AttributeType.STRING,
-        keys=(
-            "network.transport",
-            "mcp.transport",
-            "net.transport",
-        ),
+        keys=("net.transport",),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="tcp",
         deprecation=DeprecationInfo(
-            replacement="network.transport", status=DeprecationStatus.BACKFILL
+            replacement="network.transport",
+            reason="This attribute is being deprecated in favor of network.transport. The values change from ip_tcp and ip_udp to tcp and udp, so the old value cannot be copied over.",
         ),
         aliases=["network.transport", "mcp.transport"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                description="Set net.transport to _status null, because its values change on the replacement",
+            ),
             ChangelogEntry(version="0.1.0", prs=[61, 127]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -21492,7 +21527,11 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example=65400,
+        aliases=["net.sock.peer.port"],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added net.sock.peer.port as an alias"
+            ),
             ChangelogEntry(version="0.4.0", prs=[228]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -21548,7 +21587,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         keys=(
             "network.transport",
             "mcp.transport",
-            "net.transport",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
@@ -24021,8 +24059,12 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "net.host.name",
             "http.host",
             "server_name",
+            "net.peer.name",
         ],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added net.peer.name as an alias"
+            ),
             ChangelogEntry(
                 version="0.19.0", prs=[534], description="Added address as an alias"
             ),
@@ -24076,8 +24118,12 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "http.server_name",
             "net.host.name",
             "http.host",
+            "net.peer.name",
         ],
         changelog=[
+            ChangelogEntry(
+                version="next", description="Added net.peer.name as an alias"
+            ),
             ChangelogEntry(
                 version="0.19.0", prs=[534], description="Added address as an alias"
             ),


### PR DESCRIPTION
Following were missing:

- `net.peer.name` replaces onto `server.address` but was not part of that alias group. It now joins it, like `http.host`, which is ambiguous between server and client in the same way.
- `net.sock.peer.port` replaces onto `network.peer.port` and neither named the other. The equivalent host pair, `net.sock.host.port` and `network.local.port`, already does.
- `net.transport` changes its values from `ip_tcp` and `ip_udp` to `tcp` and `udp`, so it needs a transformation rather than a plain rename. Adds `net_transport_to_network_transport`.

`net.host.port` and `net.peer.port` are left untouched. Both correctly replace onto `server.port`, while `network.local.port` and `network.peer.port` descend from the `net.sock.*` attributes, per the OpenTelemetry split.

Replaced by https://github.com/getsentry/sentry-javascript/pull/23301