### PR TITLE
fix(names): Add `gen_ai.function_id` and `gen_ai.pipeline.name` to agent span name templates

### DIFF
--- a/model/name/gen_ai.json
+++ b/model/name/gen_ai.json
@@ -9,10 +9,18 @@
       "ops": ["gen_ai.create_agent", "gen_ai.handoff", "gen_ai.invoke_agent"],
       "templates": [
         "{{gen_ai.operation.name}} {{gen_ai.agent.name}}",
+        "{{gen_ai.operation.name}} {{gen_ai.pipeline.name}}",
+        "{{gen_ai.operation.name}} {{gen_ai.function_id}}",
         "{{gen_ai.operation.name}}",
         "Generative AI agent operation"
       ],
-      "examples": ["text_completion Zed", "text_completion Claude Code", "embeddings"]
+      "examples": [
+        "text_completion Zed",
+        "text_completion Claude Code",
+        "invoke_agent format_prompt",
+        "invoke_agent weather_agent",
+        "embeddings"
+      ]
     },
     {
       "name": "Inference",


### PR DESCRIPTION
The agent category currently only offers `{{gen_ai.operation.name}} {{gen_ai.agent.name}}` before falling through to the bare operation, so agent span names the SDKs already emit have no template backing them:

- `invoke_agent weather_agent` — Vercel AI, value on `gen_ai.function_id`
- `invoke_agent format_prompt` — LangChain, value on `gen_ai.pipeline.name` (after the `getsentry/sentry-javascript` follow-up; JS currently uses `langchain.chain.name`)
- `invoke_agent {run_name}` — `sentry-python` already emits this for LangChain agent executors, with `run_name` on `gen_ai.function_id`

Both attributes are already registered and both carry bounded, low-cardinality values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)