### PR TITLE
feat(attributes): Add `cache.item_age` and `cache.tags`

### DIFF
--- a/javascript/sentry-conventions/src/attributes.ts
+++ b/javascript/sentry-conventions/src/attributes.ts
@@ -3854,6 +3854,28 @@ export const CACHE_HIT = 'cache.hit';
  */
 export type CACHE_HIT_TYPE = boolean;
 
+// Path: model/attributes/cache/cache__item_age.json
+
+/**
+ * The age of the cache entry in seconds, measured at read time. `cache.item_age`
+ *
+ * Attribute Value Type: `number` {@link CACHE_ITEM_AGE_TYPE}
+ *
+ * Apply Scrubbing: manual
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example 5
+ * @example 3600
+ */
+export const CACHE_ITEM_AGE = 'cache.item_age';
+
+/**
+ * Type for {@link CACHE_ITEM_AGE} cache.item_age
+ */
+export type CACHE_ITEM_AGE_TYPE = number;
+
 // Path: model/attributes/cache/cache__item_size.json
 
 /**
@@ -3918,6 +3940,28 @@ export const CACHE_OPERATION = 'cache.operation';
  * Type for {@link CACHE_OPERATION} cache.operation
  */
 export type CACHE_OPERATION_TYPE = string;
+
+// Path: model/attributes/cache/cache__tags.json
+
+/**
+ * The tags attached to the cache entry. Tags group entries so a cache can invalidate them together. `cache.tags`
+ *
+ * Attribute Value Type: `Array<string>` {@link CACHE_TAGS_TYPE}
+ *
+ * Apply Scrubbing: auto - Applications pick tag values freely and often build them from record identifiers such as a user id.
+ *
+ * Attribute defined in OTEL: No
+ * Visibility: public
+ *
+ * @example ["blog-posts","post-42"]
+ * @example ["products"]
+ */
+export const CACHE_TAGS = 'cache.tags';
+
+/**
+ * Type for {@link CACHE_TAGS} cache.tags
+ */
+export type CACHE_TAGS_TYPE = Array<string>;
 
 // Path: model/attributes/cache/cache__ttl.json
 
@@ -18857,9 +18901,11 @@ export const ATTRIBUTE_TYPE: Record<string, AttributeType> = {
   'browser.web_vital.ttfb.request_time': 'double',
   'browser.web_vital.ttfb.value': 'double',
   'cache.hit': 'boolean',
+  'cache.item_age': 'integer',
   'cache.item_size': 'integer',
   'cache.key': 'string[]',
   'cache.operation': 'string',
+  'cache.tags': 'string[]',
   'cache.ttl': 'integer',
   'cache.write': 'boolean',
   channel: 'string',
@@ -19693,9 +19739,11 @@ export type AttributeName =
   | typeof BROWSER_WEB_VITAL_TTFB_REQUEST_TIME
   | typeof BROWSER_WEB_VITAL_TTFB_VALUE
   | typeof CACHE_HIT
+  | typeof CACHE_ITEM_AGE
   | typeof CACHE_ITEM_SIZE
   | typeof CACHE_KEY
   | typeof CACHE_OPERATION
+  | typeof CACHE_TAGS
   | typeof CACHE_TTL
   | typeof CACHE_WRITE
   | typeof CHANNEL
@@ -23049,6 +23097,28 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: true,
     changelog: [{ version: '0.0.0' }],
   },
