### PR TITLE
feat(attributes): Add `sentry.app.url.domain` attribute

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -14564,6 +14564,30 @@ export const SENTRY_ACTION = 'sentry.action';
  */
 export type SENTRY_ACTION_TYPE = string;
 
+// Path: model/attributes/sentry/sentry__app__url__domain.json
+
+/**
+ * The domain the instrumented app is running on. For browsers, that's the current window's url. For server-side applications, the domain the application is deployed on. Importantly, this attribute MUST NOT be used to describe urls of outgoing requests. `sentry.app.url.domain`
+ *
+ * Attribute Value Type: `string` {@link SENTRY_APP_URL_DOMAIN_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example "localhost"
+ * @example "api.project.com"
+ * @example "127.0.01"
+ * @example "::1"
+ */
+export const SENTRY_APP_URL_DOMAIN = 'sentry.app.url.domain';
+
+/**
+ * Type for {@link SENTRY_APP_URL_DOMAIN} sentry.app.url.domain
+ */
+export type SENTRY_APP_URL_DOMAIN_TYPE = string;
+
 // Path: model/attributes/sentry/sentry__browser__name.json
 
 /**
@@ -19335,6 +19359,7 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'score.total': 'double',
   'score.weight.<key>': 'double',
   'sentry.action': 'string',
+  'sentry.app.url.domain': 'string',
   'sentry.browser.name': 'string',
   'sentry.browser.version': 'string',
   'sentry.cancellation_reason': 'string',
@@ -20171,6 +20196,7 @@ export type AttributeName =
   | typeof SCORE_TOTAL
   | typeof SCORE_WEIGHT_KEY
   | typeof SENTRY_ACTION
+  | typeof SENTRY_APP_URL_DOMAIN
   | typeof SENTRY_BROWSER_NAME
   | typeof SENTRY_BROWSER_VERSION
   | typeof SENTRY_CANCELLATION_REASON
@@ -30739,6 +30765,20 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
       name: 'span.action',
     },
   },
+  'sentry.app.url.domain': {
+    brief:
+      "The domain the instrumented app is running on. For browsers, that's the current window's url. For server-side applications, the domain the application is deployed on. Importantly, this attribute MUST NOT be used to describe urls of outgoing requests.",
+    type: 'string',
+    keys: ['sentry.app.url.domain'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 'localhost',
+    examples: ['localhost', 'api.project.com', '127.0.01', '::1'],
+    changelog: [{ version: 'next', prs: [635], description: 'Added sentry.app.url.domain attribute' }],
+  },
   'sentry.browser.name': {
     brief: 'The name of the browser.',
     type: 'string',
@@ -34128,6 +34168,7 @@ export type Attributes = {
   [SCORE_TOTAL]?: SCORE_TOTAL_TYPE;
   [SCORE_WEIGHT_KEY]?: SCORE_WEIGHT_KEY_TYPE;
   [SENTRY_ACTION]?: SENTRY_ACTION_TYPE;
+  [SENTRY_APP_URL_DOMAIN]?: SENTRY_APP_URL_DOMAIN_TYPE;
   [SENTRY_BROWSER_NAME]?: SENTRY_BROWSER_NAME_TYPE;
   [SENTRY_BROWSER_VERSION]?: SENTRY_BROWSER_VERSION_TYPE;
   [SENTRY_CANCELLATION_REASON]?: SENTRY_CANCELLATION_REASON_TYPE;

--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -30778,6 +30778,12 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'localhost',
     examples: ['localhost', 'api.project.com', '127.0.01', '::1'],
     changelog: [{ version: 'next', prs: [635], description: 'Added sentry.app.url.domain attribute' }],
+    additionalContext: [
+      "This attribute exists to enable sending the app's domain on every span, regardless of span kind. Other, existing URL attributes are ambiguous and serve different purposes for spans describing incoming or outgoing requests.",
+      "This attribute is used for Sentry's Inbound filters, for example, to filter out telemetry emitted from localhost",
+      'The attribute MAY carry an IP address, if a resolved domain name is not available.',
+      "To avoid conflicts with OTel's definition of the `app` namespace, this attribute is prefixed with `sentry.`",
+    ],
   },
   'sentry.browser.name': {
     brief: 'The name of the browser.',

--- a/javascript/sentry-conventions/src/search.ts
+++ b/javascript/sentry-conventions/src/search.ts
@@ -3740,6 +3740,11 @@ export const SEARCH_SDK__VERSION = 'sdk.version';
 export const SEARCH_SENTRY__ACTION = 'sentry.action';
 
 /**
+ * Search name for {@link attributes.SENTRY_APP_URL_DOMAIN}. `sentry.app.url.domain`
+ */
+export const SEARCH_SENTRY__APP__URL__DOMAIN = 'sentry.app.url.domain';
+
+/**
  * Search name for {@link attributes.SENTRY_BROWSER_VERSION}. `sentry.browser.version`
  *
  * @deprecated Use {@link SEARCH_BROWSER__VERSION} (`browser.version`) instead
@@ -5466,6 +5471,7 @@ export type AttributeSearchName =
   | typeof SEARCH_SDK__NAME
   | typeof SEARCH_SDK__VERSION
   | typeof SEARCH_SENTRY__ACTION
+  | typeof SEARCH_SENTRY__APP__URL__DOMAIN
   | typeof SEARCH_SENTRY__BROWSER__VERSION
   | typeof SEARCH_SENTRY__CANCELLATION_REASON
   | typeof SEARCH_SENTRY__CATEGORY
@@ -9877,6 +9883,13 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief: 'The sentry sdk version.',
     deprecationChain: ['sentry.sdk.version', 'sdk.version'],
+  },
+  'sentry.app.url.domain': {
+    canonicalName: 'sentry.app.url.domain',
+    type: 'string',
+    brief:
+      "The domain the instrumented app is running on. For browsers, that's the current window's url. For server-side applications, the domain the application is deployed on. Importantly, this attribute MUST NOT be used to describe urls of outgoing requests.",
+    deprecationChain: ['sentry.app.url.domain'],
   },
   'sentry.browser.version': {
     canonicalName: 'browser.version',

--- a/model/attributes/sentry/sentry__app__url__domain.json
+++ b/model/attributes/sentry/sentry__app__url__domain.json
@@ -1,7 +1,7 @@
 {
   "key": "sentry.app.url.domain",
   "brief": "The domain the instrumented app is running on. For browsers, that's the current window's url. For server-side applications, the domain the application is deployed on. Importantly, this attribute MUST NOT be used to describe urls of outgoing requests.",
-  "aditional_context": [
+  "additional_context": [
     "This attribute exists to enable sending the app's domain on every span, regardless of span kind. Other, existing URL attributes are ambiguous and serve different purposes for spans describing incoming or outgoing requests.",
     "This attribute is used for Sentry's Inbound filters, for example, to filter out telemetry emitted from localhost",
     "The attribute MAY carry an IP address, if a resolved domain name is not available.",

--- a/model/attributes/sentry/sentry__app__url__domain.json
+++ b/model/attributes/sentry/sentry__app__url__domain.json
@@ -1,0 +1,24 @@
+{
+  "key": "sentry.app.url.domain",
+  "brief": "The domain the instrumented app is running on. For browsers, that's the current window's url. For server-side applications, the domain the application is deployed on. Importantly, this attribute MUST NOT be used to describe urls of outgoing requests.",
+  "aditional_context": [
+    "This attribute exists to enable sending the app's domain on every span, regardless of span kind. Other, existing URL attributes are ambiguous and serve different purposes for spans describing incoming or outgoing requests.",
+    "This attribute is used for Sentry's Inbound filters, for example, to filter out telemetry emitted from localhost",
+    "The attribute MAY carry an IP address, if a resolved domain name is not available.",
+    "To avoid conflicts with OTel's definition of the `app` namespace, this attribute is prefixed with `sentry.`"
+  ],
+  "type": "string",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": ["localhost", "api.project.com", "127.0.01", "::1"],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [635],
+      "description": "Added sentry.app.url.domain attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -8588,6 +8588,20 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "SELECT"
     """
 
+    # Path: model/attributes/sentry/sentry__app__url__domain.json
+    SENTRY_APP_URL_DOMAIN: Literal["sentry.app.url.domain"] = "sentry.app.url.domain"
+    """The domain the instrumented app is running on. For browsers, that's the current window's url. For server-side applications, the domain the application is deployed on. Importantly, this attribute MUST NOT be used to describe urls of outgoing requests.
+
+    Type: str
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: "localhost"
+    Example: "api.project.com"
+    Example: "127.0.01"
+    Example: "::1"
+    """
+
     # Path: model/attributes/sentry/sentry__browser__name.json
     SENTRY_BROWSER_NAME: Literal["sentry.browser.name"] = "sentry.browser.name"
     """The name of the browser.
@@ -23101,6 +23115,23 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         ],
         search_alias=SearchAlias(name="span.action"),
     ),
+    "sentry.app.url.domain": AttributeMetadata(
+        brief="The domain the instrumented app is running on. For browsers, that's the current window's url. For server-side applications, the domain the application is deployed on. Importantly, this attribute MUST NOT be used to describe urls of outgoing requests.",
+        type=AttributeType.STRING,
+        keys=("sentry.app.url.domain",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example="localhost",
+        examples=["localhost", "api.project.com", "127.0.01", "::1"],
+        changelog=[
+            ChangelogEntry(
+                version="next",
+                prs=[635],
+                description="Added sentry.app.url.domain attribute",
+            ),
+        ],
+    ),
     "sentry.browser.name": AttributeMetadata(
         brief="The name of the browser.",
         type=AttributeType.STRING,
@@ -26792,6 +26823,7 @@ Attributes = TypedDict(
         "score.total": float,
         "score.weight.<key>": float,
         "sentry.action": str,
+        "sentry.app.url.domain": str,
         "sentry.browser.name": str,
         "sentry.browser.version": str,
         "sentry.cancellation_reason": str,

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -23131,6 +23131,12 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
                 description="Added sentry.app.url.domain attribute",
             ),
         ],
+        additional_context=[
+            "This attribute exists to enable sending the app's domain on every span, regardless of span kind. Other, existing URL attributes are ambiguous and serve different purposes for spans describing incoming or outgoing requests.",
+            "This attribute is used for Sentry's Inbound filters, for example, to filter out telemetry emitted from localhost",
+            "The attribute MAY carry an IP address, if a resolved domain name is not available.",
+            "To avoid conflicts with OTel's definition of the `app` namespace, this attribute is prefixed with `sentry.`",
+        ],
     ),
     "sentry.browser.name": AttributeMetadata(
         brief="The name of the browser.",


### PR DESCRIPTION
## Description

Today, all/most of our `url`, `server` or `http` attributes are interchangeably used to describe incoming and outgoing requests. This is (mostly) in line with OTel's definition. To differentiate, OTel uses `span.kind` and we use `sentry.op` (as well as `sentry.kind` for OTLP AFAIK). 

**Why do we need yet another URL attribute then?**

This PR adds a new attribute to serve a specific purpose: Provide the URL of the instrumented application on _every_ span, regardless of its kind/op. We need this to be able to make Sentry's "filter out events from localhost" inbound filter work. This includes `http.client` (outgoing request) spans. Their `url.*` attributes point to the request URL, so we can't set them to the application's URL. There are other spans like this, where we have similar issues (resource spans, db spans to a degree, etc). 

**Why the `sentry.*` Prefix?** 

Initially I wanted to go with `app.url.domain`, but then saw that OTel [defines](https://opentelemetry.io/docs/specs/semconv/registry/attributes/app/) the `app` namespace as _"attributes related to client-side applications"_. So I'd prefer not "misusing" this namespace for server-side applications. 

**Why this specific name?**

- `url.domain` already exists. Prefixing it with `sentry.app.` means we re-use an established pattern for a more specific purpose.
- We need some kind of prefix but I'm happy to change it if anyone has a better idea

**Alternatives considered?**

- Having two attributes, one for server, one for client. 
  - would work with inbound filters
  - For example: `browser.document.url.domain` (something [similar is in O](https://opentelemetry.io/docs/specs/semconv/registry/attributes/browser/#browser-document-url-full)Tel) and `http.server.url.domain` for the server-side. 
  - There's no precedence for this in OTel for the server side, and no server namespace exists for this, that isn't also used in e.g. browser-side outfoing request spans. 
  - That being said, this is still an option and we can also use this if anyone prefers
- A very specific "filtering attribute", something like `sentry.inbound_filter.url.domain`
  - Also an option I'm not opposed to
  - The counter argument is, attributes should describe a concept/semantic, not the purpose for what they are potentially used. 

## PR Checklist

<!-- Check these to make sure the PR is ready for review -->

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [x] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md) 