### PR TITLE
chore(attributes): Clarify parameter name casing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ Here's a list of policies that any newly added attributes MUST follow. Most of t
 - The attribute MUST be namespaced. Example: `nextjs.function_id`, not `function_id`.
 - Use dots as separators for namespaces and logical grouoing, not underscores (`http.request.method`, not `http_request_method`)
 - Use `snake_case` for multi-word names (`browser.web_vital.ttfb.request_time`, not `browser.webVital.ttfb.request-time`)
-- Namespace first (`db.system`, not `system.db`)
+  - Exception: For names where the separating delimiter is already established in the ecosystem, do not convert them to snake_case. For example, http headers like `user-agent` SHOULD keep the separating `-` to retain integrity of the value. Other examples are parameter names (URL, Routing, DB query parameters, etc).
 - The `apply_scrubbing` field in the attribute definition MUST be `manual` or `auto` (if the attribute can contain sensitive data). It SHOULD be `never` only if scrubbing the attribute value for PII would potentially break product features. For example, `sentry.replay_id` should have `apply_scrubbing` set to `never`.
 - When an attribute is added that deprecates an old one:
   - The old one should be marked as deprecated, and it MUST point to the new one using the `deprecation.replacement` field.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,7 @@ Here's a list of policies that any newly added attributes MUST follow. Most of t
 - Use dots as separators for namespaces and logical grouoing, not underscores (`http.request.method`, not `http_request_method`)
 - Use `snake_case` for multi-word names (`browser.web_vital.ttfb.request_time`, not `browser.webVital.ttfb.request-time`)
   - Exception: For names where the separating delimiter is already established in the ecosystem, do not convert them to snake_case. For example, http headers like `user-agent` SHOULD keep the separating `-` to retain integrity of the value. Other examples are parameter names (URL, Routing, DB query parameters, etc).
