### PR TITLE
feat(attributes): Add `sveltekit.*` attributes emitted by SvelteKit's native spans

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -16664,6 +16664,27 @@ export const SUBPROCESS_PID = 'subprocess.pid';
  */
 export type SUBPROCESS_PID_TYPE = number;
 
+// Path: model/attributes/sveltekit/sveltekit__tracing__original_name.json
+
+/**
+ * The original span name as emitted by SvelteKit. `sveltekit.tracing.original_name`
+ *
+ * Attribute Value Type: `string` {@link SVELTEKIT_TRACING_ORIGINAL_NAME_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "sveltekit.handle.root"
+ */
+export const SVELTEKIT_TRACING_ORIGINAL_NAME = 'sveltekit.tracing.original_name';
+
+/**
+ * Type for {@link SVELTEKIT_TRACING_ORIGINAL_NAME} sveltekit.tracing.original_name
+ */
+export type SVELTEKIT_TRACING_ORIGINAL_NAME_TYPE = string;
+
 // Path: model/attributes/thread/thread__id.json
 
 /**
@@ -19329,6 +19350,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'starlite.middleware_name': 'string',
   'state.type': 'string',
   'subprocess.pid': 'integer',
+  'sveltekit.tracing.original_name': 'string',
   'thread.id': 'integer',
   'thread.name': 'string',
   'timber.tag': 'string',
@@ -20160,6 +20182,7 @@ export type AttributeName =
   | typeof STARLITE_MIDDLEWARE_NAME
   | typeof STATE_TYPE
   | typeof SUBPROCESS_PID
+  | typeof SVELTEKIT_TRACING_ORIGINAL_NAME
   | typeof THREAD_ID
   | typeof THREAD_NAME
   | typeof TIMBER_TAG
@@ -32128,6 +32151,22 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       },
     ],
   },
+  'sveltekit.tracing.original_name': {
+    brief: 'The original span name as emitted by SvelteKit.',
+    type: 'string',
+    keys: ['sveltekit.tracing.original_name'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'sveltekit.handle.root',
+    examples: ['sveltekit.handle.root'],
+    changelog: [{ version: 'next', prs: [611], description: 'Added sveltekit.tracing.original_name attribute' }],
+    additionalContext: [
+      "The Sentry SDK renames SvelteKit-emitted spans to match Sentry's span name semantics, and preserves the name SvelteKit originally set in this attribute.",
+    ],
+  },
   'thread.id': {
     brief: 'Current “managed” thread ID.',
     type: 'integer',
@@ -37964,6 +38003,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     brief: 'The process ID of a subprocess.',
     deprecationChain: ['process.pid', 'subprocess.pid'],
   },
+  'sveltekit.tracing.original_name': {
+    canonicalName: 'sveltekit.tracing.original_name',
+    type: 'string',
+    brief: 'The original span name as emitted by SvelteKit.',
+    deprecationChain: ['sveltekit.tracing.original_name'],
+  },
   'thread.id': {
     canonicalName: 'thread.id',
     type: 'integer',
@@ -39249,6 +39294,7 @@ export type Attributes = {
   [STARLITE_MIDDLEWARE_NAME]?: STARLITE_MIDDLEWARE_NAME_TYPE;
   [STATE_TYPE]?: STATE_TYPE_TYPE;
   [SUBPROCESS_PID]?: SUBPROCESS_PID_TYPE;
+  [SVELTEKIT_TRACING_ORIGINAL_NAME]?: SVELTEKIT_TRACING_ORIGINAL_NAME_TYPE;
   [THREAD_ID]?: THREAD_ID_TYPE;
   [THREAD_NAME]?: THREAD_NAME_TYPE;
   [TIMBER_TAG]?: TIMBER_TAG_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -4608,7 +4608,7 @@ export type CODE_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link CODE_FILE_PATH} `code.file.path`
+ * Aliases: {@link CODE_FILE_PATH} `code.file.path`, {@link SVELTEKIT_LOAD_NODE_ID} `sveltekit.load.node_id`
  *
  * @deprecated Use {@link CODE_FILE_PATH} (code.file.path) instead
  * @example "/app/myapplication/http/handler/server.py"
@@ -4632,7 +4632,7 @@ export type CODE_FILEPATH_TYPE = string;
  * Attribute defined in OTEL: Yes
  * Visibility: public
  *
- * Aliases: {@link CODE_FILEPATH} `code.filepath`
+ * Aliases: {@link CODE_FILEPATH} `code.filepath`, {@link SVELTEKIT_LOAD_NODE_ID} `sveltekit.load.node_id`
  *
  * @example "/app/myapplication/http/handler/server.py"
  */
