### PR TITLE
feat(names): Add `db.operation.name` as a valid span name template

### DIFF
--- a/model/name/db.json
+++ b/model/name/db.json
@@ -27,6 +27,7 @@
         "{{db.collection.name}}",
         "{{db.stored_procedure.name}}",
         "{{db.namespace}}",
+        "{{db.operation.name}}",
         "{{server.address}}:{{server.port}}",
         "{{db.system.name}}",
         "Database operation"


### PR DESCRIPTION
Adds a `{{db.operation.name}}` template rule to span names because in some DB instrumentations, we can get an operation but no other attribute it pairs with in the current rule set. Fwiw, in some rare edge cases `db.summary` also only contains an operation so this is implicitly already handled.

Concrete example: Redis spans. None of the `db.operation.name` pair rules apply to them besides the `server.address` one which IMHO isn't really useful information to have in a span name. OTel isn't super clear when to use server.address, but they seem to [recommend it](https://opentelemetry.io/docs/specs/semconv/db/database-spans/#:~:text=server.address%3Aserver.port%20SHOULD%20be%20used%20for%20other%20operations%20not%20targeting%20any%20specific%20collection(s)%2C%20stored%20procedure(s)%2C%20or%20namespace(s).) for operations that don't target a specific collection or namespace. For Redis, we have a `db.namespace` but it's only a numeric value, and [explicitly discouraged](https://opentelemetry.io/docs/specs/semconv/db/redis/#:~:text=except%20that%20db.namespace%20SHOULD%20NOT%20be%20used) to be used for a span name

No super strong opinions. We can also use `{{db.operation.name}} {{server.address}}:{{server.port}}` for redis and drop this PR. 

ref: https://github.com/getsentry/sentry-javascript/pull/23741