### PR TITLE
feat(names): Add `cache` span name rules

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3840,6 +3840,8 @@ export type CACHE_KEY_TYPE = Array<string>;
  * Visibility: public
  *
  * @example "get"
+ * @example "put"
+ * @example "remove"
  */
 export const CACHE_OPERATION = 'cache.operation';
 
@@ -22759,6 +22761,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     isInOtel: false,
     visibility: 'public',
     example: 'get',
+    examples: ['get', 'put', 'remove'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
   },
   'cache.ttl': {

--- a/model/attributes/cache/cache__operation.json
+++ b/model/attributes/cache/cache__operation.json
@@ -6,7 +6,7 @@
     "key": "manual"
   },
   "is_in_otel": false,
-  "example": "get",
+  "examples": ["get", "put", "remove"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/name/cache.json
+++ b/model/name/cache.json
@@ -7,8 +7,8 @@
       "is_in_otel": false,
       "otel_notes": "Cache conventions proposal pending: https://github.com/open-telemetry/semantic-conventions/issues/1747",
       "ops": ["cache", "cache.get", "cache.put", "cache.remove"],
-      "templates": ["{{cache.operation}}", "Cache operation"],
-      "examples": ["get", "put", "remove"]
+      "templates": ["cache.{{cache.operation}}", "Cache operation"],
+      "examples": ["cache.get", "cache.put", "cache.remove", "Cache operation"]
     }
   ]
 }

--- a/model/name/cache.json
+++ b/model/name/cache.json
@@ -1,0 +1,14 @@
+{
+  "brief": "Cache",
+  "operations": [
+    {
+      "name": "Cache operations",
+      "brief": "Operations that interact with a cache, such as reading or writing cached values.",
+      "is_in_otel": false,
+      "otel_notes": "Cache conventions proposal pending: https://github.com/open-telemetry/semantic-conventions/issues/1747",
+      "ops": ["cache", "cache.get", "cache.put", "cache.remove"],
+      "templates": ["{{cache.operation}}", "Cache operation"],
+      "examples": ["get", "put", "remove"]
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2595,6 +2595,8 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Defined in OTEL: No
     Visibility: public
     Example: "get"
+    Example: "put"
+    Example: "remove"
     """
 
     # Path: model/attributes/cache/cache__ttl.json
@@ -13930,6 +13932,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         example="get",
+        examples=["get", "put", "remove"],
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),


### PR DESCRIPTION
We were missing `cache` span name rules. This PR adds them based on https://github.com/open-telemetry/semantic-conventions/issues/1747. Basically, this will lead to span name and op being identical but I think that's fine. Happy to adjust based on others' opinions though

