### PR TITLE
chore(descriptions): Fix `http.client` span description example

### DIFF
--- a/model/description/http.json
+++ b/model/description/http.json
@@ -6,7 +6,7 @@
       "brief": "Operations that represent outgoing HTTP requests.",
       "ops": ["http.client", "http.client.stream"],
       "templates": ["{{http.request.method}} {{url.full}}"],
-      "examples": ["GET /users/123"]
+      "examples": ["GET https://api.mydomain.com/users/123?expand=full"]
     },
     {
       "name": "Server",


### PR DESCRIPTION
## Description

`http.client` span descriptions call for the full URL as a description and not for just the path. The example incorrectly only included the path.

Side-note: Unfortunately, span descriptions will change slightly once they're inferred because SDKs had a dynamic logic to build `http.client` span descriptions:

- for same-origin requests, we'd include the relative URL (`/users/123?expand=full`)
- for 3rd-party origins, we'd include the full URL (`https://example.com/123?expand=full`)

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [ ] I have run `yarn test` and verified that the tests pass.
- [ ] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
