### PR TITLE
feat(op): Deprecate framework-specific span ops

### DIFF
--- a/javascript/sentry-conventions/src/op.ts
+++ b/javascript/sentry-conventions/src/op.ts
@@ -197,22 +197,49 @@ export const UI_ACTION = 'ui.action';
 
 export const UI_ACTION_CLICK = 'ui.action.click';
 
+/**
+ * @deprecated Use {@link UI} (ui) instead - Framework-specific UI ops are replaced by framework-agnostic ones.
+ */
 export const UI_REACT = 'ui.react';
 
+/**
+ * @deprecated Use {@link UI_MOUNT} (ui.mount) instead - Framework-specific UI ops are replaced by framework-agnostic ones.
+ */
 export const UI_REACT_MOUNT = 'ui.react.mount';
 
+/**
+ * @deprecated Use {@link UI_RENDER} (ui.render) instead - Framework-specific UI ops are replaced by framework-agnostic ones.
+ */
 export const UI_REACT_RENDER = 'ui.react.render';
 
+/**
+ * @deprecated Use {@link UI_UPDATE} (ui.update) instead - Framework-specific UI ops are replaced by framework-agnostic ones.
+ */
 export const UI_REACT_UPDATE = 'ui.react.update';
 
+/**
+ * @deprecated Use {@link UI} (ui) instead - Framework-specific UI ops are replaced by framework-agnostic ones.
+ */
 export const UI_VUE = 'ui.vue';
 
+/**
+ * @deprecated Use {@link UI} (ui) instead - Framework-specific UI ops are replaced by framework-agnostic ones.
+ */
 export const UI_SVELTE = 'ui.svelte';
 
+/**
+ * @deprecated Use {@link UI} (ui) instead - Framework-specific UI ops are replaced by framework-agnostic ones.
+ */
 export const UI_ANGULAR = 'ui.angular';
 
+/**
+ * @deprecated Use {@link UI} (ui) instead - Framework-specific UI ops are replaced by framework-agnostic ones.
+ */
 export const UI_EMBER = 'ui.ember';
 
+/**
+ * @deprecated Use {@link UI} (ui) instead - Framework-specific UI ops are replaced by framework-agnostic ones.
+ */
 export const UI_LIVEWIRE = 'ui.livewire';
 
 // Path: model/op/database.json

--- a/javascript/sentry-conventions/src/op.ts
+++ b/javascript/sentry-conventions/src/op.ts
@@ -545,8 +545,14 @@ export const VIEW = 'view';
 
 export const TEMPLATE = 'template';
 
+/**
+ * @deprecated Use {@link FUNCTION} (function) instead - Framework-specific function ops are replaced by framework-agnostic ones.
+ */
 export const FUNCTION_REMIX = 'function.remix';
 
+/**
+ * @deprecated Use {@link FUNCTION} (function) instead - Framework-specific function ops are replaced by framework-agnostic ones.
+ */
 export const FUNCTION_NEXTJS = 'function.nextjs';
 
 export const CONSOLE = 'console';

--- a/model/op/browser.json
+++ b/model/op/browser.json
@@ -175,31 +175,67 @@
       "name": "ui.action.click"
     },
     {
-      "name": "ui.react"
+      "name": "ui.react",
+      "deprecation": {
+        "replacement": "ui",
+        "reason": "Framework-specific UI ops are replaced by framework-agnostic ones."
+      }
     },
     {
-      "name": "ui.react.mount"
+      "name": "ui.react.mount",
+      "deprecation": {
+        "replacement": "ui.mount",
+        "reason": "Framework-specific UI ops are replaced by framework-agnostic ones."
+      }
     },
     {
-      "name": "ui.react.render"
+      "name": "ui.react.render",
+      "deprecation": {
+        "replacement": "ui.render",
+        "reason": "Framework-specific UI ops are replaced by framework-agnostic ones."
+      }
     },
     {
-      "name": "ui.react.update"
+      "name": "ui.react.update",
+      "deprecation": {
+        "replacement": "ui.update",
+        "reason": "Framework-specific UI ops are replaced by framework-agnostic ones."
+      }
     },
     {
-      "name": "ui.vue"
+      "name": "ui.vue",
+      "deprecation": {
+        "replacement": "ui",
+        "reason": "Framework-specific UI ops are replaced by framework-agnostic ones."
+      }
     },
     {
-      "name": "ui.svelte"
+      "name": "ui.svelte",
+      "deprecation": {
+        "replacement": "ui",
+        "reason": "Framework-specific UI ops are replaced by framework-agnostic ones."
+      }
     },
     {
-      "name": "ui.angular"
+      "name": "ui.angular",
+      "deprecation": {
+        "replacement": "ui",
+        "reason": "Framework-specific UI ops are replaced by framework-agnostic ones."
+      }
     },
     {
-      "name": "ui.ember"
+      "name": "ui.ember",
+      "deprecation": {
+        "replacement": "ui",
+        "reason": "Framework-specific UI ops are replaced by framework-agnostic ones."
+      }
     },
     {
-      "name": "ui.livewire"
+      "name": "ui.livewire",
+      "deprecation": {
+        "replacement": "ui",
+        "reason": "Framework-specific UI ops are replaced by framework-agnostic ones."
+      }
     }
   ]
 }

