### PR TITLE
feat(attributes): Add browser.navigation.type, move navigation.* to router.navigation.*

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3240,6 +3240,31 @@ export const BROWSER_NAME = 'browser.name';
  */
 export type BROWSER_NAME_TYPE = string;
 
+// Path: model/attributes/browser/browser__navigation__type.json
+
+/**
+ * The type of navigation the browser performed to arrive at the page the metrics were measured on. `browser.navigation.type`
+ *
+ * Attribute Value Type: `string` {@link BROWSER_NAVIGATION_TYPE_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "navigate"
+ * @example "reload"
+ * @example "prerender"
+ * @example "bfcache"
+ * @example "soft-navigation"
+ */
+export const BROWSER_NAVIGATION_TYPE = 'browser.navigation.type';
+
+/**
+ * Type for {@link BROWSER_NAVIGATION_TYPE} browser.navigation.type
+ */
+export type BROWSER_NAVIGATION_TYPE_TYPE = string;
+
 // Path: model/attributes/browser/browser__paint__type.json
 
 /**
@@ -12380,8 +12405,9 @@ export type MIDDLEWARE_NAME_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link SENTRY_SVELTEKIT_NAVIGATION_FROM} `sentry.sveltekit.navigation.from`
+ * Aliases: {@link ROUTER_NAVIGATION_ORIGIN} `router.navigation.origin`, {@link SENTRY_SVELTEKIT_NAVIGATION_FROM} `sentry.sveltekit.navigation.from`
  *
+ * @deprecated Use {@link ROUTER_NAVIGATION_ORIGIN} (router.navigation.origin) instead - Moved to the router.* namespace to separate client-side router navigations from browser navigations.
  * @example "/users/:id"
  */
 export const NAVIGATION_ORIGIN = 'navigation.origin';
@@ -12403,6 +12429,9 @@ export type NAVIGATION_ORIGIN_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link ROUTER_NAVIGATION_ROUTE_ID} `router.navigation.route.id`
+ *
+ * @deprecated Use {@link ROUTER_NAVIGATION_ROUTE_ID} (router.navigation.route.id) instead - Moved to the router.* namespace to separate client-side router navigations from browser navigations.
  * @example "AboutView"
  */
 export const NAVIGATION_ROUTE_ID = 'navigation.route.id';
@@ -12424,8 +12453,9 @@ export type NAVIGATION_ROUTE_ID_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link SENTRY_SVELTEKIT_NAVIGATION_TYPE} `sentry.sveltekit.navigation.type`
+ * Aliases: {@link ROUTER_NAVIGATION_TYPE} `router.navigation.type`, {@link SENTRY_SVELTEKIT_NAVIGATION_TYPE} `sentry.sveltekit.navigation.type`
  *
+ * @deprecated Use {@link ROUTER_NAVIGATION_TYPE} (router.navigation.type) instead - Moved to the router.* namespace to separate client-side router navigations from browser navigations.
  * @example "router.push"
  */
 export const NAVIGATION_TYPE = 'navigation.type';
@@ -14080,6 +14110,75 @@ export const ROUTE = 'route';
  * Type for {@link ROUTE} route
  */
 export type ROUTE_TYPE = string;
+
+// Path: model/attributes/router/router__navigation__origin.json
+
+/**
+ * The origin of the navigation (usually client side router navigations). Should preferably be a parameterized template (like url.template) or a URL path otherwise. `router.navigation.origin`
+ *
+ * Attribute Value Type: `string` {@link ROUTER_NAVIGATION_ORIGIN_TYPE}
+ *
+ * Apply Scrubbing: auto
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link NAVIGATION_ORIGIN} `navigation.origin`, {@link SENTRY_SVELTEKIT_NAVIGATION_FROM} `sentry.sveltekit.navigation.from`
+ *
+ * @example "/users/:id"
+ */
+export const ROUTER_NAVIGATION_ORIGIN = 'router.navigation.origin';
+
+/**
+ * Type for {@link ROUTER_NAVIGATION_ORIGIN} router.navigation.origin
+ */
+export type ROUTER_NAVIGATION_ORIGIN_TYPE = string;
+
+// Path: model/attributes/router/router__navigation__route__id.json
+
+/**
+ * The identifier of the matched client-side route, as assigned by the routing framework (e.g., vue-router name, react-router id). `router.navigation.route.id`
+ *
+ * Attribute Value Type: `string` {@link ROUTER_NAVIGATION_ROUTE_ID_TYPE}
+ *
+ * Apply Scrubbing: auto
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link NAVIGATION_ROUTE_ID} `navigation.route.id`
+ *
+ * @example "AboutView"
+ */
+export const ROUTER_NAVIGATION_ROUTE_ID = 'router.navigation.route.id';
+
+/**
+ * Type for {@link ROUTER_NAVIGATION_ROUTE_ID} router.navigation.route.id
+ */
+export type ROUTER_NAVIGATION_ROUTE_ID_TYPE = string;
+
+// Path: model/attributes/router/router__navigation__type.json
+
+/**
+ * The type of navigation done by a client-side router. `router.navigation.type`
+ *
+ * Attribute Value Type: `string` {@link ROUTER_NAVIGATION_TYPE_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link NAVIGATION_TYPE} `navigation.type`, {@link SENTRY_SVELTEKIT_NAVIGATION_TYPE} `sentry.sveltekit.navigation.type`
+ *
+ * @example "router.push"
+ */
+export const ROUTER_NAVIGATION_TYPE = 'router.navigation.type';
+
+/**
+ * Type for {@link ROUTER_NAVIGATION_TYPE} router.navigation.type
+ */
+export type ROUTER_NAVIGATION_TYPE_TYPE = string;
 
 // Path: model/attributes/rpc/rpc__grpc__status_code.json
 
