### PR TITLE
fix(descriptions): Add graphql-enhanced http.client span description template

### DIFF
--- a/model/description/http.json
+++ b/model/description/http.json
@@ -5,8 +5,14 @@
       "name": "Client",
       "brief": "Operations that represent outgoing HTTP requests.",
       "ops": ["http.client", "http.client.stream"],
-      "templates": ["{{http.request.method}} {{url.full}}"],
-      "examples": ["GET https://api.mydomain.com/users/123?expand=full"]
+      "templates": [
+        "{{http.request.method}} {{url.full}} ({{graphql.operation.type}} {{graphql.operation.name}})",
+        "{{http.request.method}} {{url.full}}"
+      ],
+      "examples": [
+        "GET https://api.mydomain.com/users/123?expand=full",
+        "POST https://api.mydomain.com/graphql (query GetUser)"
+      ]
     },
     {
       "name": "Server",

--- a/model/description/http.json
+++ b/model/description/http.json
@@ -7,6 +7,7 @@
       "ops": ["http.client", "http.client.stream"],
       "templates": [
         "{{http.request.method}} {{url.full}} ({{graphql.operation.type}} {{graphql.operation.name}})",
+        "{{http.request.method}} {{url.full}} ({{graphql.operation.type}})",
         "{{http.request.method}} {{url.full}}"
       ],
       "examples": [


### PR DESCRIPTION
The JS Browser SDK has an optional [graphql client integration](https://docs.sentry.io/platforms/javascript/configuration/integrations/graphqlclient/) which identifies `http.client` spans that make requests to graphql endpoints. If such a request is found, the `http.client` span description (under transactions) was enhanced with `({{graphql.operation.type}} {{graphql.operation.name}})`. This PR adds this enhancement as a rule for `http.client` streamed span description inference.

~Technically, both operation type and name are low card. so we could also add this enhancement to span names. Gonna PR separately though since we can also decide not to do this.~ Decided to avoid this for now and re-add by popular demand rather than having this kind of specific rule from the get-go.