### PR TITLE
fix: Alias `server_name` to `device.name` instead of `server.address`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -16272,7 +16272,7 @@ export type SERVER_ADDRESS_TYPE = string;
  *
  * Attribute Value Type: `string` {@link SERVER_NAME_TYPE}
  *
- * Apply Scrubbing: manual
+ * Apply Scrubbing: auto
  *
  * Attribute defined in OTEL: No
  * Visibility: public
@@ -31600,7 +31600,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     type: 'string',
     keys: ['device.name', 'server_name'],
     applyScrubbing: {
-      key: 'manual',
+      key: 'auto',
     },
     isInOtel: false,
     visibility: 'public',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -24144,7 +24144,10 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'localhost',
     aliases: ['server_name'],
-    changelog: [{ version: '0.5.0', prs: [303], description: 'Added device.name attribute' }],
+    changelog: [
+      { version: 'next', description: 'Added server_name as an alias' },
+      { version: '0.5.0', prs: [303], description: 'Added device.name attribute' },
+    ],
   },
   'device.online': {
     brief: 'Whether the device was online or not.',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -12,7 +12,7 @@
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`, {@link NET_PEER_NAME} `net.peer.name`
+ * Aliases: {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link NET_PEER_NAME} `net.peer.name`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead - Old namespace-less attribute, to be replaced with server.address for span-first future
  * @example "example.com"
@@ -5927,6 +5927,8 @@ export type DEVICE_MODEL_ID_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
+ * Aliases: {@link SERVER_NAME} `server_name`
+ *
  * @example "localhost"
  */
 export const DEVICE_NAME = 'device.name';
@@ -9352,7 +9354,7 @@ export type HTTP_FRAGMENT_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link CLIENT_ADDRESS} `client.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link SERVER_NAME} `server_name`, {@link NET_PEER_NAME} `net.peer.name`
+ * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link CLIENT_ADDRESS} `client.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link NET_PEER_NAME} `net.peer.name`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead - Deprecated, use one of `server.address` or `client.address`, depending on the usage
  * @example "example.com"
@@ -10215,7 +10217,7 @@ export type HTTP_SCHEME_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`, {@link NET_PEER_NAME} `net.peer.name`
+ * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link NET_PEER_NAME} `net.peer.name`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead
  * @example "example.com"
