### PR TITLE
feat(names): Add `function` span name and description rules

### DIFF
--- a/model/description/function.json
+++ b/model/description/function.json
@@ -1,0 +1,12 @@
+{
+  "brief": "Function",
+  "operations": [
+    {
+      "name": "Function execution",
+      "brief": "The execution of a function or a set of instructions that isn't covered by a more specific operation.",
+      "ops": ["function"],
+      "templates": ["{{code.function.name}}"],
+      "examples": ["server_request", "handleSubmit"]
+    }
+  ]
+}

--- a/model/name/function.json
+++ b/model/name/function.json
@@ -1,0 +1,13 @@
+{
+  "brief": "Function",
+  "operations": [
+    {
+      "name": "Function execution",
+      "brief": "The execution of a function or a set of instructions that isn't covered by a more specific operation.",
+      "is_in_otel": false,
+      "ops": ["function"],
+      "templates": ["{{code.function.name}}", "Function execution"],
+      "examples": ["server_request", "handleSubmit", "Function execution"]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adds name and description templates for `function` spans, used to group code function invocations. I propose for both, name and description, we rely on the `{code.function.name}` attribute which is what our SDKs set today mostly. Should be low card. enough. 

ref https://github.com/getsentry/sentry-javascript/issues/23954

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [ ] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [ ] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md) 