--- a/model/op/web_server.json
+++ b/model/op/web_server.json
@@ -48,10 +48,18 @@
       "name": "function"
     },
     {
-      "name": "function.remix"
+      "name": "function.remix",
+      "deprecation": {
+        "replacement": "function",
+        "reason": "Framework-specific function ops are replaced by framework-agnostic ones."
+      }
     },
     {
-      "name": "function.nextjs"
+      "name": "function.nextjs",
+      "deprecation": {
+        "replacement": "function",
+        "reason": "Framework-specific function ops are replaced by framework-agnostic ones."
+      }
     },
     {
       "name": "serialize"

--- a/rust/src/op.rs
+++ b/rust/src/op.rs
@@ -366,8 +366,10 @@ pub const VIEW: &str = "view";
 
 pub const TEMPLATE: &str = "template";
 
+#[deprecated(note = "Use `FUNCTION` (function) instead - Framework-specific function ops are replaced by framework-agnostic ones.")]
 pub const FUNCTION_REMIX: &str = "function.remix";
 
+#[deprecated(note = "Use `FUNCTION` (function) instead - Framework-specific function ops are replaced by framework-agnostic ones.")]
 pub const FUNCTION_NEXTJS: &str = "function.nextjs";
 
 pub const CONSOLE: &str = "console";

--- a/rust/src/op.rs
+++ b/rust/src/op.rs
@@ -129,22 +129,31 @@ pub const UI_ACTION: &str = "ui.action";
 
 pub const UI_ACTION_CLICK: &str = "ui.action.click";
 
+#[deprecated(note = "Use `UI` (ui) instead - Framework-specific UI ops are replaced by framework-agnostic ones.")]
 pub const UI_REACT: &str = "ui.react";
 
+#[deprecated(note = "Use `UI_MOUNT` (ui.mount) instead - Framework-specific UI ops are replaced by framework-agnostic ones.")]
 pub const UI_REACT_MOUNT: &str = "ui.react.mount";
 
+#[deprecated(note = "Use `UI_RENDER` (ui.render) instead - Framework-specific UI ops are replaced by framework-agnostic ones.")]
 pub const UI_REACT_RENDER: &str = "ui.react.render";
 
+#[deprecated(note = "Use `UI_UPDATE` (ui.update) instead - Framework-specific UI ops are replaced by framework-agnostic ones.")]
 pub const UI_REACT_UPDATE: &str = "ui.react.update";
 
+#[deprecated(note = "Use `UI` (ui) instead - Framework-specific UI ops are replaced by framework-agnostic ones.")]
 pub const UI_VUE: &str = "ui.vue";
 
+#[deprecated(note = "Use `UI` (ui) instead - Framework-specific UI ops are replaced by framework-agnostic ones.")]
 pub const UI_SVELTE: &str = "ui.svelte";
 
+#[deprecated(note = "Use `UI` (ui) instead - Framework-specific UI ops are replaced by framework-agnostic ones.")]
 pub const UI_ANGULAR: &str = "ui.angular";
 
+#[deprecated(note = "Use `UI` (ui) instead - Framework-specific UI ops are replaced by framework-agnostic ones.")]
 pub const UI_EMBER: &str = "ui.ember";
 
+#[deprecated(note = "Use `UI` (ui) instead - Framework-specific UI ops are replaced by framework-agnostic ones.")]
 pub const UI_LIVEWIRE: &str = "ui.livewire";
 
 // Path: model/op/database.json


### PR DESCRIPTION
## Description

Deprecates the framework specific `ui.*` and `function.*` ops. SDKs should use the framework agnostic ops instead. The constants are still generated, just marked as deprecated.

- `ui.react`, `ui.vue`, `ui.svelte` become `ui`
- `ui.angular`, `ui.ember`, `ui.livewire` become `ui`
- `ui.react.mount` becomes `ui.mount`
- `ui.react.render` becomes `ui.render`
- `ui.react.update` becomes `ui.update`
- `function.nextjs`, `function.remix` become `function`

Needs #621 to merge first.

## PR Checklist

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.