+    When in doubt, check the OTel semantic conventions, since they follow the same approach (see [request headers](https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/#http-request-header) for example).
 - The `apply_scrubbing` field in the attribute definition MUST be `manual` or `auto` (if the attribute can contain sensitive data). It SHOULD be `never` only if scrubbing the attribute value for PII would potentially break product features. For example, `sentry.replay_id` should have `apply_scrubbing` set to `never`.
 - When an attribute is added that deprecates an old one:
   - The old one should be marked as deprecated, and it MUST point to the new one using the `deprecation.replacement` field.

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -9683,7 +9683,7 @@ export type HTTP_REQUEST_FETCH_START_TYPE = number;
 // Path: model/attributes/http/http__request__header__[key].json
 
 /**
- * HTTP request headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values. `http.request.header.<key>`
+ * HTTP request headers, <key> being the lower-cased, but otherwise unchanged HTTP Header name, the value being the header values. `http.request.header.<key>`
  *
  * Attribute Value Type: `Array<string>` {@link HTTP_REQUEST_HEADER_KEY_TYPE}
  *
@@ -9695,6 +9695,7 @@ export type HTTP_REQUEST_FETCH_START_TYPE = number;
  * Has Dynamic Suffix: true
  *
  * @example "http.request.header.custom-header=['foo', 'bar']"
+ * @example "http.request.header.content-length=['123']"
  */
 export const HTTP_REQUEST_HEADER_KEY = 'http.request.header.<key>';
 
@@ -10087,7 +10088,7 @@ export type HTTP_RESPONSE_HEADER_CONTENT_LENGTH_TYPE = string;
 // Path: model/attributes/http/http__response__header__[key].json
 
 /**
- * HTTP response headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values. `http.response.header.<key>`
+ * HTTP response headers, <key> being the lower-cased, but otherwise unchanged HTTP Header name, the value being the header values. `http.response.header.<key>`
  *
  * Attribute Value Type: `Array<string>` {@link HTTP_RESPONSE_HEADER_KEY_TYPE}
  *
@@ -10099,6 +10100,7 @@ export type HTTP_RESPONSE_HEADER_CONTENT_LENGTH_TYPE = string;
  * Has Dynamic Suffix: true
  *
  * @example "http.response.header.custom-header=['foo', 'bar']"
+ * @example "http.response.header.content-length=['123']"
  */
 export const HTTP_RESPONSE_HEADER_KEY = 'http.response.header.<key>';
 
@@ -27180,7 +27182,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   },
   'http.request.header.<key>': {
     brief:
-      'HTTP request headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.',
+      'HTTP request headers, <key> being the lower-cased, but otherwise unchanged HTTP Header name, the value being the header values.',
     type: 'string[]',
     keys: ['http.request.header.<key>'],
     applyScrubbing: {
@@ -27190,6 +27192,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     hasDynamicSuffix: true,
     example: "http.request.header.custom-header=['foo', 'bar']",
+    examples: ["http.request.header.custom-header=['foo', 'bar']", "http.request.header.content-length=['123']"],
     changelog: [
       { version: '0.4.0', prs: [201, 204] },
       { version: '0.1.0', prs: [103] },
@@ -27460,7 +27463,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
   },
   'http.response.header.<key>': {
     brief:
-      'HTTP response headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.',
+      'HTTP response headers, <key> being the lower-cased, but otherwise unchanged HTTP Header name, the value being the header values.',
     type: 'string[]',
     keys: ['http.response.header.<key>'],
     applyScrubbing: {
@@ -27470,6 +27473,7 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     visibility: 'public',
     hasDynamicSuffix: true,
     example: "http.response.header.custom-header=['foo', 'bar']",
+    examples: ["http.response.header.custom-header=['foo', 'bar']", "http.response.header.content-length=['123']"],
     changelog: [
       { version: '0.4.0', prs: [201, 204] },
       { version: '0.1.0', prs: [103] },

--- a/javascript/sentry-conventions/src/search.ts
+++ b/javascript/sentry-conventions/src/search.ts
@@ -8424,7 +8424,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'http.request.header.<key>',
     type: 'string[]',
     brief:
-      'HTTP request headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.',
+      'HTTP request headers, <key> being the lower-cased, but otherwise unchanged HTTP Header name, the value being the header values.',
     deprecationChain: ['http.request.header.<key>'],
   },
   'http.request.method': {
@@ -8542,7 +8542,7 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     canonicalName: 'http.response.header.<key>',
     type: 'string[]',
     brief:
-      'HTTP response headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.',
+      'HTTP response headers, <key> being the lower-cased, but otherwise unchanged HTTP Header name, the value being the header values.',
     deprecationChain: ['http.response.header.<key>'],
   },
   'http.response.header.content-length': {

--- a/model/attributes/http/http__request__header__[key].json
+++ b/model/attributes/http/http__request__header__[key].json
@@ -1,13 +1,13 @@
 {
   "key": "http.request.header.<key>",
-  "brief": "HTTP request headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.",
+  "brief": "HTTP request headers, <key> being the lower-cased, but otherwise unchanged HTTP Header name, the value being the header values.",
   "has_dynamic_suffix": true,
   "type": "string[]",
   "apply_scrubbing": {
     "key": "auto"
   },
   "is_in_otel": true,
-  "example": "http.request.header.custom-header=['foo', 'bar']",
+  "examples": ["http.request.header.custom-header=['foo', 'bar']", "http.request.header.content-length=['123']"],
   "visibility": "public",
   "changelog": [
     {

--- a/model/attributes/http/http__response__header__[key].json
+++ b/model/attributes/http/http__response__header__[key].json
@@ -1,13 +1,13 @@
 {
   "key": "http.response.header.<key>",
-  "brief": "HTTP response headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.",
+  "brief": "HTTP response headers, <key> being the lower-cased, but otherwise unchanged HTTP Header name, the value being the header values.",
   "has_dynamic_suffix": true,
   "type": "string[]",
   "apply_scrubbing": {
     "key": "auto"
   },
   "is_in_otel": true,
-  "example": "http.response.header.custom-header=['foo', 'bar']",
+  "examples": ["http.response.header.custom-header=['foo', 'bar']", "http.response.header.content-length=['123']"],
   "visibility": "public",
   "changelog": [
     {

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -5854,7 +5854,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     HTTP_REQUEST_HEADER_KEY: Literal["http.request.header.<key>"] = (
         "http.request.header.<key>"
     )
-    """HTTP request headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.
+    """HTTP request headers, <key> being the lower-cased, but otherwise unchanged HTTP Header name, the value being the header values.
 
     Type: List[str]
     Apply Scrubbing: auto
@@ -5862,6 +5862,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Visibility: public
     Has Dynamic Suffix: true
     Example: "http.request.header.custom-header=['foo', 'bar']"
+    Example: "http.request.header.content-length=['123']"
     """
 
     # Path: model/attributes/http/http__request__method.json
@@ -6082,7 +6083,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     HTTP_RESPONSE_HEADER_KEY: Literal["http.response.header.<key>"] = (
         "http.response.header.<key>"
     )
-    """HTTP response headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.
+    """HTTP response headers, <key> being the lower-cased, but otherwise unchanged HTTP Header name, the value being the header values.
 
     Type: List[str]
     Apply Scrubbing: auto
@@ -6090,6 +6091,7 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Visibility: public
     Has Dynamic Suffix: true
     Example: "http.response.header.custom-header=['foo', 'bar']"
+    Example: "http.response.header.content-length=['123']"
     """
 
     # Path: model/attributes/http/http__response__header__content-length.json
@@ -18934,7 +18936,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "http.request.header.<key>": AttributeMetadata(
-        brief="HTTP request headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.",
+        brief="HTTP request headers, <key> being the lower-cased, but otherwise unchanged HTTP Header name, the value being the header values.",
         type=AttributeType.STRING_ARRAY,
         keys=("http.request.header.<key>",),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
@@ -18942,6 +18944,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         has_dynamic_suffix=True,
         example="http.request.header.custom-header=['foo', 'bar']",
+        examples=[
+            "http.request.header.custom-header=['foo', 'bar']",
+            "http.request.header.content-length=['123']",
+        ],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[201, 204]),
             ChangelogEntry(version="0.1.0", prs=[103]),
@@ -19228,7 +19234,7 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
     ),
     "http.response.header.<key>": AttributeMetadata(
-        brief="HTTP response headers, <key> being the normalized HTTP Header name (lowercase), the value being the header values.",
+        brief="HTTP response headers, <key> being the lower-cased, but otherwise unchanged HTTP Header name, the value being the header values.",
         type=AttributeType.STRING_ARRAY,
         keys=("http.response.header.<key>",),
         apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.AUTO),
@@ -19236,6 +19242,10 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         visibility=Visibility.PUBLIC,
         has_dynamic_suffix=True,
         example="http.response.header.custom-header=['foo', 'bar']",
+        examples=[
+            "http.response.header.custom-header=['foo', 'bar']",
+            "http.response.header.content-length=['123']",
+        ],
         changelog=[
             ChangelogEntry(version="0.4.0", prs=[201, 204]),
             ChangelogEntry(version="0.1.0", prs=[103]),


### PR DESCRIPTION
Came up via https://github.com/getsentry/sentry-javascript/pull/24222

Makes it more explicit that we should follow established name patterns rather than force-normalize them, giving a couple of examples. The snake_case recommendation still stands, for example when we make up our own multi-word attributes like `*.web_vitals.*`.