@@ -15918,9 +16017,9 @@ export type SENTRY_STATUS_MESSAGE_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link NAVIGATION_ORIGIN} `navigation.origin`
+ * Aliases: {@link NAVIGATION_ORIGIN} `navigation.origin`, {@link ROUTER_NAVIGATION_ORIGIN} `router.navigation.origin`
  *
- * @deprecated Use {@link NAVIGATION_ORIGIN} (navigation.origin) instead - Use the more generic attribute instead
+ * @deprecated Use {@link ROUTER_NAVIGATION_ORIGIN} (router.navigation.origin) instead - Use the more generic attribute instead
  * @example "/home"
  */
 export const SENTRY_SVELTEKIT_NAVIGATION_FROM = 'sentry.sveltekit.navigation.from';
@@ -15964,9 +16063,9 @@ export type SENTRY_SVELTEKIT_NAVIGATION_TO_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link NAVIGATION_TYPE} `navigation.type`
+ * Aliases: {@link NAVIGATION_TYPE} `navigation.type`, {@link ROUTER_NAVIGATION_TYPE} `router.navigation.type`
  *
- * @deprecated Use {@link NAVIGATION_TYPE} (navigation.type) instead - Use the more generic attribute instead
+ * @deprecated Use {@link ROUTER_NAVIGATION_TYPE} (router.navigation.type) instead - Use the more generic attribute instead
  * @example "link"
  */
 export const SENTRY_SVELTEKIT_NAVIGATION_TYPE = 'sentry.sveltekit.navigation.type';
@@ -18629,6 +18728,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'browser.bfcache.outcome': 'string',
   'browser.bfcache.reason': 'string',
   'browser.name': 'string',
+  'browser.navigation.type': 'string',
   'browser.paint.type': 'string',
   'browser.performance.navigation.activation_start': 'double',
   'browser.performance.time_origin': 'double',
@@ -19114,6 +19214,9 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'resource.deployment.environment.name': 'string',
   'resource.render_blocking_status': 'string',
   route: 'string',
+  'router.navigation.origin': 'string',
+  'router.navigation.route.id': 'string',
+  'router.navigation.type': 'string',
   'rpc.grpc.status_code': 'integer',
   'rpc.method': 'string',
   'rpc.response.status_code': 'string',
@@ -19456,6 +19559,7 @@ export type AttributeName =
   | typeof BROWSER_BFCACHE_OUTCOME
   | typeof BROWSER_BFCACHE_REASON
   | typeof BROWSER_NAME
+  | typeof BROWSER_NAVIGATION_TYPE
   | typeof BROWSER_PAINT_TYPE
   | typeof BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START
   | typeof BROWSER_PERFORMANCE_TIME_ORIGIN
@@ -19941,6 +20045,9 @@ export type AttributeName =
   | typeof RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME
   | typeof RESOURCE_RENDER_BLOCKING_STATUS
   | typeof ROUTE
+  | typeof ROUTER_NAVIGATION_ORIGIN
+  | typeof ROUTER_NAVIGATION_ROUTE_ID
+  | typeof ROUTER_NAVIGATION_TYPE
   | typeof RPC_GRPC_STATUS_CODE
   | typeof RPC_METHOD
   | typeof RPC_RESPONSE_STATUS_CODE
@@ -22465,6 +22572,25 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'Chrome',
     aliases: ['sentry.browser.name'],
     changelog: [{ version: '0.1.0', prs: [127, 139] }, { version: '0.0.0' }],
