### PR TITLE
feat(attributes): Deprecate sentry.device.class in favor of device.class

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -5556,7 +5556,7 @@ export type DEVICE_CHIPSET_TYPE = string;
 // Path: model/attributes/device/device__class.json
 
 /**
- * The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly. `device.class`
+ * The classification of the device. For example, `1`, `2`, or `3`. Typically inferred by Relay - SDKs generally do not need to set this directly. `device.class`
  *
  * Attribute Value Type: `string` {@link DEVICE_CLASS_TYPE}
  *
@@ -14527,7 +14527,7 @@ export type SENTRY_DESCRIPTION_TYPE = string;
 // Path: model/attributes/sentry/sentry__device__class.json
 
 /**
- * The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly. `sentry.device.class`
+ * The classification of the device. For example, `1`, `2`, or `3`. Typically inferred by Relay - SDKs generally do not need to set this directly. `sentry.device.class`
  *
  * Attribute Value Type: `string` {@link SENTRY_DEVICE_CLASS_TYPE}
  *
@@ -23941,7 +23941,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   },
   'device.class': {
     brief:
-      'The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.',
+      'The classification of the device. For example, `1`, `2`, or `3`. Typically inferred by Relay - SDKs generally do not need to set this directly.',
     type: 'string',
     keys: ['device.class', 'sentry.device.class'],
     applyScrubbing: {
@@ -23956,13 +23956,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       {
         version: 'next',
         prs: [604],
-        description:
-          "Added sentry.device.class as a deprecated alias and documented Relay's stringified numeric class codes",
+        description: 'Added sentry.device.class as a deprecated alias and documented class codes 1/2/3',
       },
       { version: '0.5.0', prs: [300], description: 'Added device.class attribute' },
     ],
     additionalContext: [
-      'Relay currently writes this as a stringified numeric class code: `"1"` (low), `"2"` (medium), or `"3"` (high), not the labels `low`, `medium`, or `high`.',
+      'The product maps these stringified numeric class codes to `low` (`"1"`), `medium` (`"2"`), and `high` (`"3"`).',
     ],
   },
   'device.connection_type': {
@@ -30426,7 +30425,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   },
   'sentry.device.class': {
     brief:
-      'The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.',
+      'The classification of the device. For example, `1`, `2`, or `3`. Typically inferred by Relay - SDKs generally do not need to set this directly.',
     type: 'string',
     keys: ['device.class', 'sentry.device.class'],
     applyScrubbing: {
@@ -30446,7 +30445,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       { version: 'next', prs: [604], description: 'Added and deprecated sentry.device.class in favor of device.class' },
     ],
     additionalContext: [
-      'Relay currently writes this as a stringified numeric class code: `"1"` (low), `"2"` (medium), or `"3"` (high), not the labels `low`, `medium`, or `high`.',
+      'The product maps these stringified numeric class codes to `low` (`"1"`), `medium` (`"2"`), and `high` (`"3"`).',
     ],
   },
   'sentry.dist': {
@@ -34603,7 +34602,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'device.class',
     type: 'string',
     brief:
-      'The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.',
+      'The classification of the device. For example, `1`, `2`, or `3`. Typically inferred by Relay - SDKs generally do not need to set this directly.',
     deprecationChain: ['device.class', 'sentry.device.class'],
   },
   'device.connection_type': {
@@ -37209,7 +37208,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'device.class',
     type: 'string',
     brief:
-      'The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.',
+      'The classification of the device. For example, `1`, `2`, or `3`. Typically inferred by Relay - SDKs generally do not need to set this directly.',
     deprecationChain: ['device.class', 'sentry.device.class'],
   },
   'sentry.dist': {

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -5565,7 +5565,11 @@ export type DEVICE_CHIPSET_TYPE = string;
  * Attribute defined in OTEL: No
  * Visibility: public
  *
- * @example "medium"
+ * Aliases: {@link SENTRY_DEVICE_CLASS} `sentry.device.class`
+ *
+ * @example "1"
+ * @example "2"
+ * @example "3"
  */
 export const DEVICE_CLASS = 'device.class';
 
@@ -14520,6 +14524,32 @@ export const SENTRY_DESCRIPTION = 'sentry.description';
  */
 export type SENTRY_DESCRIPTION_TYPE = string;
 