+  'cache.item_age': {
+    brief: 'The age of the cache entry in seconds, measured at read time.',
+    type: 'integer',
+    keys: ['cache.item_age'],
+    applyScrubbing: {
+      key: 'manual',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: 5,
+    examples: [5, 3600],
+    changelog: [{ version: 'next', prs: [637], description: 'Added cache.item_age attribute' }],
+    additionalContext: [
+      'Set on reads that return an entry. Absent on a miss, or when the cache does not report a write time.',
+      "Clamped to 0. On a shared cache, the writer's clock and the reader's clock can drift far enough to make the age negative.",
+      'Can exceed `cache.ttl`. A cache that discards an expired entry on read still reports the age of that entry, with `cache.hit: false`.',
+    ],
+    searchAlias: {
+      name: 'cache.item_age',
+      type: 'second',
+    },
+  },
   'cache.item_size': {
     brief: 'The size of the requested item in the cache. In bytes.',
     type: 'integer',
@@ -23089,6 +23159,26 @@ export const ATTRIBUTE_METADATA: Record<AttributeName, AttributeMetadata> = {
     example: 'get',
     examples: ['get', 'put', 'remove'],
     changelog: [{ version: '0.1.0', prs: [127] }, { version: '0.0.0' }],
+  },
+  'cache.tags': {
+    brief: 'The tags attached to the cache entry. Tags group entries so a cache can invalidate them together.',
+    type: 'string[]',
+    keys: ['cache.tags'],
+    applyScrubbing: {
+      key: 'auto',
+      reason: 'Applications pick tag values freely and often build them from record identifiers such as a user id.',
+    },
+    isInOtel: false,
+    visibility: 'public',
+    example: ['blog-posts', 'post-42'],
+    examples: [['blog-posts', 'post-42'], ['products']],
+    changelog: [{ version: 'next', prs: [637], description: 'Added cache.tags attribute' }],
+    additionalContext: [
+      'Cache library examples that support tags: Next.js `cacheTag()`, Symfony `ItemInterface::tag()`, Laravel `Cache::tags()`.',
+      'HTTP caches take tags from a response header. Cloudflare reads `Cache-Tag`, Fastly reads `Surrogate-Key`.',
+      'Record only the tags the application declared. Leave out implicit tags that the framework adds itself, for example one tag per route.',
+      'The tags describe the entry, not the operation. Take them from the entry the cache returned or stored.',
+    ],
   },
   'cache.ttl': {
     brief: 'The ttl of the cache in seconds',
@@ -33654,9 +33744,11 @@ export type Attributes = {
   [BROWSER_WEB_VITAL_TTFB_REQUEST_TIME]?: BROWSER_WEB_VITAL_TTFB_REQUEST_TIME_TYPE;
   [BROWSER_WEB_VITAL_TTFB_VALUE]?: BROWSER_WEB_VITAL_TTFB_VALUE_TYPE;
   [CACHE_HIT]?: CACHE_HIT_TYPE;
+  [CACHE_ITEM_AGE]?: CACHE_ITEM_AGE_TYPE;
   [CACHE_ITEM_SIZE]?: CACHE_ITEM_SIZE_TYPE;
   [CACHE_KEY]?: CACHE_KEY_TYPE;
   [CACHE_OPERATION]?: CACHE_OPERATION_TYPE;
+  [CACHE_TAGS]?: CACHE_TAGS_TYPE;
   [CACHE_TTL]?: CACHE_TTL_TYPE;
   [CACHE_WRITE]?: CACHE_WRITE_TYPE;
   [CHANNEL]?: CHANNEL_TYPE;

--- a/javascript/sentry-conventions/src/search.ts
+++ b/javascript/sentry-conventions/src/search.ts
@@ -1006,6 +1006,11 @@ export const SEARCH_BROWSER__WEB_VITAL__TTFB__VALUE = 'browser.web_vital.ttfb.va
 export const SEARCH_CACHE__HIT = 'cache.hit';
 
 /**
+ * Search name for {@link attributes.CACHE_ITEM_AGE}. `cache.item_age`
+ */
+export const SEARCH_CACHE__ITEM_AGE = 'cache.item_age';
+
+/**
  * Search name for {@link attributes.CACHE_ITEM_SIZE}. `cache.item_size`
  */
 export const SEARCH_CACHE__ITEM_SIZE = 'cache.item_size';
@@ -1019,6 +1024,11 @@ export const SEARCH_CACHE__KEY = 'cache.key';
  * Search name for {@link attributes.CACHE_OPERATION}. `cache.operation`
  */
 export const SEARCH_CACHE__OPERATION = 'cache.operation';
+
+/**
+ * Search name for {@link attributes.CACHE_TAGS}. `cache.tags`
+ */
+export const SEARCH_CACHE__TAGS = 'cache.tags';
 
 /**
  * Search name for {@link attributes.CACHE_TTL}. `cache.ttl`
@@ -4975,9 +4985,11 @@ export type AttributeSearchName =
   | typeof SEARCH_BROWSER__WEB_VITAL__TTFB__REQUEST_TIME
   | typeof SEARCH_BROWSER__WEB_VITAL__TTFB__VALUE
   | typeof SEARCH_CACHE__HIT
+  | typeof SEARCH_CACHE__ITEM_AGE
   | typeof SEARCH_CACHE__ITEM_SIZE
   | typeof SEARCH_CACHE__KEY
   | typeof SEARCH_CACHE__OPERATION
+  | typeof SEARCH_CACHE__TAGS
   | typeof SEARCH_CACHE__TTL
   | typeof SEARCH_CACHE__WRITE
   | typeof SEARCH_CHANNEL
@@ -6771,6 +6783,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     brief: 'If the cache was hit during this span.',
     deprecationChain: ['cache.hit'],
   },
+  'cache.item_age': {
+    canonicalName: 'cache.item_age',
+    type: 'second',
+    brief: 'The age of the cache entry in seconds, measured at read time.',
+    deprecationChain: ['cache.item_age'],
+  },
   'cache.item_size': {
     canonicalName: 'cache.item_size',
     type: 'byte',
@@ -6788,6 +6806,12 @@ export const ATTRIBUTE_SEARCH_METADATA: Record<string, AttributeSearchMetadata> 
     type: 'string',
     brief: 'The operation being performed on the cache.',
     deprecationChain: ['cache.operation'],
+  },
+  'cache.tags': {
+    canonicalName: 'cache.tags',
+    type: 'string[]',
+    brief: 'The tags attached to the cache entry. Tags group entries so a cache can invalidate them together.',
+    deprecationChain: ['cache.tags'],
   },
   'cache.ttl': {
     canonicalName: 'cache.ttl',

--- a/model/attributes/cache/cache__item_age.json
+++ b/model/attributes/cache/cache__item_age.json
@@ -1,0 +1,27 @@
+{
+  "key": "cache.item_age",
+  "brief": "The age of the cache entry in seconds, measured at read time.",
+  "type": "integer",
+  "apply_scrubbing": {
+    "key": "manual"
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": [5, 3600],
+  "search_alias": {
+    "name": "cache.item_age",
+    "type": "second"
+  },
+  "additional_context": [
+    "Set on reads that return an entry. Absent on a miss, or when the cache does not report a write time.",
+    "Clamped to 0. On a shared cache, the writer's clock and the reader's clock can drift far enough to make the age negative.",
+    "Can exceed `cache.ttl`. A cache that discards an expired entry on read still reports the age of that entry, with `cache.hit: false`."
+  ],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [637],
+      "description": "Added cache.item_age attribute"
+    }
+  ]
+}

--- a/model/attributes/cache/cache__tags.json
+++ b/model/attributes/cache/cache__tags.json
@@ -1,0 +1,25 @@
+{
+  "key": "cache.tags",
+  "brief": "The tags attached to the cache entry. Tags group entries so a cache can invalidate them together.",
+  "type": "string[]",
+  "apply_scrubbing": {
+    "key": "auto",
+    "reason": "Applications pick tag values freely and often build them from record identifiers such as a user id."
+  },
+  "is_in_otel": false,
+  "visibility": "public",
+  "examples": [["blog-posts", "post-42"], ["products"]],
+  "additional_context": [
+    "Cache library examples that support tags: Next.js `cacheTag()`, Symfony `ItemInterface::tag()`, Laravel `Cache::tags()`.",
+    "HTTP caches take tags from a response header. Cloudflare reads `Cache-Tag`, Fastly reads `Surrogate-Key`.",
+    "Record only the tags the application declared. Leave out implicit tags that the framework adds itself, for example one tag per route.",
+    "The tags describe the entry, not the operation. Take them from the entry the cache returned or stored."
+  ],
+  "changelog": [
+    {
+      "version": "next",
+      "prs": [637],
+      "description": "Added cache.tags attribute"
+    }
+  ]
+}

--- a/python/src/sentry_conventions/attributes.py
+++ b/python/src/sentry_conventions/attributes.py
@@ -2609,6 +2609,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: true
     """
 
+    # Path: model/attributes/cache/cache__item_age.json
+    CACHE_ITEM_AGE: Literal["cache.item_age"] = "cache.item_age"
+    """The age of the cache entry in seconds, measured at read time.
+
+    Type: int
+    Apply Scrubbing: manual
+    Defined in OTEL: No
+    Visibility: public
+    Example: 5
+    Example: 3600
+    """
+
     # Path: model/attributes/cache/cache__item_size.json
     CACHE_ITEM_SIZE: Literal["cache.item_size"] = "cache.item_size"
     """The size of the requested item in the cache. In bytes.
@@ -2642,6 +2654,18 @@ class ATTRIBUTE_NAMES(metaclass=_AttributeNamesMeta):
     Example: "get"
     Example: "put"
     Example: "remove"
+    """
+
+    # Path: model/attributes/cache/cache__tags.json
+    CACHE_TAGS: Literal["cache.tags"] = "cache.tags"
+    """The tags attached to the cache entry. Tags group entries so a cache can invalidate them together.
+
+    Type: List[str]
+    Apply Scrubbing: auto - Applications pick tag values freely and often build them from record identifiers such as a user id.
+    Defined in OTEL: No
+    Visibility: public
+    Example: ["blog-posts","post-42"]
+    Example: ["products"]
     """
 
     # Path: model/attributes/cache/cache__ttl.json
@@ -14129,6 +14153,27 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
             ChangelogEntry(version="0.0.0"),
         ],
     ),
+    "cache.item_age": AttributeMetadata(
+        brief="The age of the cache entry in seconds, measured at read time.",
+        type=AttributeType.INTEGER,
+        keys=("cache.item_age",),
+        apply_scrubbing=ApplyScrubbingInfo(key=ApplyScrubbing.MANUAL),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=5,
+        examples=[5, 3600],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[637], description="Added cache.item_age attribute"
+            ),
+        ],
+        additional_context=[
+            "Set on reads that return an entry. Absent on a miss, or when the cache does not report a write time.",
+            "Clamped to 0. On a shared cache, the writer's clock and the reader's clock can drift far enough to make the age negative.",
+            "Can exceed `cache.ttl`. A cache that discards an expired entry on read still reports the age of that entry, with `cache.hit: false`.",
+        ],
+        search_alias=SearchAlias(name="cache.item_age", type="second"),
+    ),
     "cache.item_size": AttributeMetadata(
         brief="The size of the requested item in the cache. In bytes.",
         type=AttributeType.INTEGER,
@@ -14167,6 +14212,30 @@ ATTRIBUTE_METADATA: Dict[str, AttributeMetadata] = {
         changelog=[
             ChangelogEntry(version="0.1.0", prs=[127]),
             ChangelogEntry(version="0.0.0"),
+        ],
+    ),
+    "cache.tags": AttributeMetadata(
+        brief="The tags attached to the cache entry. Tags group entries so a cache can invalidate them together.",
+        type=AttributeType.STRING_ARRAY,
+        keys=("cache.tags",),
+        apply_scrubbing=ApplyScrubbingInfo(
+            key=ApplyScrubbing.AUTO,
+            reason="Applications pick tag values freely and often build them from record identifiers such as a user id.",
+        ),
+        is_in_otel=False,
+        visibility=Visibility.PUBLIC,
+        example=["blog-posts", "post-42"],
+        examples=[["blog-posts", "post-42"], ["products"]],
+        changelog=[
+            ChangelogEntry(
+                version="next", prs=[637], description="Added cache.tags attribute"
+            ),
+        ],
+        additional_context=[
+            "Cache library examples that support tags: Next.js `cacheTag()`, Symfony `ItemInterface::tag()`, Laravel `Cache::tags()`.",
+            "HTTP caches take tags from a response header. Cloudflare reads `Cache-Tag`, Fastly reads `Surrogate-Key`.",
+            "Record only the tags the application declared. Leave out implicit tags that the framework adds itself, for example one tag per route.",
+            "The tags describe the entry, not the operation. Take them from the entry the cache returned or stored.",
         ],
     ),
     "cache.ttl": AttributeMetadata(
@@ -26319,9 +26388,11 @@ Attributes = TypedDict(
         "browser.web_vital.ttfb.request_time": float,
         "browser.web_vital.ttfb.value": float,
         "cache.hit": bool,
+        "cache.item_age": int,
         "cache.item_size": int,
         "cache.key": List[str],
         "cache.operation": str,
+        "cache.tags": List[str],
         "cache.ttl": int,
         "cache.write": bool,
         "channel": str,


### PR DESCRIPTION
## Description

Closes https://github.com/getsentry/sentry-javascript/issues/24292

## PR Checklist

- [x] I have run `yarn test` and verified that the tests pass.
- [x] I have run `yarn generate` to generate and format code and docs.

If an attribute was added:

- [ ] The attribute is in a namespace (e.g. `nextjs.function_id`, not `function_id`)
- [x] I have used the correct value for `apply_scrubbing` (i.e. `manual` or `auto`. Use `never` only for values that should never be scrubbed such as IDs)

If an attribute was deprecated:

- [x] I've followed the policies described in [CONTRIBUTING.md](https://github.com/getsentry/sentry-conventions/blob/main/CONTRIBUTING.md)
