### PR TITLE
fix(attributes): Change deprecation status from `backfill` to `normalize`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -23210,7 +23210,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '/app/myapplication/http/handler/server.py',
     deprecation: {
       replacement: 'code.file.path',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['code.file.path'],
     changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
@@ -23276,7 +23276,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 42,
     deprecation: {
       replacement: 'code.line.number',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['code.line.number'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61, 108] }, { version: '0.0.0' }],
@@ -23500,7 +23500,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'customers',
     deprecation: {
       replacement: 'db.namespace',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['db.namespace'],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
@@ -26612,7 +26612,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'example.com',
     deprecation: {
       replacement: 'client.address',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['client.address'],
     changelog: [{ version: '0.1.0', prs: [61, 106, 127] }, { version: '0.0.0' }],
@@ -26658,7 +26658,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '1.1',
     deprecation: {
       replacement: 'network.protocol.version',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['network.protocol.version', 'net.protocol.version', 'messaging.protocol_version'],
     changelog: [
@@ -27291,7 +27291,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'https',
     deprecation: {
       replacement: 'url.scheme',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['url.scheme'],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
@@ -27308,7 +27308,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'example.com',
     deprecation: {
       replacement: 'server.address',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['address', 'server.address', 'net.host.name', 'http.host', 'net.peer.name'],
     changelog: [
@@ -27343,7 +27343,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 404,
     deprecation: {
       replacement: 'http.response.status_code',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['http.response.status_code'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
@@ -27408,7 +27408,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'https://example.com/test?foo=bar#buzz',
     deprecation: {
       replacement: 'url.full',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['url.full', 'url', 'aws.request.url', 'messaging.url'],
     changelog: [
@@ -27430,7 +27430,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       'Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1',
     deprecation: {
       replacement: 'user_agent.original',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['user_agent.original'],
     changelog: [{ version: '0.1.0', prs: [61, 127] }, { version: '0.0.0' }],
@@ -29123,7 +29123,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '192.168.0.1',
     deprecation: {
       replacement: 'network.local.address',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['network.local.address', 'net.sock.host.addr'],
     changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
@@ -29141,7 +29141,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'example.com',
     deprecation: {
       replacement: 'server.address',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['address', 'server.address', 'http.server_name', 'http.host', 'net.peer.name'],
     changelog: [
@@ -29163,7 +29163,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 1337,
     deprecation: {
       replacement: 'server.port',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['server.port', 'port'],
     changelog: [
@@ -29185,7 +29185,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '192.168.0.1',
     deprecation: {
       replacement: 'network.peer.address',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['network.peer.address', 'net.sock.peer.addr'],
     changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
@@ -29240,7 +29240,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'http',
     deprecation: {
       replacement: 'network.protocol.name',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['network.protocol.name', 'mcp.resource.protocol', 'messaging.protocol'],
     changelog: [
@@ -29261,7 +29261,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '1.1',
     deprecation: {
       replacement: 'network.protocol.version',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['network.protocol.version', 'http.flavor', 'messaging.protocol_version'],
     changelog: [
@@ -29298,7 +29298,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '/var/my.sock',
     deprecation: {
       replacement: 'network.local.address',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['network.local.address', 'net.host.ip'],
     changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
@@ -29315,7 +29315,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 8080,
     deprecation: {
       replacement: 'network.local.port',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['network.local.port'],
     changelog: [{ version: '0.4.0', prs: [228] }, { version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
@@ -29332,7 +29332,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '192.168.0.1',
     deprecation: {
       replacement: 'network.peer.address',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['network.peer.address', 'net.peer.ip'],
     changelog: [{ version: '0.1.0', prs: [61, 108, 127] }, { version: '0.0.0' }],
@@ -29364,7 +29364,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 8080,
     deprecation: {
       replacement: 'network.peer.port',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['network.peer.port'],
     changelog: [
@@ -30159,7 +30159,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'process.runtime.name',
       reason: 'Prefer OTel-aligned process.runtime.name',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['process.runtime.name'],
     changelog: [
@@ -30184,7 +30184,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'process.runtime.description',
       reason: 'Prefer OTel-aligned process.runtime.description',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['process.runtime.description'],
     changelog: [
@@ -30208,7 +30208,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     deprecation: {
       replacement: 'process.runtime.version',
       reason: 'Prefer OTel-aligned process.runtime.version',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['process.runtime.version'],
     changelog: [
@@ -30299,7 +30299,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'Chrome',
     deprecation: {
       replacement: 'browser.name',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['browser.name'],
     changelog: [{ version: '0.1.0', prs: [139] }],
@@ -30319,7 +30319,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: '120.0.6099.130',
     deprecation: {
       replacement: 'browser.version',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['browser.version'],
     changelog: [{ version: '0.1.0', prs: [139] }],
@@ -31437,7 +31437,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.email',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['user.email'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -31456,7 +31456,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.geo.city',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['user.geo.city'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -31475,7 +31475,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.geo.country_code',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['user.geo.country_code'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -31494,7 +31494,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.geo.region',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['user.geo.region'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -31513,7 +31513,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.geo.subdivision',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['user.geo.subdivision'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -31532,7 +31532,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.id',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['user.id'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -31551,7 +31551,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.ip_address',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['user.ip_address'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -31570,7 +31570,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     deprecation: {
       replacement: 'user.name',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['user.name'],
     changelog: [{ version: '0.10.0', prs: [406] }],
@@ -32150,7 +32150,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'https://example.com/test?foo=bar#buzz',
     deprecation: {
       replacement: 'url.full',
-      status: 'backfill',
+      status: 'normalize',
     },
     aliases: ['url.full', 'http.url', 'aws.request.url', 'messaging.url'],
     changelog: [

--- a/model/attributes/code/code__filepath.json
+++ b/model/attributes/code/code__filepath.json
@@ -9,7 +9,7 @@
   "example": "/app/myapplication/http/handler/server.py",
   "alias": ["code.file.path"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "code.file.path"
   },
   "visibility": "public",

--- a/model/attributes/code/code__lineno.json
+++ b/model/attributes/code/code__lineno.json
@@ -9,7 +9,7 @@
   "example": 42,
   "alias": ["code.line.number"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "code.line.number"
   },
   "visibility": "public",

--- a/model/attributes/db/db__name.json
+++ b/model/attributes/db/db__name.json
@@ -9,7 +9,7 @@
   "example": "customers",
   "alias": ["db.namespace"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "db.namespace"
   },
   "visibility": "public",

--- a/model/attributes/http/http__client_ip.json
+++ b/model/attributes/http/http__client_ip.json
@@ -9,7 +9,7 @@
   "example": "example.com",
   "alias": ["client.address"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "client.address"
   },
   "visibility": "public",

--- a/model/attributes/http/http__flavor.json
+++ b/model/attributes/http/http__flavor.json
@@ -9,7 +9,7 @@
   "example": "1.1",
   "alias": ["network.protocol.version", "net.protocol.version", "messaging.protocol_version"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "network.protocol.version"
   },
   "visibility": "public",

--- a/model/attributes/http/http__scheme.json
+++ b/model/attributes/http/http__scheme.json
@@ -9,7 +9,7 @@
   "example": "https",
   "alias": ["url.scheme"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "url.scheme"
   },
   "visibility": "public",

--- a/model/attributes/http/http__server_name.json
+++ b/model/attributes/http/http__server_name.json
@@ -9,7 +9,7 @@
   "example": "example.com",
   "alias": ["address", "server.address", "net.host.name", "http.host", "net.peer.name"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "server.address"
   },
   "visibility": "public",

--- a/model/attributes/http/http__status_code.json
+++ b/model/attributes/http/http__status_code.json
@@ -9,7 +9,7 @@
   "example": 404,
   "alias": ["http.response.status_code"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "http.response.status_code"
   },
   "visibility": "public",

--- a/model/attributes/http/http__url.json
+++ b/model/attributes/http/http__url.json
@@ -9,7 +9,7 @@
   "example": "https://example.com/test?foo=bar#buzz",
   "alias": ["url.full", "url", "aws.request.url", "messaging.url"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "url.full"
   },
   "visibility": "public",

--- a/model/attributes/http/http__user_agent.json
+++ b/model/attributes/http/http__user_agent.json
@@ -9,7 +9,7 @@
   "example": "Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1",
   "alias": ["user_agent.original"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "user_agent.original"
   },
   "visibility": "public",

--- a/model/attributes/net/net__host__ip.json
+++ b/model/attributes/net/net__host__ip.json
@@ -9,7 +9,7 @@
   "example": "192.168.0.1",
   "alias": ["network.local.address", "net.sock.host.addr"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "network.local.address"
   },
   "visibility": "public",

--- a/model/attributes/net/net__host__name.json
+++ b/model/attributes/net/net__host__name.json
@@ -9,7 +9,7 @@
   "example": "example.com",
   "alias": ["address", "server.address", "http.server_name", "http.host", "net.peer.name"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "server.address"
   },
   "visibility": "public",

--- a/model/attributes/net/net__host__port.json
+++ b/model/attributes/net/net__host__port.json
@@ -9,7 +9,7 @@
   "example": 1337,
   "alias": ["server.port", "port"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "server.port"
   },
   "visibility": "public",

--- a/model/attributes/net/net__peer__ip.json
+++ b/model/attributes/net/net__peer__ip.json
@@ -9,7 +9,7 @@
   "example": "192.168.0.1",
   "alias": ["network.peer.address", "net.sock.peer.addr"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "network.peer.address"
   },
   "visibility": "public",

--- a/model/attributes/net/net__protocol__name.json
+++ b/model/attributes/net/net__protocol__name.json
@@ -9,7 +9,7 @@
   "example": "http",
   "alias": ["network.protocol.name", "mcp.resource.protocol", "messaging.protocol"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "network.protocol.name"
   },
   "visibility": "public",

--- a/model/attributes/net/net__protocol__version.json
+++ b/model/attributes/net/net__protocol__version.json
@@ -9,7 +9,7 @@
   "example": "1.1",
   "alias": ["network.protocol.version", "http.flavor", "messaging.protocol_version"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "network.protocol.version"
   },
   "visibility": "public",

--- a/model/attributes/net/net__sock__host__addr.json
+++ b/model/attributes/net/net__sock__host__addr.json
@@ -9,7 +9,7 @@
   "example": "/var/my.sock",
   "alias": ["network.local.address", "net.host.ip"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "network.local.address"
   },
   "visibility": "public",

--- a/model/attributes/net/net__sock__host__port.json
+++ b/model/attributes/net/net__sock__host__port.json
@@ -9,7 +9,7 @@
   "example": 8080,
   "alias": ["network.local.port"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "network.local.port"
   },
   "visibility": "public",

--- a/model/attributes/net/net__sock__peer__addr.json
+++ b/model/attributes/net/net__sock__peer__addr.json
@@ -9,7 +9,7 @@
   "example": "192.168.0.1",
   "alias": ["network.peer.address", "net.peer.ip"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "network.peer.address"
   },
   "visibility": "public",

--- a/model/attributes/net/net__sock__peer__port.json
+++ b/model/attributes/net/net__sock__peer__port.json
@@ -9,7 +9,7 @@
   "example": 8080,
   "alias": ["network.peer.port"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "network.peer.port"
   },
   "visibility": "public",

--- a/model/attributes/runtime/runtime__name.json
+++ b/model/attributes/runtime/runtime__name.json
@@ -11,7 +11,7 @@
   "deprecation": {
     "replacement": "process.runtime.name",
     "reason": "Prefer OTel-aligned process.runtime.name",
-    "_status": "backfill"
+    "_status": "normalize"
   },
   "alias": ["process.runtime.name"],
   "changelog": [

--- a/model/attributes/runtime/runtime__raw_description.json
+++ b/model/attributes/runtime/runtime__raw_description.json
@@ -11,7 +11,7 @@
   "deprecation": {
     "replacement": "process.runtime.description",
     "reason": "Prefer OTel-aligned process.runtime.description",
-    "_status": "backfill"
+    "_status": "normalize"
   },
   "alias": ["process.runtime.description"],
   "changelog": [

--- a/model/attributes/runtime/runtime__version.json
+++ b/model/attributes/runtime/runtime__version.json
@@ -11,7 +11,7 @@
   "deprecation": {
     "replacement": "process.runtime.version",
     "reason": "Prefer OTel-aligned process.runtime.version",
-    "_status": "backfill"
+    "_status": "normalize"
   },
   "alias": ["process.runtime.version"],
   "changelog": [

--- a/model/attributes/sentry/sentry__browser__name.json
+++ b/model/attributes/sentry/sentry__browser__name.json
@@ -9,7 +9,7 @@
   "example": "Chrome",
   "alias": ["browser.name"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "browser.name"
   },
   "visibility": "public",

--- a/model/attributes/sentry/sentry__browser__version.json
+++ b/model/attributes/sentry/sentry__browser__version.json
@@ -9,7 +9,7 @@
   "example": "120.0.6099.130",
   "alias": ["browser.version"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "browser.version"
   },
   "visibility": "public",

--- a/model/attributes/sentry/sentry__user__email.json
+++ b/model/attributes/sentry/sentry__user__email.json
@@ -9,7 +9,7 @@
   "alias": ["user.email"],
   "deprecation": {
     "replacement": "user.email",
-    "_status": "backfill"
+    "_status": "normalize"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/sentry/sentry__user__geo__city.json
+++ b/model/attributes/sentry/sentry__user__geo__city.json
@@ -9,7 +9,7 @@
   "alias": ["user.geo.city"],
   "deprecation": {
     "replacement": "user.geo.city",
-    "_status": "backfill"
+    "_status": "normalize"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/sentry/sentry__user__geo__country_code.json
+++ b/model/attributes/sentry/sentry__user__geo__country_code.json
@@ -9,7 +9,7 @@
   "alias": ["user.geo.country_code"],
   "deprecation": {
     "replacement": "user.geo.country_code",
-    "_status": "backfill"
+    "_status": "normalize"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/sentry/sentry__user__geo__region.json
+++ b/model/attributes/sentry/sentry__user__geo__region.json
@@ -9,7 +9,7 @@
   "alias": ["user.geo.region"],
   "deprecation": {
     "replacement": "user.geo.region",
-    "_status": "backfill"
+    "_status": "normalize"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/sentry/sentry__user__geo__subdivision.json
+++ b/model/attributes/sentry/sentry__user__geo__subdivision.json
@@ -9,7 +9,7 @@
   "alias": ["user.geo.subdivision"],
   "deprecation": {
     "replacement": "user.geo.subdivision",
-    "_status": "backfill"
+    "_status": "normalize"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/sentry/sentry__user__id.json
+++ b/model/attributes/sentry/sentry__user__id.json
@@ -9,7 +9,7 @@
   "alias": ["user.id"],
   "deprecation": {
     "replacement": "user.id",
-    "_status": "backfill"
+    "_status": "normalize"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/sentry/sentry__user__ip.json
+++ b/model/attributes/sentry/sentry__user__ip.json
@@ -9,7 +9,7 @@
   "alias": ["user.ip_address"],
   "deprecation": {
     "replacement": "user.ip_address",
-    "_status": "backfill"
+    "_status": "normalize"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/sentry/sentry__user__username.json
+++ b/model/attributes/sentry/sentry__user__username.json
@@ -9,7 +9,7 @@
   "alias": ["user.name"],
   "deprecation": {
     "replacement": "user.name",
-    "_status": "backfill"
+    "_status": "normalize"
   },
   "visibility": "public",
   "search_alias": {

--- a/model/attributes/url.json
+++ b/model/attributes/url.json
@@ -9,7 +9,7 @@
   "example": "https://example.com/test?foo=bar#buzz",
   "alias": ["url.full", "http.url", "aws.request.url", "messaging.url"],
   "deprecation": {
-    "_status": "backfill",
+    "_status": "normalize",
     "replacement": "url.full"
   },
   "visibility": "public",

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -14477,7 +14477,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="/app/myapplication/http/handler/server.py",
         deprecation=DeprecationInfo(
-            replacement="code.file.path", status=DeprecationStatus.BACKFILL
+            replacement="code.file.path", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["code.file.path"],
         changelog=[
@@ -14560,7 +14560,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=42,
         deprecation=DeprecationInfo(
-            replacement="code.line.number", status=DeprecationStatus.BACKFILL
+            replacement="code.line.number", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["code.line.number"],
         changelog=[
@@ -14808,7 +14808,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="customers",
         deprecation=DeprecationInfo(
-            replacement="db.namespace", status=DeprecationStatus.BACKFILL
+            replacement="db.namespace", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["db.namespace"],
         changelog=[
@@ -18434,7 +18434,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="example.com",
         deprecation=DeprecationInfo(
-            replacement="client.address", status=DeprecationStatus.BACKFILL
+            replacement="client.address", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["client.address"],
         changelog=[
@@ -18489,7 +18489,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="1.1",
         deprecation=DeprecationInfo(
-            replacement="network.protocol.version", status=DeprecationStatus.BACKFILL
+            replacement="network.protocol.version", status=DeprecationStatus.NORMALIZE
         ),
         aliases=[
             "network.protocol.version",
@@ -19215,7 +19215,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="https",
         deprecation=DeprecationInfo(
-            replacement="url.scheme", status=DeprecationStatus.BACKFILL
+            replacement="url.scheme", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["url.scheme"],
         changelog=[
@@ -19249,7 +19249,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="example.com",
         deprecation=DeprecationInfo(
-            replacement="server.address", status=DeprecationStatus.BACKFILL
+            replacement="server.address", status=DeprecationStatus.NORMALIZE
         ),
         aliases=[
             "address",
@@ -19284,7 +19284,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=404,
         deprecation=DeprecationInfo(
-            replacement="http.response.status_code", status=DeprecationStatus.BACKFILL
+            replacement="http.response.status_code", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["http.response.status_code"],
         changelog=[
@@ -19353,7 +19353,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="https://example.com/test?foo=bar#buzz",
         deprecation=DeprecationInfo(
-            replacement="url.full", status=DeprecationStatus.BACKFILL
+            replacement="url.full", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["url.full", "url", "aws.request.url", "messaging.url"],
         changelog=[
@@ -19378,7 +19378,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1",
         deprecation=DeprecationInfo(
-            replacement="user_agent.original", status=DeprecationStatus.BACKFILL
+            replacement="user_agent.original", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["user_agent.original"],
         changelog=[
@@ -21118,7 +21118,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="192.168.0.1",
         deprecation=DeprecationInfo(
-            replacement="network.local.address", status=DeprecationStatus.BACKFILL
+            replacement="network.local.address", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["network.local.address", "net.sock.host.addr"],
         changelog=[
@@ -21140,7 +21140,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="example.com",
         deprecation=DeprecationInfo(
-            replacement="server.address", status=DeprecationStatus.BACKFILL
+            replacement="server.address", status=DeprecationStatus.NORMALIZE
         ),
         aliases=[
             "address",
@@ -21175,7 +21175,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=1337,
         deprecation=DeprecationInfo(
-            replacement="server.port", status=DeprecationStatus.BACKFILL
+            replacement="server.port", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["server.port", "port"],
         changelog=[
@@ -21200,7 +21200,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="192.168.0.1",
         deprecation=DeprecationInfo(
-            replacement="network.peer.address", status=DeprecationStatus.BACKFILL
+            replacement="network.peer.address", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["network.peer.address", "net.sock.peer.addr"],
         changelog=[
@@ -21269,7 +21269,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="http",
         deprecation=DeprecationInfo(
-            replacement="network.protocol.name", status=DeprecationStatus.BACKFILL
+            replacement="network.protocol.name", status=DeprecationStatus.NORMALIZE
         ),
         aliases=[
             "network.protocol.name",
@@ -21300,7 +21300,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="1.1",
         deprecation=DeprecationInfo(
-            replacement="network.protocol.version", status=DeprecationStatus.BACKFILL
+            replacement="network.protocol.version", status=DeprecationStatus.NORMALIZE
         ),
         aliases=[
             "network.protocol.version",
@@ -21347,7 +21347,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="/var/my.sock",
         deprecation=DeprecationInfo(
-            replacement="network.local.address", status=DeprecationStatus.BACKFILL
+            replacement="network.local.address", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["network.local.address", "net.host.ip"],
         changelog=[
@@ -21367,7 +21367,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=8080,
         deprecation=DeprecationInfo(
-            replacement="network.local.port", status=DeprecationStatus.BACKFILL
+            replacement="network.local.port", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["network.local.port"],
         changelog=[
@@ -21389,7 +21389,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="192.168.0.1",
         deprecation=DeprecationInfo(
-            replacement="network.peer.address", status=DeprecationStatus.BACKFILL
+            replacement="network.peer.address", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["network.peer.address", "net.peer.ip"],
         changelog=[
@@ -21425,7 +21425,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example=8080,
         deprecation=DeprecationInfo(
-            replacement="network.peer.port", status=DeprecationStatus.BACKFILL
+            replacement="network.peer.port", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["network.peer.port"],
         changelog=[
@@ -22563,7 +22563,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="process.runtime.name",
             reason="Prefer OTel-aligned process.runtime.name",
-            status=DeprecationStatus.BACKFILL,
+            status=DeprecationStatus.NORMALIZE,
         ),
         aliases=["process.runtime.name"],
         changelog=[
@@ -22588,7 +22588,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="process.runtime.description",
             reason="Prefer OTel-aligned process.runtime.description",
-            status=DeprecationStatus.BACKFILL,
+            status=DeprecationStatus.NORMALIZE,
         ),
         aliases=["process.runtime.description"],
         changelog=[
@@ -22613,7 +22613,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="process.runtime.version",
             reason="Prefer OTel-aligned process.runtime.version",
-            status=DeprecationStatus.BACKFILL,
+            status=DeprecationStatus.NORMALIZE,
         ),
         aliases=["process.runtime.version"],
         changelog=[
@@ -22714,7 +22714,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="Chrome",
         deprecation=DeprecationInfo(
-            replacement="browser.name", status=DeprecationStatus.BACKFILL
+            replacement="browser.name", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["browser.name"],
         changelog=[
@@ -22734,7 +22734,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="120.0.6099.130",
         deprecation=DeprecationInfo(
-            replacement="browser.version", status=DeprecationStatus.BACKFILL
+            replacement="browser.version", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["browser.version"],
         changelog=[
@@ -23964,7 +23964,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         deprecation=DeprecationInfo(
-            replacement="user.email", status=DeprecationStatus.BACKFILL
+            replacement="user.email", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["user.email"],
         changelog=[
@@ -23983,7 +23983,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         deprecation=DeprecationInfo(
-            replacement="user.geo.city", status=DeprecationStatus.BACKFILL
+            replacement="user.geo.city", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["user.geo.city"],
         changelog=[
@@ -24002,7 +24002,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         deprecation=DeprecationInfo(
-            replacement="user.geo.country_code", status=DeprecationStatus.BACKFILL
+            replacement="user.geo.country_code", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["user.geo.country_code"],
         changelog=[
@@ -24021,7 +24021,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         deprecation=DeprecationInfo(
-            replacement="user.geo.region", status=DeprecationStatus.BACKFILL
+            replacement="user.geo.region", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["user.geo.region"],
         changelog=[
@@ -24040,7 +24040,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         deprecation=DeprecationInfo(
-            replacement="user.geo.subdivision", status=DeprecationStatus.BACKFILL
+            replacement="user.geo.subdivision", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["user.geo.subdivision"],
         changelog=[
@@ -24059,7 +24059,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         deprecation=DeprecationInfo(
-            replacement="user.id", status=DeprecationStatus.BACKFILL
+            replacement="user.id", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["user.id"],
         changelog=[
@@ -24079,7 +24079,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         deprecation=DeprecationInfo(
-            replacement="user.ip_address", status=DeprecationStatus.BACKFILL
+            replacement="user.ip_address", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["user.ip_address"],
         changelog=[
@@ -24099,7 +24099,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         deprecation=DeprecationInfo(
-            replacement="user.name", status=DeprecationStatus.BACKFILL
+            replacement="user.name", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["user.name"],
         changelog=[
@@ -25003,7 +25003,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         example="https://example.com/test?foo=bar#buzz",
         deprecation=DeprecationInfo(
-            replacement="url.full", status=DeprecationStatus.BACKFILL
+            replacement="url.full", status=DeprecationStatus.NORMALIZE
         ),
         aliases=["url.full", "http.url", "aws.request.url", "messaging.url"],
         changelog=[


### PR DESCRIPTION
Changes the deprecation status of the attributes marked `backfill` in #571 to `normalize`.

Backfilling these straight renames means the value is stored under both the old and the new key. That increased log and metric sizes. Normalizing ensures a large value like `url.full` only ends up once in the stored metric.

Two attributes from #571 are untouched: `net.transport` (already reverted to `null` in #588) and `network.local.address` (that PR only changed its example).

@ Reviewers: If you prefer a more fine-grained change instead, I'm also happy to drop the bulk change. 