### PR TITLE
feat(descriptions): Add `graphql` span description rules

### DIFF
--- a/model/description/graphql.json
+++ b/model/description/graphql.json
@@ -1,0 +1,29 @@
+{
+  "brief": "GraphQL",
+  "operations": [
+    {
+      "name": "GraphQL",
+      "brief": "Any and all operations that fall under GraphQL",
+      "ops": [
+        "http.graphql",
+        "http.graphql.query",
+        "http.graphql.mutation",
+        "http.graphql.subscription",
+        "graphql.execute",
+        "graphql.parse",
+        "graphql.resolve",
+        "graphql.request",
+        "graphql.query",
+        "graphql.mutation",
+        "graphql.subscription",
+        "graphql.validate"
+      ],
+      "templates": [
+        "{{graphql.document}}",
+        "{{graphql.operation.type}} {{graphql.operation.name}}",
+        "{{graphql.operation.type}}"
+      ],
+      "examples": ["query findBookById { bookById(id: ?) { name } }", "query findBookById", "query"]
+    }
+  ]
+}

--- a/model/description/graphql.json
+++ b/model/description/graphql.json
@@ -9,6 +9,7 @@
         "http.graphql.query",
         "http.graphql.mutation",
         "http.graphql.subscription",
+        "graphql",
         "graphql.execute",
         "graphql.parse",
         "graphql.resolve",
@@ -21,9 +22,10 @@
       "templates": [
         "{{graphql.document}}",
         "{{graphql.operation.type}} {{graphql.operation.name}}",
-        "{{graphql.operation.type}}"
+        "{{graphql.operation.type}}",
+        "{{graphql.processing.type}}"
       ],
-      "examples": ["query findBookById { bookById(id: ?) { name } }", "query findBookById", "query"]
+      "examples": ["query findBookById { bookById(id: ?) { name } }", "query findBookById", "query", "parse"]
     }
   ]
 }


### PR DESCRIPTION
## Description

We already have span name rules for graphql spans, but we were missing description rules. This PR adds them.

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