@@ -12777,7 +12779,7 @@ export type NET_HOST_IP_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`, {@link NET_PEER_NAME} `net.peer.name`
+ * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link HTTP_HOST} `http.host`, {@link NET_PEER_NAME} `net.peer.name`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead
  * @example "example.com"
@@ -12849,7 +12851,7 @@ export type NET_PEER_IP_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`
+ * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`
  *
  * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead - Deprecated, use server.address on client spans and client.address on server spans.
  * @example "example.com"
@@ -16252,7 +16254,7 @@ export type SENTRY_USER_USERNAME_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link ADDRESS} `address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link SERVER_NAME} `server_name`, {@link NET_PEER_NAME} `net.peer.name`
+ * Aliases: {@link ADDRESS} `address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link NET_PEER_NAME} `net.peer.name`
  *
  * @example "example.com"
  */
@@ -16266,7 +16268,7 @@ export type SERVER_ADDRESS_TYPE = string;
 // Path: model/attributes/server_name.json
 
 /**
- * Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name. `server_name`
+ * The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname. `server_name`
  *
  * Attribute Value Type: `string` {@link SERVER_NAME_TYPE}
  *
@@ -16275,9 +16277,9 @@ export type SERVER_ADDRESS_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * Aliases: {@link ADDRESS} `address`, {@link SERVER_ADDRESS} `server.address`, {@link HTTP_SERVER_NAME} `http.server_name`, {@link NET_HOST_NAME} `net.host.name`, {@link HTTP_HOST} `http.host`, {@link NET_PEER_NAME} `net.peer.name`
+ * Aliases: {@link DEVICE_NAME} `device.name`
  *
- * @deprecated Use {@link SERVER_ADDRESS} (server.address) instead - This attribute is being deprecated in favor of server.address, which is the OTel-aligned replacement.
+ * @deprecated Use {@link DEVICE_NAME} (device.name) instead - This attribute is being deprecated in favor of device.name.
  * @example "example.com"
  */
 export const SERVER_NAME = 'server_name';
@@ -20086,7 +20088,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   address: {
     brief: 'The destination hostname or IP address for a TCP connection.',
     type: 'string',
-    keys: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
+    keys: ['server.address', 'address', 'http.server_name', 'net.host.name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -20099,7 +20101,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       reason: 'Old namespace-less attribute, to be replaced with server.address for span-first future',
       status: 'backfill',
     },
-    aliases: ['server.address', 'http.server_name', 'net.host.name', 'http.host', 'server_name', 'net.peer.name'],
+    aliases: ['server.address', 'http.server_name', 'net.host.name', 'http.host', 'net.peer.name'],
     changelog: [
       { version: 'next', description: 'Added net.peer.name as an alias' },
       { version: '0.19.0', prs: [534], description: 'Added address attribute' },
@@ -24134,13 +24136,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname.',
     type: 'string',
-    keys: ['device.name'],
+    keys: ['device.name', 'server_name'],
     applyScrubbing: {
       key: 'auto',
     },
     isInOtel: false,
     visibility: 'public',
     example: 'localhost',
+    aliases: ['server_name'],
     changelog: [{ version: '0.5.0', prs: [303], description: 'Added device.name attribute' }],
   },
   'device.online': {
@@ -26688,15 +26691,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'server.address',
       reason: 'Deprecated, use one of `server.address` or `client.address`, depending on the usage',
     },
-    aliases: [
-      'address',
-      'server.address',
-      'client.address',
-      'http.server_name',
-      'net.host.name',
-      'server_name',
-      'net.peer.name',
-    ],
+    aliases: ['address', 'server.address', 'client.address', 'http.server_name', 'net.host.name', 'net.peer.name'],
     changelog: [
       { version: 'next', description: 'Added net.peer.name as an alias' },
       { version: '0.19.0', prs: [534], description: 'Added address as an alias' },
@@ -27301,7 +27296,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   'http.server_name': {
     brief: 'The server domain name',
     type: 'string',
-    keys: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
+    keys: ['server.address', 'address', 'http.server_name', 'net.host.name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -27312,7 +27307,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'server.address',
       status: 'backfill',
     },
-    aliases: ['address', 'server.address', 'net.host.name', 'http.host', 'server_name', 'net.peer.name'],
+    aliases: ['address', 'server.address', 'net.host.name', 'http.host', 'net.peer.name'],
     changelog: [
       { version: 'next', description: 'Added net.peer.name as an alias' },
       { version: '0.19.0', prs: [534], description: 'Added address as an alias' },
@@ -29133,7 +29128,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
     type: 'string',
-    keys: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
+    keys: ['server.address', 'address', 'http.server_name', 'net.host.name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -29144,7 +29139,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'server.address',
       status: 'backfill',
     },
-    aliases: ['address', 'server.address', 'http.server_name', 'http.host', 'server_name', 'net.peer.name'],
+    aliases: ['address', 'server.address', 'http.server_name', 'http.host', 'net.peer.name'],
     changelog: [
       { version: 'next', description: 'Added net.peer.name as an alias' },
       { version: '0.19.0', prs: [534], description: 'Added address as an alias' },
@@ -29206,7 +29201,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'server.address',
       reason: 'Deprecated, use server.address on client spans and client.address on server spans.',
     },
-    aliases: ['address', 'server.address', 'http.server_name', 'net.host.name', 'http.host', 'server_name'],
+    aliases: ['address', 'server.address', 'http.server_name', 'net.host.name', 'http.host'],
     changelog: [
       { version: 'next', description: 'Added the server.address alias group to net.peer.name' },
       { version: '0.1.0', prs: [61, 127] },
@@ -31582,14 +31577,14 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
     type: 'string',
-    keys: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
+    keys: ['server.address', 'address', 'http.server_name', 'net.host.name'],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: true,
     visibility: 'public',
     example: 'example.com',
-    aliases: ['address', 'http.server_name', 'net.host.name', 'http.host', 'server_name', 'net.peer.name'],
+    aliases: ['address', 'http.server_name', 'net.host.name', 'http.host', 'net.peer.name'],
     changelog: [
       { version: 'next', description: 'Added net.peer.name as an alias' },
       { version: '0.19.0', prs: [534], description: 'Added address as an alias' },
@@ -31599,9 +31594,9 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   },
   server_name: {
     brief:
-      'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
+      'The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname.',
     type: 'string',
-    keys: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
+    keys: ['device.name', 'server_name'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -31609,13 +31604,16 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     example: 'example.com',
     deprecation: {
-      replacement: 'server.address',
-      reason: 'This attribute is being deprecated in favor of server.address, which is the OTel-aligned replacement.',
+      replacement: 'device.name',
+      reason: 'This attribute is being deprecated in favor of device.name.',
       status: 'backfill',
     },
-    aliases: ['address', 'server.address', 'http.server_name', 'net.host.name', 'http.host', 'net.peer.name'],
+    aliases: ['device.name'],
     changelog: [
-      { version: 'next', description: 'Added net.peer.name as an alias' },
+      {
+        version: 'next',
+        description: 'Deprecated server_name in favor of device.name, removed from server.address alias group',
+      },
       { version: '0.19.0', prs: [534], description: 'Added address as an alias' },
       {
         version: '0.16.0',
@@ -32945,7 +32943,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'server.address',
     type: 'string',
     brief: 'The destination hostname or IP address for a TCP connection.',
-    deprecationChain: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
+    deprecationChain: ['server.address', 'address', 'http.server_name', 'net.host.name'],
   },
   'ai.citations': {
     canonicalName: 'ai.citations',
@@ -34635,7 +34633,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief:
       'The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname.',
-    deprecationChain: ['device.name'],
+    deprecationChain: ['device.name', 'server_name'],
   },
   'device.online': {
     canonicalName: 'device.online',
@@ -35897,7 +35895,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'server.address',
     type: 'string',
     brief: 'The server domain name',
-    deprecationChain: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
+    deprecationChain: ['server.address', 'address', 'http.server_name', 'net.host.name'],
   },
   'http.status_code': {
     canonicalName: 'http.response.status_code',
@@ -36573,7 +36571,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief:
       'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
-    deprecationChain: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
+    deprecationChain: ['server.address', 'address', 'http.server_name', 'net.host.name'],
   },
   'net.host.port': {
     canonicalName: 'server.port',
@@ -37464,7 +37462,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief:
       'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
-    deprecationChain: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
+    deprecationChain: ['server.address', 'address', 'http.server_name', 'net.host.name'],
   },
   'server.port': {
     canonicalName: 'server.port',
@@ -37473,11 +37471,11 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     deprecationChain: ['server.port', 'net.host.port', 'port'],
   },
   server_name: {
-    canonicalName: 'server.address',
+    canonicalName: 'device.name',
     type: 'string',
     brief:
-      'Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.',
-    deprecationChain: ['server.address', 'address', 'http.server_name', 'net.host.name', 'server_name'],
+      'The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname.',
+    deprecationChain: ['device.name', 'server_name'],
   },
   server_sample_rate: {
     canonicalName: 'sentry.server_sample_rate',

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -16268,7 +16268,7 @@ export type SERVER_ADDRESS_TYPE = string;
 // Path: model/attributes/server_name.json
 
 /**
- * The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname. `server_name`
+ * The name of the device. On servers and desktops, this is typically the hostname. `server_name`
  *
  * Attribute Value Type: `string` {@link SERVER_NAME_TYPE}
  *
@@ -31593,8 +31593,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     ],
   },
   server_name: {
-    brief:
-      'The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname.',
+    brief: 'The name of the device. On servers and desktops, this is typically the hostname.',
     type: 'string',
     keys: ['device.name', 'server_name'],
     applyScrubbing: {
@@ -31610,10 +31609,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     },
     aliases: ['device.name'],
     changelog: [
-      {
-        version: 'next',
-        description: 'Deprecated server_name in favor of device.name, removed from server.address alias group',
-      },
+      { version: 'next', description: 'Alias device.name instead of the server.address alias group' },
       { version: '0.19.0', prs: [534], description: 'Added address as an alias' },
       {
         version: '0.16.0',
@@ -37473,8 +37469,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
   server_name: {
     canonicalName: 'device.name',
     type: 'string',
-    brief:
-      'The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname.',
+    brief: 'The name of the device. On servers and desktops, this is typically the hostname.',
     deprecationChain: ['device.name', 'server_name'],
   },
   server_sample_rate: {

--- a/model/attributes/address.json
+++ b/model/attributes/address.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": false,
   "examples": ["example.com"],
-  "alias": ["server.address", "http.server_name", "net.host.name", "http.host", "server_name", "net.peer.name"],
+  "alias": ["server.address", "http.server_name", "net.host.name", "http.host", "net.peer.name"],
   "deprecation": {
     "replacement": "server.address",
     "reason": "Old namespace-less attribute, to be replaced with server.address for span-first future",

--- a/model/attributes/device/device__name.json
+++ b/model/attributes/device/device__name.json
@@ -11,6 +11,10 @@
   "visibility": "public",
   "changelog": [
     {
+      "version": "next",
+      "description": "Added server_name as an alias"
+    },
+    {
       "version": "0.5.0",
       "prs": [303],
       "description": "Added device.name attribute"

--- a/model/attributes/device/device__name.json
+++ b/model/attributes/device/device__name.json
@@ -7,6 +7,7 @@
   },
   "is_in_otel": false,
   "example": "localhost",
+  "alias": ["server_name"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__host.json
+++ b/model/attributes/http/http__host.json
@@ -7,15 +7,7 @@
   },
   "is_in_otel": true,
   "example": "example.com",
-  "alias": [
-    "address",
-    "server.address",
-    "client.address",
-    "http.server_name",
-    "net.host.name",
-    "server_name",
-    "net.peer.name"
-  ],
+  "alias": ["address", "server.address", "client.address", "http.server_name", "net.host.name", "net.peer.name"],
   "deprecation": {
     "_status": null,
     "replacement": "server.address",

--- a/model/attributes/http/http__server_name.json
+++ b/model/attributes/http/http__server_name.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "example.com",
-  "alias": ["address", "server.address", "net.host.name", "http.host", "server_name", "net.peer.name"],
+  "alias": ["address", "server.address", "net.host.name", "http.host", "net.peer.name"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "server.address"

--- a/model/attributes/net/net__host__name.json
+++ b/model/attributes/net/net__host__name.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "example.com",
-  "alias": ["address", "server.address", "http.server_name", "http.host", "server_name", "net.peer.name"],
+  "alias": ["address", "server.address", "http.server_name", "http.host", "net.peer.name"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "server.address"

--- a/model/attributes/net/net__peer__name.json
+++ b/model/attributes/net/net__peer__name.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "example.com",
-  "alias": ["address", "server.address", "http.server_name", "net.host.name", "http.host", "server_name"],
+  "alias": ["address", "server.address", "http.server_name", "net.host.name", "http.host"],
   "deprecation": {
     "_status": null,
     "replacement": "server.address",

--- a/model/attributes/server/server__address.json
+++ b/model/attributes/server/server__address.json
@@ -7,7 +7,7 @@
   },
   "is_in_otel": true,
   "example": "example.com",
-  "alias": ["address", "http.server_name", "net.host.name", "http.host", "server_name", "net.peer.name"],
+  "alias": ["address", "http.server_name", "net.host.name", "http.host", "net.peer.name"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/server_name.json
+++ b/model/attributes/server_name.json
@@ -1,6 +1,6 @@
 {
   "key": "server_name",
-  "brief": "The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname.",
+  "brief": "The name of the device. On servers and desktops, this is typically the hostname.",
   "type": "string",
   "apply_scrubbing": {
     "key": "manual"
@@ -17,7 +17,7 @@
   "changelog": [
     {
       "version": "next",
-      "description": "Deprecated server_name in favor of device.name, removed from server.address alias group"
+      "description": "Alias device.name instead of the server.address alias group"
     },
     {
       "version": "0.19.0",

--- a/model/attributes/server_name.json
+++ b/model/attributes/server_name.json
@@ -3,7 +3,7 @@
   "brief": "The name of the device. On servers and desktops, this is typically the hostname.",
   "type": "string",
   "apply_scrubbing": {
-    "key": "manual"
+    "key": "auto"
   },
   "is_in_otel": false,
   "example": "example.com",

--- a/model/attributes/server_name.json
+++ b/model/attributes/server_name.json
@@ -1,23 +1,23 @@
 {
   "key": "server_name",
-  "brief": "Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
+  "brief": "The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname.",
   "type": "string",
   "apply_scrubbing": {
     "key": "manual"
   },
   "is_in_otel": false,
   "example": "example.com",
-  "alias": ["address", "server.address", "http.server_name", "net.host.name", "http.host", "net.peer.name"],
+  "alias": ["device.name"],
   "deprecation": {
     "_status": "backfill",
-    "replacement": "server.address",
-    "reason": "This attribute is being deprecated in favor of server.address, which is the OTel-aligned replacement."
+    "replacement": "device.name",
+    "reason": "This attribute is being deprecated in favor of device.name."
   },
   "visibility": "public",
   "changelog": [
     {
       "version": "next",
-      "description": "Added net.peer.name as an alias"
+      "description": "Deprecated server_name in favor of device.name, removed from server.address alias group"
     },
     {
       "version": "0.19.0",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -15515,6 +15515,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         example="localhost",
         aliases=["server_name"],
         changelog=[
+            ChangelogEntry(version="next", description="Added server_name as an alias"),
             ChangelogEntry(
                 version="0.5.0", prs=[303], description="Added device.name attribute"
             ),

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -9543,7 +9543,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     """The name of the device. On servers and desktops, this is typically the hostname.
 
     Type: str
-    Apply Scrubbing: manual
+    Apply Scrubbing: auto
     Defined in OTEL: No
     Visibility: public
     Aliases: device.name
@@ -24096,7 +24096,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "device.name",
             "server_name",
         ),
-        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="example.com",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -420,7 +420,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: server.address, http.server_name, net.host.name, http.host, server_name, net.peer.name
+    Aliases: server.address, http.server_name, net.host.name, http.host, net.peer.name
     DEPRECATED: Use server.address instead - Old namespace-less attribute, to be replaced with server.address for span-first future
     Example: "example.com"
     """
@@ -3728,6 +3728,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto
     Defined in OTEL: No
     Visibility: public
+    Aliases: server_name
     Example: "localhost"
     """
 
@@ -5683,7 +5684,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: address, server.address, client.address, http.server_name, net.host.name, server_name, net.peer.name
+    Aliases: address, server.address, client.address, http.server_name, net.host.name, net.peer.name
     DEPRECATED: Use server.address instead - Deprecated, use one of `server.address` or `client.address`, depending on the usage
     Example: "example.com"
     """
@@ -6203,7 +6204,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: address, server.address, net.host.name, http.host, server_name, net.peer.name
+    Aliases: address, server.address, net.host.name, http.host, net.peer.name
     DEPRECATED: Use server.address instead
     Example: "example.com"
     """
@@ -7475,7 +7476,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: address, server.address, http.server_name, http.host, server_name, net.peer.name
+    Aliases: address, server.address, http.server_name, http.host, net.peer.name
     DEPRECATED: Use server.address instead
     Example: "example.com"
     """
@@ -7514,7 +7515,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: auto
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: address, server.address, http.server_name, net.host.name, http.host, server_name
+    Aliases: address, server.address, http.server_name, net.host.name, http.host
     DEPRECATED: Use server.address instead - Deprecated, use server.address on client spans and client.address on server spans.
     Example: "example.com"
     """
@@ -9521,7 +9522,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: address, http.server_name, net.host.name, http.host, server_name, net.peer.name
+    Aliases: address, http.server_name, net.host.name, http.host, net.peer.name
     Example: "example.com"
     """
 
@@ -9539,14 +9540,14 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/server_name.json
     SERVER_NAME: Literal["server_name"] = "server_name"
-    """Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
+    """The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname.
 
     Type: str
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Aliases: address, server.address, http.server_name, net.host.name, http.host, net.peer.name
-    DEPRECATED: Use server.address instead - This attribute is being deprecated in favor of server.address, which is the OTel-aligned replacement.
+    Aliases: device.name
+    DEPRECATED: Use device.name instead - This attribute is being deprecated in favor of device.name.
     Example: "example.com"
     """
 
@@ -10639,7 +10640,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "address",
             "http.server_name",
             "net.host.name",
-            "server_name",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
@@ -10656,7 +10656,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "http.server_name",
             "net.host.name",
             "http.host",
-            "server_name",
             "net.peer.name",
         ],
         changelog=[
@@ -15506,11 +15505,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "device.name": AttributeMetadata(
         brief="The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname.",
         type=AttributeType.STRING,
-        keys=("device.name",),
+        keys=(
+            "device.name",
+            "server_name",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="localhost",
+        aliases=["server_name"],
         changelog=[
             ChangelogEntry(
                 version="0.5.0", prs=[303], description="Added device.name attribute"
@@ -18493,7 +18496,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "client.address",
             "http.server_name",
             "net.host.name",
-            "server_name",
             "net.peer.name",
         ],
         changelog=[
@@ -19199,7 +19201,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "address",
             "http.server_name",
             "net.host.name",
-            "server_name",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
@@ -19213,7 +19214,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "server.address",
             "net.host.name",
             "http.host",
-            "server_name",
             "net.peer.name",
         ],
         changelog=[
@@ -21079,7 +21079,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "address",
             "http.server_name",
             "net.host.name",
-            "server_name",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
@@ -21093,7 +21092,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "server.address",
             "http.server_name",
             "http.host",
-            "server_name",
             "net.peer.name",
         ],
         changelog=[
@@ -21171,7 +21169,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "http.server_name",
             "net.host.name",
             "http.host",
-            "server_name",
         ],
         changelog=[
             ChangelogEntry(
@@ -24047,7 +24044,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "address",
             "http.server_name",
             "net.host.name",
-            "server_name",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
@@ -24058,7 +24054,6 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             "http.server_name",
             "net.host.name",
             "http.host",
-            "server_name",
             "net.peer.name",
         ],
         changelog=[
@@ -24094,13 +24089,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "server_name": AttributeMetadata(
-        brief="Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.",
+        brief="The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname.",
         type=AttributeType.STRING,
         keys=(
-            "server.address",
-            "address",
-            "http.server_name",
-            "net.host.name",
+            "device.name",
             "server_name",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
@@ -24108,21 +24100,15 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="example.com",
         deprecation=DeprecationInfo(
-            replacement="server.address",
-            reason="This attribute is being deprecated in favor of server.address, which is the OTel-aligned replacement.",
+            replacement="device.name",
+            reason="This attribute is being deprecated in favor of device.name.",
             status=DeprecationStatus.BACKFILL,
         ),
-        aliases=[
-            "address",
-            "server.address",
-            "http.server_name",
-            "net.host.name",
-            "http.host",
-            "net.peer.name",
-        ],
+        aliases=["device.name"],
         changelog=[
             ChangelogEntry(
-                version="next", description="Added net.peer.name as an alias"
+                version="next",
+                description="Deprecated server_name in favor of device.name, removed from server.address alias group",
             ),
             ChangelogEntry(
                 version="0.19.0", prs=[534], description="Added address as an alias"

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -9540,7 +9540,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/server_name.json
     SERVER_NAME: Literal["server_name"] = "server_name"
-    """The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname.
+    """The name of the device. On servers and desktops, this is typically the hostname.
 
     Type: str
     Apply Scrubbing: manual
@@ -24089,7 +24089,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "server_name": AttributeMetadata(
-        brief="The name of the device. On mobile, this is the user-assigned device name. On servers and desktops, this is typically the hostname.",
+        brief="The name of the device. On servers and desktops, this is typically the hostname.",
         type=AttributeType.STRING,
         keys=(
             "device.name",
@@ -24108,7 +24108,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(
                 version="next",
-                description="Deprecated server_name in favor of device.name, removed from server.address alias group",
+                description="Alias device.name instead of the server.address alias group",
             ),
             ChangelogEntry(
                 version="0.19.0", prs=[534], description="Added address as an alias"

--- a/python/tests/test_attribute_keys.py
+++ b/python/tests/test_attribute_keys.py
@@ -79,5 +79,4 @@ def test_key_chain_omits_deprecated_aliases_outside_the_family() -> None:
         "address",
         "http.server_name",
         "net.host.name",
-        "server_name",
     )

--- a/test/generated-attribute-keys.test.ts
+++ b/test/generated-attribute-keys.test.ts
@@ -314,7 +314,6 @@ describe('generated attribute key chains', () => {
       'address',
       'http.server_name',
       'net.host.name',
-      'server_name',
     ]);
   });
 });


### PR DESCRIPTION
## Description

<!-- Describe your changes -->

The `server_name` comes from `socket.gethostname()` in the transaction world.

The `server_name` is therefore the name of the machine running the Python program. This is not the server domain name or IP address as in the description of `server.address`. The former is a property of a machine, which may not be a web server. The latter is for web servers in Python integrations.

Related to https://github.com/getsentry/sentry-python/pull/7311

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [ ] I have run `yarn test` and verified that the tests pass.
- [ ] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
