### PR TITLE
feat(names): Add FAAS function span name and description rules

### DIFF
--- a/model/description/faas.json
+++ b/model/description/faas.json
@@ -1,0 +1,12 @@
+{
+  "brief": "Serverless (FAAS)",
+  "operations": [
+    {
+      "name": "Serverless function execution",
+      "brief": "The invocation of a serverless function on a cloud provider.",
+      "ops": ["function.aws", "function.gcp", "function.azure"],
+      "templates": ["{{faas.name}}"],
+      "examples": ["my_function", "process-upload"]
+    }
+  ]
+}

--- a/model/name/faas.json
+++ b/model/name/faas.json
@@ -1,0 +1,13 @@
+{
+  "brief": "Serverless (FAAS)",
+  "operations": [
+    {
+      "name": "Serverless function execution",
+      "brief": "The invocation of a serverless function on a cloud provider.",
+      "is_in_otel": false,
+      "ops": ["function.aws", "function.gcp", "function.azure"],
+      "templates": ["{{faas.name}}", "Serverless function execution"],
+      "examples": ["my_function", "process-upload", "Serverless function execution"]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adds serverless function execution span (`function.(aws|gcp|azure)`) name and description rules, relying on the  `faas.name` attribute

ref: https://github.com/getsentry/sentry-javascript/issues/23954

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
