### PR TITLE
feat(op): Add span op deprecation support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,16 @@ Here's a list of policies that any newly added attributes MUST follow. Most of t
   - If the value cannot be copied directly to the replacement attribute, use `_status: "transform"` and reference an attribute transformation with `deprecation.transformation`.
 - Prefer keeping names stable. Renames require deprecation cycles across all SDKs that adopted the attribute!
 
+### Span operations
+
+Span ops live in `model/op/` and are shipped to SDKs as generated constants, so they can't just be removed.
+
+- Deprecate an op instead of deleting it, by adding a `deprecation` object to its field in `model/op/<category>.json`.
+- Point at the successor with `deprecation.replacement` whenever there is one. It MUST be an existing, non-deprecated op.
+- Add a `deprecation.reason` if the replacement alone doesn't explain the change.
+- If the op is listed in more than one category, all of its definitions MUST declare the same `deprecation`, because they share a single generated constant.
+- Run `yarn run generate` afterwards. Deprecated ops keep their constant, marked with a JSDoc `@deprecated` tag in JavaScript and `#[deprecated]` in Rust.
+
 ## Testing
 
 This repo uses [Vitest](https://vitest.dev/) for testing. To run the tests, run `yarn test`.

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -109,6 +109,12 @@ const descriptions = defineCollection({
 const opFieldSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
+  deprecation: z
+    .object({
+      replacement: z.string().optional(),
+      reason: z.string().optional(),
+    })
+    .optional(),
 });
 
 const opSchema = z.object({

--- a/docs/src/pages/ops/index.astro
+++ b/docs/src/pages/ops/index.astro
@@ -90,13 +90,32 @@ const totalOps = allOps.reduce((acc, op) => acc + op.data.fields.length, 0);
             </thead>
             <tbody>
               {op.data.fields.map(field => (
-                <tr>
-                  <td class="whitespace-nowrap align-top"><code class="text-xs">{field.name}</code></td>
+                <tr class:list={[{ 'opacity-70': !!field.deprecation }]}>
+                  <td class="whitespace-nowrap align-top">
+                    <code class:list={['text-xs', { 'line-through': !!field.deprecation }]}>{field.name}</code>
+                    {field.deprecation && (
+                      <span class="badge badge-deprecated ml-2">Deprecated</span>
+                    )}
+                  </td>
                   <td class="text-text-secondary">
                     {field.description ? (
                       <span set:html={renderMarkdownLinks(field.description)} />
-                    ) : (
+                    ) : !field.deprecation ? (
                       <span class="text-text-muted">—</span>
+                    ) : null}
+                    {field.deprecation && (
+                      <div class:list={['p-3 bg-error-soft rounded-md border-l-[3px] border-error', { 'mt-3': !!field.description }]}>
+                        <p class="text-sm m-0">
+                          {field.deprecation.replacement ? (
+                            <Fragment>Use <code class="text-xs">{field.deprecation.replacement}</code> instead.</Fragment>
+                          ) : (
+                            'No replacement available at this time.'
+                          )}
+                        </p>
+                        {field.deprecation.reason && (
+                          <p class="mt-2 text-text-muted text-sm m-0">{field.deprecation.reason}</p>
+                        )}
+                      </div>
                     )}
                   </td>
                 </tr>

--- a/docs/src/pages/ops/index.astro
+++ b/docs/src/pages/ops/index.astro
@@ -18,6 +18,19 @@ allOps.sort((a, b) => {
 
 // Count total operations across all categories
 const totalOps = allOps.reduce((acc, op) => acc + op.data.fields.length, 0);
+
+// An op can be listed in several categories, so anchors are scoped to their category.
+const opAnchor = (categoryId: string, opName: string) => `${categoryId}-${opName.replace(/\./g, '-')}`;
+
+// Where a deprecation notice links to: the first listing of the replacement op.
+const anchorByOp = new Map<string, string>();
+for (const category of allOps) {
+  for (const field of category.data.fields) {
+    if (!anchorByOp.has(field.name)) {
+      anchorByOp.set(field.name, opAnchor(category.id, field.name));
+    }
+  }
+}
 ---
 
 <BaseLayout
@@ -90,9 +103,9 @@ const totalOps = allOps.reduce((acc, op) => acc + op.data.fields.length, 0);
             </thead>
             <tbody>
               {op.data.fields.map(field => (
-                <tr class:list={[{ 'opacity-70': !!field.deprecation }]}>
+                <tr id={opAnchor(op.id, field.name)} class="scroll-mt-20">
                   <td class="whitespace-nowrap align-top">
-                    <code class:list={['text-xs', { 'line-through': !!field.deprecation }]}>{field.name}</code>
+                    <code class:list={['text-xs', { 'line-through text-text-muted': !!field.deprecation }]}>{field.name}</code>
                     {field.deprecation && (
                       <span class="badge badge-deprecated ml-2">Deprecated</span>
                     )}
@@ -104,17 +117,21 @@ const totalOps = allOps.reduce((acc, op) => acc + op.data.fields.length, 0);
                       <span class="text-text-muted">—</span>
                     ) : null}
                     {field.deprecation && (
-                      <div class:list={['p-3 bg-error-soft rounded-md border-l-[3px] border-error', { 'mt-3': !!field.description }]}>
-                        <p class="text-sm m-0">
+                      <div class:list={['text-sm pl-2 border-l-2 border-error', { 'mt-2': !!field.description }]}>
+                        <span class="text-text-primary">
                           {field.deprecation.replacement ? (
-                            <Fragment>Use <code class="text-xs">{field.deprecation.replacement}</code> instead.</Fragment>
+                            <Fragment>Use{' '}
+                              {anchorByOp.has(field.deprecation.replacement) ? (
+                                <a href={`#${anchorByOp.get(field.deprecation.replacement)}`} class="text-accent hover:text-accent-hover"><code class="text-xs">{field.deprecation.replacement}</code></a>
+                              ) : (
+                                <code class="text-xs">{field.deprecation.replacement}</code>
+                              )} instead.
+                            </Fragment>
                           ) : (
                             'No replacement available at this time.'
                           )}
-                        </p>
-                        {field.deprecation.reason && (
-                          <p class="mt-2 text-text-muted text-sm m-0">{field.deprecation.reason}</p>
-                        )}
+                        </span>
+                        {field.deprecation.reason && <span class="text-text-secondary">{' '}{field.deprecation.reason}</span>}
                       </div>
                     )}
                   </td>

--- a/schemas/op.schema.json
+++ b/schemas/op.schema.json
@@ -31,6 +31,21 @@
         },
         "description": {
           "type": "string"
+        },
+        "deprecation": {
+          "description": "If a span op was deprecated, and what it was replaced with. Deprecated ops keep their generated constant, which is marked as deprecated for SDKs.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "replacement": {
+              "description": "The span op to use instead. Must be an op defined in model/op/",
+              "type": "string"
+            },
+            "reason": {
+              "description": "Why the op was deprecated",
+              "type": "string"
+            }
+          }
         }
       },
       "required": ["name"],

--- a/scripts/generate_op.ts
+++ b/scripts/generate_op.ts
@@ -1,34 +1,40 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import type { OpFieldJson, OpJson } from './types';
 
-interface OpField {
-  name: string;
-  description?: string;
+interface GenerateOpsOptions {
+  opDir: string;
+  jsOutputFilePath: string;
+  rustOutputFilePath: string;
 }
 
-interface OpCategory {
+interface OpCategory extends OpJson {
   file: string;
-  name: string;
-  description?: string;
-  fields: OpField[];
 }
 
-export async function generateOps() {
-  const opDir = path.join(__dirname, '..', 'model', 'op');
+type OpDeprecation = NonNullable<OpFieldJson['deprecation']>;
+
+export async function generateOps(options?: Partial<GenerateOpsOptions>) {
+  const repositoryRoot = path.join(__dirname, '..');
+  const opDir = options?.opDir ?? path.join(repositoryRoot, 'model', 'op');
+  const jsOutputFilePath =
+    options?.jsOutputFilePath ?? path.join(repositoryRoot, 'javascript', 'sentry-conventions', 'src', 'op.ts');
+  const rustOutputFilePath = options?.rustOutputFilePath ?? path.join(repositoryRoot, 'rust', 'src', 'op.rs');
 
   const opFiles = await fs.promises.readdir(opDir);
   const categories = readCategories(opDir, opFiles);
   const owners = resolveConstantOwners(categories);
+  const deprecations = resolveDeprecations(categories);
 
-  writeToJs(categories, owners);
-  writeToRust(categories, owners);
+  writeToJs(categories, owners, deprecations, jsOutputFilePath);
+  writeToRust(categories, owners, deprecations, rustOutputFilePath);
 }
 
 function readCategories(opDir: string, opFiles: string[]): OpCategory[] {
   // Sort for deterministic output: the file order decides both the order of the emitted blocks and,
   // for ops defined in multiple categories without a description, which category owns the constant.
   return [...opFiles].sort().map((file) => {
-    const opJson = JSON.parse(fs.readFileSync(path.join(opDir, file), 'utf-8'));
+    const opJson = JSON.parse(fs.readFileSync(path.join(opDir, file), 'utf-8')) as OpJson;
     return { file, name: opJson.name, description: opJson.description, fields: opJson.fields };
   });
 }
@@ -59,12 +65,50 @@ function resolveConstantOwners(categories: OpCategory[]): Map<string, string> {
   return new Map([...owners].map(([name, { file }]) => [name, file]));
 }
 
+/**
+ * An op defined in multiple categories only yields one constant, so its deprecation is looked up by
+ * op name rather than per definition. Every definition of an op must declare the same deprecation
+ * (enforced by the test suite), which makes the first one found authoritative.
+ *
+ * Returns a map of op name -> deprecation, for deprecated ops only.
+ */
+function resolveDeprecations(categories: OpCategory[]): Map<string, OpDeprecation> {
+  const deprecations = new Map<string, OpDeprecation>();
+
+  for (const category of categories) {
+    for (const field of category.fields) {
+      if (field.deprecation && !deprecations.has(field.name)) {
+        deprecations.set(field.name, field.deprecation);
+      }
+    }
+  }
+
+  return deprecations;
+}
+
 /** The fields of `category` whose constant is emitted in this category. */
-function ownedFields(category: OpCategory, owners: Map<string, string>): OpField[] {
+function ownedFields(category: OpCategory, owners: Map<string, string>): OpFieldJson[] {
   return category.fields.filter((field) => owners.get(field.name) === category.file);
 }
 
-function writeToRust(categories: OpCategory[], owners: Map<string, string>) {
+/** The `Use X instead - reason` part of a deprecation notice, with the replacement constant linked as `link`. */
+function deprecationNote(deprecation: OpDeprecation, link: (replacement: string) => string): string {
+  const parts: string[] = [];
+  if (deprecation.replacement) {
+    parts.push(`Use ${link(deprecation.replacement)} (${deprecation.replacement}) instead`);
+  }
+  if (deprecation.reason) {
+    parts.push(deprecation.reason);
+  }
+  return parts.join(' - ');
+}
+
+function writeToRust(
+  categories: OpCategory[],
+  owners: Map<string, string>,
+  deprecations: Map<string, OpDeprecation>,
+  opFilePath: string,
+) {
   let opContent = '// This is an auto-generated file. Do not edit!\n\n';
 
   for (const category of categories) {
@@ -86,6 +130,11 @@ function writeToRust(categories: OpCategory[], owners: Map<string, string>) {
         opContent += field.description.split('\n').join('\n/// ');
         opContent += '\n';
       }
+      const deprecation = deprecations.get(field.name);
+      if (deprecation) {
+        const note = deprecationNote(deprecation, (replacement) => `\`${constantName(replacement)}\``);
+        opContent += note ? `#[deprecated(note = "${escapeRustString(note)}")]\n` : '#[deprecated]\n';
+      }
       opContent += `pub const ${constantName(field.name)}: &str = "${field.name}";\n\n`;
     }
   }
@@ -93,12 +142,19 @@ function writeToRust(categories: OpCategory[], owners: Map<string, string>) {
   // Remove the trailing newline character
   opContent = opContent.trimEnd();
 
-  const opFilePath = path.join(__dirname, '..', 'rust', 'src', 'op.rs');
-
   fs.writeFileSync(opFilePath, opContent);
 }
 
-function writeToJs(categories: OpCategory[], owners: Map<string, string>) {
+function escapeRustString(value: string): string {
+  return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+}
+
+function writeToJs(
+  categories: OpCategory[],
+  owners: Map<string, string>,
+  deprecations: Map<string, OpDeprecation>,
+  opFilePath: string,
+) {
   let opContent = '// This is an auto-generated file. Do not edit!\n';
 
   for (const category of categories) {
@@ -115,9 +171,19 @@ function writeToJs(categories: OpCategory[], owners: Map<string, string>) {
     }
 
     for (const field of fields) {
-      if (field.description) {
+      const deprecation = deprecations.get(field.name);
+      if (field.description || deprecation) {
         opContent += '\n/**\n';
-        opContent += ` * ${field.description}\n`;
+        if (field.description) {
+          opContent += ` * ${field.description}\n`;
+        }
+        if (deprecation) {
+          if (field.description) {
+            opContent += ' *\n';
+          }
+          const note = deprecationNote(deprecation, (replacement) => `{@link ${constantName(replacement)}}`);
+          opContent += ` * @deprecated${note ? ` ${note}` : ''}\n`;
+        }
         opContent += ' */\n';
       } else {
         opContent += '\n';
@@ -125,8 +191,6 @@ function writeToJs(categories: OpCategory[], owners: Map<string, string>) {
       opContent += `export const ${constantName(field.name)} = '${field.name}';\n`;
     }
   }
-
-  const opFilePath = path.join(__dirname, '..', 'javascript', 'sentry-conventions', 'src', 'op.ts');
 
   fs.writeFileSync(opFilePath, opContent);
 }

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -53,6 +53,21 @@ export interface DescriptionJson {
   }[];
 }
 
+export interface OpFieldJson {
+  name: string;
+  description?: string;
+  deprecation?: {
+    replacement?: string;
+    reason?: string;
+  };
+}
+
+export interface OpJson {
+  name: string;
+  description?: string;
+  fields: OpFieldJson[];
+}
+
 export interface AttributeTransformationJson {
   id: string;
   brief: string;

--- a/test/op.test.ts
+++ b/test/op.test.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Ajv from 'ajv';
+import { describe, expect, it } from 'vitest';
+
+import schema from '../schemas/op.schema.json';
+import { generateOps } from '../scripts/generate_op';
+import type { OpJson } from '../scripts/types';
+
+const opsFolder = path.resolve(__dirname, '../model/op');
+
+describe('Op JSON', async () => {
+  const filesIterator = fs.promises.glob(`${opsFolder}/*.json`);
+  const files = await Array.fromAsync(filesIterator);
+  const ajv = new Ajv();
+
+  const categories = await Promise.all(
+    files.map(async (file) => ({
+      file: path.basename(file),
+      content: JSON.parse(await fs.promises.readFile(file, 'utf-8')) as OpJson,
+    })),
+  );
+
+  const allFields = categories.flatMap(({ content }) => content.fields);
+  const opNames = new Set(allFields.map((field) => field.name));
+  const deprecatedOpNames = new Set(allFields.filter((field) => field.deprecation).map((field) => field.name));
+
+  for (const { file, content } of categories) {
+    describe(file, () => {
+      it('should follow the op json schema', () => {
+        ajv.validate(schema, content);
+        expect(ajv.errors).toBe(null);
+      });
+
+      it('should not have duplicate ops', () => {
+        const names = content.fields.map((field) => field.name);
+        expect(new Set(names).size).toBe(names.length);
+      });
+
+      it('should only deprecate ops in favor of an existing, non-deprecated op', () => {
+        for (const field of content.fields) {
+          const replacement = field.deprecation?.replacement;
+          if (replacement === undefined) {
+            continue;
+          }
+
+          expect(replacement, `${field.name} cannot replace itself`).not.toBe(field.name);
+          expect([...opNames], `replacement "${replacement}" of "${field.name}" must exist`).toContain(replacement);
+          expect(
+            [...deprecatedOpNames],
+            `replacement "${replacement}" of "${field.name}" must not be deprecated`,
+          ).not.toContain(replacement);
+        }
+      });
+    });
+  }
+
+  // Ops defined in multiple categories (e.g. `http`) share a single generated constant, so the
+  // deprecation cannot differ between their definitions.
+  it('should declare the same deprecation for every definition of an op', () => {
+    const deprecationsByOp = new Map<string, string[]>();
+
+    for (const field of allFields) {
+      const deprecations = deprecationsByOp.get(field.name) ?? [];
+      deprecations.push(JSON.stringify(field.deprecation ?? null));
+      deprecationsByOp.set(field.name, deprecations);
+    }
+
+    for (const [name, deprecations] of deprecationsByOp) {
+      expect(new Set(deprecations).size, `definitions of "${name}" declare different deprecations`).toBe(1);
+    }
+  });
+});
+
+describe('generateOps', () => {
+  it('marks deprecated ops in the generated JavaScript and Rust constants', async () => {
+    const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'sentry-conventions-'));
+    const opDir = path.join(temporaryDirectory, 'op');
+    const jsOutputFilePath = path.join(temporaryDirectory, 'op.ts');
+    const rustOutputFilePath = path.join(temporaryDirectory, 'op.rs');
+    fs.mkdirSync(opDir);
+    fs.writeFileSync(
+      path.join(opDir, 'test.json'),
+      JSON.stringify({
+        name: 'test',
+        fields: [
+          { name: 'test.new', description: 'The replacement op.' },
+          {
+            name: 'test.old',
+            description: 'The deprecated op.',
+            deprecation: { replacement: 'test.new', reason: 'Renamed for consistency' },
+          },
+          { name: 'test.gone', deprecation: {} },
+        ],
+      }),
+    );
+
+    try {
+      await generateOps({ opDir, jsOutputFilePath, rustOutputFilePath });
+
+      const javascript = fs.readFileSync(jsOutputFilePath, 'utf8');
+      expect(javascript).toContain(
+        ' * @deprecated Use {@link TEST_NEW} (test.new) instead - Renamed for consistency\n',
+      );
+      expect(javascript).toContain(" * @deprecated\n */\nexport const TEST_GONE = 'test.gone';");
+      expect(javascript).toContain("export const TEST_OLD = 'test.old';");
+
+      const rust = fs.readFileSync(rustOutputFilePath, 'utf8');
+      expect(rust).toContain('#[deprecated(note = "Use `TEST_NEW` (test.new) instead - Renamed for consistency")]\n');
+      expect(rust).toContain('#[deprecated]\npub const TEST_GONE: &str = "test.gone";');
+      expect(rust).toContain('/// The replacement op.\npub const TEST_NEW: &str = "test.new";');
+    } finally {
+      fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Description

Adds a way to deprecate span ops, like we already have for attributes. An op can now have a `deprecation` object with a `replacement` and a `reason`. No op is deprecated yet, this only adds the mechanism.

- Optional `deprecation` field in op schema
- Emits `@deprecated` JSDoc in JavaScript constants
- Emits `#[deprecated]` attribute on Rust constants
- Shows deprecation and replacement on docs site
- Adds op tests, there were none before

Simpler than attribute deprecation on purpose: no `_status`, because this only concerns SDKs and not ingestion.

Fixes #619

## PR Checklist

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.