+// Path: model/attributes/sentry/sentry__device__class.json
+
+/**
+ * The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly. `sentry.device.class`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_DEVICE_CLASS_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link DEVICE_CLASS} `device.class`
+ *
+ * @deprecated Use {@link DEVICE_CLASS} (device.class) instead - Deprecated in favor of device.class
+ * @example "1"
+ * @example "2"
+ * @example "3"
+ */
+export const SENTRY_DEVICE_CLASS = 'sentry.device.class';
+
+/**
+ * Type for {@link SENTRY_DEVICE_CLASS} sentry.device.class
+ */
+export type SENTRY_DEVICE_CLASS_TYPE = string;
+
 // Path: model/attributes/sentry/sentry__dist.json
 
 /**
@@ -19084,6 +19114,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'sentry.category': 'string',
   'sentry.client_sample_rate': 'double',
   'sentry.description': 'string',
+  'sentry.device.class': 'string',
   'sentry.dist': 'string',
   'sentry.domain': 'string',
   'sentry.dsc.environment': 'string',
@@ -19909,6 +19940,7 @@ export type AttributeName =
   | typeof SENTRY_CATEGORY
   | typeof SENTRY_CLIENT_SAMPLE_RATE
   | typeof SENTRY_DESCRIPTION
+  | typeof SENTRY_DEVICE_CLASS
   | typeof SENTRY_DIST
   | typeof SENTRY_DOMAIN
   | typeof SENTRY_DSC_ENVIRONMENT
@@ -23911,14 +23943,27 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.',
     type: 'string',
-    keys: ['device.class'],
+    keys: ['device.class', 'sentry.device.class'],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: false,
     visibility: 'public',
-    example: 'medium',
-    changelog: [{ version: '0.5.0', prs: [300], description: 'Added device.class attribute' }],
+    example: '1',
+    examples: ['1', '2', '3'],
+    aliases: ['sentry.device.class'],
+    changelog: [
+      {
+        version: 'next',
+        prs: [604],
+        description:
+          "Added sentry.device.class as a deprecated alias and documented Relay's stringified numeric class codes",
+      },
+      { version: '0.5.0', prs: [300], description: 'Added device.class attribute' },
+    ],
+    additionalContext: [
+      'Relay currently writes this as a stringified numeric class code: `"1"` (low), `"2"` (medium), or `"3"` (high), not the labels `low`, `medium`, or `high`.',
+    ],
   },
   'device.connection_type': {
     brief: 'The internet connection type currently being used by the device.',
@@ -30379,6 +30424,31 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'index view query',
     changelog: [{ version: '0.1.0', prs: [135] }],
   },
+  'sentry.device.class': {
+    brief:
+      'The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.',
+    type: 'string',
+    keys: ['device.class', 'sentry.device.class'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '1',
+    examples: ['1', '2', '3'],
+    deprecation: {
+      replacement: 'device.class',
+      reason: 'Deprecated in favor of device.class',
+      status: 'backfill',
+    },
+    aliases: ['device.class'],
+    changelog: [
+      { version: 'next', prs: [604], description: 'Added and deprecated sentry.device.class in favor of device.class' },
+    ],
+    additionalContext: [
+      'Relay currently writes this as a stringified numeric class code: `"1"` (low), `"2"` (medium), or `"3"` (high), not the labels `low`, `medium`, or `high`.',
+    ],
+  },
   'sentry.dist': {
     brief: 'The sentry dist.',
     type: 'string',
@@ -34534,7 +34604,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief:
       'The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.',
-    deprecationChain: ['device.class'],
+    deprecationChain: ['device.class', 'sentry.device.class'],
   },
   'device.connection_type': {
     canonicalName: 'network.connection.type',
@@ -37135,6 +37205,13 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     brief: 'The human-readable description of a span.',
     deprecationChain: ['sentry.description'],
   },
+  'sentry.device.class': {
+    canonicalName: 'device.class',
+    type: 'string',
+    brief:
+      'The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.',
+    deprecationChain: ['device.class', 'sentry.device.class'],
+  },
   'sentry.dist': {
     canonicalName: 'sentry.dist',
     type: 'string',
@@ -38803,6 +38880,7 @@ export type Attributes = {
   [SENTRY_CATEGORY]?: SENTRY_CATEGORY_TYPE;
   [SENTRY_CLIENT_SAMPLE_RATE]?: SENTRY_CLIENT_SAMPLE_RATE_TYPE;
   [SENTRY_DESCRIPTION]?: SENTRY_DESCRIPTION_TYPE;
+  [SENTRY_DEVICE_CLASS]?: SENTRY_DEVICE_CLASS_TYPE;
   [SENTRY_DIST]?: SENTRY_DIST_TYPE;
   [SENTRY_DOMAIN]?: SENTRY_DOMAIN_TYPE;
   [SENTRY_DSC_ENVIRONMENT]?: SENTRY_DSC_ENVIRONMENT_TYPE;

--- a/model/attributes/device/device__class.json
+++ b/model/attributes/device/device__class.json
@@ -1,6 +1,6 @@
 {
   "key": "device.class",
-  "brief": "The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.",
+  "brief": "The classification of the device. For example, `1`, `2`, or `3`. Typically inferred by Relay - SDKs generally do not need to set this directly.",
   "type": "string",
   "apply_scrubbing": {
     "key": "manual"
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "examples": ["1", "2", "3"],
   "additional_context": [
-    "Relay currently writes this as a stringified numeric class code: `\"1\"` (low), `\"2\"` (medium), or `\"3\"` (high), not the labels `low`, `medium`, or `high`."
+    "The product maps these stringified numeric class codes to `low` (`\"1\"`), `medium` (`\"2\"`), and `high` (`\"3\"`)."
   ],
   "alias": ["sentry.device.class"],
   "visibility": "public",
@@ -16,7 +16,7 @@
     {
       "version": "next",
       "prs": [604],
-      "description": "Added sentry.device.class as a deprecated alias and documented Relay's stringified numeric class codes"
+      "description": "Added sentry.device.class as a deprecated alias and documented class codes 1/2/3"
     },
     {
       "version": "0.5.0",

--- a/model/attributes/sentry/sentry__device__class.json
+++ b/model/attributes/sentry/sentry__device__class.json
@@ -1,5 +1,5 @@
 {
-  "key": "device.class",
+  "key": "sentry.device.class",
   "brief": "The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.",
   "type": "string",
   "apply_scrubbing": {
@@ -10,18 +10,18 @@
   "additional_context": [
     "Relay currently writes this as a stringified numeric class code: `\"1\"` (low), `\"2\"` (medium), or `\"3\"` (high), not the labels `low`, `medium`, or `high`."
   ],
-  "alias": ["sentry.device.class"],
+  "alias": ["device.class"],
+  "deprecation": {
+    "replacement": "device.class",
+    "reason": "Deprecated in favor of device.class",
+    "_status": "backfill"
+  },
   "visibility": "public",
   "changelog": [
     {
       "version": "next",
       "prs": [604],
-      "description": "Added sentry.device.class as a deprecated alias and documented Relay's stringified numeric class codes"
-    },
-    {
-      "version": "0.5.0",
-      "prs": [300],
-      "description": "Added device.class attribute"
+      "description": "Added and deprecated sentry.device.class in favor of device.class"
     }
   ]
 }

--- a/model/attributes/sentry/sentry__device__class.json
+++ b/model/attributes/sentry/sentry__device__class.json
@@ -1,6 +1,6 @@
 {
   "key": "sentry.device.class",
-  "brief": "The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.",
+  "brief": "The classification of the device. For example, `1`, `2`, or `3`. Typically inferred by Relay - SDKs generally do not need to set this directly.",
   "type": "string",
   "apply_scrubbing": {
     "key": "manual"
@@ -8,7 +8,7 @@
   "is_in_otel": false,
   "examples": ["1", "2", "3"],
   "additional_context": [
-    "Relay currently writes this as a stringified numeric class code: `\"1\"` (low), `\"2\"` (medium), or `\"3\"` (high), not the labels `low`, `medium`, or `high`."
+    "The product maps these stringified numeric class codes to `low` (`\"1\"`), `medium` (`\"2\"`), and `high` (`\"3\"`)."
   ],
   "alias": ["device.class"],
   "deprecation": {

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3527,7 +3527,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/device/device__class.json
     DEVICE_CLASS: Literal["device.class"] = "device.class"
-    """The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.
+    """The classification of the device. For example, `1`, `2`, or `3`. Typically inferred by Relay - SDKs generally do not need to set this directly.
 
     Type: str
     Apply Scrubbing: manual
@@ -8559,7 +8559,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
 
     # Path: model/attributes/sentry/sentry__device__class.json
     SENTRY_DEVICE_CLASS: Literal["sentry.device.class"] = "sentry.device.class"
-    """The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.
+    """The classification of the device. For example, `1`, `2`, or `3`. Typically inferred by Relay - SDKs generally do not need to set this directly.
 
     Type: str
     Apply Scrubbing: manual
@@ -15270,7 +15270,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "device.class": AttributeMetadata(
-        brief="The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.",
+        brief="The classification of the device. For example, `1`, `2`, or `3`. Typically inferred by Relay - SDKs generally do not need to set this directly.",
         type=AttributeType.STRING,
         keys=(
             "device.class",
@@ -15286,14 +15286,14 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(
                 version="next",
                 prs=[604],
-                description="Added sentry.device.class as a deprecated alias and documented Relay's stringified numeric class codes",
+                description="Added sentry.device.class as a deprecated alias and documented class codes 1/2/3",
             ),
             ChangelogEntry(
                 version="0.5.0", prs=[300], description="Added device.class attribute"
             ),
         ],
         additional_context=[
-            'Relay currently writes this as a stringified numeric class code: `"1"` (low), `"2"` (medium), or `"3"` (high), not the labels `low`, `medium`, or `high`.'
+            'The product maps these stringified numeric class codes to `low` (`"1"`), `medium` (`"2"`), and `high` (`"3"`).'
         ],
     ),
     "device.connection_type": AttributeMetadata(
@@ -22830,7 +22830,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "sentry.device.class": AttributeMetadata(
-        brief="The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.",
+        brief="The classification of the device. For example, `1`, `2`, or `3`. Typically inferred by Relay - SDKs generally do not need to set this directly.",
         type=AttributeType.STRING,
         keys=(
             "device.class",
@@ -22855,7 +22855,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
         additional_context=[
-            'Relay currently writes this as a stringified numeric class code: `"1"` (low), `"2"` (medium), or `"3"` (high), not the labels `low`, `medium`, or `high`.'
+            'The product maps these stringified numeric class codes to `low` (`"1"`), `medium` (`"2"`), and `high` (`"3"`).'
         ],
     ),
     "sentry.dist": AttributeMetadata(

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -360,6 +360,7 @@ class _AttributeNamesMeta(type):
         "RUNTIME_VERSION",
         "SENTRY_BROWSER_NAME",
         "SENTRY_BROWSER_VERSION",
+        "SENTRY_DEVICE_CLASS",
         "SENTRY_FRAMES_FROZEN",
         "SENTRY_FRAMES_SLOW",
         "SENTRY_FRAMES_TOTAL",
@@ -3532,7 +3533,10 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: No
     Visibility: public
-    Example: "medium"
+    Aliases: sentry.device.class
+    Example: "1"
+    Example: "2"
+    Example: "3"
     """
 
     # Path: model/attributes/device/device__connection_type.json
@@ -8551,6 +8555,21 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Visibility: public
     Example: "index view query"
+    """
+
+    # Path: model/attributes/sentry/sentry__device__class.json
+    SENTRY_DEVICE_CLASS: Literal["sentry.device.class"] = "sentry.device.class"
+    """The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: device.class
+    DEPRECATED: Use device.class instead - Deprecated in favor of device.class
+    Example: "1"
+    Example: "2"
+    Example: "3"
     """
 
     # Path: model/attributes/sentry/sentry__dist.json
@@ -15253,15 +15272,28 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
     "device.class": AttributeMetadata(
         brief="The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.",
         type=AttributeType.STRING,
-        keys=("device.class",),
+        keys=(
+            "device.class",
+            "sentry.device.class",
+        ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
-        example="medium",
+        example="1",
+        examples=["1", "2", "3"],
+        aliases=["sentry.device.class"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[604],
+                description="Added sentry.device.class as a deprecated alias and documented Relay's stringified numeric class codes",
+            ),
             ChangelogEntry(
                 version="0.5.0", prs=[300], description="Added device.class attribute"
             ),
+        ],
+        additional_context=[
+            'Relay currently writes this as a stringified numeric class code: `"1"` (low), `"2"` (medium), or `"3"` (high), not the labels `low`, `medium`, or `high`.'
         ],
     ),
     "device.connection_type": AttributeMetadata(
@@ -22797,6 +22829,35 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.1.0", prs=[135]),
         ],
     ),
+    "sentry.device.class": AttributeMetadata(
+        brief="The classification of the device. For example, `low`, `medium`, or `high`. Typically inferred by Relay - SDKs generally do not need to set this directly.",
+        type=AttributeType.STRING,
+        keys=(
+            "device.class",
+            "sentry.device.class",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="1",
+        examples=["1", "2", "3"],
+        deprecation=DeprecationInfo(
+            replacement="device.class",
+            reason="Deprecated in favor of device.class",
+            status=DeprecationStatus.BACKFILL,
+        ),
+        aliases=["device.class"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[604],
+                description="Added and deprecated sentry.device.class in favor of device.class",
+            ),
+        ],
+        additional_context=[
+            'Relay currently writes this as a stringified numeric class code: `"1"` (low), `"2"` (medium), or `"3"` (high), not the labels `low`, `medium`, or `high`.'
+        ],
+    ),
     "sentry.dist": AttributeMetadata(
         brief="The sentry dist.",
         type=AttributeType.STRING,
@@ -26295,6 +26356,7 @@ Attributes = TypedDict(
         "sentry.category": str,
         "sentry.client_sample_rate": float,
         "sentry.description": str,
+        "sentry.device.class": str,
         "sentry.dist": str,
         "sentry.domain": str,
         "sentry.dsc.environment": str,


### PR DESCRIPTION
## Description

Add `sentry.device.class` as a deprecated alias of `device.class` (`_status: backfill`) so ingest can copy the value onto the stable name.

`device.class` stays a string. The brief still describes the labels `low` / `medium` / `high`. Examples and additional context document what Relay actually writes today: stringified numeric class codes `"1"` / `"2"` / `"3"`, not those labels.

## PR Checklist

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