+  },
+  'browser.navigation.type': {
+    brief: 'The type of navigation the browser performed to arrive at the page the metrics were measured on.',
+    type: 'string',
+    keys: ['browser.navigation.type'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'navigate',
+    examples: ['navigate', 'reload', 'prerender', 'bfcache', 'soft-navigation'],
+    changelog: [{ version: 'next', prs: [600], description: 'Added browser.navigation.type attribute' }],
+    additionalContext: [
+      'Mirrors the `navigationType` field reported by the web-vitals library, which combines the Navigation Timing `PerformanceNavigationTiming.type` value with states that API does not cover: back/forward cache restores, prerendering, and soft navigations.',
+      '`bfcache` is only set when the page was actually restored from the back/forward cache. A back/forward navigation that missed the cache reports `navigate`. Use the `browser.bfcache.*` attributes to diagnose misses.',
+      '`prerender` pages finish painting before activation, so their paint timings are offset by `browser.performance.navigation.activation_start`. Keep them separate when aggregating web vitals.',
+      "Not to be confused with `router.navigation.type`, which holds the client-side router's own vocabulary (`link`, `goto`, `router.push`). The two are independent and can both be set on the same span.",
+    ],
   },
   'browser.paint.type': {
     brief: 'The type of paint timing entry reported by the browser.',
@@ -28924,41 +29050,64 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'The origin of the navigation (usually client side router navigations). Should preferrably parameterized template (like url.template) or a URL path otherwise.',
     type: 'string',
-    keys: ['navigation.origin', 'sentry.sveltekit.navigation.from'],
+    keys: ['router.navigation.origin', 'navigation.origin', 'sentry.sveltekit.navigation.from'],
     applyScrubbing: {
       key: 'auto',
     },
     isInOtel: false,
     visibility: 'public',
     example: '/users/:id',
-    aliases: ['sentry.sveltekit.navigation.from'],
-    changelog: [{ version: '0.16.0', prs: [467], description: 'Added navigation.origin attribute' }],
+    deprecation: {
+      replacement: 'router.navigation.origin',
+      reason: 'Moved to the router.* namespace to separate client-side router navigations from browser navigations.',
+      status: 'backfill',
+    },
+    aliases: ['router.navigation.origin', 'sentry.sveltekit.navigation.from'],
+    changelog: [
+      { version: 'next', prs: [600], description: 'Deprecated in favor of router.navigation.origin' },
+      { version: '0.16.0', prs: [467], description: 'Added navigation.origin attribute' },
+    ],
   },
   'navigation.route.id': {
     brief:
       'The identifier of the matched client-side route, as assigned by the routing framework (e.g., vue-router name, react-router id).',
     type: 'string',
-    keys: ['navigation.route.id'],
+    keys: ['router.navigation.route.id', 'navigation.route.id'],
     applyScrubbing: {
       key: 'auto',
     },
     isInOtel: false,
     visibility: 'public',
     example: 'AboutView',
-    changelog: [{ version: '0.16.0', prs: [468], description: 'Added navigation.route.id attribute' }],
+    deprecation: {
+      replacement: 'router.navigation.route.id',
+      reason: 'Moved to the router.* namespace to separate client-side router navigations from browser navigations.',
+      status: 'backfill',
+    },
+    aliases: ['router.navigation.route.id'],
+    changelog: [
+      { version: 'next', prs: [600], description: 'Deprecated in favor of router.navigation.route.id' },
+      { version: '0.16.0', prs: [468], description: 'Added navigation.route.id attribute' },
+    ],
   },
   'navigation.type': {
     brief: 'The type of navigation done by a client-side router.',
     type: 'string',
-    keys: ['navigation.type', 'sentry.sveltekit.navigation.type'],
+    keys: ['router.navigation.type', 'navigation.type', 'sentry.sveltekit.navigation.type'],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: false,
     visibility: 'public',
     example: 'router.push',
-    aliases: ['sentry.sveltekit.navigation.type'],
+    deprecation: {
+      replacement: 'router.navigation.type',
+      reason: 'Moved to the router.* namespace to separate client-side router navigations from browser navigations.',
+      status: 'backfill',
+    },
+    aliases: ['router.navigation.type', 'sentry.sveltekit.navigation.type'],
     changelog: [
+      { version: 'next', prs: [600], description: 'Deprecated in favor of router.navigation.type' },
       { version: '0.16.0', prs: [467], description: 'Added new deprecated alias' },
       { version: '0.1.0', prs: [127] },
       { version: '0.0.0' },
@@ -30115,6 +30264,61 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     aliases: ['http.route'],
     changelog: [{ version: '0.1.0', prs: [61, 74] }, { version: '0.0.0' }],
+  },
+  'router.navigation.origin': {
+    brief:
+      'The origin of the navigation (usually client side router navigations). Should preferably be a parameterized template (like url.template) or a URL path otherwise.',
+    type: 'string',
+    keys: ['router.navigation.origin', 'navigation.origin', 'sentry.sveltekit.navigation.from'],
+    applyScrubbing: {
+      key: 'auto',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '/users/:id',
+    aliases: ['navigation.origin', 'sentry.sveltekit.navigation.from'],
+    changelog: [
+      {
+        version: 'next',
+        prs: [600],
+        description: 'Added router.navigation.origin attribute, replacing navigation.origin',
+      },
+    ],
+  },
+  'router.navigation.route.id': {
+    brief:
+      'The identifier of the matched client-side route, as assigned by the routing framework (e.g., vue-router name, react-router id).',
+    type: 'string',
+    keys: ['router.navigation.route.id', 'navigation.route.id'],
+    applyScrubbing: {
+      key: 'auto',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'AboutView',
+    aliases: ['navigation.route.id'],
+    changelog: [
+      {
+        version: 'next',
+        prs: [600],
+        description: 'Added router.navigation.route.id attribute, replacing navigation.route.id',
+      },
+    ],
+  },
+  'router.navigation.type': {
+    brief: 'The type of navigation done by a client-side router.',
+    type: 'string',
+    keys: ['router.navigation.type', 'navigation.type', 'sentry.sveltekit.navigation.type'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'router.push',
+    aliases: ['navigation.type', 'sentry.sveltekit.navigation.type'],
+    changelog: [
+      { version: 'next', prs: [600], description: 'Added router.navigation.type attribute, replacing navigation.type' },
+    ],
   },
   'rpc.grpc.status_code': {
     brief: 'The numeric status code of the gRPC request.',
@@ -31369,7 +31573,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'sentry.sveltekit.navigation.from': {
     brief: 'the navigation origin (sveltekit router)',
     type: 'string',
-    keys: ['navigation.origin', 'sentry.sveltekit.navigation.from'],
+    keys: ['router.navigation.origin', 'navigation.origin', 'sentry.sveltekit.navigation.from'],
     applyScrubbing: {
       key: 'auto',
     },
@@ -31377,12 +31581,19 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: '/home',
     deprecation: {
-      replacement: 'navigation.origin',
+      replacement: 'router.navigation.origin',
       reason: 'Use the more generic attribute instead',
       status: 'backfill',
     },
-    aliases: ['navigation.origin'],
-    changelog: [{ version: '0.16.0', prs: [467], description: 'Added sentry.sveltekit.navigation.from attribute' }],
+    aliases: ['navigation.origin', 'router.navigation.origin'],
+    changelog: [
+      {
+        version: 'next',
+        prs: [600],
+        description: 'Re-pointed deprecation from navigation.origin to router.navigation.origin',
+      },
+      { version: '0.16.0', prs: [467], description: 'Added sentry.sveltekit.navigation.from attribute' },
+    ],
   },
   'sentry.sveltekit.navigation.to': {
     brief: 'the navigation destination',
@@ -31402,7 +31613,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'sentry.sveltekit.navigation.type': {
     brief: 'The type of navigation event emitted from the sveltekit client router',
     type: 'string',
-    keys: ['navigation.type', 'sentry.sveltekit.navigation.type'],
+    keys: ['router.navigation.type', 'navigation.type', 'sentry.sveltekit.navigation.type'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -31410,12 +31621,19 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'link',
     deprecation: {
-      replacement: 'navigation.type',
+      replacement: 'router.navigation.type',
       reason: 'Use the more generic attribute instead',
       status: 'backfill',
     },
-    aliases: ['navigation.type'],
-    changelog: [{ version: '0.16.0', prs: [467], description: 'Added sentry.sveltekit.navigation.type attribute' }],
+    aliases: ['navigation.type', 'router.navigation.type'],
+    changelog: [
+      {
+        version: 'next',
+        prs: [600],
+        description: 'Re-pointed deprecation from navigation.type to router.navigation.type',
+      },
+      { version: '0.16.0', prs: [467], description: 'Added sentry.sveltekit.navigation.type attribute' },
+    ],
   },
   'sentry.thread.id': {
     brief: 'Current "managed" thread ID.',
@@ -33983,6 +34201,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief: 'The name of the browser.',
     deprecationChain: ['browser.name', 'sentry.browser.name'],
+  },
+  'browser.navigation.type': {
+    canonicalName: 'browser.navigation.type',
+    type: 'string',
+    brief: 'The type of navigation the browser performed to arrive at the page the metrics were measured on.',
+    deprecationChain: ['browser.navigation.type'],
   },
   'browser.paint.type': {
     canonicalName: 'browser.paint.type',
@@ -36620,24 +36844,24 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     deprecationChain: ['app.vitals.frames.total.count', 'frames.total', 'mobile.total_frames', 'sentry.frames.total'],
   },
   'navigation.origin': {
-    canonicalName: 'navigation.origin',
+    canonicalName: 'router.navigation.origin',
     type: 'string',
     brief:
       'The origin of the navigation (usually client side router navigations). Should preferrably parameterized template (like url.template) or a URL path otherwise.',
-    deprecationChain: ['navigation.origin', 'sentry.sveltekit.navigation.from'],
+    deprecationChain: ['router.navigation.origin', 'navigation.origin', 'sentry.sveltekit.navigation.from'],
   },
   'navigation.route.id': {
-    canonicalName: 'navigation.route.id',
+    canonicalName: 'router.navigation.route.id',
     type: 'string',
     brief:
       'The identifier of the matched client-side route, as assigned by the routing framework (e.g., vue-router name, react-router id).',
-    deprecationChain: ['navigation.route.id'],
+    deprecationChain: ['router.navigation.route.id', 'navigation.route.id'],
   },
   'navigation.type': {
-    canonicalName: 'navigation.type',
+    canonicalName: 'router.navigation.type',
     type: 'string',
     brief: 'The type of navigation done by a client-side router.',
-    deprecationChain: ['navigation.type', 'sentry.sveltekit.navigation.type'],
+    deprecationChain: ['router.navigation.type', 'navigation.type', 'sentry.sveltekit.navigation.type'],
   },
   'nel.elapsed_time': {
     canonicalName: 'nel.elapsed_time',
@@ -37123,6 +37347,26 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
       'The matched route, that is, the path template in the format used by the respective server framework. Also used by mobile SDKs to indicate the current route in the application.',
     deprecationChain: ['route'],
   },
+  'router.navigation.origin': {
+    canonicalName: 'router.navigation.origin',
+    type: 'string',
+    brief:
+      'The origin of the navigation (usually client side router navigations). Should preferably be a parameterized template (like url.template) or a URL path otherwise.',
+    deprecationChain: ['router.navigation.origin', 'navigation.origin', 'sentry.sveltekit.navigation.from'],
+  },
+  'router.navigation.route.id': {
+    canonicalName: 'router.navigation.route.id',
+    type: 'string',
+    brief:
+      'The identifier of the matched client-side route, as assigned by the routing framework (e.g., vue-router name, react-router id).',
+    deprecationChain: ['router.navigation.route.id', 'navigation.route.id'],
+  },
+  'router.navigation.type': {
+    canonicalName: 'router.navigation.type',
+    type: 'string',
+    brief: 'The type of navigation done by a client-side router.',
+    deprecationChain: ['router.navigation.type', 'navigation.type', 'sentry.sveltekit.navigation.type'],
+  },
   'rpc.grpc.status_code': {
     canonicalName: 'rpc.response.status_code',
     type: 'integer',
@@ -37530,10 +37774,10 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     deprecationChain: ['sentry.span.source'],
   },
   'sentry.sveltekit.navigation.from': {
-    canonicalName: 'navigation.origin',
+    canonicalName: 'router.navigation.origin',
     type: 'string',
     brief: 'the navigation origin (sveltekit router)',
-    deprecationChain: ['navigation.origin', 'sentry.sveltekit.navigation.from'],
+    deprecationChain: ['router.navigation.origin', 'navigation.origin', 'sentry.sveltekit.navigation.from'],
   },
   'sentry.sveltekit.navigation.to': {
     canonicalName: 'sentry.sveltekit.navigation.to',
@@ -37542,10 +37786,10 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     deprecationChain: ['sentry.sveltekit.navigation.to'],
   },
   'sentry.sveltekit.navigation.type': {
-    canonicalName: 'navigation.type',
+    canonicalName: 'router.navigation.type',
     type: 'string',
     brief: 'The type of navigation event emitted from the sveltekit client router',
-    deprecationChain: ['navigation.type', 'sentry.sveltekit.navigation.type'],
+    deprecationChain: ['router.navigation.type', 'navigation.type', 'sentry.sveltekit.navigation.type'],
   },
   'sentry.timestamp.sequence': {
     canonicalName: 'sentry.timestamp.sequence',
@@ -38404,6 +38648,7 @@ export type Attributes = {
   [BROWSER_BFCACHE_OUTCOME]?: BROWSER_BFCACHE_OUTCOME_TYPE;
   [BROWSER_BFCACHE_REASON]?: BROWSER_BFCACHE_REASON_TYPE;
   [BROWSER_NAME]?: BROWSER_NAME_TYPE;
+  [BROWSER_NAVIGATION_TYPE]?: BROWSER_NAVIGATION_TYPE_TYPE;
   [BROWSER_PAINT_TYPE]?: BROWSER_PAINT_TYPE_TYPE;
   [BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START]?: BROWSER_PERFORMANCE_NAVIGATION_ACTIVATION_START_TYPE;
   [BROWSER_PERFORMANCE_TIME_ORIGIN]?: BROWSER_PERFORMANCE_TIME_ORIGIN_TYPE;
@@ -38889,6 +39134,9 @@ export type Attributes = {
   [RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME]?: RESOURCE_DEPLOYMENT_ENVIRONMENT_NAME_TYPE;
   [RESOURCE_RENDER_BLOCKING_STATUS]?: RESOURCE_RENDER_BLOCKING_STATUS_TYPE;
   [ROUTE]?: ROUTE_TYPE;
+  [ROUTER_NAVIGATION_ORIGIN]?: ROUTER_NAVIGATION_ORIGIN_TYPE;
+  [ROUTER_NAVIGATION_ROUTE_ID]?: ROUTER_NAVIGATION_ROUTE_ID_TYPE;
+  [ROUTER_NAVIGATION_TYPE]?: ROUTER_NAVIGATION_TYPE_TYPE;
   [RPC_GRPC_STATUS_CODE]?: RPC_GRPC_STATUS_CODE_TYPE;
   [RPC_METHOD]?: RPC_METHOD_TYPE;
   [RPC_RESPONSE_STATUS_CODE]?: RPC_RESPONSE_STATUS_CODE_TYPE;

--- a/model/attributes/browser/browser__navigation__type.json
+++ b/model/attributes/browser/browser__navigation__type.json
@@ -1,0 +1,24 @@
+{
+  "key": "browser.navigation.type",
+  "brief": "The type of navigation the browser performed to arrive at the page the metrics were measured on.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["navigate", "reload", "prerender", "bfcache", "soft-navigation"],
+  "additional_context": [
+    "Mirrors the `navigationType` field reported by the web-vitals library, which combines the Navigation Timing `PerformanceNavigationTiming.type` value with states that API does not cover: back/forward cache restores, prerendering, and soft navigations.",
+    "`bfcache` is only set when the page was actually restored from the back/forward cache. A back/forward navigation that missed the cache reports `navigate`. Use the `browser.bfcache.*` attributes to diagnose misses.",
+    "`prerender` pages finish painting before activation, so their paint timings are offset by `browser.performance.navigation.activation_start`. Keep them separate when aggregating web vitals.",
+    "Not to be confused with `router.navigation.type`, which holds the client-side router's own vocabulary (`link`, `goto`, `router.push`). The two are independent and can both be set on the same span."
+  ],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [600],
+      "description": "Added browser.navigation.type attribute"
+    }
+  ]
+}

--- a/model/attributes/navigation/navigation__origin.json
+++ b/model/attributes/navigation/navigation__origin.json
@@ -8,8 +8,18 @@
   "is_in_otel": false,
   "visibility": "public",
   "example": "/users/:id",
-  "alias": ["sentry.sveltekit.navigation.from"],
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "router.navigation.origin",
+    "reason": "Moved to the router.* namespace to separate client-side router navigations from browser navigations."
+  },
+  "alias": ["router.navigation.origin", "sentry.sveltekit.navigation.from"],
   "changelog": [
+    {
+      "version": "next",
+      "prs": [600],
+      "description": "Deprecated in favor of router.navigation.origin"
+    },
     {
       "version": "0.16.0",
       "prs": [467],

--- a/model/attributes/navigation/navigation__route__id.json
+++ b/model/attributes/navigation/navigation__route__id.json
@@ -8,7 +8,18 @@
   "is_in_otel": false,
   "example": "AboutView",
   "visibility": "public",
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "router.navigation.route.id",
+    "reason": "Moved to the router.* namespace to separate client-side router navigations from browser navigations."
+  },
+  "alias": ["router.navigation.route.id"],
   "changelog": [
+    {
+      "version": "next",
+      "prs": [600],
+      "description": "Deprecated in favor of router.navigation.route.id"
+    },
     {
       "version": "0.16.0",
       "prs": [468],

--- a/model/attributes/navigation/navigation__type.json
+++ b/model/attributes/navigation/navigation__type.json
@@ -8,7 +8,17 @@
   "is_in_otel": false,
   "example": "router.push",
   "visibility": "public",
+  "deprecation": {
+    "_status": "backfill",
+    "replacement": "router.navigation.type",
+    "reason": "Moved to the router.* namespace to separate client-side router navigations from browser navigations."
+  },
   "changelog": [
+    {
+      "version": "next",
+      "prs": [600],
+      "description": "Deprecated in favor of router.navigation.type"
+    },
     {
       "version": "0.16.0",
       "prs": [467],
@@ -22,5 +32,5 @@
       "version": "0.0.0"
     }
   ],
-  "alias": ["sentry.sveltekit.navigation.type"]
+  "alias": ["router.navigation.type", "sentry.sveltekit.navigation.type"]
 }

--- a/model/attributes/router/router__navigation__origin.json
+++ b/model/attributes/router/router__navigation__origin.json
@@ -1,0 +1,19 @@
+{
+  "key": "router.navigation.origin",
+  "brief": "The origin of the navigation (usually client side router navigations). Should preferably be a parameterized template (like url.template) or a URL path otherwise.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "auto"
+  },
+  "is_in_otel": false,
+  "example": "/users/:id",
+  "visibility": "public",
+  "alias": ["navigation.origin", "sentry.sveltekit.navigation.from"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [600],
+      "description": "Added router.navigation.origin attribute, replacing navigation.origin"
+    }
+  ]
+}

--- a/model/attributes/router/router__navigation__route__id.json
+++ b/model/attributes/router/router__navigation__route__id.json
@@ -1,0 +1,19 @@
+{
+  "key": "router.navigation.route.id",
+  "brief": "The identifier of the matched client-side route, as assigned by the routing framework (e.g., vue-router name, react-router id).",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "auto"
+  },
+  "is_in_otel": false,
+  "example": "AboutView",
+  "visibility": "public",
+  "alias": ["navigation.route.id"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [600],
+      "description": "Added router.navigation.route.id attribute, replacing navigation.route.id"
+    }
+  ]
+}

--- a/model/attributes/router/router__navigation__type.json
+++ b/model/attributes/router/router__navigation__type.json
@@ -1,0 +1,19 @@
+{
+  "key": "router.navigation.type",
+  "brief": "The type of navigation done by a client-side router.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "example": "router.push",
+  "visibility": "public",
+  "alias": ["navigation.type", "sentry.sveltekit.navigation.type"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [600],
+      "description": "Added router.navigation.type attribute, replacing navigation.type"
+    }
+  ]
+}

--- a/model/attributes/sentry/sentry__sveltekit__navigation__from.json
+++ b/model/attributes/sentry/sentry__sveltekit__navigation__from.json
@@ -9,12 +9,17 @@
   "visibility": "public",
   "example": "/home",
   "deprecation": {
-    "replacement": "navigation.origin",
+    "replacement": "router.navigation.origin",
     "_status": "backfill",
     "reason": "Use the more generic attribute instead"
   },
-  "alias": ["navigation.origin"],
+  "alias": ["navigation.origin", "router.navigation.origin"],
   "changelog": [
+    {
+      "version": "next",
+      "prs": [600],
+      "description": "Re-pointed deprecation from navigation.origin to router.navigation.origin"
+    },
     {
       "version": "0.16.0",
       "prs": [467],

--- a/model/attributes/sentry/sentry__sveltekit__navigation__type.json
+++ b/model/attributes/sentry/sentry__sveltekit__navigation__type.json
@@ -8,13 +8,18 @@
   "is_in_otel": false,
   "visibility": "public",
   "example": "link",
-  "alias": ["navigation.type"],
+  "alias": ["navigation.type", "router.navigation.type"],
   "deprecation": {
-    "replacement": "navigation.type",
+    "replacement": "router.navigation.type",
     "reason": "Use the more generic attribute instead",
     "_status": "backfill"
   },
   "changelog": [
+    {
+      "version": "next",
+      "prs": [600],
+      "description": "Re-pointed deprecation from navigation.type to router.navigation.type"
+    },
     {
       "version": "0.16.0",
       "prs": [467],

--- a/model/description/browser.json
+++ b/model/description/browser.json
@@ -5,14 +5,14 @@
       "name": "Pageload",
       "brief": "A full page load of a web application.",
       "ops": ["pageload"],
-      "templates": ["{{navigation.route.id}}", "{{url.template}}", "{{url.path}}", "{{url.full}}"],
+      "templates": ["{{router.navigation.route.id}}", "{{url.template}}", "{{url.path}}", "{{url.full}}"],
       "examples": ["UserProfile", "/users/:id", "/users/123", "http://example.com/users/123"]
     },
     {
       "name": "Navigation",
       "brief": "Client-side browser history change in a web application.",
       "ops": ["navigation", "navigation.redirect"],
-      "templates": ["{{navigation.route.id}}", "{{url.template}}", "{{url.path}}", "{{url.full}}"],
+      "templates": ["{{router.navigation.route.id}}", "{{url.template}}", "{{url.path}}", "{{url.full}}"],
       "examples": ["UserProfile", "/users/:id", "/users/123", "http://example.com/users/123"]
     },
     {

--- a/model/description/routing.json
+++ b/model/description/routing.json
@@ -5,7 +5,7 @@
       "name": "Router",
       "brief": "Operations that match and dispatch requests or navigations through an application router.",
       "ops": ["router"],
-      "templates": ["{{navigation.route.id}}", "{{http.route}}", "{{url.template}}", "{{url.path}}"],
+      "templates": ["{{router.navigation.route.id}}", "{{http.route}}", "{{url.template}}", "{{url.path}}"],
       "examples": ["UserProfile", "/users/:id", "/users/{id}", "/users/123"]
     }
   ]

--- a/model/name/routing.json
+++ b/model/name/routing.json
@@ -6,7 +6,7 @@
       "brief": "Operations that match and dispatch requests or navigations through an application router.",
       "is_in_otel": false,
       "ops": ["router"],
-      "templates": ["{{navigation.route.id}}", "{{http.route}}", "{{url.template}}", "Router"],
+      "templates": ["{{router.navigation.route.id}}", "{{http.route}}", "{{url.template}}", "Router"],
       "examples": ["UserProfile", "/users/:id", "/users/{id}", "Router"]
     }
   ]

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -323,6 +323,9 @@ class _AttributeNamesMeta(type):
         "MESSAGING_RABBITMQ_ROUTING_KEY",
         "MESSAGING_URL",
         "METHOD",
+        "NAVIGATION_ORIGIN",
+        "NAVIGATION_ROUTE_ID",
+        "NAVIGATION_TYPE",
         "NET_HOST_IP",
         "NET_HOST_NAME",
         "NET_HOST_PORT",
@@ -2241,6 +2244,23 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Visibility: public
     Aliases: sentry.browser.name
     Example: "Chrome"
+    """
+
+    # Path: model/attributes/browser/browser__navigation__type.json
+    BROWSER_NAVIGATION_TYPE: Literal["browser.navigation.type"] = (
+        "browser.navigation.type"
+    )
+    """The type of navigation the browser performed to arrive at the page the metrics were measured on.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "navigate"
+    Example: "reload"
+    Example: "prerender"
+    Example: "bfcache"
+    Example: "soft-navigation"
     """
 
     # Path: model/attributes/browser/browser__paint__type.json
@@ -7402,7 +7422,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto
     Defined in OTEL: No
     Visibility: public
-    Aliases: sentry.sveltekit.navigation.from
+    Aliases: router.navigation.origin, sentry.sveltekit.navigation.from
+    DEPRECATED: Use router.navigation.origin instead - Moved to the router.* namespace to separate client-side router navigations from browser navigations.
     Example: "/users/:id"
     """
 
@@ -7414,6 +7435,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto
     Defined in OTEL: No
     Visibility: public
+    Aliases: router.navigation.route.id
+    DEPRECATED: Use router.navigation.route.id instead - Moved to the router.* namespace to separate client-side router navigations from browser navigations.
     Example: "AboutView"
     """
 
@@ -7425,7 +7448,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: sentry.sveltekit.navigation.type
+    Aliases: router.navigation.type, sentry.sveltekit.navigation.type
+    DEPRECATED: Use router.navigation.type instead - Moved to the router.* namespace to separate client-side router navigations from browser navigations.
     Example: "router.push"
     """
 
@@ -8321,6 +8345,46 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Aliases: http.route
     DEPRECATED: Use http.route instead
     Example: "App\\Controller::indexAction"
+    """
+
+    # Path: model/attributes/router/router__navigation__origin.json
+    ROUTER_NAVIGATION_ORIGIN: Literal["router.navigation.origin"] = (
+        "router.navigation.origin"
+    )
+    """The origin of the navigation (usually client side router navigations). Should preferably be a parameterized template (like url.template) or a URL path otherwise.
+
+    Type: str
+    Apply Scrubbing: auto
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: navigation.origin, sentry.sveltekit.navigation.from
+    Example: "/users/:id"
+    """
+
+    # Path: model/attributes/router/router__navigation__route__id.json
+    ROUTER_NAVIGATION_ROUTE_ID: Literal["router.navigation.route.id"] = (
+        "router.navigation.route.id"
+    )
+    """The identifier of the matched client-side route, as assigned by the routing framework (e.g., vue-router name, react-router id).
+
+    Type: str
+    Apply Scrubbing: auto
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: navigation.route.id
+    Example: "AboutView"
+    """
+
+    # Path: model/attributes/router/router__navigation__type.json
+    ROUTER_NAVIGATION_TYPE: Literal["router.navigation.type"] = "router.navigation.type"
+    """The type of navigation done by a client-side router.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: navigation.type, sentry.sveltekit.navigation.type
+    Example: "router.push"
     """
 
     # Path: model/attributes/rpc/rpc__grpc__status_code.json
@@ -9335,8 +9399,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto
     Defined in OTEL: No
     Visibility: public
-    Aliases: navigation.origin
-    DEPRECATED: Use navigation.origin instead - Use the more generic attribute instead
+    Aliases: navigation.origin, router.navigation.origin
+    DEPRECATED: Use router.navigation.origin instead - Use the more generic attribute instead
     Example: "/home"
     """
 
@@ -9364,8 +9428,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: navigation.type
-    DEPRECATED: Use navigation.type instead - Use the more generic attribute instead
+    Aliases: navigation.type, router.navigation.type
+    DEPRECATED: Use router.navigation.type instead - Use the more generic attribute instead
     Example: "link"
     """
 
@@ -13541,6 +13605,29 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127, 139]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "browser.navigation.type": AttributeMetadata(
+        brief="The type of navigation the browser performed to arrive at the page the metrics were measured on.",
+        type=AttributeType.STRING,
+        keys=("browser.navigation.type",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="navigate",
+        examples=["navigate", "reload", "prerender", "bfcache", "soft-navigation"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[600],
+                description="Added browser.navigation.type attribute",
+            ),
+        ],
+        additional_context=[
+            "Mirrors the `navigationType` field reported by the web-vitals library, which combines the Navigation Timing `PerformanceNavigationTiming.type` value with states that API does not cover: back/forward cache restores, prerendering, and soft navigations.",
+            "`bfcache` is only set when the page was actually restored from the back/forward cache. A back/forward navigation that missed the cache reports `navigate`. Use the `browser.bfcache.*` attributes to diagnose misses.",
+            "`prerender` pages finish painting before activation, so their paint timings are offset by `browser.performance.navigation.activation_start`. Keep them separate when aggregating web vitals.",
+            "Not to be confused with `router.navigation.type`, which holds the client-side router's own vocabulary (`link`, `goto`, `router.push`). The two are independent and can both be set on the same span.",
         ],
     ),
     "browser.paint.type": AttributeMetadata(
@@ -21077,6 +21164,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="The origin of the navigation (usually client side router navigations). Should preferrably parameterized template (like url.template) or a URL path otherwise.",
         type=AttributeType.STRING,
         keys=(
+            "router.navigation.origin",
             "navigation.origin",
             "sentry.sveltekit.navigation.from",
         ),
@@ -21084,8 +21172,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="/users/:id",
-        aliases=["sentry.sveltekit.navigation.from"],
+        deprecation=DeprecationInfo(
+            replacement="router.navigation.origin",
+            reason="Moved to the router.* namespace to separate client-side router navigations from browser navigations.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["router.navigation.origin", "sentry.sveltekit.navigation.from"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[600],
+                description="Deprecated in favor of router.navigation.origin",
+            ),
             ChangelogEntry(
                 version="0.16.0",
                 prs=[467],
@@ -21096,12 +21194,26 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "navigation.route.id": AttributeMetadata(
         brief="The identifier of the matched client-side route, as assigned by the routing framework (e.g., vue-router name, react-router id).",
         type=AttributeType.STRING,
-        keys=("navigation.route.id",),
+        keys=(
+            "router.navigation.route.id",
+            "navigation.route.id",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="AboutView",
+        deprecation=DeprecationInfo(
+            replacement="router.navigation.route.id",
+            reason="Moved to the router.* namespace to separate client-side router navigations from browser navigations.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["router.navigation.route.id"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[600],
+                description="Deprecated in favor of router.navigation.route.id",
+            ),
             ChangelogEntry(
                 version="0.16.0",
                 prs=[468],
@@ -21113,6 +21225,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="The type of navigation done by a client-side router.",
         type=AttributeType.STRING,
         keys=(
+            "router.navigation.type",
             "navigation.type",
             "sentry.sveltekit.navigation.type",
         ),
@@ -21120,8 +21233,18 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="router.push",
-        aliases=["sentry.sveltekit.navigation.type"],
+        deprecation=DeprecationInfo(
+            replacement="router.navigation.type",
+            reason="Moved to the router.* namespace to separate client-side router navigations from browser navigations.",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["router.navigation.type", "sentry.sveltekit.navigation.type"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[600],
+                description="Deprecated in favor of router.navigation.type",
+            ),
             ChangelogEntry(
                 version="0.16.0", prs=[467], description="Added new deprecated alias"
             ),
@@ -22485,6 +22608,68 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[61, 74]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "router.navigation.origin": AttributeMetadata(
+        brief="The origin of the navigation (usually client side router navigations). Should preferably be a parameterized template (like url.template) or a URL path otherwise.",
+        type=AttributeType.STRING,
+        keys=(
+            "router.navigation.origin",
+            "navigation.origin",
+            "sentry.sveltekit.navigation.from",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="/users/:id",
+        aliases=["navigation.origin", "sentry.sveltekit.navigation.from"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[600],
+                description="Added router.navigation.origin attribute, replacing navigation.origin",
+            ),
+        ],
+    ),
+    "router.navigation.route.id": AttributeMetadata(
+        brief="The identifier of the matched client-side route, as assigned by the routing framework (e.g., vue-router name, react-router id).",
+        type=AttributeType.STRING,
+        keys=(
+            "router.navigation.route.id",
+            "navigation.route.id",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="AboutView",
+        aliases=["navigation.route.id"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[600],
+                description="Added router.navigation.route.id attribute, replacing navigation.route.id",
+            ),
+        ],
+    ),
+    "router.navigation.type": AttributeMetadata(
+        brief="The type of navigation done by a client-side router.",
+        type=AttributeType.STRING,
+        keys=(
+            "router.navigation.type",
+            "navigation.type",
+            "sentry.sveltekit.navigation.type",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="router.push",
+        aliases=["navigation.type", "sentry.sveltekit.navigation.type"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[600],
+                description="Added router.navigation.type attribute, replacing navigation.type",
+            ),
         ],
     ),
     "rpc.grpc.status_code": AttributeMetadata(
@@ -23860,6 +24045,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="the navigation origin (sveltekit router)",
         type=AttributeType.STRING,
         keys=(
+            "router.navigation.origin",
             "navigation.origin",
             "sentry.sveltekit.navigation.from",
         ),
@@ -23868,12 +24054,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="/home",
         deprecation=DeprecationInfo(
-            replacement="navigation.origin",
+            replacement="router.navigation.origin",
             reason="Use the more generic attribute instead",
             status=DeprecationStatus.BACKFILL,
         ),
-        aliases=["navigation.origin"],
+        aliases=["navigation.origin", "router.navigation.origin"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[600],
+                description="Re-pointed deprecation from navigation.origin to router.navigation.origin",
+            ),
             ChangelogEntry(
                 version="0.16.0",
                 prs=[467],
@@ -23904,6 +24095,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         brief="The type of navigation event emitted from the sveltekit client router",
         type=AttributeType.STRING,
         keys=(
+            "router.navigation.type",
             "navigation.type",
             "sentry.sveltekit.navigation.type",
         ),
@@ -23912,12 +24104,17 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="link",
         deprecation=DeprecationInfo(
-            replacement="navigation.type",
+            replacement="router.navigation.type",
             reason="Use the more generic attribute instead",
             status=DeprecationStatus.BACKFILL,
         ),
-        aliases=["navigation.type"],
+        aliases=["navigation.type", "router.navigation.type"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[600],
+                description="Re-pointed deprecation from navigation.type to router.navigation.type",
+            ),
             ChangelogEntry(
                 version="0.16.0",
                 prs=[467],
@@ -25877,6 +26074,7 @@ Attributes = TypedDict(
         "browser.bfcache.outcome": str,
         "browser.bfcache.reason": str,
         "browser.name": str,
+        "browser.navigation.type": str,
         "browser.paint.type": str,
         "browser.performance.navigation.activation_start": float,
         "browser.performance.time_origin": float,
@@ -26362,6 +26560,9 @@ Attributes = TypedDict(
         "resource.deployment.environment.name": str,
         "resource.render_blocking_status": str,
         "route": str,
+        "router.navigation.origin": str,
+        "router.navigation.route.id": str,
+        "router.navigation.type": str,
         "rpc.grpc.status_code": int,
         "rpc.method": str,
         "rpc.response.status_code": str,


### PR DESCRIPTION
Adds `browser.navigation.type` for web vital spans: `navigate`, `reload`, `prerender`, `bfcache`, `soft-navigation`. Mirrors what the web-vitals library reports as `navigationType`.

Also moves the `navigation.*` attributes to `router.navigation.*` so the router's own navigation type stops competing with the browser's. `navigation.type`, `navigation.origin` and `navigation.route.id` are deprecated with plain backfills, and the sveltekit aliases now point at the new names. These are straight renames so there's no transform involved.

The new attribute is going to be used to distinguish the various web vital signals so users can filter out specific (faster) types of navigations.