@@ -16664,6 +16664,74 @@ export const SUBPROCESS_PID = 'subprocess.pid';
  */
 export type SUBPROCESS_PID_TYPE = number;
 
+// Path: model/attributes/sveltekit/sveltekit__load__environment.json
+
+/**
+ * The runtime environment in which the SvelteKit load function was executed. Known values are `'server'` and `'client'`. `sveltekit.load.environment`
+ *
+ * Attribute Value Type: `string` {@link SVELTEKIT_LOAD_ENVIRONMENT_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "server"
+ * @example "client"
+ */
+export const SVELTEKIT_LOAD_ENVIRONMENT = 'sveltekit.load.environment';
+
+/**
+ * Type for {@link SVELTEKIT_LOAD_ENVIRONMENT} sveltekit.load.environment
+ */
+export type SVELTEKIT_LOAD_ENVIRONMENT_TYPE = string;
+
+// Path: model/attributes/sveltekit/sveltekit__load__node_id.json
+
+/**
+ * The path to the SvelteKit load function. `sveltekit.load.node_id`
+ *
+ * Attribute Value Type: `string` {@link SVELTEKIT_LOAD_NODE_ID_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * Aliases: {@link CODE_FILE_PATH} `code.file.path`, {@link CODE_FILEPATH} `code.filepath`
+ *
+ * @example "src/routes/users/:id/+page.server.ts"
+ */
+export const SVELTEKIT_LOAD_NODE_ID = 'sveltekit.load.node_id';
+
+/**
+ * Type for {@link SVELTEKIT_LOAD_NODE_ID} sveltekit.load.node_id
+ */
+export type SVELTEKIT_LOAD_NODE_ID_TYPE = string;
+
+// Path: model/attributes/sveltekit/sveltekit__load__node_type.json
+
+/**
+ * The kind of SvelteKit load function that was executed, distinguishing page from layout and universal from server load functions. `sveltekit.load.node_type`
+ *
+ * Attribute Value Type: `string` {@link SVELTEKIT_LOAD_NODE_TYPE_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "+page.server"
+ * @example "+layout"
+ * @example "+layout.server"
+ */
+export const SVELTEKIT_LOAD_NODE_TYPE = 'sveltekit.load.node_type';
+
+/**
+ * Type for {@link SVELTEKIT_LOAD_NODE_TYPE} sveltekit.load.node_type
+ */
+export type SVELTEKIT_LOAD_NODE_TYPE_TYPE = string;
+
 // Path: model/attributes/sveltekit/sveltekit__tracing__original_name.json
 
 /**
@@ -19350,6 +19418,9 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'starlite.middleware_name': 'string',
   'state.type': 'string',
   'subprocess.pid': 'integer',
+  'sveltekit.load.environment': 'string',
+  'sveltekit.load.node_id': 'string',
+  'sveltekit.load.node_type': 'string',
   'sveltekit.tracing.original_name': 'string',
   'thread.id': 'integer',
   'thread.name': 'string',
@@ -20182,6 +20253,9 @@ export type AttributeName =
   | typeof STARLITE_MIDDLEWARE_NAME
   | typeof STATE_TYPE
   | typeof SUBPROCESS_PID
+  | typeof SVELTEKIT_LOAD_ENVIRONMENT
+  | typeof SVELTEKIT_LOAD_NODE_ID
+  | typeof SVELTEKIT_LOAD_NODE_TYPE
   | typeof SVELTEKIT_TRACING_ORIGINAL_NAME
   | typeof THREAD_ID
   | typeof THREAD_NAME
@@ -23420,7 +23494,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     brief:
       'The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).',
     type: 'string',
-    keys: ['code.file.path', 'code.filepath'],
+    keys: ['code.file.path', 'sveltekit.load.node_id', 'code.filepath'],
     applyScrubbing: {
       key: 'manual',
     },
@@ -23431,22 +23505,29 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       replacement: 'code.file.path',
       status: 'backfill',
     },
-    aliases: ['code.file.path'],
-    changelog: [{ version: '0.1.0', prs: [61] }, { version: '0.0.0' }],
+    aliases: ['code.file.path', 'sveltekit.load.node_id'],
+    changelog: [
+      { version: 'next', prs: [611], description: 'Added sveltekit.load.node_id as an alias' },
+      { version: '0.1.0', prs: [61] },
+      { version: '0.0.0' },
+    ],
   },
   'code.file.path': {
     brief:
       'The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).',
     type: 'string',
-    keys: ['code.file.path', 'code.filepath'],
+    keys: ['code.file.path', 'sveltekit.load.node_id', 'code.filepath'],
     applyScrubbing: {
       key: 'manual',
     },
     isInOtel: true,
     visibility: 'public',
     example: '/app/myapplication/http/handler/server.py',
-    aliases: ['code.filepath'],
-    changelog: [{ version: '0.0.0' }],
+    aliases: ['code.filepath', 'sveltekit.load.node_id'],
+    changelog: [
+      { version: 'next', prs: [611], description: 'Added sveltekit.load.node_id as an alias' },
+      { version: '0.0.0' },
+    ],
   },
   'code.function': {
     brief: "The method or function name, or equivalent (usually rightmost part of the code unit's name).",
@@ -32151,6 +32232,57 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       },
     ],
   },
+  'sveltekit.load.environment': {
+    brief:
+      "The runtime environment in which the SvelteKit load function was executed. Known values are `'server'` and `'client'`.",
+    type: 'string',
+    keys: ['sveltekit.load.environment'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'server',
+    examples: ['server', 'client'],
+    changelog: [{ version: 'next', prs: [611], description: 'Added sveltekit.load.environment attribute' }],
+    additionalContext: [
+      'Added by the SvelteKit framework itself. The Sentry SDK only forwards the attribute to Sentry.',
+    ],
+  },
+  'sveltekit.load.node_id': {
+    brief: 'The path to the SvelteKit load function.',
+    type: 'string',
+    keys: ['sveltekit.load.node_id', 'code.file.path', 'code.filepath'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'src/routes/users/:id/+page.server.ts',
+    examples: ['src/routes/users/:id/+page.server.ts'],
+    aliases: ['code.file.path', 'code.filepath'],
+    changelog: [{ version: 'next', prs: [611], description: 'Added sveltekit.load.node_id attribute' }],
+    additionalContext: [
+      'Added by the SvelteKit framework itself. The Sentry SDK only forwards the attribute to Sentry.',
+    ],
+  },
+  'sveltekit.load.node_type': {
+    brief:
+      'The kind of SvelteKit load function that was executed, distinguishing page from layout and universal from server load functions.',
+    type: 'string',
+    keys: ['sveltekit.load.node_type'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: '+page.server',
+    examples: ['+page.server', '+layout', '+layout.server'],
+    changelog: [{ version: 'next', prs: [611], description: 'Added sveltekit.load.node_type attribute' }],
+    additionalContext: [
+      'Added by the SvelteKit framework itself. The Sentry SDK only forwards the attribute to Sentry.',
+    ],
+  },
   'sveltekit.tracing.original_name': {
     brief: 'The original span name as emitted by SvelteKit.',
     type: 'string',
@@ -34620,14 +34752,14 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief:
       'The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).',
-    deprecationChain: ['code.file.path', 'code.filepath'],
+    deprecationChain: ['code.file.path', 'sveltekit.load.node_id', 'code.filepath'],
   },
   'code.filepath': {
     canonicalName: 'code.file.path',
     type: 'string',
     brief:
       'The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).',
-    deprecationChain: ['code.file.path', 'code.filepath'],
+    deprecationChain: ['code.file.path', 'sveltekit.load.node_id', 'code.filepath'],
   },
   'code.function': {
     canonicalName: 'code.function',
@@ -38003,6 +38135,26 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     brief: 'The process ID of a subprocess.',
     deprecationChain: ['process.pid', 'subprocess.pid'],
   },
+  'sveltekit.load.environment': {
+    canonicalName: 'sveltekit.load.environment',
+    type: 'string',
+    brief:
+      "The runtime environment in which the SvelteKit load function was executed. Known values are `'server'` and `'client'`.",
+    deprecationChain: ['sveltekit.load.environment'],
+  },
+  'sveltekit.load.node_id': {
+    canonicalName: 'sveltekit.load.node_id',
+    type: 'string',
+    brief: 'The path to the SvelteKit load function.',
+    deprecationChain: ['sveltekit.load.node_id', 'code.file.path', 'code.filepath'],
+  },
+  'sveltekit.load.node_type': {
+    canonicalName: 'sveltekit.load.node_type',
+    type: 'string',
+    brief:
+      'The kind of SvelteKit load function that was executed, distinguishing page from layout and universal from server load functions.',
+    deprecationChain: ['sveltekit.load.node_type'],
+  },
   'sveltekit.tracing.original_name': {
     canonicalName: 'sveltekit.tracing.original_name',
     type: 'string',
@@ -39294,6 +39446,9 @@ export type Attributes = {
   [STARLITE_MIDDLEWARE_NAME]?: STARLITE_MIDDLEWARE_NAME_TYPE;
   [STATE_TYPE]?: STATE_TYPE_TYPE;
   [SUBPROCESS_PID]?: SUBPROCESS_PID_TYPE;
+  [SVELTEKIT_LOAD_ENVIRONMENT]?: SVELTEKIT_LOAD_ENVIRONMENT_TYPE;
+  [SVELTEKIT_LOAD_NODE_ID]?: SVELTEKIT_LOAD_NODE_ID_TYPE;
+  [SVELTEKIT_LOAD_NODE_TYPE]?: SVELTEKIT_LOAD_NODE_TYPE_TYPE;
   [SVELTEKIT_TRACING_ORIGINAL_NAME]?: SVELTEKIT_TRACING_ORIGINAL_NAME_TYPE;
   [THREAD_ID]?: THREAD_ID_TYPE;
   [THREAD_NAME]?: THREAD_NAME_TYPE;

--- a/model/attributes/code/code__file__path.json
+++ b/model/attributes/code/code__file__path.json
@@ -7,9 +7,14 @@
   },
   "is_in_otel": true,
   "example": "/app/myapplication/http/handler/server.py",
-  "alias": ["code.filepath"],
+  "alias": ["code.filepath", "sveltekit.load.node_id"],
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [611],
+      "description": "Added sveltekit.load.node_id as an alias"
+    },
     {
       "version": "0.0.0"
     }

--- a/model/attributes/code/code__filepath.json
+++ b/model/attributes/code/code__filepath.json
@@ -7,13 +7,18 @@
   },
   "is_in_otel": true,
   "example": "/app/myapplication/http/handler/server.py",
-  "alias": ["code.file.path"],
+  "alias": ["code.file.path", "sveltekit.load.node_id"],
   "deprecation": {
     "_status": "backfill",
     "replacement": "code.file.path"
   },
   "visibility": "public",
   "changelog": [
+    {
+      "version": "next",
+      "prs": [611],
+      "description": "Added sveltekit.load.node_id as an alias"
+    },
     {
       "version": "0.1.0",
       "prs": [61]

--- a/model/attributes/sveltekit/sveltekit__load__environment.json
+++ b/model/attributes/sveltekit/sveltekit__load__environment.json
@@ -1,0 +1,21 @@
+{
+  "key": "sveltekit.load.environment",
+  "brief": "The runtime environment in which the SvelteKit load function was executed. Known values are `'server'` and `'client'`.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["server", "client"],
+  "additional_context": [
+    "Added by the SvelteKit framework itself. The Sentry SDK only forwards the attribute to Sentry."
+  ],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [611],
+      "description": "Added sveltekit.load.environment attribute"
+    }
+  ]
+}

--- a/model/attributes/sveltekit/sveltekit__load__node_id.json
+++ b/model/attributes/sveltekit/sveltekit__load__node_id.json
@@ -1,0 +1,22 @@
+{
+  "key": "sveltekit.load.node_id",
+  "brief": "The path to the SvelteKit load function.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["src/routes/users/:id/+page.server.ts"],
+  "alias": ["code.file.path", "code.filepath"],
+  "additional_context": [
+    "Added by the SvelteKit framework itself. The Sentry SDK only forwards the attribute to Sentry."
+  ],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [611],
+      "description": "Added sveltekit.load.node_id attribute"
+    }
+  ]
+}

--- a/model/attributes/sveltekit/sveltekit__load__node_type.json
+++ b/model/attributes/sveltekit/sveltekit__load__node_type.json
@@ -1,0 +1,21 @@
+{
+  "key": "sveltekit.load.node_type",
+  "brief": "The kind of SvelteKit load function that was executed, distinguishing page from layout and universal from server load functions.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["+page.server", "+layout", "+layout.server"],
+  "additional_context": [
+    "Added by the SvelteKit framework itself. The Sentry SDK only forwards the attribute to Sentry."
+  ],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [611],
+      "description": "Added sveltekit.load.node_type attribute"
+    }
+  ]
+}

--- a/model/attributes/sveltekit/sveltekit__tracing__original_name.json
+++ b/model/attributes/sveltekit/sveltekit__tracing__original_name.json
@@ -1,0 +1,21 @@
+{
+  "key": "sveltekit.tracing.original_name",
+  "brief": "The original span name as emitted by SvelteKit.",
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["sveltekit.handle.root"],
+  "additional_context": [
+    "The Sentry SDK renames SvelteKit-emitted spans to match Sentry's span name semantics, and preserves the name SvelteKit originally set in this attribute."
+  ],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [611],
+      "description": "Added sveltekit.tracing.original_name attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -3025,7 +3025,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: code.filepath
+    Aliases: code.filepath, sveltekit.load.node_id
     Example: "/app/myapplication/http/handler/server.py"
     """
 
@@ -3037,7 +3037,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Apply Scrubbing: manual
     Defined in OTEL: Yes
     Visibility: public
-    Aliases: code.file.path
+    Aliases: code.file.path, sveltekit.load.node_id
     DEPRECATED: Use code.file.path instead
     Example: "/app/myapplication/http/handler/server.py"
     """
@@ -9756,6 +9756,47 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 12345
     """
 
+    # Path: model/attributes/sveltekit/sveltekit__load__environment.json
+    SVELTEKIT_LOAD_ENVIRONMENT: Literal["sveltekit.load.environment"] = (
+        "sveltekit.load.environment"
+    )
+    """The runtime environment in which the SvelteKit load function was executed. Known values are `'server'` and `'client'`.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "server"
+    Example: "client"
+    """
+
+    # Path: model/attributes/sveltekit/sveltekit__load__node_id.json
+    SVELTEKIT_LOAD_NODE_ID: Literal["sveltekit.load.node_id"] = "sveltekit.load.node_id"
+    """The path to the SvelteKit load function.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Aliases: code.file.path, code.filepath
+    Example: "src/routes/users/:id/+page.server.ts"
+    """
+
+    # Path: model/attributes/sveltekit/sveltekit__load__node_type.json
+    SVELTEKIT_LOAD_NODE_TYPE: Literal["sveltekit.load.node_type"] = (
+        "sveltekit.load.node_type"
+    )
+    """The kind of SvelteKit load function that was executed, distinguishing page from layout and universal from server load functions.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "+page.server"
+    Example: "+layout"
+    Example: "+layout.server"
+    """
+
     # Path: model/attributes/sveltekit/sveltekit__tracing__original_name.json
     SVELTEKIT_TRACING_ORIGINAL_NAME: Literal["sveltekit.tracing.original_name"] = (
         "sveltekit.tracing.original_name"
@@ -14607,14 +14648,20 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         type=AttributeType.STRING,
         keys=(
             "code.file.path",
+            "sveltekit.load.node_id",
             "code.filepath",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
         is_in_otel=True,
         visibility=Visibility.PUBLIC,
         example="/app/myapplication/http/handler/server.py",
-        aliases=["code.filepath"],
+        aliases=["code.filepath", "sveltekit.load.node_id"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[611],
+                description="Added sveltekit.load.node_id as an alias",
+            ),
             ChangelogEntry(version="0.0.0"),
         ],
     ),
@@ -14623,6 +14670,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         type=AttributeType.STRING,
         keys=(
             "code.file.path",
+            "sveltekit.load.node_id",
             "code.filepath",
         ),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
@@ -14632,8 +14680,13 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         deprecation=DeprecationInfo(
             replacement="code.file.path", status=DeprecationStatus.BACKFILL
         ),
-        aliases=["code.file.path"],
+        aliases=["code.file.path", "sveltekit.load.node_id"],
         changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[611],
+                description="Added sveltekit.load.node_id as an alias",
+            ),
             ChangelogEntry(version="0.1.0", prs=[61]),
             ChangelogEntry(version="0.0.0"),
         ],
@@ -24689,6 +24742,71 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "sveltekit.load.environment": AttributeMetadata(
+        brief="The runtime environment in which the SvelteKit load function was executed. Known values are `'server'` and `'client'`.",
+        type=AttributeType.STRING,
+        keys=("sveltekit.load.environment",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="server",
+        examples=["server", "client"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[611],
+                description="Added sveltekit.load.environment attribute",
+            ),
+        ],
+        additional_context=[
+            "Added by the SvelteKit framework itself. The Sentry SDK only forwards the attribute to Sentry."
+        ],
+    ),
+    "sveltekit.load.node_id": AttributeMetadata(
+        brief="The path to the SvelteKit load function.",
+        type=AttributeType.STRING,
+        keys=(
+            "sveltekit.load.node_id",
+            "code.file.path",
+            "code.filepath",
+        ),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="src/routes/users/:id/+page.server.ts",
+        examples=["src/routes/users/:id/+page.server.ts"],
+        aliases=["code.file.path", "code.filepath"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[611],
+                description="Added sveltekit.load.node_id attribute",
+            ),
+        ],
+        additional_context=[
+            "Added by the SvelteKit framework itself. The Sentry SDK only forwards the attribute to Sentry."
+        ],
+    ),
+    "sveltekit.load.node_type": AttributeMetadata(
+        brief="The kind of SvelteKit load function that was executed, distinguishing page from layout and universal from server load functions.",
+        type=AttributeType.STRING,
+        keys=("sveltekit.load.node_type",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="+page.server",
+        examples=["+page.server", "+layout", "+layout.server"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[611],
+                description="Added sveltekit.load.node_type attribute",
+            ),
+        ],
+        additional_context=[
+            "Added by the SvelteKit framework itself. The Sentry SDK only forwards the attribute to Sentry."
+        ],
+    ),
     "sveltekit.tracing.original_name": AttributeMetadata(
         brief="The original span name as emitted by SvelteKit.",
         type=AttributeType.STRING,
@@ -26708,6 +26826,9 @@ Attributes = TypedDict(
         "starlite.middleware_name": str,
         "state.type": str,
         "subprocess.pid": int,
+        "sveltekit.load.environment": str,
+        "sveltekit.load.node_id": str,
+        "sveltekit.load.node_type": str,
         "sveltekit.tracing.original_name": str,
         "thread.id": int,
         "thread.name": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -9756,6 +9756,19 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: 12345
     """
 
+    # Path: model/attributes/sveltekit/sveltekit__tracing__original_name.json
+    SVELTEKIT_TRACING_ORIGINAL_NAME: Literal["sveltekit.tracing.original_name"] = (
+        "sveltekit.tracing.original_name"
+    )
+    """The original span name as emitted by SvelteKit.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "sveltekit.handle.root"
+    """
+
     # Path: model/attributes/thread/thread__id.json
     THREAD_ID: Literal["thread.id"] = "thread.id"
     """Current “managed” thread ID.
@@ -24676,6 +24689,26 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ),
         ],
     ),
+    "sveltekit.tracing.original_name": AttributeMetadata(
+        brief="The original span name as emitted by SvelteKit.",
+        type=AttributeType.STRING,
+        keys=("sveltekit.tracing.original_name",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="sveltekit.handle.root",
+        examples=["sveltekit.handle.root"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[611],
+                description="Added sveltekit.tracing.original_name attribute",
+            ),
+        ],
+        additional_context=[
+            "The Sentry SDK renames SvelteKit-emitted spans to match Sentry's span name semantics, and preserves the name SvelteKit originally set in this attribute."
+        ],
+    ),
     "thread.id": AttributeMetadata(
         brief="Current “managed” thread ID.",
         type=AttributeType.INTEGER,
@@ -26675,6 +26708,7 @@ Attributes = TypedDict(
         "starlite.middleware_name": str,
         "state.type": str,
         "subprocess.pid": int,
+        "sveltekit.tracing.original_name": str,
         "thread.id": int,
         "thread.name": str,
         "timber.tag": str,


### PR DESCRIPTION
Adds four previously undocumented SvelteKit attributes: 
- `sveltekit.tracing.original_name` holds the span name as SvelteKit emitted it, before the Sentry SDK renames the span to match Sentry's span name semantics,
- `sveltekit.load.environment`, `sveltekit.load.node_id` and `sveltekit.load.node_type` describe the runtime, path and kind of the `load` function a span covers. SvelteKit sets those three itself and the SDK only forwards them.

`sveltekit.load.node_id` joins the `code.file.path` alias group without being deprecated, so `code.file.path` and `code.filepath` pick it up as an alias to keep the group symmetric.

For now, I decided against deprecating them, since these attributes are set by the sveltekit framework and not by use. We just forward them. 