### PR TITLE
chore(names): Add OTel divergence note for graphql span names

### DIFF
--- a/model/name/graphql.json
+++ b/model/name/graphql.json
@@ -5,7 +5,7 @@
       "name": "GraphQL",
       "brief": "Any and all operations that fall under GraphQL",
       "is_in_otel": true,
-      "otel_notes": "Unlike OTel, we prefix GraphQL operations with the word \"GraphQL\" (e.g., \"GraphQL mutation\" vs. \"mutation\".",
+      "otel_notes": "Unlike OTel, we prefix GraphQL operations with the word \"GraphQL\" (e.g., \"GraphQL query findBookById\" vs. \"query findBookById\").",
       "ops": [
         "http.graphql",
         "http.graphql.query",


### PR DESCRIPTION
While looking at graphql span names (#613) the clanker and I noticed that our span names for graphql diverge from OTel's definition, since we add a `GraphQL ` prefix to every name. I'm gonna assume this is on purpose (and we adjusted our span names accordingly in the SDK), so this PR adds a note that we diverge.

I also thought about adding the `graphql.operation.name` attribute as an addition to a name rule but dismissed because OTel warns about potential high-cardinality in this attribute.

Otel spec: https://opentelemetry.io/docs/specs/semconv/graphql/graphql-spans/